### PR TITLE
Refactor(web-react): Hook `useClassNamePrefix` now accept argument cl…

### DIFF
--- a/packages/web-react/src/components/Button/useButtonStyleProps.tsx
+++ b/packages/web-react/src/components/Button/useButtonStyleProps.tsx
@@ -1,7 +1,7 @@
 import { ElementType } from 'react';
 import classNames from 'classnames';
 import { compose } from '../../utils/compose';
-import { applyColor, applyClassNamePrefix } from '../../utils/classname';
+import { applyColor } from '../../utils/classname';
 import { useClassNamePrefix } from '../../hooks/useClassNamePrefix';
 import { ButtonColor, SpiritButtonProps } from '../../types';
 
@@ -17,13 +17,11 @@ export interface ButtonStyles {
 export function useButtonStyleProps<T extends ElementType = 'button'>(props: SpiritButtonProps<T>): ButtonStyles {
   const { color, block, disabled } = props;
 
-  const buttonClass = 'Button';
-  const classNamePrefix = useClassNamePrefix();
-  const prefixedButtonClass = applyClassNamePrefix(classNamePrefix)(buttonClass);
-  const buttonBlockClass = `${prefixedButtonClass}--block`;
-  const buttonDisabledClass = `${prefixedButtonClass}--disabled`;
+  const buttonClass = useClassNamePrefix('Button');
+  const buttonBlockClass = `${buttonClass}--block`;
+  const buttonDisabledClass = `${buttonClass}--disabled`;
 
-  const classProps = classNames(prefixedButtonClass, getButtonColorClassname(prefixedButtonClass, color), {
+  const classProps = classNames(buttonClass, getButtonColorClassname(buttonClass, color), {
     [buttonBlockClass]: block,
     [buttonDisabledClass]: disabled,
   });

--- a/packages/web-react/src/components/Tag/Tag.tsx
+++ b/packages/web-react/src/components/Tag/Tag.tsx
@@ -1,7 +1,7 @@
 import React, { ElementType } from 'react';
 import classNames from 'classnames';
 import { compose } from '../../utils/compose';
-import { applyColor, applyTheme, applyClassNamePrefix } from '../../utils/classname';
+import { applyColor, applyTheme } from '../../utils/classname';
 import { useClassNamePrefix } from '../../hooks/useClassNamePrefix';
 import { ChildrenProps } from '../../types';
 
@@ -27,11 +27,9 @@ const getTagColorAndThemeClassname = (className: string, color: Color, theme: Th
   compose(applyTheme<Theme>(theme), applyColor<Color>(color))(className);
 
 export const Tag = ({ tag: Tag, color, theme, className, children, ...restProps }: TagProps): JSX.Element => {
-  const tagClass = 'Tag';
-  const classNamePrefix = useClassNamePrefix();
-  const mainClassName = applyClassNamePrefix(classNamePrefix)(tagClass);
+  const tagClass = useClassNamePrefix('Tag');
 
-  const classes = classNames(mainClassName, getTagColorAndThemeClassname(mainClassName, color, theme), className);
+  const classes = classNames(tagClass, getTagColorAndThemeClassname(tagClass, color, theme), className);
 
   return (
     <Tag {...restProps} className={classes}>

--- a/packages/web-react/src/hooks/useClassNamePrefix.tsx
+++ b/packages/web-react/src/hooks/useClassNamePrefix.tsx
@@ -1,8 +1,16 @@
 import { useContext } from 'react';
 import ClassNamePrefixContext from '../context/ClassNamePrefixContext';
+import { applyClassNamePrefix } from '../utils/classname';
 
-export const useClassNamePrefix = () => {
-  const classNamePrefixContext = useContext(ClassNamePrefixContext);
+export const useClassNamePrefix = (className: string): string => {
+  const classNamePrefix = useContext(ClassNamePrefixContext);
+  let prefixedClassName = className;
 
-  return classNamePrefixContext || null;
+  if (className && classNamePrefix) {
+    prefixedClassName = applyClassNamePrefix(classNamePrefix)(className);
+  } else if (classNamePrefix) {
+    prefixedClassName = classNamePrefix;
+  }
+
+  return prefixedClassName;
 };


### PR DESCRIPTION
…assName

  * prefix can be now applied directly to provided class