### PR TITLE
Feat/ds 167 web react typography

### DIFF
--- a/.storybook/assets/stylesheets/index.scss
+++ b/.storybook/assets/stylesheets/index.scss
@@ -1,6 +1,7 @@
 @forward '../../../packages/design-tokens/src/scss';
 
 @use '../../../packages/web/src/foundation';
+@use '../../../packages/web/src/helpers';
 
 @use '../../../packages/web/src/components/Alert';
 @use '../../../packages/web/src/components/Button';

--- a/packages/web-react/config/jest/config.js
+++ b/packages/web-react/config/jest/config.js
@@ -31,7 +31,7 @@ const config = {
 
   // An array of regexp pattern strings that are matched against all test paths before executing the test
   // https://jestjs.io/docs/configuration#testpathignorepatterns-arraystring
-  testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/'],
+  testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/', '.*DataProvider.ts'],
 
   // The directory where Jest should output its coverage files.
   // https://jestjs.io/docs/configuration#coveragedirectory-string

--- a/packages/web-react/scripts/entryPoints.js
+++ b/packages/web-react/scripts/entryPoints.js
@@ -10,6 +10,7 @@ const entryPoints = [
   { dirs: ['components', 'Grid'] },
   { dirs: ['components', 'Stack'] },
   { dirs: ['components', 'Tag'] },
+  { dirs: ['components', 'Text'] },
   { dirs: ['components', 'TextField'] },
 ];
 

--- a/packages/web-react/scripts/entryPoints.js
+++ b/packages/web-react/scripts/entryPoints.js
@@ -8,6 +8,8 @@ const entryPoints = [
   { dirs: ['components', 'CheckboxField'] },
   { dirs: ['components', 'Container'] },
   { dirs: ['components', 'Grid'] },
+  { dirs: ['components', 'Heading'] },
+  { dirs: ['components', 'Link'] },
   { dirs: ['components', 'Stack'] },
   { dirs: ['components', 'Tag'] },
   { dirs: ['components', 'Text'] },

--- a/packages/web-react/src/components/Heading/Heading.stories.tsx
+++ b/packages/web-react/src/components/Heading/Heading.stories.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Heading from './Heading';
+import { SpiritHeadingProps } from '../../types';
+
+export default {
+  title: 'Typography/Heading',
+  argTypes: {
+    children: 'Some long Heading',
+    size: {
+      control: {
+        type: 'select',
+        options: ['xlarge', 'large', 'medium', 'small', 'xsmall'],
+      },
+    },
+  },
+};
+
+const Template = (args: SpiritHeadingProps) => <Heading {...args} />;
+
+export const XLargeHeading = Template.bind({});
+XLargeHeading.args = {
+  children: 'Heading XLarge Text',
+  size: 'xlarge',
+};
+
+export const LargeHeading = Template.bind({});
+LargeHeading.args = {
+  children: 'Heading Large Text',
+  size: 'large',
+};
+
+export const MediumHeading = Template.bind({});
+MediumHeading.args = {
+  children: 'Heading Medium Text',
+  size: 'medium',
+};
+
+export const SmallHeading = Template.bind({});
+SmallHeading.args = {
+  children: 'Heading Small Text',
+  size: 'small',
+};
+
+export const XSmallHeading = Template.bind({});
+XSmallHeading.args = {
+  children: 'Heading XSmall Text',
+  size: 'xsmall',
+};

--- a/packages/web-react/src/components/Heading/Heading.tsx
+++ b/packages/web-react/src/components/Heading/Heading.tsx
@@ -1,0 +1,17 @@
+import React, { ElementType } from 'react';
+import { useHeadingStyleProps } from './useHeadingStyleProps';
+import { SpiritHeadingProps } from '../../types';
+import { filterProps } from '../../utils/filterProps';
+
+export const Heading = <T extends ElementType = 'div'>(props: SpiritHeadingProps<T>): JSX.Element => {
+  const { elementType: ElementTag = 'div', children, ...restProps } = props;
+  const { classProps, props: modifiedProps } = useHeadingStyleProps(restProps);
+
+  return (
+    <ElementTag {...filterProps(modifiedProps)} className={classProps}>
+      {children}
+    </ElementTag>
+  );
+};
+
+export default Heading;

--- a/packages/web-react/src/components/Heading/README.md
+++ b/packages/web-react/src/components/Heading/README.md
@@ -1,0 +1,30 @@
+# Heading
+
+The Heading component provides helper classes to render headings.
+
+```jsx
+<Heading elementType="h1" size="large" />
+```
+
+## Available props
+
+| Name         | Type                                          | Description      |
+| ------------ | --------------------------------------------- | ---------------- |
+| `elementTyp` | `React.Element`, default `div`                | HTML tag         |
+| `size`       | `xlarge`, `large`, `medium`, `small`, `xmall` | Size of the text |
+
+## Custom component
+
+Heading classes are fabricated using `useHeadingStyleProps` hook. You can use it to create your own custom Heading component.
+
+```jsx
+const CustomText = (props: SpiritHeadingProps): JSX.Element => {
+  const { classProps, props: modifiedProps, children } = useHeadingStyleProps(props);
+
+  return (
+    <div className={classProps} {...modifiedProps}>
+      {children}
+    </div>
+  );
+};
+```

--- a/packages/web-react/src/components/Heading/__tests__/Heading.test.tsx
+++ b/packages/web-react/src/components/Heading/__tests__/Heading.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Heading from '../Heading';
+import { ClassNamePrefixProvider } from '../../../context/ClassNamePrefixContext';
+import headingSizeDataProvider from './headingSizeDataProvider';
+import { HeadingSize } from '../../../types';
+
+describe('Heading', () => {
+  it.each(headingSizeDataProvider)('should have for size %s an expected class %s', (size, expectedClassName) => {
+    const dom = render(<Heading size={size as HeadingSize} />);
+
+    expect(dom.container.querySelector('div')).toHaveClass(expectedClassName);
+  });
+
+  it('should have classname with lmc prefix', () => {
+    const dom = render(
+      <ClassNamePrefixProvider value="lmc">
+        <Heading size="xlarge" />
+      </ClassNamePrefixProvider>,
+    );
+
+    expect(dom.container.querySelector('div')).toHaveClass('lmc-typography-heading-xlarge-text');
+  });
+});

--- a/packages/web-react/src/components/Heading/__tests__/headingSizeDataProvider.ts
+++ b/packages/web-react/src/components/Heading/__tests__/headingSizeDataProvider.ts
@@ -1,0 +1,10 @@
+const headingSizeDataProvider = [
+  // size, expected class
+  ['xlarge', 'typography-heading-xlarge-text'],
+  ['large', 'typography-heading-large-text'],
+  ['medium', 'typography-heading-medium-text'],
+  ['small', 'typography-heading-small-text'],
+  ['xsmall', 'typography-heading-xsmall-text'],
+];
+
+export default headingSizeDataProvider;

--- a/packages/web-react/src/components/Heading/__tests__/useHeadingStyleProps.tsx
+++ b/packages/web-react/src/components/Heading/__tests__/useHeadingStyleProps.tsx
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useHeadingStyleProps } from '../useHeadingStyleProps';
+import headingSizeDataProvider from './headingSizeDataProvider';
+import { SpiritHeadingProps } from '../../../types';
+
+describe('useHeadingStyleProps', () => {
+  it.each(headingSizeDataProvider)('should return for size %s expected classs %s', (size, expectedClassName) => {
+    const props = { size } as SpiritHeadingProps;
+    const { result } = renderHook(() => useHeadingStyleProps(props));
+
+    expect(result.current.classProps).toBe(expectedClassName);
+  });
+});

--- a/packages/web-react/src/components/Heading/index.ts
+++ b/packages/web-react/src/components/Heading/index.ts
@@ -1,0 +1,3 @@
+export * from './Heading';
+export * from './useHeadingStyleProps';
+export { default as Heading } from './Heading';

--- a/packages/web-react/src/components/Heading/useHeadingStyleProps.tsx
+++ b/packages/web-react/src/components/Heading/useHeadingStyleProps.tsx
@@ -1,0 +1,22 @@
+import { ElementType } from 'react';
+import { useClassNamePrefix } from '../../hooks/useClassNamePrefix';
+import { SpiritHeadingProps, HeadingProps } from '../../types';
+
+export interface HeadingStyles<T extends ElementType = 'p'> {
+  /** className props */
+  classProps: string | null;
+  /** props to be passed to the input element */
+  props: HeadingProps<T>;
+}
+
+export function useHeadingStyleProps<T extends ElementType = 'div'>(props: SpiritHeadingProps<T>): HeadingStyles<T> {
+  const { size, ...restProps } = props;
+
+  const headingClass = useClassNamePrefix('typography-heading');
+  const className = `${headingClass}-${size}-text`;
+
+  return {
+    classProps: className,
+    props: restProps,
+  };
+}

--- a/packages/web-react/src/components/Link/Link.stories.tsx
+++ b/packages/web-react/src/components/Link/Link.stories.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import Link from './Link';
+import { SpiritLinkProps } from '../../types';
+
+export default {
+  title: 'Typography/Link',
+  argTypes: {
+    children: 'Some long Link',
+    href: '#',
+    color: {
+      control: {
+        type: 'select',
+        options: ['primary', 'secondary', 'inverted'],
+      },
+    },
+    isDisabled: {
+      control: 'boolean',
+    },
+    isUnderlined: {
+      control: 'boolean',
+    },
+  },
+};
+
+const Template = (args: SpiritLinkProps) => <Link {...args} href="/" />;
+
+export const PrimaryLink = Template.bind({});
+PrimaryLink.args = {
+  children: 'Primary Link',
+  color: 'primary',
+};
+
+export const SecondaryLink = Template.bind({});
+SecondaryLink.args = {
+  children: 'Secondary Link',
+  color: 'secondary',
+};
+
+export const InvertedLink = Template.bind({});
+InvertedLink.args = {
+  children: 'Inverted Link',
+  color: 'inverted',
+};

--- a/packages/web-react/src/components/Link/Link.tsx
+++ b/packages/web-react/src/components/Link/Link.tsx
@@ -1,0 +1,23 @@
+import React, { ElementType } from 'react';
+import { useLinkStyleProps } from './useLinkStyleProps';
+import { SpiritLinkProps } from '../../types';
+import { filterProps } from '../../utils/filterProps';
+
+const defaultProps = {
+  color: 'primary',
+};
+
+export const Link = <T extends ElementType = 'a'>(props: SpiritLinkProps<T>): JSX.Element => {
+  const { elementType: ElementTag = 'a', children, ...restProps } = props;
+  const { classProps, props: modifiedProps } = useLinkStyleProps(restProps);
+
+  return (
+    <ElementTag {...filterProps(modifiedProps)} href={restProps.href} className={classProps}>
+      {children}
+    </ElementTag>
+  );
+};
+
+Link.defaultProps = defaultProps;
+
+export default Link;

--- a/packages/web-react/src/components/Link/README.md
+++ b/packages/web-react/src/components/Link/README.md
@@ -1,0 +1,32 @@
+# Link
+
+Link allows users to follow navigation.
+
+```jsx
+<Link href="/" color="primary" isUnderlined isDisabled />
+```
+
+## Available props
+
+| Name           | Type                               | Description                                     |
+| -------------- | ---------------------------------- | ----------------------------------------------- |
+| `href`         | `string`                           | Link's href attribute                           |
+| `color`        | `primary`, `secondary`, `inverted` | Color of the link                               |
+| `isUnderlined` | `boolean`                          | Whether is the link underlined, default `false` |
+| `isDisabled`   | `boolean`                          | Wheter is the link disabled, default `false`    |
+
+## Custom component
+
+Link classes are fabricated using `useLinkStyleProps` hook. You can use it to create your own custom Link component.
+
+```jsx
+const CustomLink = (props: SpiritLinkProps): JSX.Element => {
+  const { classProps, props: modifiedProps, children } = useLinkStyleProps(props);
+
+  return (
+    <a {...modifiedProps} href={props.href} className={classProps}>
+      {children}
+    </a>
+  );
+};
+```

--- a/packages/web-react/src/components/Link/__tests__/Link.test.tsx
+++ b/packages/web-react/src/components/Link/__tests__/Link.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Link from '../Link';
+import { ClassNamePrefixProvider } from '../../../context/ClassNamePrefixContext';
+import linkPropsDataProvider from './linkPropsDataProvider';
+import { LinkColor } from '../../../types';
+
+describe('Link', () => {
+  it.each(linkPropsDataProvider)('should have class', (color, isUnderlined, isDisabled, expectedClassName) => {
+    const dom = render(
+      <Link
+        href="/"
+        color={color as LinkColor}
+        isUnderlined={isUnderlined as boolean}
+        isDisabled={isDisabled as boolean}
+      />,
+    );
+
+    expect(dom.container.querySelector('a')).toHaveClass(expectedClassName as string);
+  });
+
+  it('should have classname with lmc prefix', () => {
+    const dom = render(
+      <ClassNamePrefixProvider value="lmc">
+        <Link href="/" color="primary" />
+      </ClassNamePrefixProvider>,
+    );
+
+    expect(dom.container.querySelector('a')).toHaveClass('lmc-link-primary');
+  });
+});

--- a/packages/web-react/src/components/Link/__tests__/linkPropsDataProvider.ts
+++ b/packages/web-react/src/components/Link/__tests__/linkPropsDataProvider.ts
@@ -1,0 +1,14 @@
+const linkPropsDataProvider = [
+  // color, isUnderlined, isDisabled, expectedClassName
+  ['primary', false, false, 'link-primary'],
+  ['secondary', false, false, 'link-secondary'],
+  ['inverted', false, false, 'link-inverted'],
+  ['primary', true, false, 'link-primary link-underlined'],
+  ['secondary', true, false, 'link-secondary link-underlined'],
+  ['inverted', true, false, 'link-inverted link-underlined'],
+  ['primary', true, true, 'link-primary link-disabled link-underlined'],
+  ['secondary', true, true, 'link-secondary link-disabled link-underlined'],
+  ['inverted', true, true, 'link-inverted link-disabled link-underlined'],
+];
+
+export default linkPropsDataProvider;

--- a/packages/web-react/src/components/Link/__tests__/useLinkStyleProps.test.tsx
+++ b/packages/web-react/src/components/Link/__tests__/useLinkStyleProps.test.tsx
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useLinkStyleProps } from '../useLinkStyleProps';
+import linkPropsDataProvider from './linkPropsDataProvider';
+import { SpiritLinkProps } from '../../../types';
+
+describe('useLinkStyleProps', () => {
+  it.each(linkPropsDataProvider)('should return classname', (color, isUnderlined, isDisabled, expectedClassName) => {
+    const props = { color, isUnderlined, isDisabled } as SpiritLinkProps;
+    const { result } = renderHook(() => useLinkStyleProps(props));
+
+    expect(result.current.classProps).toBe(expectedClassName);
+  });
+});

