### PR TITLE
Chore: Move tsconfigs to package root

### DIFF
--- a/packages/web-react/config/tsconfig.eslint.json
+++ b/packages/web-react/config/tsconfig.eslint.json
@@ -1,4 +1,4 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../tsconfig.json",
   "include": ["../", "../.eslintrc.js", "../.babelrc.js"]
 }

--- a/packages/web-react/config/tsconfig.prod.json
+++ b/packages/web-react/config/tsconfig.prod.json
@@ -1,7 +1,9 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
+    "module": "es2015",
+    "target": "es2015",
     "noEmit": false
   },
-  "exclude": ["../src/**/__tests__/**/*", "../src/**/*.stories.tsx", "../docs/**/*", "../src/**/stories/**/*"]
+  "exclude": ["../docs/**/*", "../src/**/__tests__/**/*", "../src/**/*.stories.tsx", "../src/**/stories/**/*"]
 }

--- a/packages/web-react/package.json
+++ b/packages/web-react/package.json
@@ -76,7 +76,7 @@
     "build:esNext": "echo tsc --module esNext --outDir dist/_esNext --project ./config/tsconfig.prod.json",
     "postbuild": "yarn prepdist && yarn resolve && yarn build:cjs",
     "prepdist": "node ./scripts/prepareDist.js",
-    "types": "tsc -p ./config/tsconfig.json",
+    "types": "tsc",
     "webpack:dev": "webpack --mode development --config ./config/webpack.js --progress",
     "webpack:prod": "webpack --mode production --config ./config/webpack.js --progress",
     "webpack:browser": "webpack --mode production --config ./config/webpack.browser.js --progress",

--- a/packages/web-react/scripts/resolveModuleIds.ts
+++ b/packages/web-react/scripts/resolveModuleIds.ts
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies, no-shadow, no-console */
 import * as fs from 'fs';
 import * as path from 'path';
-import requireResolve from 'resolve';
 import * as recast from 'recast';
+import requireResolve from 'resolve';
 import { distDir, eachFile, reparse, reprint } from './helpers';
 
 // The primary goal of the 'npm run resolve' script is to make ECMAScript

--- a/packages/web-react/tsconfig.json
+++ b/packages/web-react/tsconfig.json
@@ -2,14 +2,12 @@
   "compileOnSave": true,
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "../dist",
+    "outDir": "./dist",
     "sourceMap": true,
     "declaration": true,
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "module": "es2015",
-    "target": "es2015",
     "noEmit": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
@@ -28,6 +26,6 @@
     "typeRoots": ["./node_modules/@types"],
     "lib": ["es2015", "dom", "dom.iterable"]
   },
-  "include": ["../src/**/*"],
-  "exclude": ["../node_modules", "../dist/**/*"]
+  "include": ["./src/**/*"],
+  "exclude": ["./node_modules", "./dist/**/*"]
 }

--- a/packages/web/config/rollup.config.js
+++ b/packages/web/config/rollup.config.js
@@ -19,7 +19,11 @@ const plugins = [
     // Include the helpers in the bundle, at most one copy of each
     babelHelpers: 'bundled',
   }),
-  typescript({ target: 'es6' }),
+  typescript({
+    target: 'es6',
+    compilerOptions: { rootDir: './src' },
+    exclude: ['**/__tests__', '**/*.test.ts'],
+  }),
 ];
 
 if (BUNDLE) {

--- a/packages/web/config/tsconfig.eslint.json
+++ b/packages/web/config/tsconfig.eslint.json
@@ -1,4 +1,4 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../tsconfig.json",
   "include": ["../", "../.eslintrc.js", "../.babelrc.js"]
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -42,7 +42,7 @@
     "test:unit": "jest --config ./config/jest.config.js",
     "test:unit:watch": "yarn test:unit --watchAll",
     "test:unit:coverage": "yarn test:unit --coverage",
-    "types": "tsc -p ./config/tsconfig.json"
+    "types": "tsc"
   },
   "dependencies": {
     "@csstools/normalize.css": "^12.0.0",

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -2,7 +2,7 @@
   "compileOnSave": true,
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "../dist/js",
+    "outDir": "./dist/js",
     "sourceMap": true,
     "declaration": true,
     "moduleResolution": "node",
@@ -24,10 +24,10 @@
     "strictFunctionTypes": true,
     "noImplicitAny": true,
     "esModuleInterop": true,
-    "typeRoots": ["../../../node_modules/@types"],
+    "typeRoots": ["../../node_modules/@types"],
     "lib": ["es2015", "dom", "dom.iterable"],
     "types": ["node", "jest"]
   },
-  "include": ["../src/**/*"],
-  "exclude": ["../node_modules", "../dist/**/*"]
+  "include": ["./src/**/*"],
+  "exclude": ["./node_modules", "./dist/**/*"]
 }


### PR DESCRIPTION
  * IDEs try to search for tsconfig.json in package root to enable
    language support
  * changed paths in extended tsconfigs for linting
  * moved some build options to appropriate tsconfigs