### PR TITLE
Fix(web): Reset vertical margin of `Stack` children

### DIFF
--- a/packages/web/src/scss/components/Stack/README.md
+++ b/packages/web/src/scss/components/Stack/README.md
@@ -3,6 +3,8 @@
 Use Stack to vertically space content. It works with lists or any other HTML elements.
 It can be used to separate form fields, for example.
 
+👉 Vertical margin of items inside Stack is reset to zero.
+
 ```html
 <div class="Stack">
   <div class="TextField">

--- a/packages/web/src/scss/components/Stack/_Stack.scss
+++ b/packages/web/src/scss/components/Stack/_Stack.scss
@@ -7,3 +7,7 @@
     margin-block: 0;
     list-style: none;
 }
+
+.Stack > * {
+    margin-block: 0;
+}


### PR DESCRIPTION
So we don't have to do this:

```html
<div class="Stack">
  <p class="mb-0">
  <p class="mb-0">
</div>
```