--- a/packages/web-react/src/components/Link/index.ts
+++ b/packages/web-react/src/components/Link/index.ts
@@ -1,0 +1,3 @@
+export * from './Link';
+export * from './useLinkStyleProps';
+export { default as Link } from './Link';

--- a/packages/web-react/src/components/Link/useLinkStyleProps.tsx
+++ b/packages/web-react/src/components/Link/useLinkStyleProps.tsx
@@ -1,0 +1,30 @@
+import { ElementType } from 'react';
+import classNames from 'classnames';
+import { useClassNamePrefix } from '../../hooks/useClassNamePrefix';
+import { SpiritLinkProps, LinkProps } from '../../types';
+
+export interface LinkStyles<T extends ElementType = 'p'> {
+  /** className props */
+  classProps: string | null;
+  /** props to be passed to the input element */
+  props: LinkProps<T>;
+}
+
+export function useLinkStyleProps<T extends ElementType = 'a'>(props: SpiritLinkProps<T>): LinkStyles<T> {
+  const { color, isDisabled, isUnderlined, ...restProps } = props;
+
+  const linkClass = useClassNamePrefix('link');
+  const linkColorClass = `${linkClass}-${color}`;
+  const linkDisabledClass = `${linkClass}-disabled`;
+  const linkUnderlinedClass = `${linkClass}-underlined`;
+
+  const className = classNames(linkColorClass, {
+    [linkDisabledClass]: isDisabled,
+    [linkUnderlinedClass]: isUnderlined,
+  });
+
+  return {
+    classProps: className,
+    props: restProps,
+  };
+}

