### PR TITLE
BREAKING CHANGES(web-react): Do not provide non-existing CSS class `Tabs-content` in `Tabs` hook

### DIFF
--- a/packages/web-react/src/components/Tabs/TabContent.tsx
+++ b/packages/web-react/src/components/Tabs/TabContent.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
 import { ChildrenProps, TransferProps } from '../../types';
-import { useTabsStyleProps } from './useTabsStyleProps';
 
 type TabContentProps = ChildrenProps & TransferProps;
 
-const TabContent = ({ children }: TabContentProps): JSX.Element => {
-  const { classProps } = useTabsStyleProps();
-
-  return <div className={classProps.content}>{children}</div>;
-};
+const TabContent = ({ children }: TabContentProps): JSX.Element => <div>{children}</div>;
 
 export default TabContent;

--- a/packages/web-react/src/components/Tabs/__tests__/TabContent.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabContent.test.tsx
@@ -1,7 +1,0 @@
-import '@testing-library/jest-dom';
-import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
-import TabContent from '../TabContent';
-
-describe('Tab', () => {
-  classNamePrefixProviderTest(TabContent, 'Tabs-content');
-});

--- a/packages/web-react/src/components/Tabs/__tests__/useTabsStyleProps.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/useTabsStyleProps.test.tsx
@@ -7,7 +7,6 @@ describe('useTabsStyleProps', () => {
     const { result } = renderHook(() => useTabsStyleProps(props));
 
     expect(result.current.classProps.root).toBe('Tabs');
-    expect(result.current.classProps.content).toBe('Tabs-content');
     expect(result.current.classProps.item).toBe('Tabs__item');
     expect(result.current.classProps.link).toBe('Tabs__link');
     expect(result.current.classProps.pane).toBe('Tabs-pane');

--- a/packages/web-react/src/components/Tabs/useTabsStyleProps.tsx
+++ b/packages/web-react/src/components/Tabs/useTabsStyleProps.tsx
@@ -1,15 +1,14 @@
 import classNames from 'classnames';
-import { useClassNamePrefix } from '../../hooks/useClassNamePrefix';
+import { useClassNamePrefix } from '../../hooks';
 import { SpiritTabsProps } from '../../types';
 
 export interface TabsStyles {
   /** className props */
   classProps: {
-    root: string;
     item: string;
-    pane: string;
-    content: string;
     link: string;
+    pane: string;
+    root: string;
   };
   /** props to be passed to the element */
   props: unknown;
@@ -20,22 +19,20 @@ export function useTabsStyleProps(props: SpiritTabsProps = { selectedTabId: '', 
 
   const tabsClass = useClassNamePrefix('Tabs');
   const tabsItemClass = `${tabsClass}__item`;
-  const tabsContentClass = `${tabsClass}-content`;
-  const tabsPaneClass = `${tabsClass}-pane`;
   const tabsLinkClass = `${tabsClass}__link`;
+  const tabsPaneClass = `${tabsClass}-pane`;
   const tabsSelectedClass = `is-selected`;
 
   return {
     classProps: {
-      root: tabsClass,
       item: tabsItemClass,
-      pane: classNames(tabsPaneClass, {
-        [tabsSelectedClass]: !!tabId && !!selectedTabId && selectedTabId === tabId,
-      }),
-      content: tabsContentClass,
       link: classNames(tabsLinkClass, {
         [tabsSelectedClass]: !!forTab && !!selectedTabId && selectedTabId === forTab,
       }),
+      pane: classNames(tabsPaneClass, {
+        [tabsSelectedClass]: !!tabId && !!selectedTabId && selectedTabId === tabId,
+      }),
+      root: tabsClass,
     },
     props: modifiedProps,
   };


### PR DESCRIPTION
Migration: Delete `content` class name provided by the `useTabsStyleProps` hook. There is no styling applied to it.