### PR TITLE
Fix(web-twig): Default components path in spirit alias

### DIFF
--- a/packages/web-twig/src/DependencyInjection/CompilerPass/OverrideServiceCompilerPass.php
+++ b/packages/web-twig/src/DependencyInjection/CompilerPass/OverrideServiceCompilerPass.php
@@ -35,7 +35,7 @@ class OverrideServiceCompilerPass implements CompilerPassInterface
         foreach ($paths as $path) {
             $this->addGlobPath($twigLoaderDefinition, $path, $pathAlias);
 
-            if ($path === SpiritWebTwigExtension::DEFAULT_COMPONENTS_PATH) {
+            if ($path === SpiritWebTwigExtension::DEFAULT_COMPONENTS_PATH || $path === SpiritWebTwigExtension::DEFAULT_TWIG_COMPONENTS_PATH) {
                 $this->addGlobPath($twigLoaderDefinition, $path, SpiritWebTwigExtension::DEFAULT_PATH_ALIAS);
             }
         }


### PR DESCRIPTION
To preserve the original functionality of [extending](https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/docs/extendComponents.md) components, it is necessary that ../Resources/twig-components be registered in the spirit alias