--- a/packages/web-react/src/components/Text/README.md
+++ b/packages/web-react/src/components/Text/README.md
@@ -1,0 +1,37 @@
+# Text
+
+The Text component provides helper classes to render text.
+
+```jsx
+<Text type="body" size="large" variant="text" emphasis="bold" />
+```
+
+## Available props
+
+| Name       | Type                                          | Description          |
+| ---------- | --------------------------------------------- | -------------------- |
+| `type`     | `heading`, `body`                             | Type of the text     |
+| `size`     | `xlarge`, `large`, `medium`, `small`, `xmall` | Size of the text     |
+| `variant`  | `text`, `link`, `button`                      | Variant of the text  |
+| `emphasis` | `regular`, `italic`, `bold`                   | Emphasis of the text |
+
+**Notes:**
+
+- `emphasis` is only available for `type="body"` with `variant="text"`
+- `type="body"` have only available `large`, `medium`, `small` sizes
+
+## Custom component
+
+Text classes are fabricated using `useTextdStyleProps` hook. You can use it to create your own custom Text component.
+
+```jsx
+const CustomText = (props: SpiritTextProps): JSX.Element => {
+  const { classProps, props: modifiedProps, children } = useTextStyleProps(props);
+
+  return (
+    <p className={classProps} {...modifiedProps}>
+      {children}
+    </p>
+  );
+};
+```

