### PR TITLE
Fix(web-twig): Variable props does not exist

### DIFF
--- a/packages/web-twig/src/Resources/components/Alert/Alert.twig
+++ b/packages/web-twig/src/Resources/components/Alert/Alert.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _color = props.color | default('success') -%}
 {%- set _iconName = props.iconName | default(null) -%}

--- a/packages/web-twig/src/Resources/components/Breadcrumbs/index.twig
+++ b/packages/web-twig/src/Resources/components/Breadcrumbs/index.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _elementType = props.elementType | default('nav') -%}
 {%- set _goBackTitle = props.goBackTitle | default('') -%}

--- a/packages/web-twig/src/Resources/components/Button/Button.twig
+++ b/packages/web-twig/src/Resources/components/Button/Button.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _color = props.color | default('primary') -%}
 {%- set _size= props.size | default('medium') -%}

--- a/packages/web-twig/src/Resources/components/ButtonLink/ButtonLink.twig
+++ b/packages/web-twig/src/Resources/components/ButtonLink/ButtonLink.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _color = props.color | default('primary') -%}
 {%- set _size = props.size | default('medium') -%}

--- a/packages/web-twig/src/Resources/components/CheckboxField/CheckboxField.twig
+++ b/packages/web-twig/src/Resources/components/CheckboxField/CheckboxField.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _id = props.id | default(null) -%}
 {%- set _isChecked = props.isChecked | default(false) | boolprop -%}

--- a/packages/web-twig/src/Resources/components/Container/Container.twig
+++ b/packages/web-twig/src/Resources/components/Container/Container.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 
 {# Class names #}

--- a/packages/web-twig/src/Resources/components/Grid/Grid.twig
+++ b/packages/web-twig/src/Resources/components/Grid/Grid.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _cols = props.cols | default(null) -%}
 {%- set _desktop = props.desktop | default(null) -%}

--- a/packages/web-twig/src/Resources/components/Heading/Heading.twig
+++ b/packages/web-twig/src/Resources/components/Heading/Heading.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _size = props.size | default('medium') -%}
 {%- set _elementType = props.elementType | default('div') -%}

--- a/packages/web-twig/src/Resources/components/Icon/Icon.twig
+++ b/packages/web-twig/src/Resources/components/Icon/Icon.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _ariaHidden = props.ariaHidden | default(true) | boolprop -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _name = props.name -%}

--- a/packages/web-twig/src/Resources/components/Link/Link.twig
+++ b/packages/web-twig/src/Resources/components/Link/Link.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _color = props.color | default('primary') -%}
 {%- set _href = props.href -%}

--- a/packages/web-twig/src/Resources/components/Modal/Modal.twig
+++ b/packages/web-twig/src/Resources/components/Modal/Modal.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _closeLabel = props.closeLabel | default('Close') -%}
 {%- set _id = props.id -%}

--- a/packages/web-twig/src/Resources/components/Pill/Pill.twig
+++ b/packages/web-twig/src/Resources/components/Pill/Pill.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _color = props.color | default('selected') -%}
 {%- set _elementType = props.elementType | default('span') -%}

--- a/packages/web-twig/src/Resources/components/Stack/Stack.twig
+++ b/packages/web-twig/src/Resources/components/Stack/Stack.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _elementType = props.elementType | default('div') -%}
 

--- a/packages/web-twig/src/Resources/components/Tabs/TabItem.twig
+++ b/packages/web-twig/src/Resources/components/Tabs/TabItem.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 
 {# Class names #}

--- a/packages/web-twig/src/Resources/components/Tabs/TabLink.twig
+++ b/packages/web-twig/src/Resources/components/Tabs/TabLink.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _ariaTarget = props.ariaTarget | default(null) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _href = props.href | default(null) -%}

--- a/packages/web-twig/src/Resources/components/Tabs/TabList.twig
+++ b/packages/web-twig/src/Resources/components/Tabs/TabList.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 
 {# Class names #}

--- a/packages/web-twig/src/Resources/components/Tabs/TabPane.twig
+++ b/packages/web-twig/src/Resources/components/Tabs/TabPane.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _id = props.id | default(null) -%}
 {%- set _isSelected = props.isSelected | default(false) | boolprop -%}

