### PR TITLE
ButtonLink component fix props and styles

### DIFF
--- a/packages/web-react/src/components/Button/ButtonLink.tsx
+++ b/packages/web-react/src/components/Button/ButtonLink.tsx
@@ -9,6 +9,7 @@ const defaultProps = {
   href: '#',
   block: false,
   disabled: false,
+  elementType: 'a',
 };
 
 export const ButtonLink = <T extends ElementType = 'a'>(props: SpiritButtonProps<T>): JSX.Element => {

--- a/packages/web-react/src/components/Button/__tests__/ButtonLink.test.tsx
+++ b/packages/web-react/src/components/Button/__tests__/ButtonLink.test.tsx
@@ -37,4 +37,10 @@ describe('ButtonLink', () => {
 
     expect(dom.container.querySelector('a').textContent).toBe('Hello World');
   });
+
+  it('should not have default type attribute', () => {
+    const { container } = render(<ButtonLink />);
+
+    expect(container.querySelector('a')).not.toHaveAttribute('type');
+  });
 });

--- a/packages/web-react/src/components/Button/useButtonAriaProps.tsx
+++ b/packages/web-react/src/components/Button/useButtonAriaProps.tsx
@@ -26,7 +26,7 @@ export function useButtonAriaProps(props: AriaButtonProps<ElementType>): ButtonA
       role: 'button',
       href: elementType === 'a' && disabled ? undefined : href,
       target: elementType === 'a' ? target : undefined,
-      type,
+      type: elementType === 'a' && type === 'button' ? undefined : type,
       disabled,
       rel: elementType === 'a' ? rel : undefined,
     };

--- a/packages/web/src/components/Button/_Button.scss
+++ b/packages/web/src/components/Button/_Button.scss
@@ -11,6 +11,7 @@
     align-items: center;
     padding: theme.$padding-y theme.$padding-x;
     text-align: center;
+    text-decoration: none;
     vertical-align: middle;
     background-color: transparent;
     border: theme.$border-width theme.$border-style transparent;


### PR DESCRIPTION
<img width="1434" alt="Snímek obrazovky 2022-03-08 v 10 31 34" src="https://user-images.githubusercontent.com/25146453/157216864-4badaeeb-2390-4f85-8b2d-4dd5ec46f09d.png">
Fix bad props in ButtonLink and define text-decoration none to prevent default styles...