--- a/packages/web-react/src/components/Text/Text.stories.tsx
+++ b/packages/web-react/src/components/Text/Text.stories.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import Text from './Text';
+import { SpiritTextProps } from '../../types';
+
+export default {
+  title: 'Typography/Text',
+  argTypes: {
+    children: 'Some long text',
+    type: {
+      control: {
+        type: 'select',
+        options: ['heading', 'body'],
+      },
+    },
+    size: {
+      control: {
+        type: 'select',
+        options: ['xlarge', 'large', 'medium', 'small', 'xsmall'],
+      },
+    },
+    variant: {
+      control: {
+        type: 'select',
+        options: ['text', 'link', 'button'],
+      },
+    },
+    emphasis: {
+      control: {
+        type: 'select',
+        options: ['regular', 'bold', 'italic'],
+      },
+    },
+  },
+};
+
+const Template = (args: SpiritTextProps) => <Text {...args} />;
+
+export const DefaultText = Template.bind({});
+DefaultText.args = {
+  children: 'Some long text',
+  type: 'heading',
+  size: 'xlarge',
+  variant: 'text',
+};

--- a/packages/web-react/src/components/Text/Text.tsx
+++ b/packages/web-react/src/components/Text/Text.tsx
@@ -1,0 +1,24 @@
+import React, { ElementType } from 'react';
+import { useTextStyleProps } from './useTextStyleProps';
+import { SpiritTextProps } from '../../types';
+import { filterProps } from '../../utils/filterProps';
+
+const defaultProps = {
+  size: 'medium',
+  emphasis: 'regular',
+};
+
+export const Text = <T extends ElementType = 'p'>(props: SpiritTextProps<T>): JSX.Element => {
+  const { elementType: ElementTag = 'p', children, ...restProps } = props;
+  const { classProps, props: modifiedProps } = useTextStyleProps(restProps);
+
+  return (
+    <ElementTag {...filterProps(modifiedProps)} className={classProps}>
+      {children}
+    </ElementTag>
+  );
+};
+
+Text.defaultProps = defaultProps;
+
+export default Text;

