### PR TITLE
Feat(web-react): Introduce PasswordField component (refs …

### DIFF
--- a/.storybook/assets/stylesheets/index.scss
+++ b/.storybook/assets/stylesheets/index.scss
@@ -6,6 +6,7 @@
 @use '../../../packages/web/src/components/CheckboxField';
 @use '../../../packages/web/src/components/Container';
 @use '../../../packages/web/src/components/Grid';
+@use '../../../packages/web/src/components/PasswordField';
 @use '../../../packages/web/src/components/Stack';
 @use '../../../packages/web/src/components/Tag';
 @use '../../../packages/web/src/components/TextField';

--- a/packages/web-react/src/components/TextField/PasswordField.stories.tsx
+++ b/packages/web-react/src/components/TextField/PasswordField.stories.tsx
@@ -1,0 +1,48 @@
+import TextFieldStory, { Default as DefaultTextField, Template } from './TextField.stories';
+
+export default {
+  title: 'Components/PasswordField',
+  argTypes: TextFieldStory.argTypes,
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  ...DefaultTextField.args,
+  type: 'password',
+};
+
+export const Required = Template.bind({});
+Required.args = {
+  ...Default.args,
+  required: true,
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  ...Default.args,
+  disabled: true,
+};
+
+export const HiddenLabel = Template.bind({});
+HiddenLabel.args = {
+  ...Default.args,
+  isLabelHidden: true,
+};
+
+export const WithSuccessState = Template.bind({});
+WithSuccessState.args = {
+  ...Default.args,
+  validationState: 'success',
+};
+
+export const WithWarningState = Template.bind({});
+WithWarningState.args = {
+  ...Default.args,
+  validationState: 'warning',
+};
+
+export const WithErrorState = Template.bind({});
+WithErrorState.args = {
+  ...Default.args,
+  validationState: 'error',
+};

--- a/packages/web-react/src/components/TextField/README.md
+++ b/packages/web-react/src/components/TextField/README.md
@@ -1,27 +1,29 @@
 # TextField
 
 TextField enables the user to type in text information. It has input, label,
-and optional message. It could be disabled or have an error state. The label could be hidden
+and an optional message. It can be of type `text` or `password`. It could be disabled or have an error state. The label could be hidden
 and show if the input is required.
 
 ```jsx
-<TextField id="example" name="example" required validationState="error" messsage="validation failed" />
+<TextField id="example" type="text" name="example" required validationState="error" messsage="validation failed" />
+<TextField id="example" type="password" name="example" required validationState="error" messsage="validation failed" />
 ```
 
 ## Available props
 
-| Name              | Type    | Description                    |
-| ----------------- | ------- | ------------------------------ |
-| `id`              | string  | Input and label identification |
-| `name`            | string  | Input name                     |
-| `label`           | string  | Label text                     |
-| `placeholder`     | string  | Input placeholder              |
-| `value`           | string  | Input value                    |
-| `message`         | string  | Validation or help message     |
-| `disabled`        | boolean | Whether is field disabled      |
-| `required`        | boolean | Whether is field required      |
-| `validationState` | `error` | Type of validation state       |
-| `isLabelHidden`   | boolean | Whether is label hidden        |
+| Name              | Type                          | Description                    |
+| ----------------- | ----------------------------- | ------------------------------ |
+| `id`              | string                        | Input and label identification |
+| `name`            | string                        | Input name                     |
+| `type`            | `text`, `password`            | Input type                     |
+| `label`           | string                        | Label text                     |
+| `placeholder`     | string                        | Input placeholder              |
+| `value`           | string                        | Input value                    |
+| `message`         | string                        | Validation or help message     |
+| `disabled`        | boolean                       | Whether is field disabled      |
+| `required`        | boolean                       | Whether is field required      |
+| `validationState` | `success`, `warning`, `error` | Type of validation state       |
+| `isLabelHidden`   | boolean                       | Whether is label hidden        |
 
 ## Custom component
 
@@ -40,4 +42,4 @@ const CustomTextField = (props: SpiritTextFieldProps): JSX.Element => {
 };
 ```
 
-For detailed information see [TextField](https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/components/TextField/README.md) component
+For detailed information see [TextField](https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/components/TextField/README.md) component and [PasswordField](https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/components/PasswordField/README.md) component.

--- a/packages/web-react/src/components/TextField/TextField.stories.tsx
+++ b/packages/web-react/src/components/TextField/TextField.stories.tsx
@@ -7,6 +7,12 @@ export default {
   argTypes: {
     id: 'default',
     placeholder: 'Placeholder',
+    type: {
+      control: {
+        type: 'select',
+        options: ['text', 'password'],
+      },
+    },
     disabled: {
       control: 'boolean',
     },
@@ -19,7 +25,7 @@ export default {
     validationState: {
       control: {
         type: 'select',
-        options: ['error'],
+        options: ['success', 'warning', 'error'],
       },
     },
     label: 'Label',
@@ -27,43 +33,36 @@ export default {
   },
 };
 
-const Template = (args: SpiritTextFieldProps) => <TextField {...args} />;
+export const Template = (args: SpiritTextFieldProps) => <TextField {...args} />;
 
-export const DefaultTextField = Template.bind({});
-DefaultTextField.args = {
+export const Default = Template.bind({});
+Default.args = {
+  type: 'text',
   placeholder: 'Placeholder',
   label: 'Label',
   message: 'Message',
 };
 
-export const RequiredTextField = Template.bind({});
-RequiredTextField.args = {
-  placeholder: 'Placeholder',
-  label: 'Label',
-  message: 'Message',
+export const Required = Template.bind({});
+Required.args = {
+  ...Default.args,
   required: true,
 };
 
-export const DisabledTextField = Template.bind({});
-DisabledTextField.args = {
-  placeholder: 'Placeholder',
-  label: 'Label',
-  message: 'Message',
+export const Disabled = Template.bind({});
+Disabled.args = {
+  ...Default.args,
   disabled: true,
 };
 
-export const ErroredTextField = Template.bind({});
-ErroredTextField.args = {
-  placeholder: 'Placeholder',
-  label: 'Label',
-  message: 'Message',
+export const WithError = Template.bind({});
+WithError.args = {
+  ...Default.args,
   validationState: 'error',
 };
 
-export const HiddenLabelTextField = Template.bind({});
-HiddenLabelTextField.args = {
-  placeholder: 'Placeholder',
-  label: 'Label',
-  message: 'Message',
+export const HiddenLabel = Template.bind({});
+HiddenLabel.args = {
+  ...Default.args,
   isLabelHidden: true,
 };

--- a/packages/web-react/src/components/TextField/TextField.tsx
+++ b/packages/web-react/src/components/TextField/TextField.tsx
@@ -2,9 +2,13 @@ import React from 'react';
 import { SpiritTextFieldProps } from '../../types';
 import { useTextFieldStyleProps } from './useTextFieldStyleProps';
 
+const defaultProps = {
+  type: 'text',
+};
+
 export const TextField = (props: SpiritTextFieldProps): JSX.Element => {
   const { classProps, props: modifiedProps } = useTextFieldStyleProps(props);
-  const { id, placeholder, disabled, required, label, message, value, ...restProps } = modifiedProps;
+  const { id, type, placeholder, disabled, required, label, message, value, ...restProps } = modifiedProps;
 
   return (
     <div className={classProps.root}>
@@ -13,7 +17,7 @@ export const TextField = (props: SpiritTextFieldProps): JSX.Element => {
       </label>
       <input
         {...restProps}
-        type="text"
+        type={type}
         id={id}
         className={classProps.input}
         placeholder={placeholder}
@@ -25,5 +29,7 @@ export const TextField = (props: SpiritTextFieldProps): JSX.Element => {
     </div>
   );
 };
+
+TextField.defaultProps = defaultProps;
 
 export default TextField;

--- a/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
+++ b/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
@@ -3,65 +3,73 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import TextField from '../TextField';
 import { ClassNamePrefixProvider } from '../../../context/ClassNamePrefixContext';
+import { TextFieldType, ValidationState } from '../../../types';
 
 describe('TextField', () => {
-  it('should have default classname', () => {
-    const dom = render(<TextField />);
+  describe.each([
+    ['text', 'Text'],
+    ['password', 'Password'],
+  ])('input type %s', (type, expectedClassPrefix) => {
+    it('should have default classname', () => {
+      const dom = render(<TextField type={type as TextFieldType} />);
 
-    const element = dom.container.querySelector('div') as HTMLElement;
-    expect(element).toHaveClass('TextField');
-  });
+      const element = dom.container.querySelector('div') as HTMLElement;
+      expect(element).toHaveClass(`${expectedClassPrefix}Field`);
+    });
 
-  it('should have classname with lmc prefix', () => {
-    const dom = render(
-      <ClassNamePrefixProvider value="lmc">
-        <TextField />
-      </ClassNamePrefixProvider>,
-    );
+    it('should have classname with lmc prefix', () => {
+      const dom = render(
+        <ClassNamePrefixProvider value="lmc">
+          <TextField type={type as TextFieldType} />
+        </ClassNamePrefixProvider>,
+      );
 
-    const element = dom.container.querySelector('div') as HTMLElement;
-    expect(element).toHaveClass('lmc-TextField');
-  });
+      const element = dom.container.querySelector('div') as HTMLElement;
+      expect(element).toHaveClass(`lmc-${expectedClassPrefix}Field`);
+    });
 
-  it('should have label classname', () => {
-    const dom = render(<TextField />);
+    it('should have label classname', () => {
+      const dom = render(<TextField type={type as TextFieldType} />);
 
-    const element = dom.container.querySelector('label') as HTMLElement;
-    expect(element).toHaveClass('TextField__label');
-  });
+      const element = dom.container.querySelector('label') as HTMLElement;
+      expect(element).toHaveClass(`${expectedClassPrefix}Field__label`);
+    });
 
-  it('should have hidden classname', () => {
-    const dom = render(<TextField isLabelHidden />);
+    it('should have hidden classname', () => {
+      const dom = render(<TextField type={type as TextFieldType} isLabelHidden />);
 
-    const element = dom.container.querySelector('label') as HTMLElement;
-    expect(element).toHaveClass('TextField__label--hidden');
-  });
+      const element = dom.container.querySelector('label') as HTMLElement;
+      expect(element).toHaveClass(`${expectedClassPrefix}Field__label--hidden`);
+    });
 
-  it('should have required classname', () => {
-    const dom = render(<TextField required />);
+    it('should have required classname', () => {
+      const dom = render(<TextField type={type as TextFieldType} required />);
 
-    const element = dom.container.querySelector('label') as HTMLElement;
-    expect(element).toHaveClass('TextField__label--required');
-  });
+      const element = dom.container.querySelector('label') as HTMLElement;
+      expect(element).toHaveClass(`${expectedClassPrefix}Field__label--required`);
+    });
 
-  it('should have input classname', () => {
-    const dom = render(<TextField />);
+    it('should have input classname', () => {
+      const dom = render(<TextField type={type as TextFieldType} />);
 
-    const element = dom.container.querySelector('input') as HTMLElement;
-    expect(element).toHaveClass('TextField__input');
-  });
+      const element = dom.container.querySelector('input') as HTMLElement;
+      expect(element).toHaveClass(`${expectedClassPrefix}Field__input`);
+    });
 
-  it('should have message', () => {
-    const dom = render(<TextField message="text" />);
+    it('should have message', () => {
+      const dom = render(<TextField type={type as TextFieldType} message="text" />);
 
-    const element = dom.container.querySelector('.TextField__message') as HTMLElement;
-    expect(element.textContent).toBe('text');
-  });
+      const element = dom.container.querySelector(`.${expectedClassPrefix}Field__message`) as HTMLElement;
+      expect(element.textContent).toBe('text');
+    });
 
-  it('should have error classname', () => {
-    const dom = render(<TextField validationState="error" />);
+    it.each([['success'], ['warning'], ['error']])('should have %s classname', (validationState) => {
+      const dom = render(
+        <TextField type={type as TextFieldType} validationState={validationState as ValidationState} />,
+      );
 
-    const element = dom.container.querySelector('div') as HTMLElement;
-    expect(element).toHaveClass('TextField--error');
+      const element = dom.container.querySelector('div') as HTMLElement;
+      expect(element).toHaveClass(`${expectedClassPrefix}Field--${validationState}`);
+    });
   });
 });

--- a/packages/web-react/src/components/TextField/__tests__/useTextFieldStyleProps.test.tsx
+++ b/packages/web-react/src/components/TextField/__tests__/useTextFieldStyleProps.test.tsx
@@ -3,36 +3,51 @@ import { useTextFieldStyleProps } from '../useTextFieldStyleProps';
 import { SpiritTextFieldProps } from '../../../types';
 
 describe('useTextFieldStyleProps', () => {
-  it('should return defaults', () => {
-    const props = {};
+  it.each([
+    // type, expectedClassPrefix
+    ['text', 'Text'],
+    ['password', 'Password'],
+  ])('should return defaults for %s type', (type, expectedClassPrefix) => {
+    const props = { type } as SpiritTextFieldProps;
     const { result } = renderHook(() => useTextFieldStyleProps(props));
 
     expect(result.current.classProps).toEqual({
-      root: 'TextField',
-      input: 'TextField__input',
-      label: 'TextField__label',
-      message: 'TextField__message',
+      root: `${expectedClassPrefix}Field`,
+      input: `${expectedClassPrefix}Field__input`,
+      label: `${expectedClassPrefix}Field__label`,
+      message: `${expectedClassPrefix}Field__message`,
     });
   });
 
-  it('should return required input', () => {
-    const props: SpiritTextFieldProps = { required: true };
-    const { result } = renderHook(() => useTextFieldStyleProps(props));
+  describe.each([
+    ['text', 'Text'],
+    ['password', 'Password'],
+  ])('input type %s', (type, expectedClassPrefix) => {
+    it('should return required input', () => {
+      const props = { required: true, type } as SpiritTextFieldProps;
+      const { result } = renderHook(() => useTextFieldStyleProps(props));
 
-    expect(result.current.classProps.label).toBe('TextField__label TextField__label--required');
-  });
+      expect(result.current.classProps.label).toBe(
+        `${expectedClassPrefix}Field__label ${expectedClassPrefix}Field__label--required`,
+      );
+    });
 
-  it('should return hidden label', () => {
-    const props: SpiritTextFieldProps = { isLabelHidden: true };
-    const { result } = renderHook(() => useTextFieldStyleProps(props));
+    it('should return hidden label', () => {
+      const props = { isLabelHidden: true, type } as SpiritTextFieldProps;
+      const { result } = renderHook(() => useTextFieldStyleProps(props));
 
-    expect(result.current.classProps.label).toBe('TextField__label TextField__label--hidden');
-  });
+      expect(result.current.classProps.label).toBe(
+        `${expectedClassPrefix}Field__label ${expectedClassPrefix}Field__label--hidden`,
+      );
+    });
 
-  it('should return field with error', () => {
-    const props: SpiritTextFieldProps = { validationState: 'error' };
-    const { result } = renderHook(() => useTextFieldStyleProps(props));
+    it.each([['success'], ['warning'], ['error']])('should return field with %s', (validationState) => {
+      const props = { validationState, type } as SpiritTextFieldProps;
+      const { result } = renderHook(() => useTextFieldStyleProps(props));
 
-    expect(result.current.classProps.root).toBe('TextField TextField--error');
+      expect(result.current.classProps.root).toBe(
+        `${expectedClassPrefix}Field ${expectedClassPrefix}Field--${validationState}`,
+      );
+    });
   });
 });

--- a/packages/web-react/src/components/TextField/useTextFieldStyleProps.tsx
+++ b/packages/web-react/src/components/TextField/useTextFieldStyleProps.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import { useClassNamePrefix } from '../../hooks/useClassNamePrefix';
 import { SpiritTextFieldProps, TextFieldProps } from '../../types';
+import { capitalize } from '../../utils/capitalize';
 
 export interface TextFieldStyles {
   /** className props */
@@ -16,11 +17,12 @@ export interface TextFieldStyles {
 
 export function useTextFieldStyleProps(props: SpiritTextFieldProps): TextFieldStyles {
   const { validationState, isLabelHidden, ...restProps } = props;
-  const { disabled, required } = restProps;
+  const { disabled, required, type } = restProps;
 
-  const textFieldClass = useClassNamePrefix('TextField');
+  const mainClass = `${capitalize(type)}Field`;
+  const textFieldClass = useClassNamePrefix(mainClass);
   const textFieldDisabledClass = `${textFieldClass}--disabled`;
-  const textFieldErrorClass = `${textFieldClass}--error`;
+  const textFieldValidationClass = `${textFieldClass}--${validationState}`;
   const textFieldInputClass = `${textFieldClass}__input`;
   const textFieldLabelClass = `${textFieldClass}__label`;
   const textFieldLabelRequiredClass = `${textFieldClass}__label--required`;
@@ -29,7 +31,7 @@ export function useTextFieldStyleProps(props: SpiritTextFieldProps): TextFieldSt
 
   const rootStyles = classNames(textFieldClass, {
     [textFieldDisabledClass]: disabled,
-    [textFieldErrorClass]: validationState === 'error',
+    [textFieldValidationClass]: validationState,
   });
   const labelStyles = classNames(textFieldLabelClass, {
     [textFieldLabelRequiredClass]: required,

--- a/packages/web-react/src/types/shared/inputs.ts
+++ b/packages/web-react/src/types/shared/inputs.ts
@@ -1,4 +1,4 @@
-export type ValidationState = 'error';
+export type ValidationState = 'success' | 'warning' | 'error';
 
 export interface Validation {
   /** Whether the input should display its "valid" or "invalid" visual styling. */

--- a/packages/web-react/src/types/textField.ts
+++ b/packages/web-react/src/types/textField.ts
@@ -4,11 +4,23 @@ import { MessageProps } from './message';
 
 interface InputProps extends InputBase, Validation, ValueBase<string | number>, TextInputBase {}
 
+export type TextFieldType = 'text' | 'password';
+
 export interface TextFieldProps extends ChildrenProps, StyleProps, LabelProps, InputProps, MessageProps {
   /** Text of control label */
   label?: string;
   /** Identificator of input */
   id?: string;
+  /** The type of text field */
+  type: TextFieldType;
+  /** The placeholder for input. */
+  placeholder?: string;
+  /** Whether the input is disabled. */
+  disabled?: boolean;
+  /** Whether the input is required. */
+  required?: boolean;
+  /** Value of the input. */
+  value?: string | number;
 }
 
 export interface SpiritTextFieldProps extends TextFieldProps {

--- a/packages/web-react/src/utils/__tests__/capitalize.test.ts
+++ b/packages/web-react/src/utils/__tests__/capitalize.test.ts
@@ -1,0 +1,10 @@
+import { capitalize } from '../capitalize';
+
+describe('#capitalize', () => {
+  it.each([
+    ['', ''],
+    ['text', 'Text'],
+  ])('should capitalize text', (input, expected) => {
+    expect(capitalize(input)).toBe(expected);
+  });
+});

--- a/packages/web-react/src/utils/capitalize.ts
+++ b/packages/web-react/src/utils/capitalize.ts
@@ -1,0 +1,1 @@
+export const capitalize = (string: string): string => `${string.charAt(0).toUpperCase()}${string.slice(1)}`;


### PR DESCRIPTION
…#DS-149)

  * TextField prop `type` is now required to display TextField or
    PasswordField
  * new validationState of `success` and `warning` is available