### PR TITLE
Chore: Declare path to repository in package.json

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -7,6 +7,11 @@
     "access": "public",
     "directory": "dist"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lmc-eu/spirit-design-system.git",
+    "directory": "packages/design-tokens"
+  },
   "scripts": {
     "build": "rm -rf dist && mkdir -p dist && cp -r package.json README.md src/* dist/ ",
     "test": "stylelint --config ../../.stylelintrc ./src/**/*.scss"

--- a/packages/web-react/package.json
+++ b/packages/web-react/package.json
@@ -7,6 +7,11 @@
     "access": "public",
     "directory": "dist"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lmc-eu/spirit-design-system.git",
+    "directory": "packages/web-react"
+  },
   "module": "_es2015/index.js",
   "esnext": "_esNext/index.js",
   "types": "_esNext/index.d.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,6 +7,11 @@
     "access": "public",
     "directory": "dist"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lmc-eu/spirit-design-system.git",
+    "directory": "packages/web"
+  },
   "scripts": {
     "prebuild": "rm -rf dist && mkdir -p dist/scss && cp package.json README.md dist/ && cp -r src/* dist/scss/",
     "build": "yarn css",


### PR DESCRIPTION
Not only link to the repo is now not shown in [package listing on npmjs.com](https://www.npmjs.com/package/@lmc-eu/spirit-design-tokens), also dependabot uses it to assemble URLs when opening issues like https://github.com/lmc-eu/cookie-consent-manager/pull/43 (where the link is now missing),