### PR TITLE
Deps: Update dependency @lmc-eu/conventional-changelog-lmc-github to …

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@babel/preset-react": "7.16.7",
     "@commitlint/cli": "16.2.3",
     "@lmc-eu/commitlint-config": "1.0.12",
-    "@lmc-eu/conventional-changelog-lmc-github": "2.0.3",
+    "@lmc-eu/conventional-changelog-lmc-github": "2.0.4",
     "@lmc-eu/eslint-config-react": "1.0.1",
     "@lmc-eu/prettier-config": "1.2.3",
     "@storybook/addon-actions": "6.4.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2656,10 +2656,10 @@
     compare-func "^2.0.0"
     q "^1.5.1"
 
-"@lmc-eu/conventional-changelog-lmc-github@2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@lmc-eu/conventional-changelog-lmc-github/-/conventional-changelog-lmc-github-2.0.3.tgz#f7821b92f7564e612ade9effc404e0aea15d6d97"
-  integrity sha512-SDYgCI6x+G+k+8ksu0UtKxPu8f2uvRdb71z46tfTSry08DOVJ8XYjJR2GJzig3dk84wxMKPUTNtpinU2zREPaA==
+"@lmc-eu/conventional-changelog-lmc-github@2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@lmc-eu/conventional-changelog-lmc-github/-/conventional-changelog-lmc-github-2.0.4.tgz#9e6a47a51a7c957deceb0135a04245604a742d3a"
+  integrity sha512-0d+VUIWih5ONPUJUndxQbTw6GgQUxr1/2IWQSymNuwkoTuqLiEpTSiiv9c7XVF73WnyLA6/eWseJMecZp8umWQ==
   dependencies:
     compare-func "^2.0.0"
     q "^1.5.1"


### PR DESCRIPTION
…2.0.4

  * fixes missing `BREAKING CHANGES` commit type in changelog