### PR TITLE
Fix(web): Find related header nav element base on data target attribute

### DIFF
--- a/packages/web/src/js/Header.ts
+++ b/packages/web/src/js/Header.ts
@@ -6,6 +6,7 @@ import { enableToggleTrigger } from './utils/ComponentFunctions';
 const NAME = 'header';
 const HEADER_TOGGLE_SELECTOR = '[data-toggle="header"]';
 const HEADER_DISMISS_ATTRIBUTE = 'data-dismiss';
+const HEADER_TARGET_ATTRIBUTE = 'data-target';
 const HEADER_BREAKPOINT = 1280;
 const OPEN_CLASSNAME = 'is-open';
 const BACKDROP_TAG_NAME = 'div';
@@ -38,9 +39,7 @@ class Header extends BaseComponent {
   }
 
   static findRelatedNavElement(target: HTMLElement) {
-    const headerEl = (target.parentElement as HTMLElement).parentElement;
-
-    return SelectorEngine.findOne('nav', headerEl as HTMLElement);
+    return SelectorEngine.findOne(target.getAttribute(HEADER_TARGET_ATTRIBUTE));
   }
 
   // Using `unknown` - Object is possibly 'null'.

--- a/packages/web/src/js/Header.ts
+++ b/packages/web/src/js/Header.ts
@@ -116,9 +116,10 @@ class Header extends BaseComponent {
       target = event.target.parentNode;
     }
 
-    const headerEl = target.parentElement;
+    const navEl = Header.findRelatedNavElement(target) || target;
+    const headerEl = navEl.parentElement;
     const toggleEl = SelectorEngine.findOne(HEADER_TOGGLE_SELECTOR, headerEl);
-    target.classList.remove(OPEN_CLASSNAME);
+    navEl.classList.remove(OPEN_CLASSNAME);
     toggleEl.setAttribute('aria-expanded', 'false');
 
     this.removeEventListeners();


### PR DESCRIPTION
Fixed desktop dialog which was not opening.

![Screenshot 2022-06-13 at 13 05 53](https://user-images.githubusercontent.com/2481010/173341008-96a33c54-936a-4e47-a12d-35199785766f.png)
