### PR TITLE
Chore(repo): Introduce @tomassychra into codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
 # Code owners for spirit-design-system
 # https://help.github.com/en/articles/about-code-owners
 
-* @lmc-eu/frontend-developers
+* @literat @tomassychra @lmc-eu/frontend-developers
 
 # Packages' owners
 
 /packages/design-tokens           @adamkudrna @crishpeen @lmc-eu/frontend-developers
 /packages/icons                   @adamkudrna @crishpeen @lmc-eu/frontend-developers
-/packages/web                     @adamkudrna @crishpeen @lmc-eu/frontend-developers
-/packages/web-react               @literat @janicekt @lmc-eu/frontend-developers
-/packages/web-twig                @literat @janicekt @lmc-eu/frontend-developers
+/packages/web                     @adamkudrna @crishpeen @tomassychra @lmc-eu/frontend-developers
+/packages/web-react               @literat @tomassychra @lmc-eu/frontend-developers
+/packages/web-twig                @literat @tomassychra @janicekt @lmc-eu/frontend-developers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
 # Code owners for spirit-design-system
 # https://help.github.com/en/articles/about-code-owners
 
-* @literat @tomassychra @lmc-eu/frontend-developers
+* @lmc-eu/spirit-design-system
 
 # Packages' owners
 
-/packages/design-tokens           @adamkudrna @crishpeen @lmc-eu/frontend-developers
-/packages/icons                   @adamkudrna @crishpeen @lmc-eu/frontend-developers
-/packages/web                     @adamkudrna @crishpeen @tomassychra @lmc-eu/frontend-developers
-/packages/web-react               @literat @tomassychra @lmc-eu/frontend-developers
-/packages/web-twig                @literat @tomassychra @janicekt @lmc-eu/frontend-developers
+/packages/design-tokens           @literat @adamkudrna @crishpeen @lmc-eu/spirit-design-system
+/packages/icons                   @literat @adamkudrna @crishpeen @lmc-eu/spirit-design-system
+/packages/web                     @literat @adamkudrna @crishpeen @tomassychra @lmc-eu/spirit-design-system
+/packages/web-react               @literat @tomassychra @lmc-eu/spirit-design-system
+/packages/web-twig                @literat @adamkudrna @crishpeen @tomassychra @lmc-eu/spirit-design-system


### PR DESCRIPTION
I have an update to `CODEOWNERS` file and have a few topics to discuss:

- should I create the team and all of us should be on the review list of every PR?
- do @vmilersky and @dlouhak want to review some packages as owners of jobs-design-system?
- do @janicekt be still the owner of `web-twig`?

The idea is that as I and @tomassychra are the full-time reviewers we should be on the review list of every package. What do you think?