### PR TITLE
Refactor monorepo paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,34 @@
 # SPIRIT
 
-> Spirit is an open-source design system built by LMC. With the LMC Design
+> Spirit is an open-source design system developed by LMC.
 
-<a href="https://lerna.js.org/">
-    <img src="https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg" alt="Maintained with Lerna" />
-</a>
+[![Maintained with Lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org)
 
-- [Getting started](#usage)
-- [Prerequisites](#prerequisites)
-- [Development](#development)
-- [Releases](#releases)
+## Getting Started
 
-<a name="usage"></a>
+See individual [packages](#packages) to learn how to get started.
 
-## Getting started
+## Packages
 
-```javascript
-npm install @spirit/<package-name>
-```
-
-If you're just getting started, check out
-[`@spirit/components`](./packages/components). If you're looking for React
-components, take a look at [`@spirit/react`](./packages/react).
-
-If you're trying to find something specific, here's a full list of packages that
-we support!
-
-| Package name                                  | Description                                                                                                                                                                                                                                   |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`@spirit/colors`](./packages/colors)  | Work with LMC Design Language colors                                                                                                                                                                                                       |
-
-<a name="prerequisites"></a>
-
-## Prerequisites
-
-- [node.js](https://nodejs.org/en/) Node Stable
-- [yarn](https://yarnpkg.com/lang/en/)
-
-### Dependencies
-
-<a name="development"></a>
+| Package name                                                 | Description                                                     |
+| ------------------------------------------------------------ | --------------------------------------------------------------- |
+| [`@lmc-eu/spirit-design-tokens`](./packages/design-tokens)   | Design tokens for Spirit Design System                          |
+| [`@lmc-eu/spirit-web`](./packages/web)                       | CSS and vanilla JS implementation of Spirit Design System       |
+| [`@lmc-eu/spirit-web-react`](./packages/web-react)           | React implementation of Spirit Design System components         |
 
 ## Development
 
-### Start development
+### Prerequisites
 
-- `git clone ssh://git@bitbucket.lmc.cz:7999/ds/spirit.git`
-- `cd spirit`
-- `yarn <script>`
+- [Node >= 14](https://nodejs.org)
+- [Yarn 1.22](https://yarnpkg.com)
+- [Lerna 4.x](https://lerna.js.org)
 
-### Scripts
+### Start Development
 
-In the project directory, you can run:
+- `git clone ssh://git@github.com:lmc-eu/spirit-design-system.git`
+- `cd spirit-design-system`
+- `yarn install`
+- `yarn build`
 
-- `build` - Compiles source code to library in `dist/` directory.
-- `format` - Alias form `format:check`.
-- `format:check` - Runs check of code format (done via `prettier`).
-- `format:fix` - Fixes code format (done via `prettier`).
-- `test` - Run in non-interactive mode.
-- `test:watch` - Run tests in interactive mode.
-- `test:coverage` - Run tests with code coverage check.
-- `types` - Checks types.
-- `lint` - Code lint with code formatting check.
-- `lint:fix` - Code linter and fixer with code formatting rules applied.
-- `ci` - Runs Continuous Integration cascade (`lint`, `types`, `test`, `format`).
-- `changelog` - Generates changelog.
-- `changelog:origin` - Generates changelog for entire history.
-- `commit:lint:test` - Test last commit message with commit linter against conventional changelog rules.
-- `version` - Releases new version.
-- `vuln` - Run audit for security vulnerabilities.
-
-<a name="releases"></a>
-
-## Releases
+See [`package.json`](./package.json) for all available tasks.

--- a/examples/web-react/package.json
+++ b/examples/web-react/package.json
@@ -8,7 +8,7 @@
     "access": "restricted"
   },
   "scripts": {
-    "precopy": "mkdirp ./built",
+    "precopy": "mkdir -p ./built",
     "copy": "yarn copy:css",
     "copy:css": "cp ../../node_modules/@lmc-eu/spirit-web/dist/css/default/components.min.css built/components.min.css",
     "prebuild": "yarn copy",
@@ -25,7 +25,6 @@
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
     "babel-loader": "^8.2.2",
-    "mkdirp": "^1.0.4",
     "webpack": "^5.50.0",
     "webpack-cli": "^4.7.2"
   }

--- a/examples/web-react/package.json
+++ b/examples/web-react/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "precopy": "mkdirp ./built",
     "copy": "yarn copy:css",
-    "copy:css": "cp ../../node_modules/@lmc-eu/spirit-web/dist/default/css/components.min.css built/components.min.css",
+    "copy:css": "cp ../../node_modules/@lmc-eu/spirit-web/dist/css/default/components.min.css built/components.min.css",
     "prebuild": "yarn copy",
     "build": "webpack --config ./webpack.config.js --mode development"
   },

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -8,16 +8,14 @@
     "access": "restricted"
   },
   "scripts": {
-    "prebuild": "mkdirp ./built",
+    "prebuild": "mkdir -p ./built",
     "build": "yarn copy",
     "copy": "yarn copy:default && yarn copy:jobs",
     "copy:default": "cp ../../node_modules/@lmc-eu/spirit-web/dist/css/default/components.min.css built/components.min.css",
     "copy:jobs": "cp ../../node_modules/@lmc-eu/spirit-web/dist/css/jobs/components.min.css built/components-jobs.min.css"
   },
   "dependencies": {
+    "@lmc-eu/spirit-design-tokens": "~0.1.0",
     "@lmc-eu/spirit-web": "~0.1.0"
-  },
-  "devDependencies": {
-    "mkdirp": "^1.0.4"
   }
 }

--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -38,8 +38,8 @@ npm install --save @lmc-eu/spirit-design-tokens
 In Sass, import individual files by token categories:
 
 ```scss
-@use 'node_modules/@lmc-eu/spirit-design-tokens/src/default/scss/colors';
-@use 'node_modules/@lmc-eu/spirit-design-tokens/src/default/scss/typography';
+@use 'node_modules/@lmc-eu/spirit-design-tokens/default/scss/colors';
+@use 'node_modules/@lmc-eu/spirit-design-tokens/default/scss/typography';
 
 .MyComponent {
     font-family: typography.$font-family-default;
@@ -50,7 +50,7 @@ In Sass, import individual files by token categories:
 Or import all tokens at once:
 
 ```scss
-@use 'node_modules/@lmc-eu/spirit-design-tokens/src/default/scss' as tokens;
+@use 'node_modules/@lmc-eu/spirit-design-tokens/default/scss/tokens';
 
 .MyComponent {
     font-family: tokens.$font-family-default;

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -4,12 +4,11 @@
   "description": "Design tokens for Spirit Design System",
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "directory": "dist"
   },
-  "files": [
-    "src/scss"
-  ],
   "scripts": {
+    "build": "rm -rf dist && mkdir -p dist && cp -r package.json README.md src/* dist/ ",
     "test": "stylelint --config ../../.stylelintrc ./src/**/*.scss"
   },
   "devDependencies": {

--- a/packages/web-react/README.md
+++ b/packages/web-react/README.md
@@ -21,7 +21,7 @@ npm install --save @lmc-eu/spirit-web @lmc-eu/spirit-web-react
 Link Spirit CSS (see [`spirit-react-web` docs][web-docs] for more options):
 
 ```html
-<link rel="stylesheet" href="node_modules/@lmc-eu/spirit-web/dist/default/css/components.min.css" />
+<link rel="stylesheet" href="node_modules/@lmc-eu/spirit-web/css/default/components.min.css" />
 ```
 
 Import React components in your app:

--- a/packages/web-react/package.json
+++ b/packages/web-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lmc-eu/spirit-web-react",
   "version": "0.1.0",
-  "description": "React components for web apps built with Spirit Design System",
+  "description": "React implementation of Spirit Design System components",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/web-react/package.json
+++ b/packages/web-react/package.json
@@ -10,7 +10,7 @@
     "@lmc-eu/browserslist-config": "^1.0.0"
   },
   "peerDependencies": {
-    "@lmc-eu/spirit-web": "~0.1.0",
+    "@lmc-eu/spirit-web": "*",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -21,7 +21,7 @@ npm install --save @lmc-eu/spirit-web
 Link the full Spirit CSS with default branding in your HTML template:
 
 ```html
-<link rel="stylesheet" href="node_modules/@lmc-eu/spirit-web/dist/default/css/components.min.css" />
+<link rel="stylesheet" href="node_modules/@lmc-eu/spirit-web/css/default/components.min.css" />
 ```
 
 ### Sass
@@ -29,11 +29,15 @@ Link the full Spirit CSS with default branding in your HTML template:
 Import just the components you need in your Sass stylesheet:
 
 ```scss
-@use 'node_modules/@lmc-eu/spirit-web/src/components/Button';
+@use 'node_modules/@lmc-eu/spirit-web/scss/components/Button';
 ```
+
+Make sure you have added Sass load paths for `tokens` and `*.theme` Sass
+modules so they are resolved correctly. See [theming] to learn how it works.
 
 ## Examples
 
 See [examples] for a live demo.
 
+[theming]: https://github.com/lmc-eu/spirit-design-system/blob/main/src/web/THEMING.md
 [examples]: https://github.com/lmc-eu/spirit-design-system/tree/main/examples/web

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lmc-eu/spirit-web",
   "version": "0.1.0",
-  "description": "CSS and JS for web apps built with Spirit Design System",
+  "description": "CSS and vanilla JS implementation of Spirit Design System",
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -4,9 +4,11 @@
   "description": "CSS and JS for web apps built with Spirit Design System",
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "directory": "dist"
   },
   "scripts": {
+    "prebuild": "rm -rf dist && mkdir -p dist/scss && cp package.json README.md dist/ && cp -r src/* dist/scss/",
     "build": "yarn css",
     "precss": "yarn css:lint",
     "css": "yarn css:compile && yarn css:prefix && yarn css:minify",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,11 +14,14 @@
     "css": "yarn css:compile && yarn css:prefix && yarn css:minify",
     "css:lint": "stylelint --config ../../.stylelintrc \"src/**/*.scss\" --cache --cache-location .cache/.stylelintcache",
     "css:compile": "yarn css:compile:default && yarn css:compile:jobs",
-    "css:compile:default": "sass --load-path=node_modules/@lmc-eu/spirit-design-tokens/src/default/scss --load-path=src/themes/default \"src/components/index.scss\" dist/css/default/components.css",
-    "css:compile:jobs": "sass --load-path=node_modules/@lmc-eu/spirit-design-tokens/src/products/jobs/scss --load-path=src/themes/products/jobs \"src/components/index.scss\" dist/css/jobs/components.css",
+    "css:compile:default": "sass --load-path=../design-tokens/dist/default/scss --load-path=src/themes/default src/components/index.scss dist/css/default/components.css",
+    "css:compile:jobs": "sass --load-path=../design-tokens/dist/products/jobs/scss --load-path=src/themes/products/jobs src/components/index.scss dist/css/jobs/components.css",
     "css:prefix": "postcss --config postcss.config.js --replace \"dist/css/*/*.css\" \"!dist/css/*/*.min.css\"",
     "css:minify": "cleancss --format breaksWith=lf --source-map-inline-sources --batch --batch-suffix \".min\" \"dist/css/*/*.css\" \"!dist/css/*/*.min.css\"",
     "test": "yarn css:lint"
+  },
+  "dependencies": {
+    "@lmc-eu/spirit-design-tokens": "*"
   },
   "devDependencies": {
     "@lmc-eu/browserslist-config": "^1.0.0",
@@ -30,8 +33,5 @@
     "sass": "^1.37.5",
     "stylelint": "^13.13.1",
     "stylelint-order": "^4.1.0"
-  },
-  "dependencies": {
-    "@lmc-eu/spirit-design-tokens": "~0.1.0"
   }
 }


### PR DESCRIPTION
- Refactor: Keep source for publishing in `dist` directory in all packages
- Refactor: Prefer `mkdir` system command over a cross-platform dependency in examples
- Chore: Cross-link monorepo packages with `*` and simplify cross-package paths in npm scripts
- Docs: Update main `README` to be in sync with code