### PR TITLE
Fix(web-react): Add missing default prop size for Heading component

### DIFF
--- a/packages/web-react/src/components/Heading/Heading.tsx
+++ b/packages/web-react/src/components/Heading/Heading.tsx
@@ -3,6 +3,10 @@ import { useHeadingStyleProps } from './useHeadingStyleProps';
 import { SpiritHeadingProps } from '../../types';
 import { filterProps } from '../../utils/filterProps';
 
+const defaultProps = {
+  size: 'medium',
+};
+
 export const Heading = <T extends ElementType = 'div'>(props: SpiritHeadingProps<T>): JSX.Element => {
   const { elementType: ElementTag = 'div', children, ...restProps } = props;
   const { classProps, props: modifiedProps } = useHeadingStyleProps(restProps);
@@ -13,5 +17,7 @@ export const Heading = <T extends ElementType = 'div'>(props: SpiritHeadingProps
     </ElementTag>
   );
 };
+
+Heading.defaultProps = defaultProps;
 
 export default Heading;

--- a/packages/web-react/src/components/Heading/__tests__/Heading.test.tsx
+++ b/packages/web-react/src/components/Heading/__tests__/Heading.test.tsx
@@ -2,24 +2,16 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Heading from '../Heading';
-import { ClassNamePrefixProvider } from '../../../context/ClassNamePrefixContext';
 import headingSizeDataProvider from './headingSizeDataProvider';
 import { HeadingSize } from '../../../types';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 
 describe('Heading', () => {
+  classNamePrefixProviderTest(Heading, 'typography-heading-medium-text');
+
   it.each(headingSizeDataProvider)('should have for size %s an expected class %s', (size, expectedClassName) => {
     const dom = render(<Heading size={size as HeadingSize} />);
 
     expect(dom.container.querySelector('div')).toHaveClass(expectedClassName);
-  });
-
-  it('should have classname with lmc prefix', () => {
-    const dom = render(
-      <ClassNamePrefixProvider value="lmc">
-        <Heading size="xlarge" />
-      </ClassNamePrefixProvider>,
-    );
-
-    expect(dom.container.querySelector('div')).toHaveClass('lmc-typography-heading-xlarge-text');
   });
 });

--- a/packages/web-react/src/components/Heading/stories/Heading.tsx
+++ b/packages/web-react/src/components/Heading/stories/Heading.tsx
@@ -9,7 +9,6 @@ const Story: ComponentStory<typeof Heading> = <T extends ElementType = 'div'>(ar
 
 Story.args = {
   children: 'Heading Text',
-  size: 'medium',
 };
 
 export default Story;


### PR DESCRIPTION
Disscused on Slack (private): https://lmccz.slack.com/archives/DHNJX3A2F/p1649858291902679

https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web-react/src/components/Heading

have not optional type size and have no default.