### PR TITLE
Fix(web): Stretch input to entire container

### DIFF
--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -188,10 +188,26 @@
               <input type="text" id="textfield8" class="TextField__input" placeholder="Placeholder" value="Filled" disabled />
               <div class="TextField__message">Message</div>
             </div>
+            <div class="TextField TextField--fluid">
+              <label for="textfield9" class="TextField__label TextField__label--required">Label</label>
+              <input type="text" id="textfield9" class="TextField__input" placeholder="Placeholder" value="Filled" />
+              <div class="TextField__message">Message</div>
+            </div>
             <div style="display: flex; gap: 1rem">
               <div class="TextField">
-                <label for="textfield9" class="TextField__label TextField__label--hidden">Hidden Label</label>
-                <input type="text" id="textfield9" class="TextField__input" placeholder="Placeholder" value="Filled" />
+                <label for="textfield10" class="TextField__label TextField__label--hidden">Hidden Label</label>
+                <input type="text" id="textfield10" class="TextField__input" placeholder="Placeholder" value="Filled" />
+              </div>
+              <button type="button" class="Button Button--primary">Button</button>
+            </div>
+            <div style="display: flex; gap: 1rem">
+              <div class="TextField">
+                <label for="textfield11" class="TextField__label TextField__label--hidden">Hidden Label</label>
+                <input type="text" id="textfield11" class="TextField__input" placeholder="Placeholder" value="Filled" />
+              </div>
+              <div class="TextField">
+                <label for="textfield12" class="TextField__label TextField__label--hidden">Hidden Label</label>
+                <input type="text" id="textfield12" class="TextField__input" placeholder="Placeholder" value="Filled" />
               </div>
               <button type="button" class="Button Button--primary">Button</button>
             </div>

--- a/examples/web/jobs.html
+++ b/examples/web/jobs.html
@@ -195,10 +195,26 @@
               <input type="text" id="textfield8" class="jobs-TextField__input" placeholder="Placeholder" value="Filled" disabled />
               <div class="jobs-TextField__message">Message</div>
             </div>
+            <div class="jobs-TextField jobs-TextField--fluid">
+              <label for="textfield9" class="jobs-TextField__label jobs-TextField__label--required">Label</label>
+              <input type="text" id="textfield9" class="jobs-TextField__input" placeholder="Placeholder" value="Filled" />
+              <div class="jobs-TextField__message">Message</div>
+            </div>
             <div style="display: flex; gap: 1rem">
               <div class="jobs-TextField">
-                <label for="textfield9" class="jobs-TextField__label jobs-TextField__label--hidden">Hidden Label</label>
-                <input type="text" id="textfield9" class="jobs-TextField__input" placeholder="Placeholder" value="Filled" />
+                <label for="textfield10" class="jobs-TextField__label jobs-TextField__label--hidden">Hidden Label</label>
+                <input type="text" id="textfield10" class="jobs-TextField__input" placeholder="Placeholder" value="Filled" />
+              </div>
+              <button type="button" class="jobs-Button jobs-Button--primary">Button</button>
+            </div>
+            <div style="display: flex; gap: 1rem">
+              <div class="jobs-TextField">
+                <label for="textfield11" class="jobs-TextField__label jobs-TextField__label--hidden">Hidden Label</label>
+                <input type="text" id="textfield11" class="jobs-TextField__input" placeholder="Placeholder" value="Filled" />
+              </div>
+              <div class="jobs-TextField">
+                <label for="textfield12" class="jobs-TextField__label jobs-TextField__label--hidden">Hidden Label</label>
+                <input type="text" id="textfield12" class="jobs-TextField__input" placeholder="Placeholder" value="Filled" />
               </div>
               <button type="button" class="jobs-Button jobs-Button--primary">Button</button>
             </div>

--- a/packages/web-react/docs/stories/examples/LoginForm.stories.tsx
+++ b/packages/web-react/docs/stories/examples/LoginForm.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { TextField, CheckboxField, Button, Container, Grid, Stack } from '../../../src/components';
+
+export default {
+  title: 'Examples/Forms',
+};
+
+export const LoginForm = () => (
+  <Container>
+    <Grid layout="narrow">
+      <Stack>
+        <TextField type="text" id="name" label="Name" isFluid />
+        <TextField type="password" id="password" label="Password" isFluid />
+        <CheckboxField label="Stay Logged In" />
+        <Button isBlock>Login</Button>
+      </Stack>
+    </Grid>
+  </Container>
+);