--- a/packages/web-twig/src/Resources/components/Tabs/TabsItem.twig
+++ b/packages/web-twig/src/Resources/components/Tabs/TabsItem.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 
 {# Class names #}

--- a/packages/web-twig/src/Resources/components/Tabs/TabsLink.twig
+++ b/packages/web-twig/src/Resources/components/Tabs/TabsLink.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _ariaTarget = props.ariaTarget | default(null) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _href = props.href | default(null) -%}

--- a/packages/web-twig/src/Resources/components/Tabs/TabsPane.twig
+++ b/packages/web-twig/src/Resources/components/Tabs/TabsPane.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _id = props.id | default(null) -%}
 {%- set _isSelected = props.isSelected | default(false) -%}

--- a/packages/web-twig/src/Resources/components/Tag/Tag.twig
+++ b/packages/web-twig/src/Resources/components/Tag/Tag.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _color = props.color | default('default') -%}
 {%- set _size = props.size | default('medium') -%}

--- a/packages/web-twig/src/Resources/components/Text/Text.twig
+++ b/packages/web-twig/src/Resources/components/Text/Text.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _emphasis = props.emphasis | default('regular') -%}
 {%- set _size = props.size | default('medium') -%}

--- a/packages/web-twig/src/Resources/components/TextField/TextField.twig
+++ b/packages/web-twig/src/Resources/components/TextField/TextField.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _id = props.id -%}
 {%- set _isDisabled = props.isDisabled | default(false) | boolprop -%}

--- a/packages/web-twig/src/Resources/components/Tooltip/Tooltip.twig
+++ b/packages/web-twig/src/Resources/components/Tooltip/Tooltip.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _closeLabel = props.closeLabel | default('Close') -%}
 {%- set _id = props.id | default(null) -%}

--- a/packages/web-twig/src/Resources/components/Tooltip/TooltipWrapper.twig
+++ b/packages/web-twig/src/Resources/components/Tooltip/TooltipWrapper.twig
@@ -1,4 +1,5 @@
 {# API #}
+{%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 
 {# Class names #}

--- a/packages/web-twig/src/Twig/PropsExtension.php
+++ b/packages/web-twig/src/Twig/PropsExtension.php
@@ -76,7 +76,7 @@ class PropsExtension extends AbstractExtension
      */
     public function renderClassProp(Environment $environment, array $classNames): string
     {
-        $filteredClassNames = array_values(array_filter($classNames , fn($value) => !is_null($value) && $value !== ''));
+        $filteredClassNames = array_values(array_filter($classNames, fn ($value) => ! is_null($value) && $value !== ''));
 
         return $environment->render('@partials/classProp.twig', [
             'classNames' => $filteredClassNames,

--- a/packages/web-twig/tests/Twig/PropsExtensionTest.php
+++ b/packages/web-twig/tests/Twig/PropsExtensionTest.php
@@ -159,7 +159,7 @@ class PropsExtensionTest extends TestCase
     }
 
     /**
-     * @return array<string, array<int, array<int|string, array<int, string>|string>>>
+     * @return array<string, array<int, array<int|string, array<int, string>|string|null>>>
      */
     public function renderClassNamesDataProvider(): array
     {
@@ -184,15 +184,15 @@ class PropsExtensionTest extends TestCase
                 ],
             ]],
             'multiple class names without empty values ' => [[
-              'test-class',
-              null,
-              'another-test-class',
-              null,
-            ], [
-              'classNames' => [
                 'test-class',
+                null,
                 'another-test-class',
-              ],
+                null,
+            ], [
+                'classNames' => [
+                    'test-class',
+                    'another-test-class',
+                ],
             ]],
         ];
     }


### PR DESCRIPTION
If anyone use vanilla twig implementation without definition with { props: {...} } in embed or include
for example:
```
{% embed "@seduo-design-system/stack.twig" %}
    {% block content %}
        <div>Block 1</div>
        <div>Block 2</div>
        <div>Block 3</div>
    {% endblock %}
{% endembed %} 
```
an error occurs
<img width="717" alt="Snímek obrazovky 2022-09-20 v 10 57 35" src="https://user-images.githubusercontent.com/25146453/191223200-3f981697-3a12-475f-9d5f-faf14e9f7f4c.png">
because macro which use props generate Runtime Error  (for example `mainProps`)
