### PR TITLE
Test(web-react): Refactor prefix testing into more general provider test

### DIFF
--- a/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
+++ b/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
@@ -1,28 +1,18 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { ClassNamePrefixProvider } from '../../../context/ClassNamePrefixContext';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { AlertColor } from '../../../types';
 import Alert from '../Alert';
 
 describe('Alert', () => {
+  classNamePrefixProviderTest(Alert, 'Alert');
+
   it('should have default classname', () => {
     const dom = render(<Alert />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
-    expect(element).toHaveClass('Alert');
     expect(element).toHaveClass('Alert--success');
-  });
-
-  it('should have classname with lmc prefix', () => {
-    const dom = render(
-      <ClassNamePrefixProvider value="lmc">
-        <Alert />
-      </ClassNamePrefixProvider>,
-    );
-
-    const element = dom.container.querySelector('div') as HTMLElement;
-    expect(element).toHaveClass('lmc-Alert');
   });
 
   it('should render text children', () => {

--- a/packages/web-react/src/components/Button/__tests__/Button.test.tsx
+++ b/packages/web-react/src/components/Button/__tests__/Button.test.tsx
@@ -1,28 +1,17 @@
-import React from 'react';
-import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import Button from '../Button';
-import { ClassNamePrefixProvider } from '../../../context/ClassNamePrefixContext';
 
 describe('Button', () => {
+  classNamePrefixProviderTest(Button, 'Button');
+
   it('should have default classname', () => {
     const dom = render(<Button />);
 
     const element = dom.container.querySelector('button') as HTMLElement;
-    expect(element).toHaveClass('Button');
     expect(element).toHaveClass('Button--primary');
-  });
-
-  it('should have classname with lmc prefix', () => {
-    const dom = render(
-      <ClassNamePrefixProvider value="lmc">
-        <Button />
-      </ClassNamePrefixProvider>,
-    );
-
-    const element = dom.container.querySelector('button') as HTMLElement;
-    expect(element).toHaveClass('lmc-Button');
-    expect(element).toHaveClass('lmc-Button--primary');
   });
 
   it('should render text children', () => {

--- a/packages/web-react/src/components/Button/__tests__/ButtonLink.test.tsx
+++ b/packages/web-react/src/components/Button/__tests__/ButtonLink.test.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
-import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import ButtonLink from '../ButtonLink';
-import { ClassNamePrefixProvider } from '../../../context/ClassNamePrefixContext';
 
 describe('ButtonLink', () => {
+  classNamePrefixProviderTest(ButtonLink, 'Button');
+
   it('should have default classname', () => {
     const { container } = render(<ButtonLink />);
 
     const element = container.querySelector('a') as HTMLElement;
-    expect(element).toHaveClass('Button');
     expect(element).toHaveClass('Button--primary');
   });
 
@@ -21,18 +22,12 @@ describe('ButtonLink', () => {
     expect(element).toHaveClass('Button--disabled');
   });
 
-  it('should have classname with lmc prefix', () => {
-    const { container } = render(
-      <ClassNamePrefixProvider value="lmc">
-        <ButtonLink isDisabled isBlock />
-      </ClassNamePrefixProvider>,
-    );
+  it('should have block classname', () => {
+    const { container } = render(<ButtonLink isBlock />);
 
     const element = container.querySelector('a') as HTMLElement;
-    expect(element).toHaveClass('lmc-Button');
-    expect(element).toHaveClass('lmc-Button--primary');
-    expect(element).toHaveClass('lmc-Button--block');
-    expect(element).toHaveClass('lmc-Button--disabled');
+    expect(element).toHaveClass('Button');
+    expect(element).toHaveClass('Button--block');
   });
 
   it('should render text children', () => {

--- a/packages/web-react/src/components/CheckboxField/__tests__/CheckboxField.test.tsx
+++ b/packages/web-react/src/components/CheckboxField/__tests__/CheckboxField.test.tsx
@@ -2,26 +2,10 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import CheckboxField from '../CheckboxField';
-import { ClassNamePrefixProvider } from '../../../context/ClassNamePrefixContext';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 
 describe('CheckboxField', () => {
-  it('should have default classname', () => {
-    const dom = render(<CheckboxField />);
-
-    const element = dom.container.querySelector('label') as HTMLElement;
-    expect(element).toHaveClass('CheckboxField');
-  });
-
-  it('should have classname with lmc prefix', () => {
-    const dom = render(
-      <ClassNamePrefixProvider value="lmc">
-        <CheckboxField />
-      </ClassNamePrefixProvider>,
-    );
-
-    const element = dom.container.querySelector('label') as HTMLElement;
-    expect(element).toHaveClass('lmc-CheckboxField');
-  });
+  classNamePrefixProviderTest(CheckboxField, 'CheckboxField');
 
   it('should have text classname', () => {
     const dom = render(<CheckboxField />);

--- a/packages/web-react/src/components/Container/__tests__/Container.test.tsx
+++ b/packages/web-react/src/components/Container/__tests__/Container.test.tsx
@@ -2,26 +2,10 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Container from '../Container';
-import { ClassNamePrefixProvider } from '../../../context/ClassNamePrefixContext';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 
 describe('Container', () => {
-  it('should have default classname', () => {
-    const dom = render(<Container />);
-
-    const element = dom.container.querySelector('div') as HTMLElement;
-    expect(element).toHaveClass('Container');
-  });
-
-  it('should have classname with lmc prefix', () => {
-    const dom = render(
-      <ClassNamePrefixProvider value="lmc">
-        <Container />
-      </ClassNamePrefixProvider>,
-    );
-
-    const element = dom.container.querySelector('div') as HTMLElement;
-    expect(element).toHaveClass('lmc-Container');
-  });
+  classNamePrefixProviderTest(Container, 'Container');
 
   it('should render text children', () => {
     const dom = render(<Container>Hello World</Container>);

--- a/packages/web-react/src/components/Grid/__tests__/Grid.test.tsx
+++ b/packages/web-react/src/components/Grid/__tests__/Grid.test.tsx
@@ -1,27 +1,11 @@
-import React from 'react';
-import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import Grid from '../Grid';
-import { ClassNamePrefixProvider } from '../../../context/ClassNamePrefixContext';
 
 describe('Grid', () => {
-  it('should have default classname', () => {
-    const dom = render(<Grid />);
-
-    const element = dom.container.querySelector('div') as HTMLElement;
-    expect(element).toHaveClass('Grid');
-  });
-
-  it('should have classname with lmc prefix', () => {
-    const dom = render(
-      <ClassNamePrefixProvider value="lmc">
-        <Grid />
-      </ClassNamePrefixProvider>,
-    );
-
-    const element = dom.container.querySelector('div') as HTMLElement;
-    expect(element).toHaveClass('lmc-Grid');
-  });
+  classNamePrefixProviderTest(Grid, 'Grid');
 
   it('should render text children', () => {
     const dom = render(<Grid>Hello World</Grid>);

--- a/packages/web-react/src/components/Link/__tests__/Link.test.tsx
+++ b/packages/web-react/src/components/Link/__tests__/Link.test.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import Link from '../Link';
-import { ClassNamePrefixProvider } from '../../../context/ClassNamePrefixContext';
-import linkPropsDataProvider from './linkPropsDataProvider';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { LinkColor } from '../../../types';
+import Link from '../Link';
+import linkPropsDataProvider from './linkPropsDataProvider';
 
 describe('Link', () => {
   it.each(linkPropsDataProvider)('should have class', (color, isUnderlined, isDisabled, expectedClassName) => {
@@ -20,13 +20,5 @@ describe('Link', () => {
     expect(dom.container.querySelector('a')).toHaveClass(expectedClassName as string);
   });
 
-  it('should have classname with lmc prefix', () => {
-    const dom = render(
-      <ClassNamePrefixProvider value="lmc">
-        <Link href="/" color="primary" />
-      </ClassNamePrefixProvider>,
-    );
-
-    expect(dom.container.querySelector('a')).toHaveClass('lmc-link-primary');
-  });
+  classNamePrefixProviderTest(Link, 'link-primary');
 });

--- a/packages/web-react/src/components/Stack/__tests__/Stack.test.tsx
+++ b/packages/web-react/src/components/Stack/__tests__/Stack.test.tsx
@@ -1,27 +1,11 @@
-import React from 'react';
-import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import Stack from '../Stack';
-import { ClassNamePrefixProvider } from '../../../context/ClassNamePrefixContext';
 
 describe('Stack', () => {
-  it('should have default classname', () => {
-    const dom = render(<Stack />);
-
-    const element = dom.container.querySelector('div') as HTMLElement;
-    expect(element).toHaveClass('Stack');
-  });
-
-  it('should have classname with lmc prefix', () => {
-    const dom = render(
-      <ClassNamePrefixProvider value="lmc">
-        <Stack />
-      </ClassNamePrefixProvider>,
-    );
-
-    const element = dom.container.querySelector('div') as HTMLElement;
-    expect(element).toHaveClass('lmc-Stack');
-  });
+  classNamePrefixProviderTest(Stack, 'Stack');
 
   it('should render text children', () => {
     const dom = render(<Stack>Hello World</Stack>);

--- a/packages/web-react/src/components/Tag/__tests__/Tag.test.tsx
+++ b/packages/web-react/src/components/Tag/__tests__/Tag.test.tsx
@@ -2,24 +2,14 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Tag from '../Tag';
-import { ClassNamePrefixProvider } from '../../../context/ClassNamePrefixContext';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 
 describe('Tag', () => {
+  classNamePrefixProviderTest(Tag, 'Tag');
+
   it('should have default classname', () => {
     const dom = render(<Tag />);
 
-    expect(dom.container.firstChild).toHaveClass('Tag');
     expect(dom.container.firstChild).toHaveClass('Tag--default-dark');
-  });
-
-  it('should have classname with lmc prefix', () => {
-    const dom = render(
-      <ClassNamePrefixProvider value="lmc">
-        <Tag />
-      </ClassNamePrefixProvider>,
-    );
-
-    expect(dom.container.firstChild).toHaveClass('lmc-Tag');
-    expect(dom.container.firstChild).toHaveClass('lmc-Tag--default-dark');
   });
 });

--- a/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
+++ b/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
@@ -2,28 +2,12 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import TextField from '../TextField';
-import { ClassNamePrefixProvider } from '../../../context/ClassNamePrefixContext';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { TextFieldType, ValidationState } from '../../../types';
 
 describe('TextField', () => {
   describe.each(['text', 'password', 'email'])('input type %s', (type) => {
-    it('should have default classname', () => {
-      const dom = render(<TextField type={type as TextFieldType} />);
-
-      const element = dom.container.querySelector('div') as HTMLElement;
-      expect(element).toHaveClass(`TextField`);
-    });
-
-    it('should have classname with lmc prefix', () => {
-      const dom = render(
-        <ClassNamePrefixProvider value="lmc">
-          <TextField type={type as TextFieldType} />
-        </ClassNamePrefixProvider>,
-      );
-
-      const element = dom.container.querySelector('div') as HTMLElement;
-      expect(element).toHaveClass(`lmc-TextField`);
-    });
+    classNamePrefixProviderTest(TextField, 'TextField');
 
     it('should have label classname', () => {
       const dom = render(<TextField type={type as TextFieldType} />);

--- a/packages/web-react/tests/providerTests/classNamePrefixProviderTest.tsx
+++ b/packages/web-react/tests/providerTests/classNamePrefixProviderTest.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import React, { ComponentType } from 'react';
+import { ClassNamePrefixProvider } from '../../src/context/ClassNamePrefixContext';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const classNamePrefixProviderTest = (Component: ComponentType<any>, className: string) => {
+  it('renders with class name prefix', () => {
+    const prefix = 'lmc';
+    const dom = render(
+      <ClassNamePrefixProvider value={prefix}>
+        <Component />
+      </ClassNamePrefixProvider>,
+    );
+
+    const element = dom.container.firstChild as HTMLElement;
+    expect(element).toHaveClass(`${prefix}-${className}`);
+  });
+
+  it('renders without class name prefix', () => {
+    const dom = render(<Component />);
+
+    const element = dom.container.firstChild as HTMLElement;
+    expect(element).toHaveClass(className);
+  });
+};


### PR DESCRIPTION
Removing repeating prefix text and refactoring them into a more general one which is included as a single test function.