### PR TITLE
Fix(web-react): Add missing children prop in buttons

### DIFF
--- a/packages/web-react/src/components/Button/Button.tsx
+++ b/packages/web-react/src/components/Button/Button.tsx
@@ -13,11 +13,15 @@ const defaultProps = {
 };
 
 export const Button = <T extends ElementType = 'button'>(props: SpiritButtonProps<T>): JSX.Element => {
-  const { elementType: ElementType = 'button', className, ...restProps } = props;
+  const { elementType: ElementType = 'button', className, children, ...restProps } = props;
   const { buttonProps } = useButtonAriaProps(props);
   const { classProps } = useButtonStyleProps(restProps);
 
-  return <ElementType {...buttonProps} className={classNames(className, classProps)} />;
+  return (
+    <ElementType {...buttonProps} className={classNames(className, classProps)}>
+      {children}
+    </ElementType>
+  );
 };
 
 Button.defaultProps = defaultProps;

--- a/packages/web-react/src/components/Button/ButtonLink.tsx
+++ b/packages/web-react/src/components/Button/ButtonLink.tsx
@@ -12,11 +12,15 @@ const defaultProps = {
 };
 
 export const ButtonLink = <T extends ElementType = 'a'>(props: SpiritButtonProps<T>): JSX.Element => {
-  const { className, ...restProps } = props;
+  const { className, children, ...restProps } = props;
   const { buttonProps } = useButtonAriaProps(props);
   const { classProps } = useButtonStyleProps(restProps);
 
-  return <a {...buttonProps} className={classNames(className, classProps)} />;
+  return (
+    <a {...buttonProps} className={classNames(className, classProps)}>
+      {children}
+    </a>
+  );
 };
 
 ButtonLink.defaultProps = defaultProps;

--- a/packages/web-react/src/components/Button/__tests__/Button.test.tsx
+++ b/packages/web-react/src/components/Button/__tests__/Button.test.tsx
@@ -22,4 +22,10 @@ describe('Button', () => {
     expect(dom.container.querySelector('button')).toHaveClass('lmc-Button');
     expect(dom.container.querySelector('button')).toHaveClass('lmc-Button--primary');
   });
+
+  it('should render text children', () => {
+    const dom = render(<Button>Hello World</Button>);
+
+    expect(dom.container.querySelector('button').textContent).toBe('Hello World');
+  });
 });

--- a/packages/web-react/src/components/Button/__tests__/ButtonLink.test.tsx
+++ b/packages/web-react/src/components/Button/__tests__/ButtonLink.test.tsx
@@ -31,4 +31,10 @@ describe('ButtonLink', () => {
     expect(container.querySelector('a')).toHaveClass('lmc-Button--block');
     expect(container.querySelector('a')).toHaveClass('lmc-Button--disabled');
   });
+
+  it('should render text children', () => {
+    const dom = render(<ButtonLink>Hello World</ButtonLink>);
+
+    expect(dom.container.querySelector('a').textContent).toBe('Hello World');
+  });
 });


### PR DESCRIPTION
By refactoring buttons to use hooks we accidentally omit children props.