### PR TITLE
Fix(web): Fix underlined Link

### DIFF
--- a/packages/web/src/scss/helpers/_links.scss
+++ b/packages/web/src/scss/helpers/_links.scss
@@ -9,23 +9,22 @@
     cursor: cursors.$disabled;
 }
 
-// Allows link underline everywhere, except for headings
-.link-underlined {
+// Allows link underline everywhere, except for headings default state
+.link-underlined,
+[class*='typography-heading'] a:hover,
+[class*='typography-heading'] a:focus {
     text-decoration: underline;
+    text-decoration-skip-ink: none;
+    text-underline-offset: 0.1875em;
 }
 
 .link-stretched {
     @include links.stretch();
 }
 
-// All links in headings behave the same, underlined only in hover and active states
+// All links in headings behave the same
 [class*='typography-heading'] a {
     text-decoration: none;
-
-    &:hover,
-    &:active {
-        text-decoration: underline;
-    }
 }
 
 // Only links in headings have visited state


### PR DESCRIPTION
Now looks Link component with `text-decoration: underline` same as in Figma! 🎉 

Figma
![image](https://user-images.githubusercontent.com/33354913/188650598-8da26065-db90-4474-9b8b-d4154dabc7fa.png)

Web
- before:
![image](https://user-images.githubusercontent.com/33354913/188652158-15b34227-2b48-41f5-b2c5-497a4e4066f4.png)
- after:
![image](https://user-images.githubusercontent.com/33354913/188650262-d4436136-7bdc-413d-a220-da416a93ba9e.png)

Unfortunately, I still don't know what causes the difference in rendered text styles between Figma and web. 😞 