--- a/packages/web-react/src/components/Text/__tests__/Text.test.tsx
+++ b/packages/web-react/src/components/Text/__tests__/Text.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Text from '../Text';
+import { ClassNamePrefixProvider } from '../../../context/ClassNamePrefixContext';
+import textPropsDataProvider from './textPropsDataProvider';
+import { TextEmphasis, TextSize } from '../../../types';
+
+describe('Text', () => {
+  it('should have default classname', () => {
+    const dom = render(<Text />);
+
+    expect(dom.container.querySelector('p')).toHaveClass('typography-body-medium-text-regular');
+  });
+
+  it('should have classname with lmc prefix', () => {
+    const dom = render(
+      <ClassNamePrefixProvider value="lmc">
+        <Text />
+      </ClassNamePrefixProvider>,
+    );
+
+    expect(dom.container.querySelector('p')).toHaveClass('lmc-typography-body-medium-text-regular');
+  });
+
+  it.each(textPropsDataProvider)('should have classname', (size, emphasis, expectedClassName) => {
+    const dom = render(<Text size={size as TextSize} emphasis={emphasis as TextEmphasis} />);
+
+    expect(dom.container.querySelector('p')).toHaveClass(expectedClassName);
+  });
+});

--- a/packages/web-react/src/components/Text/__tests__/textPropsDataProvider.ts
+++ b/packages/web-react/src/components/Text/__tests__/textPropsDataProvider.ts
@@ -1,0 +1,17 @@
+const textPropsDataProvider = [
+  // [size, emphasis, expectedClassName]
+  ['large', 'regular', 'typography-body-large-text-regular'],
+  ['medium', 'regular', 'typography-body-medium-text-regular'],
+  ['small', 'regular', 'typography-body-small-text-regular'],
+  ['xsmall', 'regular', 'typography-body-xsmall-text-regular'],
+  ['large', 'italic', 'typography-body-large-text-italic'],
+  ['medium', 'italic', 'typography-body-medium-text-italic'],
+  ['small', 'italic', 'typography-body-small-text-italic'],
+  ['xsmall', 'italic', 'typography-body-xsmall-text-italic'],
+  ['large', 'bold', 'typography-body-large-text-bold'],
+  ['medium', 'bold', 'typography-body-medium-text-bold'],
+  ['small', 'bold', 'typography-body-small-text-bold'],
+  ['xsmall', 'bold', 'typography-body-xsmall-text-bold'],
+];
+
+export default textPropsDataProvider;

