### PR TITLE
Chore(ci): Do not run Netlify deploy when upgrading dependencies

### DIFF
--- a/packages/web/netlify.toml
+++ b/packages/web/netlify.toml
@@ -17,3 +17,10 @@
 
   # Default build command.
   command = "yarn examples:build"
+
+  # Ignore builds on Netlify
+  ignore = "node ../../scripts/ignoreNetlifyBuilds.js"
+
+[context.deploy-preview]
+  # Deploy preview only if there are changes in some directories
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./src/"

--- a/scripts/ignoreNetlifyBuilds.js
+++ b/scripts/ignoreNetlifyBuilds.js
@@ -1,0 +1,4 @@
+// Ignore Netlify Builds
+// @see: https://docs.netlify.com/configure-builds/ignore-builds/
+// @see: https://answers.netlify.com/t/support-guide-how-to-use-the-ignore-command/37517
+process.exitCode = process.env.BRANCH.includes('dependencies') ? 0 : 1;


### PR DESCRIPTION
  * or updating code outside of package source directory

Saving time, build minutes and money. It is tested enough using `Test Build`