### PR TITLE
Fix(web): Load script using defer instead of async in examples

### DIFF
--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -14,7 +14,7 @@
     <link rel="stylesheet" href="built/utilities.min.css">
 
     <!-- Load Spirit JS. -->
-    <script src="built/spirit-web.js" async></script>
+    <script src="built/spirit-web.js" defer></script>
 
     <style>
       .example-box {


### PR DESCRIPTION
   * causes not proper loading of the bundle in safari
   * DOMContentLoaded event is sometimes trigger earlier then script is
     ready