### PR TITLE
Fix(web-react): Pass rest props to input element in field components

### DIFF
--- a/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
+++ b/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { AlertColor } from '../../../types';
 import Alert from '../Alert';
 
@@ -10,6 +11,8 @@ describe('Alert', () => {
   classNamePrefixProviderTest(Alert, 'Alert');
 
   stylePropsTest(Alert);
+
+  restPropsTest(Alert, 'div');
 
   it('should have default classname', () => {
     const dom = render(<Alert />);

--- a/packages/web-react/src/components/Button/Button.tsx
+++ b/packages/web-react/src/components/Button/Button.tsx
@@ -1,5 +1,5 @@
-import React, { ElementType } from 'react';
 import classNames from 'classnames';
+import React, { ElementType } from 'react';
 import { useStyleProps } from '../../hooks/styleProps';
 import { SpiritButtonProps } from '../../types';
 import { useButtonAriaProps } from './useButtonAriaProps';
@@ -17,11 +17,16 @@ const defaultProps = {
 export const Button = <T extends ElementType = 'button'>(props: SpiritButtonProps<T>): JSX.Element => {
   const { elementType: ElementTag = 'button', children, ...restProps } = props;
   const { buttonProps } = useButtonAriaProps(props);
-  const { classProps } = useButtonStyleProps(restProps);
-  const { styleProps } = useStyleProps(restProps);
+  const { classProps, props: modifiedProps } = useButtonStyleProps(restProps);
+  const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
 
   return (
-    <ElementTag {...styleProps} {...buttonProps} className={classNames(classProps, styleProps.className)}>
+    <ElementTag
+      {...otherProps}
+      {...styleProps}
+      {...buttonProps}
+      className={classNames(classProps, styleProps.className)}
+    >
       {children}
     </ElementTag>
   );

--- a/packages/web-react/src/components/Button/ButtonLink.tsx
+++ b/packages/web-react/src/components/Button/ButtonLink.tsx
@@ -1,29 +1,34 @@
-import React, { ElementType } from 'react';
 import classNames from 'classnames';
-import { SpiritButtonProps } from '../../types';
+import React, { ElementType } from 'react';
 import { useStyleProps } from '../../hooks/styleProps';
+import { SpiritButtonProps } from '../../types';
 import { useButtonAriaProps } from './useButtonAriaProps';
 import { useButtonStyleProps } from './useButtonStyleProps';
 
 const defaultProps = {
   color: 'primary',
   href: '#',
-  block: false,
-  disabled: false,
+  isBlock: false,
+  isDisabled: false,
   isSquare: false,
   elementType: 'a',
 };
 
 export const ButtonLink = <T extends ElementType = 'a'>(props: SpiritButtonProps<T>): JSX.Element => {
-  const { children, ...restProps } = props;
+  const { elementType: ElementTag = 'a', children, ...restProps } = props;
   const { buttonProps } = useButtonAriaProps(props);
-  const { classProps } = useButtonStyleProps(restProps);
-  const { styleProps } = useStyleProps(restProps);
+  const { classProps, props: modifiedProps } = useButtonStyleProps(restProps);
+  const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
 
   return (
-    <a {...styleProps} {...buttonProps} className={classNames(classProps, styleProps.className)}>
+    <ElementTag
+      {...otherProps}
+      {...styleProps}
+      {...buttonProps}
+      className={classNames(classProps, styleProps.className)}
+    >
       {children}
-    </a>
+    </ElementTag>
   );
 };
 

--- a/packages/web-react/src/components/Button/__tests__/Button.test.tsx
+++ b/packages/web-react/src/components/Button/__tests__/Button.test.tsx
@@ -3,12 +3,15 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import Button from '../Button';
 
 describe('Button', () => {
   classNamePrefixProviderTest(Button, 'Button');
 
   stylePropsTest(Button);
+
+  restPropsTest(Button, 'button');
 
   it('should have default classname', () => {
     const dom = render(<Button />);

--- a/packages/web-react/src/components/Button/__tests__/ButtonLink.test.tsx
+++ b/packages/web-react/src/components/Button/__tests__/ButtonLink.test.tsx
@@ -3,12 +3,15 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import ButtonLink from '../ButtonLink';
 
 describe('ButtonLink', () => {
   classNamePrefixProviderTest(ButtonLink, 'Button');
 
   stylePropsTest(ButtonLink);
+
+  restPropsTest(ButtonLink, 'a');
 
   it('should have default classname', () => {
     const { container } = render(<ButtonLink />);

--- a/packages/web-react/src/components/Button/useButtonStyleProps.tsx
+++ b/packages/web-react/src/components/Button/useButtonStyleProps.tsx
@@ -9,13 +9,17 @@ import { ButtonColor, SpiritButtonProps } from '../../types';
 const getButtonColorClassname = (className: string, color: ButtonColor): string =>
   compose(applyColor<ButtonColor>(color))(className);
 
-export interface ButtonStyles {
+export interface ButtonStyles<T> {
   /** className props */
   classProps: string;
+  /** Props for the button element */
+  props: T;
 }
 
-export function useButtonStyleProps<T extends ElementType = 'button'>(props: SpiritButtonProps<T>): ButtonStyles {
-  const { color, isBlock, isDisabled, isSquare } = props;
+export function useButtonStyleProps<T extends ElementType = 'button'>(
+  props: SpiritButtonProps<T>,
+): ButtonStyles<Omit<SpiritButtonProps<T>, 'color'>> {
+  const { color, isBlock, isDisabled, isSquare, ...restProps } = props;
 
   const buttonClass = useClassNamePrefix('Button');
   const buttonBlockClass = `${buttonClass}--block`;

--- a/packages/web-react/src/components/Button/useButtonStyleProps.tsx
+++ b/packages/web-react/src/components/Button/useButtonStyleProps.tsx
@@ -35,5 +35,6 @@ export function useButtonStyleProps<T extends ElementType = 'button'>(props: Spi
 
   return {
     classProps,
+    props: restProps,
   };
 }

--- a/packages/web-react/src/components/CheckboxField/CheckboxField.tsx
+++ b/packages/web-react/src/components/CheckboxField/CheckboxField.tsx
@@ -1,17 +1,18 @@
-import React from 'react';
 import classNames from 'classnames';
-import { SpiritCheckboxFieldProps } from '../../types';
+import React from 'react';
 import { useStyleProps } from '../../hooks/styleProps';
+import { SpiritCheckboxFieldProps } from '../../types';
 import { useCheckboxFieldStyleProps } from './useCheckboxFieldStyleProps';
 
 export const CheckboxField = (props: SpiritCheckboxFieldProps): JSX.Element => {
   const { classProps, props: modifiedProps } = useCheckboxFieldStyleProps(props);
   const { id, label, message, value, isDisabled, isRequired, isChecked, ...restProps } = modifiedProps;
-  const { styleProps } = useStyleProps(restProps);
+  const { styleProps, props: otherProps } = useStyleProps(restProps);
 
   return (
     <div {...styleProps} className={classNames(classProps.root, styleProps.className)}>
       <input
+        {...otherProps}
         type="checkbox"
         id={id}
         className={classProps.input}

--- a/packages/web-react/src/components/CheckboxField/__tests__/CheckboxField.test.tsx
+++ b/packages/web-react/src/components/CheckboxField/__tests__/CheckboxField.test.tsx
@@ -1,14 +1,17 @@
-import React from 'react';
-import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import CheckboxField from '../CheckboxField';
+import { render } from '@testing-library/react';
+import React from 'react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
+import CheckboxField from '../CheckboxField';
 
 describe('CheckboxField', () => {
   classNamePrefixProviderTest(CheckboxField, 'CheckboxField');
 
   stylePropsTest(CheckboxField);
+
+  restPropsTest(CheckboxField, 'input');
 
   it('should have text classname', () => {
     const dom = render(<CheckboxField />);

--- a/packages/web-react/src/components/Container/Container.tsx
+++ b/packages/web-react/src/components/Container/Container.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import classNames from 'classnames';
+import React from 'react';
 import { useStyleProps } from '../../hooks/styleProps';
 import { useClassNamePrefix } from '../../hooks/useClassNamePrefix';
 import { ChildrenProps, StyleProps } from '../../types';
@@ -8,10 +8,10 @@ export interface ContainerProps extends ChildrenProps, StyleProps {}
 
 export const Container = ({ children, ...restProps }: ContainerProps): JSX.Element => {
   const containerClass = useClassNamePrefix('Container');
-  const { styleProps } = useStyleProps(restProps);
+  const { styleProps, props: otherProps } = useStyleProps(restProps);
 
   return (
-    <div {...styleProps} className={classNames(containerClass, styleProps.className)}>
+    <div {...otherProps} {...styleProps} className={classNames(containerClass, styleProps.className)}>
       {children}
     </div>
   );

--- a/packages/web-react/src/components/Container/__tests__/Container.test.tsx
+++ b/packages/web-react/src/components/Container/__tests__/Container.test.tsx
@@ -4,11 +4,14 @@ import '@testing-library/jest-dom';
 import Container from '../Container';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 
 describe('Container', () => {
   classNamePrefixProviderTest(Container, 'Container');
 
   stylePropsTest(Container);
+
+  restPropsTest(Container, 'div');
 
   it('should render text children', () => {
     const dom = render(<Container>Hello World</Container>);

--- a/packages/web-react/src/components/Grid/__tests__/Grid.test.tsx
+++ b/packages/web-react/src/components/Grid/__tests__/Grid.test.tsx
@@ -3,12 +3,15 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import Grid from '../Grid';
 
 describe('Grid', () => {
   classNamePrefixProviderTest(Grid, 'Grid');
 
   stylePropsTest(Grid);
+
+  restPropsTest(Grid, 'div');
 
   it('should render text children', () => {
     const dom = render(<Grid>Hello World</Grid>);

--- a/packages/web-react/src/components/Header/__tests__/Header.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/Header.test.tsx
@@ -4,11 +4,14 @@ import React from 'react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import Header from '../Header';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 
 describe('Header', () => {
   classNamePrefixProviderTest(Header, 'Header');
 
   stylePropsTest((props) => <Header {...props} data-testid="header-test" />, 'header-test');
+
+  restPropsTest((props) => <Header {...props} />, 'header');
 
   it('should render text children', () => {
     const dom = render(<Header id="test">Hello World</Header>);

--- a/packages/web-react/src/components/Header/__tests__/HeaderActions.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderActions.test.tsx
@@ -4,6 +4,7 @@ import { classNamePrefixProviderTest } from '../../../../tests/providerTests/cla
 import { renderWithHeaderContext, withHeader } from '../../../../tests/testUtils';
 import HeaderActions from '../HeaderActions';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 
 describe('HeaderActions', () => {
   classNamePrefixProviderTest(
@@ -19,6 +20,11 @@ describe('HeaderActions', () => {
       </HeaderActions>
     )),
     'header-actions-test',
+  );
+
+  restPropsTest(
+    withHeader((props) => <HeaderActions {...props}>Hello World</HeaderActions>),
+    'div',
   );
 
   it('should render text children', () => {

--- a/packages/web-react/src/components/Header/__tests__/Nav.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/Nav.test.tsx
@@ -4,6 +4,7 @@ import { classNamePrefixProviderTest } from '../../../../tests/providerTests/cla
 import { renderWithHeaderContext, withHeader } from '../../../../tests/testUtils';
 import Nav from '../Nav';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 
 describe('Nav', () => {
   classNamePrefixProviderTest(
@@ -19,6 +20,11 @@ describe('Nav', () => {
       </Nav>
     )),
     'nav-test',
+  );
+
+  restPropsTest(
+    withHeader((props) => <Nav {...props}>Hello World</Nav>),
+    'ul',
   );
 
   it('should render text children', () => {

--- a/packages/web-react/src/components/Header/__tests__/NavItem.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/NavItem.test.tsx
@@ -4,6 +4,7 @@ import { classNamePrefixProviderTest } from '../../../../tests/providerTests/cla
 import { renderWithHeaderContext, withHeader } from '../../../../tests/testUtils';
 import NavItem from '../NavItem';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 
 describe('NavItem', () => {
   classNamePrefixProviderTest(
@@ -19,6 +20,11 @@ describe('NavItem', () => {
       </NavItem>
     )),
     'navitem-test',
+  );
+
+  restPropsTest(
+    withHeader((props) => <NavItem {...props}>Hello World</NavItem>),
+    'li',
   );
 
   it('should render text children', () => {

--- a/packages/web-react/src/components/Header/__tests__/NavLink.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/NavLink.test.tsx
@@ -4,6 +4,7 @@ import { classNamePrefixProviderTest } from '../../../../tests/providerTests/cla
 import { renderWithHeaderContext, withHeader } from '../../../../tests/testUtils';
 import NavLink from '../NavLink';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 
 describe('NavLink', () => {
   classNamePrefixProviderTest(
@@ -15,6 +16,11 @@ describe('NavLink', () => {
   stylePropsTest(
     withHeader((props) => <NavLink href="/" {...props} data-testid="navlink-test" />),
     'navlink-test',
+  );
+
+  restPropsTest(
+    withHeader((props) => <NavLink href="/" {...props} />),
+    'a',
   );
 
   it('should render text children', () => {

--- a/packages/web-react/src/components/Header/__tests__/Navbar.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/Navbar.test.tsx
@@ -5,6 +5,7 @@ import { renderWithHeaderContext, withHeader } from '../../../../tests/testUtils
 import { HeaderContextType } from '../HeaderContext';
 import Navbar, { NavbarVariant } from '../Navbar';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 
 describe('Navbar', () => {
   classNamePrefixProviderTest(
@@ -16,6 +17,11 @@ describe('Navbar', () => {
   stylePropsTest(
     withHeader((props) => <Navbar {...props} data-testid="navbar-test" />),
     'navbar-test',
+  );
+
+  restPropsTest(
+    withHeader((props) => <Navbar {...props} />),
+    'nav',
   );
 
   it('should render text children', () => {

--- a/packages/web-react/src/components/Header/__tests__/NavbarClose.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/NavbarClose.test.tsx
@@ -3,6 +3,7 @@ import NavbarClose from '../NavbarClose';
 import { withHeader } from '../../../../tests/testUtils';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 
 describe('NavbarClose', () => {
   classNamePrefixProviderTest(
@@ -14,5 +15,10 @@ describe('NavbarClose', () => {
   stylePropsTest(
     withHeader((props) => <NavbarClose {...props} data-testid="navbar-close-test" />),
     'navbar-close-test',
+  );
+
+  restPropsTest(
+    withHeader((props) => <NavbarClose {...props} />),
+    'button',
   );
 });

--- a/packages/web-react/src/components/Header/__tests__/NavbarToggler.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/NavbarToggler.test.tsx
@@ -3,6 +3,7 @@ import { classNamePrefixProviderTest } from '../../../../tests/providerTests/cla
 import { withHeader } from '../../../../tests/testUtils';
 import NavbarToggler from '../NavbarToggler';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 
 describe('NavbarToggler', () => {
   classNamePrefixProviderTest(
@@ -14,5 +15,10 @@ describe('NavbarToggler', () => {
   stylePropsTest(
     withHeader((props) => <NavbarToggler {...props} data-testid="navbar-toggler-test" />),
     'navbar-toggler-test',
+  );
+
+  restPropsTest(
+    withHeader((props) => <NavbarToggler {...props} />),
+    'div',
   );
 });

--- a/packages/web-react/src/components/Heading/Heading.tsx
+++ b/packages/web-react/src/components/Heading/Heading.tsx
@@ -1,8 +1,8 @@
-import React, { ElementType } from 'react';
 import classNames from 'classnames';
-import { useHeadingStyleProps } from './useHeadingStyleProps';
-import { SpiritHeadingProps } from '../../types';
+import React, { ElementType } from 'react';
 import { useStyleProps } from '../../hooks/styleProps';
+import { SpiritHeadingProps } from '../../types';
+import { useHeadingStyleProps } from './useHeadingStyleProps';
 
 const defaultProps = {
   size: 'medium',
@@ -11,10 +11,10 @@ const defaultProps = {
 export const Heading = <T extends ElementType = 'div'>(props: SpiritHeadingProps<T>): JSX.Element => {
   const { elementType: ElementTag = 'div', children, ...restProps } = props;
   const { classProps, props: modifiedProps } = useHeadingStyleProps(restProps);
-  const { styleProps } = useStyleProps(modifiedProps);
+  const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
 
   return (
-    <ElementTag {...styleProps} className={classNames(classProps, styleProps.className)}>
+    <ElementTag {...otherProps} {...styleProps} className={classNames(classProps, styleProps.className)}>
       {children}
     </ElementTag>
   );

--- a/packages/web-react/src/components/Heading/__tests__/Heading.test.tsx
+++ b/packages/web-react/src/components/Heading/__tests__/Heading.test.tsx
@@ -6,11 +6,14 @@ import headingSizeDataProvider from './headingSizeDataProvider';
 import { HeadingSize } from '../../../types';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 
 describe('Heading', () => {
   classNamePrefixProviderTest(Heading, 'typography-heading-medium-text');
 
   stylePropsTest(Heading);
+
+  restPropsTest(Heading, 'div');
 
   it.each(headingSizeDataProvider)('should have for size %s an expected class %s', (size, expectedClassName) => {
     const dom = render(<Heading size={size as HeadingSize} />);

--- a/packages/web-react/src/components/Link/Link.tsx
+++ b/packages/web-react/src/components/Link/Link.tsx
@@ -1,8 +1,8 @@
-import React, { ElementType } from 'react';
 import classNames from 'classnames';
-import { useLinkStyleProps } from './useLinkStyleProps';
-import { SpiritLinkProps } from '../../types';
+import React, { ElementType } from 'react';
 import { useStyleProps } from '../../hooks/styleProps';
+import { SpiritLinkProps } from '../../types';
+import { useLinkStyleProps } from './useLinkStyleProps';
 
 const defaultProps = {
   color: 'primary',
@@ -11,10 +11,15 @@ const defaultProps = {
 export const Link = <T extends ElementType = 'a'>(props: SpiritLinkProps<T>): JSX.Element => {
   const { elementType: ElementTag = 'a', children, ...restProps } = props;
   const { classProps, props: modifiedProps } = useLinkStyleProps(restProps);
-  const { styleProps } = useStyleProps(modifiedProps);
+  const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
 
   return (
-    <ElementTag {...styleProps} href={restProps.href} className={classNames(classProps, styleProps.className)}>
+    <ElementTag
+      {...otherProps}
+      {...styleProps}
+      href={restProps.href}
+      className={classNames(classProps, styleProps.className)}
+    >
       {children}
     </ElementTag>
   );

--- a/packages/web-react/src/components/Link/__tests__/Link.test.tsx
+++ b/packages/web-react/src/components/Link/__tests__/Link.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { LinkColor } from '../../../types';
 import Link from '../Link';
 import linkPropsDataProvider from './linkPropsDataProvider';
@@ -11,6 +12,8 @@ describe('Link', () => {
   classNamePrefixProviderTest(Link, 'link-primary');
 
   stylePropsTest(Link);
+
+  restPropsTest(Link, 'a');
 
   it.each(linkPropsDataProvider)('should have class', (color, isUnderlined, isDisabled, expectedClassName) => {
     const dom = render(

--- a/packages/web-react/src/components/Pill/__tests__/Pill.test.tsx
+++ b/packages/web-react/src/components/Pill/__tests__/Pill.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { PillColor } from '../../../types';
 import Pill from '../Pill';
 
@@ -10,6 +11,8 @@ describe('Pill', () => {
   classNamePrefixProviderTest(Pill, 'Pill');
 
   stylePropsTest(Pill);
+
+  restPropsTest(Pill, 'span');
 
   it('should have default classname', () => {
     const dom = render(<Pill />);

--- a/packages/web-react/src/components/Stack/Stack.tsx
+++ b/packages/web-react/src/components/Stack/Stack.tsx
@@ -21,10 +21,10 @@ const defaultProps = {
 export const Stack = <T extends ElementType = 'div'>(props: StackProps<T>): JSX.Element => {
   const { elementType: ElementTag = 'div', children, ...restProps } = props;
   const stackClass = useClassNamePrefix('Stack');
-  const { styleProps } = useStyleProps(restProps);
+  const { styleProps, props: otherProps } = useStyleProps(restProps);
 
   return (
-    <ElementTag {...styleProps} className={classNames(stackClass, styleProps.className)}>
+    <ElementTag {...otherProps} {...styleProps} className={classNames(stackClass, styleProps.className)}>
       {children}
     </ElementTag>
   );

--- a/packages/web-react/src/components/Stack/__tests__/Stack.test.tsx
+++ b/packages/web-react/src/components/Stack/__tests__/Stack.test.tsx
@@ -3,12 +3,15 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import Stack from '../Stack';
 
 describe('Stack', () => {
   classNamePrefixProviderTest(Stack, 'Stack');
 
   stylePropsTest(Stack);
+
+  restPropsTest(Stack, 'div');
 
   it('should render text children', () => {
     const dom = render(<Stack>Hello World</Stack>);

--- a/packages/web-react/src/components/Tag/Tag.tsx
+++ b/packages/web-react/src/components/Tag/Tag.tsx
@@ -1,10 +1,10 @@
-import React, { ElementType, JSXElementConstructor } from 'react';
 import classNames from 'classnames';
+import React, { ElementType, JSXElementConstructor } from 'react';
 import { useStyleProps } from '../../hooks/styleProps';
-import { compose } from '../../utils/compose';
-import { applyColor, applySize, applyTheme } from '../../utils/classname';
 import { useClassNamePrefix } from '../../hooks/useClassNamePrefix';
 import { ChildrenProps } from '../../types';
+import { applyColor, applySize, applyTheme } from '../../utils/classname';
+import { compose } from '../../utils/compose';
 
 type TagColor = 'default' | 'informative' | 'success' | 'warning' | 'danger';
 
@@ -39,7 +39,7 @@ const getTagThemeClassname = (className: string, theme: TagTheme): string =>
 
 export const Tag = <T extends ElementType = 'span'>(props: TagProps<T>): JSX.Element => {
   const { tag: ElementTag = 'span', color, size, theme, children, ...restProps } = props;
-  const { styleProps } = useStyleProps(restProps);
+  const { styleProps, props: otherProps } = useStyleProps(restProps);
   const tagClass = useClassNamePrefix('Tag');
 
   const classes = classNames(
@@ -51,7 +51,7 @@ export const Tag = <T extends ElementType = 'span'>(props: TagProps<T>): JSX.Ele
   );
 
   return (
-    <ElementTag {...styleProps} className={classes}>
+    <ElementTag {...otherProps} {...styleProps} className={classes}>
       {children}
     </ElementTag>
   );

--- a/packages/web-react/src/components/Tag/__tests__/Tag.test.tsx
+++ b/packages/web-react/src/components/Tag/__tests__/Tag.test.tsx
@@ -4,11 +4,14 @@ import '@testing-library/jest-dom';
 import Tag from '../Tag';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 
 describe('Tag', () => {
   classNamePrefixProviderTest(Tag, 'Tag');
 
   stylePropsTest(Tag);
+
+  restPropsTest(Tag, 'span');
 
   it('should have default classname', () => {
     const dom = render(<Tag />);

--- a/packages/web-react/src/components/Text/Text.tsx
+++ b/packages/web-react/src/components/Text/Text.tsx
@@ -1,8 +1,8 @@
-import React, { ElementType } from 'react';
 import classNames from 'classnames';
-import { useTextStyleProps } from './useTextStyleProps';
-import { SpiritTextProps } from '../../types';
+import React, { ElementType } from 'react';
 import { useStyleProps } from '../../hooks/styleProps';
+import { SpiritTextProps } from '../../types';
+import { useTextStyleProps } from './useTextStyleProps';
 
 const defaultProps = {
   size: 'medium',
@@ -11,10 +11,10 @@ const defaultProps = {
 export const Text = <T extends ElementType = 'p'>(props: SpiritTextProps<T>): JSX.Element => {
   const { elementType: ElementTag = 'p', children, ...restProps } = props;
   const { classProps, props: modifiedProps } = useTextStyleProps(restProps);
-  const { styleProps } = useStyleProps(modifiedProps);
+  const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
 
   return (
-    <ElementTag {...styleProps} className={classNames(classProps, styleProps.className)}>
+    <ElementTag {...otherProps} {...styleProps} className={classNames(classProps, styleProps.className)}>
       {children}
     </ElementTag>
   );

--- a/packages/web-react/src/components/Text/__tests__/Text.test.tsx
+++ b/packages/web-react/src/components/Text/__tests__/Text.test.tsx
@@ -6,11 +6,14 @@ import textPropsDataProvider from './textPropsDataProvider';
 import { TextEmphasis, TextSize } from '../../../types';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 
 describe('Text', () => {
   classNamePrefixProviderTest(Text, 'typography-body-medium-text-regular');
 
   stylePropsTest(Text);
+
+  restPropsTest(Text, 'p');
 
   it.each(textPropsDataProvider)('should have classname', (size, emphasis, expectedClassName) => {
     const dom = render(<Text size={size as TextSize} emphasis={emphasis as TextEmphasis} />);

--- a/packages/web-react/src/components/TextField/TextField.tsx
+++ b/packages/web-react/src/components/TextField/TextField.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import classNames from 'classnames';
+import React from 'react';
 import { useStyleProps } from '../../hooks/styleProps';
 import { SpiritTextFieldProps } from '../../types';
 import { useTextFieldStyleProps } from './useTextFieldStyleProps';
@@ -11,7 +11,7 @@ const defaultProps = {
 export const TextField = (props: SpiritTextFieldProps): JSX.Element => {
   const { classProps, props: modifiedProps } = useTextFieldStyleProps(props);
   const { id, type, placeholder, isDisabled, isRequired, label, message, value, ...restProps } = modifiedProps;
-  const { styleProps } = useStyleProps(restProps);
+  const { styleProps, props: otherProps } = useStyleProps(restProps);
 
   return (
     <div {...styleProps} className={classNames(classProps.root, styleProps.className)}>
@@ -19,6 +19,7 @@ export const TextField = (props: SpiritTextFieldProps): JSX.Element => {
         {label}
       </label>
       <input
+        {...otherProps}
         type={type}
         id={id}
         className={classProps.input}

--- a/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
+++ b/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
@@ -1,16 +1,19 @@
-import React from 'react';
-import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import TextField from '../TextField';
+import { render } from '@testing-library/react';
+import React from 'react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { TextFieldType, ValidationState } from '../../../types';
+import TextField from '../TextField';
 
 describe('TextField', () => {
   describe.each(['text', 'password', 'email'])('input type %s', (type) => {
     classNamePrefixProviderTest(TextField, 'TextField');
 
     stylePropsTest(TextField);
+
+    restPropsTest(TextField, 'input');
 
     it('should have label classname', () => {
       const dom = render(<TextField type={type as TextFieldType} />);

--- a/packages/web-react/src/types/button.ts
+++ b/packages/web-react/src/types/button.ts
@@ -8,6 +8,12 @@ type ButtonType = 'button' | 'submit' | 'reset';
 interface ButtonProps extends ChildrenProps, ClickEvents {
   /** Whether the button is disabled. */
   isDisabled?: boolean;
+  /** The color of the button. */
+  color: ButtonColor;
+  /** Whether the button should be displayed with a block style. */
+  isBlock?: boolean;
+  /** Whether the button should be displayed as a square. */
+  isSquare?: boolean;
 }
 
 export interface AriaButtonElementTypeProps<T extends ElementType = 'button'> {
@@ -47,12 +53,6 @@ export interface SpiritButtonProps<T extends ElementType = 'button'>
     ButtonProps,
     LinkButtonProps<T>,
     StyleProps {
-  /** The color of the button. */
-  color: ButtonColor;
-  /** Whether the button should be displayed with a block style. */
-  isBlock?: boolean;
-  /** Whether the button should be displayed as a square. */
-  isSquare?: boolean;
   // tag?: ElementType;
   innerRef?: Ref<HTMLButtonElement>;
 }

--- a/packages/web-react/tests/providerTests/restPropsTest.tsx
+++ b/packages/web-react/tests/providerTests/restPropsTest.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import React, { ComponentType } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const restPropsTest = (Component: ComponentType<any>, selector: string) => {
+  it('should pass rest props to main element', () => {
+    const testId = 'testRestProp';
+    const dom = render(<Component data-testid={testId} />);
+
+    const element = dom.container.querySelector(selector) as HTMLElement;
+    expect(element).toHaveAttribute('data-testid', testId);
+  });
+};


### PR DESCRIPTION
```Warning: You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`.```

We do not handle correctly passing rest props to an input element. Especially in the case of `onChange` and other handlers.