### PR TITLE
Chore/dependabot sentence case

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
     open-pull-requests-limit: 3
     versioning-strategy: increase-if-necessary
     commit-message:
-      prefix: deps
+      prefix: Deps

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,5 +3,13 @@ module.exports = {
   ignores: [
     (commit) => commit.includes('[ci-skip]'),
     (commit) => commit.includes('Pull request'),
+    /**
+     * Ignore Dependabot commits because they are violating sentence case rule
+     * and cannot be configured or forced to respect commitlint configuration.
+     *
+     * @see https://github.com/dependabot/dependabot-core/issues/1666
+     * @see https://github.com/dependabot/dependabot-core/issues/406
+     */
+    (commit) => commit.includes('Deps: bump'),
   ],
 };


### PR DESCRIPTION
Ignore Dependabot commits because they are violating sentence case rule and cannot be configure or respect commitlint configuration.

https://github.com/dependabot/dependabot-core/issues/1666
https://github.com/dependabot/dependabot-core/issues/406