### PR TITLE
BREAKING CHANGES: Remove default prefix from CSS class names to make it opt-in

### DIFF
--- a/examples/web-react/package.json
+++ b/examples/web-react/package.json
@@ -15,8 +15,8 @@
     "build": "webpack --config ./webpack.config.js --mode development"
   },
   "dependencies": {
-    "@lmc-eu/spirit-web": "^0.4.4",
-    "@lmc-eu/spirit-web-react": "^0.2.5",
+    "@lmc-eu/spirit-web": "^0.4.5",
+    "@lmc-eu/spirit-web-react": "^0.3.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -54,29 +54,29 @@
 <main>
   <section>
     <h2>Button</h2>
-    <button type="button" class="lmc-Button lmc-Button--primary">
+    <button type="button" class="Button Button--primary">
       Primary button
     </button>
-    <button type="button" class="lmc-Button lmc-Button--secondary">
+    <button type="button" class="Button Button--secondary">
       Secondary button
     </button>
-    <button type="button" class="lmc-Button lmc-Button--tertiary">
+    <button type="button" class="Button Button--tertiary">
       Tertiary button
     </button>
   </section>
 
   <section>
     <h2>Tag</h2>
-    <span class="lmc-Tag lmc-Tag--default-light">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--default-dark">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--info-light">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--info-dark">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--success-light">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--success-dark">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--warning-light">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--warning-dark">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--danger-light">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--danger-dark">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="Tag Tag--default-light">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="Tag Tag--default-dark">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="Tag Tag--info-light">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="Tag Tag--info-dark">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="Tag Tag--success-light">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="Tag Tag--success-dark">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="Tag Tag--warning-light">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="Tag Tag--warning-dark">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="Tag Tag--danger-light">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="Tag Tag--danger-dark">I'm tag. I feel like filling marketing pages :-)</span>
   </section>
 </main>
 

--- a/examples/web/jobs.html
+++ b/examples/web/jobs.html
@@ -67,29 +67,29 @@
 <main>
   <section>
     <h2>Button</h2>
-    <button type="button" class="lmc-Button lmc-Button--primary">
+    <button type="button" class="jobs-Button jobs-Button--primary">
       Primary button
     </button>
-    <button type="button" class="lmc-Button lmc-Button--secondary">
+    <button type="button" class="jobs-Button jobs-Button--secondary">
       Secondary button
     </button>
-    <button type="button" class="lmc-Button lmc-Button--tertiary">
+    <button type="button" class="jobs-Button jobs-Button--tertiary">
       Tertiary button
     </button>
   </section>
 
   <section>
     <h2>Tag</h2>
-    <span class="lmc-Tag lmc-Tag--default-light">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--default-dark">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--info-light">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--info-dark">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--success-light">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--success-dark">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--warning-light">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--warning-dark">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--danger-light">I'm tag. I feel like filling marketing pages :-)</span>
-    <span class="lmc-Tag lmc-Tag--danger-dark">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="jobs-Tag jobs-Tag--default-light">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="jobs-Tag jobs-Tag--default-dark">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="jobs-Tag jobs-Tag--info-light">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="jobs-Tag jobs-Tag--info-dark">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="jobs-Tag jobs-Tag--success-light">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="jobs-Tag jobs-Tag--success-dark">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="jobs-Tag jobs-Tag--warning-light">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="jobs-Tag jobs-Tag--warning-dark">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="jobs-Tag jobs-Tag--danger-light">I'm tag. I feel like filling marketing pages :-)</span>
+    <span class="jobs-Tag jobs-Tag--danger-dark">I'm tag. I feel like filling marketing pages :-)</span>
   </section>
 </main>
 

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -12,11 +12,18 @@
     "build": "yarn copy && yarn css",
     "copy": "cp ../../node_modules/@lmc-eu/spirit-web/dist/css/components.min.css built/components.min.css",
     "css": "yarn css:jobs",
-    "css:jobs": "sass --load-path=../../node_modules --load-path=src/jobs src/jobs/jobs.scss built/jobs.css"
+    "css:jobs": "yarn css:jobs:compile && yarn css:jobs:prefix",
+    "css:jobs:compile": "sass --load-path=../../node_modules --load-path=src/jobs src/jobs/jobs.scss built/jobs.css",
+    "css:jobs:prefix": "postcss --config postcss.config.js --replace \"built/jobs.css\""
   },
   "dependencies": {
-    "@lmc-eu/spirit-design-tokens": "^0.4.4",
-    "@lmc-eu/spirit-web": "^0.4.4",
+    "@lmc-eu/spirit-design-tokens": "^0.4.5",
+    "@lmc-eu/spirit-web": "^0.4.5"
+  },
+  "devDependencies": {
+    "postcss": "^8.4.4",
+    "postcss-cli": "^9.0.2",
+    "postcss-prefixer": "^2.1.3",
     "sass": "^1.37.5"
   }
 }

