### PR TITLE
Feat(web-react): Pass down an access to button dom via ref prop

### DIFF
--- a/packages/web-react/src/components/Button/Button.tsx
+++ b/packages/web-react/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, ElementType } from 'react';
+import React, { MouseEvent, ElementType, Ref } from 'react';
 import classNames from 'classnames';
 import { WithChildren } from '../../types/main';
 import { compose } from '../../utils/compose';
@@ -16,6 +16,7 @@ export interface ButtonProps extends WithChildren {
   ariaLabel?: string;
   className?: string;
   tag: ElementType;
+  innerRef?: Ref<HTMLButtonElement>;
 }
 
 const defaultProps = {
@@ -39,6 +40,7 @@ export const Button = ({
   disabled,
   className,
   tag: Tag,
+  innerRef,
   ...restProps
 }: ButtonProps): JSX.Element => {
   const buttonClass = 'Button';
@@ -75,6 +77,7 @@ export const Button = ({
       type={type}
       disabled={disabled}
       aria-label={ariaLabel || undefined}
+      ref={innerRef}
     />
   );
 };


### PR DESCRIPTION
  * solves problem when using button in <Link> component of react-router
  * "Function components cannot be given refs. Attempts to access this
    ref will fail. Did you mean to use React.forwardRef()?"

Read more:
- https://reactjs.org/docs/refs-and-the-dom.html