### PR TITLE
Fix: Render text with `sans-serif` when Inter font is not available

### DIFF
--- a/packages/design-tokens/src/scss/_typography.scss
+++ b/packages/design-tokens/src/scss/_typography.scss
@@ -1,5 +1,5 @@
 // Font Family
-$font-family-default: 'Inter' !default;
+$font-family-default: 'Inter', sans-serif !default;
 
 // Line Height
 $line-height-small: 1.2 !default;


### PR DESCRIPTION
Otherwise browser's default font would be applied.

`sans-serif` is now applied when:

1. Inter font is linked correctly, but has not yet been downloaded,
2. Inter font is not available at all.