### PR TITLE
BREAKING CHANGES(web): Remove `Button__icon` class as we don't use it…

### DIFF
--- a/packages/web/src/scss/components/Button/_Button.scss
+++ b/packages/web/src/scss/components/Button/_Button.scss
@@ -33,10 +33,6 @@
     }
 }
 
-.Button__icon {
-    font-size: 1.5em;
-}
-
 .Button--square {
     @include tools.square(
         theme.$breakpoints,


### PR DESCRIPTION
… and don't need it

FYI @janicekt you might want to add this to your DS directly