### PR TITLE
BREAKING CHANGES(web-react): Use `is` prefix for boolean props (refs …

### DIFF
--- a/packages/web-react/src/components/Button/Button.stories.tsx
+++ b/packages/web-react/src/components/Button/Button.stories.tsx
@@ -11,8 +11,8 @@ export default {
     },
     onClick: { action: 'onClick' },
     type: 'button',
-    disabled: { control: 'boolean' },
-    block: { control: 'boolean' },
+    isDisabled: { control: 'boolean' },
+    isBlock: { control: 'boolean' },
     isSquare: { control: 'boolean' },
     ariaLabel: { control: 'text' },
     children: {
@@ -57,14 +57,14 @@ export const DisabledButton = Template.bind({});
 DisabledButton.args = {
   color: 'primary',
   children: 'Button',
-  disabled: true,
+  isDisabled: true,
 };
 
 export const BlockButton = Template.bind({});
 BlockButton.args = {
   color: 'primary',
   children: 'Button',
-  block: true,
+  isBlock: true,
 };
 
 export const SquareButton = Template.bind({});

--- a/packages/web-react/src/components/Button/Button.tsx
+++ b/packages/web-react/src/components/Button/Button.tsx
@@ -7,8 +7,8 @@ import { useButtonStyleProps } from './useButtonStyleProps';
 const defaultProps = {
   color: 'primary',
   type: 'button',
-  block: false,
-  disabled: false,
+  isBlock: false,
+  isDisabled: false,
   isSquare: false,
   elementType: 'button',
 };

--- a/packages/web-react/src/components/Button/ButtonLink.stories.tsx
+++ b/packages/web-react/src/components/Button/ButtonLink.stories.tsx
@@ -14,8 +14,8 @@ export default {
       options: ['_blank', '_self', '_parent', '_top'],
       control: { type: 'select' },
     },
-    disabled: { control: 'boolean' },
-    block: { control: 'boolean' },
+    isDisabled: { control: 'boolean' },
+    isBlock: { control: 'boolean' },
     ariaLabel: { control: 'text' },
     children: {
       control: 'text',
@@ -30,6 +30,6 @@ ExampleButton.args = {
   color: 'primary',
   href: '#',
   children: 'Button',
-  disabled: false,
-  block: false,
+  isDisabled: false,
+  isBlock: false,
 };

--- a/packages/web-react/src/components/Button/__tests__/ButtonLink.test.tsx
+++ b/packages/web-react/src/components/Button/__tests__/ButtonLink.test.tsx
@@ -14,7 +14,7 @@ describe('ButtonLink', () => {
   });
 
   it('should have disabled classname', () => {
-    const { container } = render(<ButtonLink disabled />);
+    const { container } = render(<ButtonLink isDisabled />);
 
     const element = container.querySelector('a') as HTMLElement;
     expect(element).toHaveClass('Button');
@@ -24,7 +24,7 @@ describe('ButtonLink', () => {
   it('should have classname with lmc prefix', () => {
     const { container } = render(
       <ClassNamePrefixProvider value="lmc">
-        <ButtonLink disabled block />
+        <ButtonLink isDisabled isBlock />
       </ClassNamePrefixProvider>,
     );
 

--- a/packages/web-react/src/components/Button/__tests__/useButtonStyleProps.test.tsx
+++ b/packages/web-react/src/components/Button/__tests__/useButtonStyleProps.test.tsx
@@ -6,7 +6,7 @@ declare const global: any;
 
 describe('useButtonStyleProps', () => {
   it.each([
-    // color, block, disabled, isSquare, expectedClasses
+    // color, isBlock, isDisabled, isSquare, expectedClasses
     ['primary', false, false, false, 'Button Button--primary'],
     ['secondary', false, false, false, 'Button Button--secondary'],
     ['tertiary', false, false, false, 'Button Button--tertiary'],
@@ -15,8 +15,8 @@ describe('useButtonStyleProps', () => {
     ['primary', true, false, false, 'Button Button--primary Button--block'],
     ['primary', false, true, false, 'Button Button--primary Button--disabled'],
     ['primary', false, false, true, 'Button Button--primary Button--square'],
-  ])('should return classes', (color, block, disabled, isSquare, expectedClasses) => {
-    const props = { color, block, disabled, isSquare } as SpiritButtonProps;
+  ])('should return classes', (color, isBlock, isDisabled, isSquare, expectedClasses) => {
+    const props = { color, isBlock, isDisabled, isSquare } as SpiritButtonProps;
     const { result } = renderHook(() => useButtonStyleProps(props));
 
     expect(result.current.classProps).toBe(expectedClasses);
@@ -25,7 +25,7 @@ describe('useButtonStyleProps', () => {
   it('should warn when using unsupported sizes on body', () => {
     const consoleWarnMock = jest.spyOn(global.console, 'warn').mockImplementation();
 
-    const props = { color: 'primary', block: true, isSquare: true } as SpiritButtonProps;
+    const props = { color: 'primary', isBlock: true, isSquare: true } as SpiritButtonProps;
     renderHook(() => useButtonStyleProps(props));
 
     expect(consoleWarnMock).toHaveBeenCalledWith('isBlock and isSquare props are mutually exclusive');

--- a/packages/web-react/src/components/Button/useButtonAriaProps.tsx
+++ b/packages/web-react/src/components/Button/useButtonAriaProps.tsx
@@ -13,27 +13,27 @@ export function useButtonAriaProps(
 export function useButtonAriaProps(props: AriaButtonProps<ElementType>): ButtonAria<HTMLAttributes<HTMLElement>>;
 
 export function useButtonAriaProps(props: AriaButtonProps<ElementType>): ButtonAria<HTMLAttributes<unknown>> {
-  const { elementType = 'button', disabled, onClick, href, target, rel, type = 'button', ariaLabel } = props;
+  const { elementType = 'button', isDisabled, onClick, href, target, rel, type = 'button', ariaLabel } = props;
 
   let additionalProps;
   if (elementType === 'button') {
     additionalProps = {
       type,
-      disabled,
+      disabled: isDisabled,
     };
   } else {
     additionalProps = {
       role: 'button',
-      href: elementType === 'a' && disabled ? undefined : href,
+      href: elementType === 'a' && isDisabled ? undefined : href,
       target: elementType === 'a' ? target : undefined,
       type: elementType === 'a' && type === 'button' ? undefined : type,
-      disabled,
+      disabled: isDisabled,
       rel: elementType === 'a' ? rel : undefined,
     };
   }
 
   const handleClick = (event: ClickEvent) => {
-    if (disabled) {
+    if (isDisabled) {
       event.preventDefault();
 
       return;

--- a/packages/web-react/src/components/Button/useButtonStyleProps.tsx
+++ b/packages/web-react/src/components/Button/useButtonStyleProps.tsx
@@ -15,22 +15,22 @@ export interface ButtonStyles {
 }
 
 export function useButtonStyleProps<T extends ElementType = 'button'>(props: SpiritButtonProps<T>): ButtonStyles {
-  const { color, block, disabled, isSquare } = props;
+  const { color, isBlock, isDisabled, isSquare } = props;
 
   const buttonClass = useClassNamePrefix('Button');
   const buttonBlockClass = `${buttonClass}--block`;
   const buttonDisabledClass = `${buttonClass}--disabled`;
   const buttonSquareClass = `${buttonClass}--square`;
 
-  if (block && isSquare) {
+  if (isBlock && isSquare) {
     // eslint-disable-next-line no-console
     console.warn('isBlock and isSquare props are mutually exclusive');
   }
 
   const classProps = classNames(buttonClass, getButtonColorClassname(buttonClass, color), {
-    [buttonBlockClass]: block && !isSquare,
-    [buttonDisabledClass]: disabled,
-    [buttonSquareClass]: isSquare && !block,
+    [buttonBlockClass]: isBlock && !isSquare,
+    [buttonDisabledClass]: isDisabled,
+    [buttonSquareClass]: isSquare && !isBlock,
   });
 
   return {

--- a/packages/web-react/src/components/CheckboxField/CheckboxField.stories.tsx
+++ b/packages/web-react/src/components/CheckboxField/CheckboxField.stories.tsx
@@ -6,10 +6,13 @@ export default {
   title: 'Components/CheckboxField',
   argTypes: {
     id: 'default',
-    disabled: {
+    isDisabled: {
       control: 'boolean',
     },
-    required: {
+    isRequired: {
+      control: 'boolean',
+    },
+    isChecked: {
       control: 'boolean',
     },
     validationState: {
@@ -35,21 +38,21 @@ export const CheckedCheckboxField = Template.bind({});
 DefaultCheckboxField.args = {
   label: 'Label',
   message: 'Message',
-  checked: true,
+  isChecked: true,
 };
 
 export const RequiredCheckboxField = Template.bind({});
 RequiredCheckboxField.args = {
   label: 'Label',
   message: 'Message',
-  required: true,
+  isRequired: true,
 };
 
 export const DisabledCheckboxField = Template.bind({});
 DisabledCheckboxField.args = {
   label: 'Label',
   message: 'Message',
-  disabled: true,
+  isDisabled: true,
 };
 
 export const ErroredCheckboxField = Template.bind({});

--- a/packages/web-react/src/components/CheckboxField/CheckboxField.tsx
+++ b/packages/web-react/src/components/CheckboxField/CheckboxField.tsx
@@ -5,7 +5,7 @@ import { useCheckboxFieldStyleProps } from './useCheckboxFieldStyleProps';
 
 export const CheckboxField = (props: SpiritCheckboxFieldProps): JSX.Element => {
   const { classProps, props: modifiedProps } = useCheckboxFieldStyleProps(props);
-  const { id, disabled, required, label, message, value, checked, ...restProps } = modifiedProps;
+  const { id, label, message, value, isDisabled, isRequired, isChecked, ...restProps } = modifiedProps;
 
   return (
     <label htmlFor={id} className={classProps.root}>
@@ -14,9 +14,9 @@ export const CheckboxField = (props: SpiritCheckboxFieldProps): JSX.Element => {
         type="checkbox"
         id={id}
         className={classProps.input}
-        disabled={disabled}
-        required={required}
-        checked={checked}
+        disabled={isDisabled}
+        required={isRequired}
+        checked={isChecked}
         value={value}
       />
       <span className={classProps.text}>

--- a/packages/web-react/src/components/CheckboxField/README.md
+++ b/packages/web-react/src/components/CheckboxField/README.md
@@ -5,7 +5,7 @@ and an optional message. It could be disabled or have an error state. The label 
 and show if the input is required.
 
 ```jsx
-<CheckboxField id="example" name="example" required checked validationState="error" messsage="validation failed" />
+<CheckboxField id="example" name="example" isRequired isChecked validationState="error" messsage="validation failed" />
 ```
 
 ## Available props
@@ -17,10 +17,10 @@ and show if the input is required.
 | `label`           | string  | Label text                     |
 | `value`           | string  | Input value                    |
 | `message`         | string  | Validation or help message     |
-| `disabled`        | boolean | Whether is field disabled      |
-| `required`        | boolean | Whether is field required      |
-| `checked`         | boolean | Whether is field checked       |
 | `validationState` | `error` | Type of validation state       |
+| `isDisabled`      | boolean | Whether is field disabled      |
+| `isRequired`      | boolean | Whether is field required      |
+| `isChecked`       | boolean | Whether is field checked       |
 | `isLabelHidden`   | boolean | Whether is label hidden        |
 
 ## Custom component

--- a/packages/web-react/src/components/CheckboxField/__tests__/CheckboxField.test.tsx
+++ b/packages/web-react/src/components/CheckboxField/__tests__/CheckboxField.test.tsx
@@ -45,7 +45,7 @@ describe('CheckboxField', () => {
   });
 
   it('should have required classname', () => {
-    const dom = render(<CheckboxField required />);
+    const dom = render(<CheckboxField isRequired />);
 
     const element = dom.container.querySelector('label > span > span') as HTMLElement;
     expect(element).toHaveClass('CheckboxField__label--required');

--- a/packages/web-react/src/components/CheckboxField/__tests__/useCheckboxFieldStyleProps.test.tsx
+++ b/packages/web-react/src/components/CheckboxField/__tests__/useCheckboxFieldStyleProps.test.tsx
@@ -17,7 +17,7 @@ describe('useCheckboxFieldStyleProps', () => {
   });
 
   it('should return required input', () => {
-    const props = { required: true } as SpiritCheckboxFieldProps;
+    const props = { isRequired: true } as SpiritCheckboxFieldProps;
     const { result } = renderHook(() => useCheckboxFieldStyleProps(props));
 
     expect(result.current.classProps.label).toBe('CheckboxField__label CheckboxField__label--required');

--- a/packages/web-react/src/components/CheckboxField/useCheckboxFieldStyleProps.tsx
+++ b/packages/web-react/src/components/CheckboxField/useCheckboxFieldStyleProps.tsx
@@ -17,7 +17,7 @@ export interface CheckboxFieldStyles {
 
 export function useCheckboxFieldStyleProps(props: SpiritCheckboxFieldProps): CheckboxFieldStyles {
   const { validationState, isLabelHidden, ...restProps } = props;
-  const { disabled, required } = restProps;
+  const { isDisabled, isRequired } = restProps;
 
   const checkboxFieldClass = useClassNamePrefix('CheckboxField');
   const checkboxFieldDisabledClass = `${checkboxFieldClass}--disabled`;
@@ -30,11 +30,11 @@ export function useCheckboxFieldStyleProps(props: SpiritCheckboxFieldProps): Che
   const checkboxFieldMessageClass = `${checkboxFieldClass}__message`;
 
   const rootStyles = classNames(checkboxFieldClass, {
-    [checkboxFieldDisabledClass]: disabled,
+    [checkboxFieldDisabledClass]: isDisabled,
     [checkboxFieldErrorClass]: validationState === 'error',
   });
   const labelStyles = classNames(checkboxFieldLabelClass, {
-    [checkboxFieldLabelRequiredClass]: required,
+    [checkboxFieldLabelRequiredClass]: isRequired,
     [checkboxFieldLabelHiddenClass]: isLabelHidden,
   });
 

--- a/packages/web-react/src/components/Stack/Stack.stories.tsx
+++ b/packages/web-react/src/components/Stack/Stack.stories.tsx
@@ -35,8 +35,8 @@ export const StackedFormFields = Template.bind({});
 StackedFormFields.args = {
   children: (
     <>
-      <TextField id="textfieldStack1" label="Label" required />
-      <TextField id="textfieldStack2" label="Label" required />
+      <TextField id="textfieldStack1" label="Label" isRequired />
+      <TextField id="textfieldStack2" label="Label" isRequired />
     </>
   ),
 };

--- a/packages/web-react/src/components/TextField/PasswordField.stories.tsx
+++ b/packages/web-react/src/components/TextField/PasswordField.stories.tsx
@@ -14,13 +14,13 @@ Default.args = {
 export const Required = Template.bind({});
 Required.args = {
   ...Default.args,
-  required: true,
+  isRequired: true,
 };
 
 export const Disabled = Template.bind({});
 Disabled.args = {
   ...Default.args,
-  disabled: true,
+  isDisabled: true,
 };
 
 export const HiddenLabel = Template.bind({});

--- a/packages/web-react/src/components/TextField/README.md
+++ b/packages/web-react/src/components/TextField/README.md
@@ -5,8 +5,8 @@ and an optional message. It can be of type `text` or `password`. It could be dis
 and show if the input is required.
 
 ```jsx
-<TextField id="example" type="text" name="example" required validationState="error" message="validation failed" />
-<TextField id="example" type="password" name="example" required validationState="error" message="validation failed" />
+<TextField id="example" type="text" name="example" isRequired validationState="error" message="validation failed" />
+<TextField id="example" type="password" name="example" isRequired validationState="error" message="validation failed" />
 ```
 
 ## Available props
@@ -20,9 +20,9 @@ and show if the input is required.
 | `placeholder`     | string                        | Input placeholder              |
 | `value`           | string                        | Input value                    |
 | `message`         | string                        | Validation or help message     |
-| `disabled`        | boolean                       | Whether is field disabled      |
-| `required`        | boolean                       | Whether is field required      |
 | `validationState` | `success`, `warning`, `error` | Type of validation state       |
+| `isDisabled`      | boolean                       | Whether is field disabled      |
+| `isRequired`      | boolean                       | Whether is field required      |
 | `isLabelHidden`   | boolean                       | Whether is label hidden        |
 
 ## Custom component

--- a/packages/web-react/src/components/TextField/TextField.stories.tsx
+++ b/packages/web-react/src/components/TextField/TextField.stories.tsx
@@ -13,10 +13,10 @@ export default {
         options: ['text', 'password'],
       },
     },
-    disabled: {
+    isDisabled: {
       control: 'boolean',
     },
-    required: {
+    isRequired: {
       control: 'boolean',
     },
     isLabelHidden: {
@@ -46,13 +46,13 @@ Default.args = {
 export const Required = Template.bind({});
 Required.args = {
   ...Default.args,
-  required: true,
+  isRequired: true,
 };
 
 export const Disabled = Template.bind({});
 Disabled.args = {
   ...Default.args,
-  disabled: true,
+  isDisabled: true,
 };
 
 export const WithError = Template.bind({});

--- a/packages/web-react/src/components/TextField/TextField.tsx
+++ b/packages/web-react/src/components/TextField/TextField.tsx
@@ -9,7 +9,7 @@ const defaultProps = {
 
 export const TextField = (props: SpiritTextFieldProps): JSX.Element => {
   const { classProps, props: modifiedProps } = useTextFieldStyleProps(props);
-  const { id, type, placeholder, disabled, required, label, message, value, ...restProps } = modifiedProps;
+  const { id, type, placeholder, isDisabled, isRequired, label, message, value, ...restProps } = modifiedProps;
 
   return (
     <div className={classProps.root}>
@@ -22,8 +22,8 @@ export const TextField = (props: SpiritTextFieldProps): JSX.Element => {
         id={id}
         className={classProps.input}
         placeholder={placeholder}
-        disabled={disabled}
-        required={required}
+        disabled={isDisabled}
+        required={isRequired}
         value={value}
       />
       {message && <div className={classProps.message}>{message}</div>}

--- a/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
+++ b/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
@@ -43,7 +43,7 @@ describe('TextField', () => {
     });
 
     it('should have required classname', () => {
-      const dom = render(<TextField type={type as TextFieldType} required />);
+      const dom = render(<TextField type={type as TextFieldType} isRequired />);
 
       const element = dom.container.querySelector('label') as HTMLElement;
       expect(element).toHaveClass(`${expectedClassPrefix}Field__label--required`);

--- a/packages/web-react/src/components/TextField/__tests__/useTextFieldStyleProps.test.tsx
+++ b/packages/web-react/src/components/TextField/__tests__/useTextFieldStyleProps.test.tsx
@@ -24,7 +24,7 @@ describe('useTextFieldStyleProps', () => {
     ['password', 'Password'],
   ])('input type %s', (type, expectedClassPrefix) => {
     it('should return required input', () => {
-      const props = { required: true, type } as SpiritTextFieldProps;
+      const props = { isRequired: true, type } as SpiritTextFieldProps;
       const { result } = renderHook(() => useTextFieldStyleProps(props));
 
       expect(result.current.classProps.label).toBe(

--- a/packages/web-react/src/components/TextField/useTextFieldStyleProps.tsx
+++ b/packages/web-react/src/components/TextField/useTextFieldStyleProps.tsx
@@ -17,7 +17,7 @@ export interface TextFieldStyles {
 
 export function useTextFieldStyleProps(props: SpiritTextFieldProps): TextFieldStyles {
   const { validationState, isLabelHidden, ...restProps } = props;
-  const { disabled, required, type } = restProps;
+  const { isDisabled, isRequired, type } = restProps;
 
   const mainClass = `${capitalize(type)}Field`;
   const textFieldClass = useClassNamePrefix(mainClass);
@@ -30,11 +30,11 @@ export function useTextFieldStyleProps(props: SpiritTextFieldProps): TextFieldSt
   const textFieldMessageClass = `${textFieldClass}__message`;
 
   const rootStyles = classNames(textFieldClass, {
-    [textFieldDisabledClass]: disabled,
+    [textFieldDisabledClass]: isDisabled,
     [textFieldValidationClass]: validationState,
   });
   const labelStyles = classNames(textFieldLabelClass, {
-    [textFieldLabelRequiredClass]: required,
+    [textFieldLabelRequiredClass]: isRequired,
     [textFieldLabelHiddenClass]: isLabelHidden,
   });
 

--- a/packages/web-react/src/types/button.ts
+++ b/packages/web-react/src/types/button.ts
@@ -7,7 +7,7 @@ type ButtonType = 'button' | 'submit' | 'reset';
 
 interface ButtonProps extends ChildrenProps, ClickEvents {
   /** Whether the button is disabled. */
-  disabled?: boolean;
+  isDisabled?: boolean;
 }
 
 export interface AriaButtonElementTypeProps<T extends ElementType = 'button'> {
@@ -50,7 +50,7 @@ export interface SpiritButtonProps<T extends ElementType = 'button'>
   /** The color of the button. */
   color: ButtonColor;
   /** Whether the button should be displayed with a block style. */
-  block?: boolean;
+  isBlock?: boolean;
   /** Whether the button should be displayed as a square. */
   isSquare?: boolean;
   // tag?: ElementType;

--- a/packages/web-react/src/types/checkboxField.ts
+++ b/packages/web-react/src/types/checkboxField.ts
@@ -12,7 +12,7 @@ export interface CheckboxFieldProps extends ChildrenProps, StyleProps, LabelProp
   /** Identificator of input */
   id?: string;
   /** Whether the checkbox is checked */
-  checked?: boolean;
+  isChecked?: boolean;
 }
 
 export interface SpiritCheckboxFieldProps extends CheckboxFieldProps {

--- a/packages/web-react/src/types/shared/inputs.ts
+++ b/packages/web-react/src/types/shared/inputs.ts
@@ -6,7 +6,7 @@ export interface Validation {
   /**
    * Whether user input is required on the input before form submission.
    */
-  required?: boolean;
+  isRequired?: boolean;
 }
 
 export interface InputBase {
@@ -15,7 +15,7 @@ export interface InputBase {
    */
   name?: string;
   /** Whether the input is disabled. */
-  disabled?: boolean;
+  isDisabled?: boolean;
 }
 
 export interface ValueBase<T> {

--- a/packages/web-react/src/types/textField.ts
+++ b/packages/web-react/src/types/textField.ts
@@ -16,9 +16,9 @@ export interface TextFieldProps extends ChildrenProps, StyleProps, LabelProps, I
   /** The placeholder for input. */
   placeholder?: string;
   /** Whether the input is disabled. */
-  disabled?: boolean;
+  isDisabled?: boolean;
   /** Whether the input is required. */
-  required?: boolean;
+  isRequired?: boolean;
   /** Value of the input. */
   value?: string | number;
 }


### PR DESCRIPTION
…#DS-160)

  * we want to use `is` and `has` prefix for boolean props to improve
    readibility
  * also most of the components are not just HTML tag wrappers so it is
    needed to distinguish components API from HTML attributes