### PR TITLE
Chore: Ignore .npmrc created by CI pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ local.mk
 
 # Distribution files
 packages/*/dist
+
+# NPM rc file created by CI
+.npmrc


### PR DESCRIPTION
  * created and updated by ./bin/ci/npm-auth.sh
  * prevents publishing new package because of uncommited updatess