### PR TITLE
Chore(ci): Remove `ci-skip` from publish message

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -10,11 +10,11 @@
       "conventionalCommits": true,
       "changelogPreset": "@lmc-eu/conventional-changelog-lmc-github",
       "push": false,
-      "message": "Chore(release): Publish [ci-skip]",
+      "message": "Chore(release): Publish",
       "ignoreChanges": ["yarn.lock"]
     },
     "publish": {
-      "message": "Chore(release): Publish [ci-skip]"
+      "message": "Chore(release): Publish"
     }
   }
 }


### PR DESCRIPTION
  * @see: https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
  * although not mentioned in documentation, the `ci-skip` string in the commit message skips the GitHub Actions pipeline run

Due to this skip publishing was not working.