### PR TITLE
BREAKING CHANGES(web-react): Remove `className` from all components r…

### DIFF
--- a/packages/web-react/src/components/Button/ButtonLink.tsx
+++ b/packages/web-react/src/components/Button/ButtonLink.tsx
@@ -1,5 +1,4 @@
 import React, { ElementType } from 'react';
-import classNames from 'classnames';
 import { SpiritButtonProps } from '../../types';
 import { useButtonAriaProps } from './useButtonAriaProps';
 import { useButtonStyleProps } from './useButtonStyleProps';
@@ -14,12 +13,12 @@ const defaultProps = {
 };
 
 export const ButtonLink = <T extends ElementType = 'a'>(props: SpiritButtonProps<T>): JSX.Element => {
-  const { className, children, ...restProps } = props;
+  const { children, ...restProps } = props;
   const { buttonProps } = useButtonAriaProps(props);
   const { classProps } = useButtonStyleProps(restProps);
 
   return (
-    <a {...buttonProps} className={classNames(className, classProps)}>
+    <a {...buttonProps} className={classProps}>
       {children}
     </a>
   );

--- a/packages/web-react/src/components/Container/Container.tsx
+++ b/packages/web-react/src/components/Container/Container.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
-import classNames from 'classnames';
 import { useClassNamePrefix } from '../../hooks/useClassNamePrefix';
 import { ChildrenProps, StyleProps } from '../../types';
 
 export interface ContainerProps extends ChildrenProps, StyleProps {}
 
-export const Container = ({ className, children, ...restProps }: ContainerProps): JSX.Element => {
+export const Container = ({ children, ...restProps }: ContainerProps): JSX.Element => {
   const containerClass = useClassNamePrefix('Container');
-  const classes = classNames(className, containerClass);
 
   return (
-    <div {...restProps} className={classes}>
+    <div {...restProps} className={containerClass}>
       {children}
     </div>
   );

--- a/packages/web-react/src/components/Grid/Grid.tsx
+++ b/packages/web-react/src/components/Grid/Grid.tsx
@@ -1,15 +1,13 @@
 import React, { ElementType } from 'react';
-import classNames from 'classnames';
 import { useGridStyleProps } from './useGridStyleProps';
 import { SpiritGridProps } from '../../types';
 
 export const Grid = <T extends ElementType = 'div'>(props: SpiritGridProps<T>): JSX.Element => {
-  const { className, elementType: ElementTag = 'div', children, ...restProps } = props;
+  const { elementType: ElementTag = 'div', children, ...restProps } = props;
   const { classProps, props: modifiedProps } = useGridStyleProps(restProps);
-  const classes = classNames(className, classProps);
 
   return (
-    <ElementTag {...modifiedProps} className={classes}>
+    <ElementTag {...modifiedProps} className={classProps}>
       {children}
     </ElementTag>
   );

--- a/packages/web-react/src/components/Grid/README.md
+++ b/packages/web-react/src/components/Grid/README.md
@@ -32,6 +32,5 @@ Use Grid to build multiple column layouts. This Grid works on twelve column syst
 | `tablet`      | `1`, `2`, `3`, `4`, `6`, `12` | Number of columns to use on tablet  |
 | `layout`      | `narrow`                      | Type of layout to display           |
 | `elementType` | HTML element                  | Element type to use for the Grid    |
-| `className`   | string                        | Additional class name               |
 
 For detailed information see [Grid](https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/components/Grid/README.md) component

--- a/packages/web-react/src/components/Stack/Stack.tsx
+++ b/packages/web-react/src/components/Stack/Stack.tsx
@@ -1,5 +1,4 @@
 import React, { ElementType, JSXElementConstructor } from 'react';
-import classNames from 'classnames';
 import { useClassNamePrefix } from '../../hooks/useClassNamePrefix';
 import { ChildrenProps, StyleProps } from '../../types';
 
@@ -18,12 +17,11 @@ const defaultProps = {
 };
 
 export const Stack = <T extends ElementType = 'div'>(props: StackProps<T>): JSX.Element => {
-  const { elementType: ElementTag = 'div', className, children, ...restProps } = props;
+  const { elementType: ElementTag = 'div', children, ...restProps } = props;
   const stackClass = useClassNamePrefix('Stack');
-  const classes = classNames(className, stackClass);
 
   return (
-    <ElementTag {...restProps} className={classes}>
+    <ElementTag {...restProps} className={stackClass}>
       {children}
     </ElementTag>
   );

--- a/packages/web-react/src/components/Tag/Tag.tsx
+++ b/packages/web-react/src/components/Tag/Tag.tsx
@@ -10,18 +10,15 @@ type Color = 'default' | 'informative' | 'success' | 'warning' | 'danger';
 type Theme = 'light' | 'dark';
 
 export interface TagProps<T extends ElementType = 'span'> extends ChildrenProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  tag?: T | JSXElementConstructor<any>;
+  tag?: T | JSXElementConstructor<unknown>;
   color?: Color;
   theme?: Theme;
-  className?: string;
 }
 
 const defaultProps = {
   color: 'default',
   theme: 'dark',
   tag: 'span',
-  className: null,
 };
 
 // `${componentClassName}--${color}-${theme}`;
@@ -29,14 +26,10 @@ const getTagColorAndThemeClassname = (className: string, color: Color, theme: Th
   compose(applyTheme<Theme>(theme), applyColor<Color>(color))(className);
 
 export const Tag = <T extends ElementType = 'span'>(props: TagProps<T>): JSX.Element => {
-  const { tag: ElementTag = 'span', color, theme, className, children, ...restProps } = props;
+  const { tag: ElementTag = 'span', color, theme, children, ...restProps } = props;
   const tagClass = useClassNamePrefix('Tag');
 
-  const classes = classNames(
-    tagClass,
-    getTagColorAndThemeClassname(tagClass, color as Color, theme as Theme),
-    className,
-  );
+  const classes = classNames(tagClass, getTagColorAndThemeClassname(tagClass, color as Color, theme as Theme));
 
   return (
     <ElementTag {...restProps} className={classes}>


### PR DESCRIPTION
…efs #DS-158

  * we want to be more defensive in styling the components
  * please use existing classes or see the docs for web package
  * @see: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web#rebranding