--- a/packages/web-react/src/components/Text/__tests__/useTextStyleProps.test.tsx
+++ b/packages/web-react/src/components/Text/__tests__/useTextStyleProps.test.tsx
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { SpiritTextProps } from '../../../types';
+import { useTextStyleProps } from '../useTextStyleProps';
+import textPropsDataProvider from './textPropsDataProvider';
+
+describe('useTextStyleProps', () => {
+  it.each(textPropsDataProvider)('should return typography class', (size, emphasis, expectedClassName) => {
+    const props = { size, emphasis } as SpiritTextProps;
+    const { result } = renderHook(() => useTextStyleProps(props));
+
+    expect(result.current.classProps).toBe(expectedClassName);
+  });
+});

--- a/packages/web-react/src/components/Text/index.tsx
+++ b/packages/web-react/src/components/Text/index.tsx
@@ -1,0 +1,3 @@
+export * from './Text';
+export * from './useTextStyleProps';
+export { default as Text } from './Text';

--- a/packages/web-react/src/components/Text/useTextStyleProps.tsx
+++ b/packages/web-react/src/components/Text/useTextStyleProps.tsx
@@ -1,0 +1,22 @@
+import { ElementType } from 'react';
+import { useClassNamePrefix } from '../../hooks/useClassNamePrefix';
+import { SpiritTextProps, TextProps } from '../../types';
+
+export interface TextStyles<T extends ElementType = 'p'> {
+  /** className props */
+  classProps: string | null;
+  /** props to be passed to the input element */
+  props: TextProps<T>;
+}
+
+export function useTextStyleProps<T extends ElementType = 'p'>(props: SpiritTextProps<T>): TextStyles<T> {
+  const { size, emphasis, ...restProps } = props;
+
+  const textClass = useClassNamePrefix('typography-body');
+  const className = `${textClass}-${size}-text-${emphasis}`;
+
+  return {
+    classProps: className,
+    props: restProps,
+  };
+}

--- a/packages/web-react/src/components/index.ts
+++ b/packages/web-react/src/components/index.ts
@@ -3,6 +3,7 @@ export * from './Button';
 export * from './CheckboxField';
 export * from './Container';
 export * from './Grid';
+export * from './Heading';
 export * from './Stack';
 export * from './Tag';
 export * from './Text';

--- a/packages/web-react/src/components/index.ts
+++ b/packages/web-react/src/components/index.ts
@@ -5,4 +5,5 @@ export * from './Container';
 export * from './Grid';
 export * from './Stack';
 export * from './Tag';
+export * from './Text';
 export * from './TextField';