--- a/examples/web/postcss.config.js
+++ b/examples/web/postcss.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: [
+    require('postcss-prefixer')({
+      prefix: 'jobs-',
+    }),
+  ],
+};

--- a/packages/web-react/src/components/Button/Button.tsx
+++ b/packages/web-react/src/components/Button/Button.tsx
@@ -3,8 +3,7 @@ import classNames from 'classnames';
 
 type Color = 'primary' | 'secondary' | 'tertiary';
 
-const getButtonColorClassname = (color: Color): string =>
-  `lmc-Button--${color}`;
+const getButtonColorClassname = (color: Color): string => `Button--${color}`;
 
 export interface ButtonProps {
   /**
@@ -32,7 +31,7 @@ export const Button = ({
   type,
 }: ButtonProps): JSX.Element => (
   <button
-    className={classNames('lmc-Button', getButtonColorClassname(color))}
+    className={classNames('Button', getButtonColorClassname(color))}
     onClick={onClick}
     type={type}
   >

--- a/packages/web-react/src/components/Tag/Tag.tsx
+++ b/packages/web-react/src/components/Tag/Tag.tsx
@@ -18,14 +18,11 @@ export interface TagProps extends WithChildren {
 }
 
 const getTagColorAndThemeClassname = (color: Color, theme: Theme): string =>
-  `lmc-Tag--${color}-${theme}`;
+  `Tag--${color}-${theme}`;
 
 export const Tag = ({ color, theme, children }: TagProps): JSX.Element => (
   <span
-    className={classNames(
-      'lmc-Tag',
-      getTagColorAndThemeClassname(color, theme),
-    )}
+    className={classNames('Tag', getTagColorAndThemeClassname(color, theme))}
   >
     {children}
   </span>

--- a/packages/web/src/components/Button/_Button.scss
+++ b/packages/web/src/components/Button/_Button.scss
@@ -1,7 +1,7 @@
 @use 'theme';
 @use 'tools';
 
-.lmc-Button {
+.Button {
     display: inline-flex;
     justify-content: center;
     align-items: center;
@@ -30,11 +30,11 @@
     }
 }
 
-.lmc-Button__icon {
+.Button__icon {
     font-size: 1.5em;
 }
 
-.lmc-Button--square {
+.Button--square {
     width: calc((1em * #{theme.$line-height}) + (#{theme.$padding-y} * 2));
     padding-left: 0;
     padding-right: 0;

--- a/packages/web/src/components/Button/_tools.scss
+++ b/packages/web/src/components/Button/_tools.scss
@@ -1,7 +1,8 @@
 @use 'sass:map';
+@use '@tokens' as tokens;
 
 @mixin variant($variant, $variables) {
-    .lmc-Button--#{$variant} {
+    .Button--#{$variant} {
         color: map.get($variables, default-color);
         background-color: map.get($variables, default-background);
         border-color: map.get($variables, default-border-color);

--- a/packages/web/src/components/Tag/_Tag.scss
+++ b/packages/web/src/components/Tag/_Tag.scss
@@ -1,7 +1,7 @@
 @use 'theme';
 @use 'tools';
 
-.lmc-Tag {
+.Tag {
     display: inline-block;
     padding: theme.$padding-y theme.$padding-x;
     font-family: theme.$font-family;

--- a/packages/web/src/components/Tag/_tools.scss
+++ b/packages/web/src/components/Tag/_tools.scss
@@ -1,7 +1,8 @@
 @use 'sass:map';
+@use '@tokens' as tokens;
 
 @mixin variant($variant, $variables) {
-    .lmc-Tag--#{$variant} {
+    .Tag--#{$variant} {
         color: map.get($variables, default-color);
         background-color: map.get($variables, default-background);
     }


### PR DESCRIPTION
- New class names are like `.Button`, `.Button--primary`, `.Tag`, etc. (the `lmc-*` prefix has been removed).
- Jobs example shows how to prefix class names on project level using a PostCSS plugin.
- `examples/web-react` starts working once `web-react` v0.3.0 is released.
- Docs is to be updated in a standalone PR, along with major docs rewrite.