### PR TITLE
Fix(web): Trick to start animation when inject backdrop (refs #DS-218)

### DIFF
--- a/packages/web/src/js/Header.ts
+++ b/packages/web/src/js/Header.ts
@@ -2,6 +2,7 @@ import SelectorEngine from './dom/SelectorEngine';
 import EventHandler from './dom/EventHandler';
 import BaseComponent from './BaseComponent';
 import { enableToggleTrigger } from './utils/ComponentFunctions';
+import { reflow } from './utils';
 
 const NAME = 'header';
 const HEADER_TOGGLE_SELECTOR = '[data-toggle="header"]';
@@ -33,6 +34,7 @@ class Header extends BaseComponent {
 
     if (!SelectorEngine.findAll(`[class*="${BACKDROP_CLASSNAME}"]`, target).length) {
       Header.findRelatedNavElement(target).appendChild(backdropEl);
+      reflow(backdropEl);
     }
 
     return backdropEl;

--- a/packages/web/src/js/Modal.ts
+++ b/packages/web/src/js/Modal.ts
@@ -1,7 +1,7 @@
-import SelectorEngine from './dom/SelectorEngine';
-import EventHandler from './dom/EventHandler';
 import BaseComponent from './BaseComponent';
-import { getElementFromSelector } from './utils/index';
+import EventHandler from './dom/EventHandler';
+import SelectorEngine from './dom/SelectorEngine';
+import { getElementFromSelector, reflow } from './utils';
 
 const MODAL_TOGGLE_SELECTOR = '[data-toggle="modal"]';
 const MODAL_DISMISS_ATTRIBUTE = 'data-dismiss';
@@ -25,6 +25,7 @@ class Modal extends BaseComponent {
 
     if (!SelectorEngine.findAll(`[class*="${BACKDROP_CLASSNAME}"]`, target).length) {
       target.appendChild(backdropEl);
+      reflow(backdropEl);
     }
 
     return backdropEl;

--- a/packages/web/src/js/utils/__tests__/index.test.ts
+++ b/packages/web/src/js/utils/__tests__/index.test.ts
@@ -1,5 +1,5 @@
-import * as Util from '../index';
 import { clearFixture, getFixture } from '../../../../tests/helpers/fixture';
+import * as Util from '../index';
 
 describe('Util', () => {
   let fixtureEl: Element;
@@ -64,6 +64,17 @@ describe('Util', () => {
       expect(Util.getElement()).toBeNull();
       expect(Util.getElement(null)).toBeNull();
       expect(Util.getElement(fixtureEl.querySelectorAll('.test'))).toBeNull();
+    });
+  });
+
+  describe('reflow', () => {
+    it('should return element offset height to force the reflow', () => {
+      fixtureEl.innerHTML = '<div></div>';
+
+      const div = fixtureEl.querySelector('div') as HTMLElement;
+      const spy = jest.spyOn(div, 'offsetHeight', 'get').mockReturnValue(0);
+      Util.reflow(div);
+      expect(spy).toHaveBeenCalled();
     });
   });
 });

--- a/packages/web/src/js/utils/index.ts
+++ b/packages/web/src/js/utils/index.ts
@@ -28,4 +28,15 @@ const getElementFromSelector = (element: HTMLElement): HTMLElement | null => {
   return selector ? document.querySelector(selector) : null;
 };
 
-export { isElement, getElement, getSelector, getElementFromSelector };
+/**
+ * Trick to restart an element's animation
+ *
+ * @param element
+ * @see https://www.charistheo.io/blog/2021/02/restart-a-css-animation-with-javascript/#restarting-a-css-animation
+ */
+const reflow = (element: HTMLElement): void => {
+  // eslint-disable-next-line no-unused-expressions
+  element.offsetHeight;
+};
+
+export { isElement, getElement, getSelector, getElementFromSelector, reflow };


### PR DESCRIPTION
Using this quick fix https://www.charistheo.io/blog/2021/02/restart-a-css-animation-with-javascript/#restarting-a-css-animation to restart animation when backdrop is injected.