--- a/packages/web-react/src/types/heading.ts
+++ b/packages/web-react/src/types/heading.ts
@@ -1,0 +1,21 @@
+import { ElementType, JSXElementConstructor } from 'react';
+import { ChildrenProps } from './shared';
+
+export type TextBodySize = 'large' | 'medium' | 'small';
+export type HeadingSize = TextBodySize | 'xlarge' | 'xsmall';
+
+export interface HeadingElementTypeProps<T extends ElementType = 'div'> {
+  /**
+   * The HTML element or React element used to render the Heading, e.g. 'div'.
+   *
+   * @default 'div'
+   */
+  elementType?: T | JSXElementConstructor<unknown>;
+}
+
+export interface HeadingProps<T extends ElementType = 'div'> extends HeadingElementTypeProps<T>, ChildrenProps {}
+
+export interface SpiritHeadingProps<T extends ElementType = 'div'> extends HeadingProps<T> {
+  /** Size of the text */
+  size: HeadingSize;
+}

--- a/packages/web-react/src/types/index.ts
+++ b/packages/web-react/src/types/index.ts
@@ -3,6 +3,7 @@ export * from './alert';
 export * from './button';
 export * from './checkboxField';
 export * from './grid';
+export * from './heading';
 export * from './label';
 export * from './message';
 export * from './text';

--- a/packages/web-react/src/types/index.ts
+++ b/packages/web-react/src/types/index.ts
@@ -5,4 +5,5 @@ export * from './checkboxField';
 export * from './grid';
 export * from './label';
 export * from './message';
+export * from './text';
 export * from './textField';

--- a/packages/web-react/src/types/index.ts
+++ b/packages/web-react/src/types/index.ts
@@ -5,6 +5,7 @@ export * from './checkboxField';
 export * from './grid';
 export * from './heading';
 export * from './label';
+export * from './link';
 export * from './message';
 export * from './text';
 export * from './textField';

--- a/packages/web-react/src/types/link.ts
+++ b/packages/web-react/src/types/link.ts
@@ -1,0 +1,27 @@
+import { ElementType, JSXElementConstructor } from 'react';
+import { ChildrenProps } from './shared';
+
+export type LinkColor = 'primary' | 'secondary' | 'inverted';
+
+export interface LinkElementTypeProps<T extends ElementType = 'div'> {
+  /**
+   * The HTML element or React element used to render the Link, e.g. 'a'.
+   *
+   * @default 'a'
+   */
+  elementType?: T | JSXElementConstructor<unknown>;
+}
+
+export interface LinkProps<T extends ElementType = 'a'> extends LinkElementTypeProps<T>, ChildrenProps {
+  /** Link's href attribute */
+  href: string;
+}
+
+export interface SpiritLinkProps<T extends ElementType = 'div'> extends LinkProps<T> {
+  /** Color of the Link */
+  color: LinkColor;
+  /** Whether is the Link underlined */
+  isUnderlined?: boolean;
+  /** Whether is the Link disabled */
+  isDisabled?: boolean;
+}

--- a/packages/web-react/src/types/text.ts
+++ b/packages/web-react/src/types/text.ts
@@ -1,0 +1,23 @@
+import { ElementType, JSXElementConstructor } from 'react';
+import { ChildrenProps } from './shared';
+
+export type TextSize = 'large' | 'medium' | 'small' | 'xsmall';
+export type TextEmphasis = 'regular' | 'bold' | 'italic';
+
+export interface TextElementTypeProps<T extends ElementType = 'p'> {
+  /**
+   * The HTML element or React element used to render the Text, e.g. 'p'.
+   *
+   * @default 'p'
+   */
+  elementType?: T | JSXElementConstructor<unknown>;
+}
+
+export interface TextProps<T extends ElementType = 'p'> extends TextElementTypeProps<T>, ChildrenProps {}
+
+export interface SpiritTextProps<T extends ElementType = 'p'> extends TextProps<T> {
+  /** Size of the text */
+  size?: TextSize;
+  /** Emphasis of the text */
+  emphasis?: TextEmphasis;
+}


### PR DESCRIPTION
Introducing `<Text />` component as a typography helper. I am still considering different names but `Typography` seems to me to be too long. `Typo` can be misunderstood. Maybe something simple like just `<T />`.

I do not know yet if we are planning to use `Text` component for different cases.

What are your opinions?