--- a/packages/web-react/src/components/TextField/PasswordField.stories.tsx
+++ b/packages/web-react/src/components/TextField/PasswordField.stories.tsx
@@ -29,6 +29,12 @@ HiddenLabel.args = {
   isLabelHidden: true,
 };
 
+export const Fluid = Template.bind({});
+Fluid.args = {
+  ...Default.args,
+  isFluid: true,
+};
+
 export const WithSuccessState = Template.bind({});
 WithSuccessState.args = {
   ...Default.args,

--- a/packages/web-react/src/components/TextField/TextField.stories.tsx
+++ b/packages/web-react/src/components/TextField/TextField.stories.tsx
@@ -22,6 +22,9 @@ export default {
     isLabelHidden: {
       control: 'boolean',
     },
+    isFluid: {
+      control: 'boolean',
+    },
     validationState: {
       control: {
         type: 'select',
@@ -65,4 +68,10 @@ export const HiddenLabel = Template.bind({});
 HiddenLabel.args = {
   ...Default.args,
   isLabelHidden: true,
+};
+
+export const Fluid = Template.bind({});
+Disabled.args = {
+  ...Default.args,
+  isFluid: true,
 };

--- a/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
+++ b/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
@@ -63,6 +63,13 @@ describe('TextField', () => {
       expect(element.textContent).toBe('text');
     });
 
+    it('should have fluid classname', () => {
+      const dom = render(<TextField type={type as TextFieldType} isFluid />);
+
+      const element = dom.container.querySelector('div') as HTMLElement;
+      expect(element).toHaveClass(`${expectedClassPrefix}Field--fluid`);
+    });
+
     it.each([['success'], ['warning'], ['error']])('should have %s classname', (validationState) => {
       const dom = render(
         <TextField type={type as TextFieldType} validationState={validationState as ValidationState} />,

--- a/packages/web-react/src/components/TextField/__tests__/useTextFieldStyleProps.test.tsx
+++ b/packages/web-react/src/components/TextField/__tests__/useTextFieldStyleProps.test.tsx
@@ -41,6 +41,13 @@ describe('useTextFieldStyleProps', () => {
       );
     });
 
+    it('should return fluid class', () => {
+      const props = { isFluid: true, type } as SpiritTextFieldProps;
+      const { result } = renderHook(() => useTextFieldStyleProps(props));
+
+      expect(result.current.classProps.root).toBe(`${expectedClassPrefix}Field ${expectedClassPrefix}Field--fluid`);
+    });
+
     it.each([['success'], ['warning'], ['error']])('should return field with %s', (validationState) => {
       const props = { validationState, type } as SpiritTextFieldProps;
       const { result } = renderHook(() => useTextFieldStyleProps(props));

--- a/packages/web-react/src/components/TextField/useTextFieldStyleProps.tsx
+++ b/packages/web-react/src/components/TextField/useTextFieldStyleProps.tsx
@@ -16,12 +16,13 @@ export interface TextFieldStyles {
 }
 
 export function useTextFieldStyleProps(props: SpiritTextFieldProps): TextFieldStyles {
-  const { validationState, isLabelHidden, ...restProps } = props;
+  const { validationState, isLabelHidden, isFluid, ...restProps } = props;
   const { isDisabled, isRequired, type } = restProps;
 
   const mainClass = `${capitalize(type)}Field`;
   const textFieldClass = useClassNamePrefix(mainClass);
   const textFieldDisabledClass = `${textFieldClass}--disabled`;
+  const textFieldFluidClass = `${textFieldClass}--fluid`;
   const textFieldValidationClass = `${textFieldClass}--${validationState}`;
   const textFieldInputClass = `${textFieldClass}__input`;
   const textFieldLabelClass = `${textFieldClass}__label`;
@@ -31,6 +32,7 @@ export function useTextFieldStyleProps(props: SpiritTextFieldProps): TextFieldSt
 
   const rootStyles = classNames(textFieldClass, {
     [textFieldDisabledClass]: isDisabled,
+    [textFieldFluidClass]: isFluid,
     [textFieldValidationClass]: validationState,
   });
   const labelStyles = classNames(textFieldLabelClass, {

--- a/packages/web-react/src/types/textField.ts
+++ b/packages/web-react/src/types/textField.ts
@@ -26,4 +26,6 @@ export interface TextFieldProps extends ChildrenProps, StyleProps, LabelProps, I
 export interface SpiritTextFieldProps extends TextFieldProps {
   /** Whether the label should be displayed */
   isLabelHidden?: boolean;
+  /** Whether the width should be controlled by container */
+  isFluid?: boolean;
 }

--- a/packages/web/src/components/PasswordField/_theme.scss
+++ b/packages/web/src/components/PasswordField/_theme.scss
@@ -1,6 +1,7 @@
 @use '@tokens' as tokens;
 
 $spacing: tokens.$space-300;
+$width-default: 18rem;
 
 $label-typography: tokens.$body-small-text-regular;
 $label-color-default: tokens.$text-secondary-default;
@@ -35,6 +36,7 @@ $message-color-error: tokens.$emotion-danger-default;
 
 $theme: (
     spacing: $spacing,
+    width-default: $width-default,
     label-typography: $label-typography,
     label-color-default: $label-color-default,
     label-color-disabled: $label-color-disabled,

--- a/packages/web/src/components/TextField/README.md
+++ b/packages/web/src/components/TextField/README.md
@@ -32,4 +32,9 @@ and show if the input is required.
   <input type="text" id="textfield6" class="TextField__input" placeholder="Placeholder" disabled />
   <div class="TextField__message">Message</div>
 </div>
+<div class="TextField TextField--fluid">
+  <label for="textfield7" class="TextField__label TextField__label--required">Label of disabled input</label>
+  <input type="text" id="textfield7" class="TextField__input" placeholder="Placeholder" />
+  <div class="TextField__message">Message</div>
+</div>
 ```

--- a/packages/web/src/components/TextField/_theme.scss
+++ b/packages/web/src/components/TextField/_theme.scss
@@ -1,6 +1,7 @@
 @use '@tokens' as tokens;
 
 $spacing: tokens.$space-300;
+$width-default: 18rem;
 
 $label-typography: tokens.$body-small-text-regular;
 $label-color-default: tokens.$text-secondary-default;
@@ -31,6 +32,7 @@ $message-color-error: tokens.$emotion-danger-default;
 
 $theme: (
     spacing: $spacing,
+    width-default: $width-default,
     label-typography: $label-typography,
     label-color-default: $label-color-default,
     label-color-disabled: $label-color-disabled,

--- a/packages/web/src/tools/_forms.scss
+++ b/packages/web/src/tools/_forms.scss
@@ -28,7 +28,7 @@
         @include typography.generate(map.get($theme, input-typography));
 
         display: block;
-        max-width: 100%;
+        width: 100%;
         padding: map.get($theme, input-padding-y) map.get($theme, input-padding-x);
         color: map.get($theme, input-color-default);
         background: map.get($theme, input-background);

--- a/packages/web/src/tools/_forms.scss
+++ b/packages/web/src/tools/_forms.scss
@@ -4,7 +4,8 @@
 
 @mixin field($type, $variants, $theme) {
     .#{$type} {
-        max-width: 100%;
+        display: inline-block;
+        width: map.get($theme, width-default);
     }
 
     .#{$type}__label {
@@ -40,6 +41,10 @@
             color: map.get($theme, input-placeholder-color-default);
             opacity: 1;
         }
+    }
+
+    .#{$type}--fluid {
+        width: 100%;
     }
 
     .#{$type}:hover > .#{$type}__input,


### PR DESCRIPTION
Stretching input to entire container space using `width` instead of `max-width`.

<img width="1531" alt="Screenshot 2022-03-22 at 21 56 56" src="https://user-images.githubusercontent.com/2481010/159657744-ecf26d35-2176-42fb-8963-97f1f8d9f2fa.png">
