### PR TITLE
Feat(web): Component triggers can find target element by target dataset

### DIFF
--- a/packages/web/src/js/Header.ts
+++ b/packages/web/src/js/Header.ts
@@ -7,7 +7,6 @@ import { enableToggleTrigger } from './utils/ComponentFunctions';
 const NAME = 'header';
 const HEADER_TOGGLE_SELECTOR = '[data-toggle="header"]';
 const HEADER_DISMISS_ATTRIBUTE = 'data-dismiss';
-const HEADER_TARGET_ATTRIBUTE = 'data-target';
 const HEADER_BREAKPOINT = 1280;
 const OPEN_CLASSNAME = 'is-open';
 const BACKDROP_TAG_NAME = 'div';
@@ -33,15 +32,11 @@ class Header extends BaseComponent {
     backdropEl.classList.add(BACKDROP_CLASSNAME);
 
     if (!SelectorEngine.findAll(`[class*="${BACKDROP_CLASSNAME}"]`, target).length) {
-      Header.findRelatedNavElement(target)?.appendChild(backdropEl);
+      target.appendChild(backdropEl);
       reflow(backdropEl);
     }
 
     return backdropEl;
-  }
-
-  static findRelatedNavElement(target: HTMLElement) {
-    return SelectorEngine.findOne(target.getAttribute(HEADER_TARGET_ATTRIBUTE));
   }
 
   // Using `unknown` - Object is possibly 'null'.
@@ -95,7 +90,7 @@ class Header extends BaseComponent {
       return;
     }
 
-    Header.findRelatedNavElement(relatedTarget)?.classList.add(OPEN_CLASSNAME);
+    this.element.classList.add(OPEN_CLASSNAME);
     relatedTarget.setAttribute('aria-expanded', 'true');
 
     this.addEventListeners();
@@ -118,7 +113,7 @@ class Header extends BaseComponent {
       target = event.target.parentNode;
     }
 
-    const navEl = Header.findRelatedNavElement(target) || target;
+    const navEl = this.element || target;
     const headerEl = navEl.parentElement;
     const toggleEl = SelectorEngine.findOne(HEADER_TOGGLE_SELECTOR, headerEl);
     target.classList.remove(OPEN_CLASSNAME);

--- a/packages/web/src/js/Modal.ts
+++ b/packages/web/src/js/Modal.ts
@@ -69,16 +69,14 @@ class Modal extends BaseComponent {
     EventHandler.off(window, 'click', (event: Event & { target: Window }) => this.onClick(event));
   }
 
-  show(event: Event & { target: HTMLOrSVGElement; currentTarget: HTMLOrSVGElement }) {
+  show() {
     if (this.isShown) {
       return;
     }
 
-    const target = SelectorEngine.findOne(event.currentTarget.dataset.target as string) as HTMLDialogElement | null;
-    const modalEl = target?.parentElement?.parentElement;
-    const toggleEl = SelectorEngine.findOne(MODAL_TOGGLE_SELECTOR, modalEl);
+    const toggleEl = SelectorEngine.findOne(MODAL_TOGGLE_SELECTOR, this.element);
     toggleEl?.setAttribute('aria-expanded', 'true');
-    target?.showModal();
+    this.element?.showModal();
 
     this.addEventListeners();
     this.isShown = true;
@@ -100,8 +98,7 @@ class Modal extends BaseComponent {
       target = event.target.parentNode;
     }
 
-    const modalEl = target.parentElement.parentElement;
-    const toggleEl = SelectorEngine.findOne(MODAL_TOGGLE_SELECTOR, modalEl);
+    const toggleEl = SelectorEngine.findOne(MODAL_TOGGLE_SELECTOR, this.element);
     target.close();
     toggleEl?.setAttribute('aria-expanded', 'false');
 
@@ -122,7 +119,7 @@ class Modal extends BaseComponent {
       return;
     }
 
-    this.isShown ? this.hide(event) : this.show(event);
+    this.isShown ? this.hide(event) : this.show();
   }
 }
 

--- a/packages/web/src/js/Tabs.ts
+++ b/packages/web/src/js/Tabs.ts
@@ -155,6 +155,6 @@ class Tabs extends BaseComponent {
   }
 }
 
-enableToggleTrigger(Tabs, 'show');
+enableToggleTrigger(Tabs, 'show', 'trigger');
 
 export default Tabs;

--- a/packages/web/src/js/utils/ComponentFunctions.ts
+++ b/packages/web/src/js/utils/ComponentFunctions.ts
@@ -1,7 +1,7 @@
 import BaseComponent from '../BaseComponent';
 import EventHandler from '../dom/EventHandler';
 import SelectorEngine from '../dom/SelectorEngine';
-import { getElement } from './index';
+import { getElement, getTargetOrElement } from './index';
 
 type DataTriggerAttribute = 'data-toggle' | 'data-dismiss';
 
@@ -18,7 +18,7 @@ const enableDataTrigger = (
   EventHandler.on(window, 'DOMContentLoaded', (event: Event) => {
     SelectorEngine.findAll(`[${dataTriggerAttribute}="${name}"]`).forEach((toggleEl) => {
       EventHandler.on(toggleEl, 'click', function handleClick() {
-        const target = getElement(this);
+        const target = getTargetOrElement(getElement(this));
         const instance = component.getOrCreateInstance(target);
 
         // No index signature with a parameter of type 'string' was found on type 'Document | HTMLElement | Window | BaseComponent'

--- a/packages/web/src/js/utils/ComponentFunctions.ts
+++ b/packages/web/src/js/utils/ComponentFunctions.ts
@@ -1,7 +1,7 @@
 import BaseComponent from '../BaseComponent';
 import EventHandler from '../dom/EventHandler';
 import SelectorEngine from '../dom/SelectorEngine';
-import { getElement, getTargetOrElement } from './index';
+import { getElement, getTriggerOrTarget, Aim } from './index';
 
 type DataTriggerAttribute = 'data-toggle' | 'data-dismiss';
 
@@ -12,13 +12,14 @@ const enableDataTrigger = (
   dataTriggerAttribute: DataTriggerAttribute,
   component: typeof BaseComponent,
   method = 'toggle',
+  aim: Aim = 'target',
 ) => {
   const name = component.NAME;
 
   EventHandler.on(window, 'DOMContentLoaded', (event: Event) => {
     SelectorEngine.findAll(`[${dataTriggerAttribute}="${name}"]`).forEach((toggleEl) => {
       EventHandler.on(toggleEl, 'click', function handleClick() {
-        const target = getTargetOrElement(getElement(this));
+        const target = getTriggerOrTarget(getElement(this), aim);
         const instance = component.getOrCreateInstance(target);
 
         // No index signature with a parameter of type 'string' was found on type 'Document | HTMLElement | Window | BaseComponent'
@@ -30,12 +31,12 @@ const enableDataTrigger = (
   });
 };
 
-const enableToggleTrigger = (component: typeof BaseComponent, method = 'toggle') => {
-  enableDataTrigger(ATTRIBUTE_DATA_TOGGLE, component, method);
+const enableToggleTrigger = (component: typeof BaseComponent, method = 'toggle', aim: Aim = 'target') => {
+  enableDataTrigger(ATTRIBUTE_DATA_TOGGLE, component, method, aim);
 };
 
-const enableDismissTrigger = (component: typeof BaseComponent, method = 'dismiss') => {
-  enableDataTrigger(ATTRIBUTE_DATA_DISMISS, component, method);
+const enableDismissTrigger = (component: typeof BaseComponent, method = 'dismiss', aim: Aim = 'target') => {
+  enableDataTrigger(ATTRIBUTE_DATA_DISMISS, component, method, aim);
 };
 
 export { enableToggleTrigger, enableDismissTrigger };

--- a/packages/web/src/js/utils/__tests__/ComponentFunctions.test.ts
+++ b/packages/web/src/js/utils/__tests__/ComponentFunctions.test.ts
@@ -43,7 +43,7 @@ describe('Plugin functions', () => {
 
       const getOrCreateInstanceSpy = jest.spyOn(DummyClass2, 'getOrCreateInstance');
       const testMethodSpy = jest.spyOn(DummyClass2.prototype, 'testMethod');
-      const componentWrapper = fixtureEl.querySelector('[data-target="#foo"]');
+      const componentWrapper = fixtureEl.querySelector('#foo');
       const btnToggle = fixtureEl.querySelector('[data-toggle="test"]') as HTMLElement;
       const event = createEvent('click');
 

--- a/packages/web/src/js/utils/__tests__/index.test.ts
+++ b/packages/web/src/js/utils/__tests__/index.test.ts
@@ -67,7 +67,7 @@ describe('Util', () => {
     });
   });
 
-  describe('getTargetElement', () => {
+  describe('getTriggerOrTarget', () => {
     it('should try to parse element base on data-target', () => {
       fixtureEl.innerHTML = [
         '<div id="foo" class="test" data-target="#bar"></div>',
@@ -77,9 +77,10 @@ describe('Util', () => {
       const el = fixtureEl.querySelector('#foo');
       const targetEl = fixtureEl.querySelector('#bar');
 
-      expect(Util.getTargetOrElement(el)).toEqual(targetEl);
-      expect(Util.getTargetOrElement('#foo')).toBe('#foo');
-      expect(Util.getTargetOrElement(null)).toBeNull();
+      expect(Util.getTriggerOrTarget(el)).toEqual(targetEl);
+      expect(Util.getTriggerOrTarget('#foo', 'trigger')).toBe('#foo');
+      expect(Util.getTriggerOrTarget('#bar')).toBeNull();
+      expect(Util.getTriggerOrTarget(null)).toBeNull();
     });
   });
 

--- a/packages/web/src/js/utils/__tests__/index.test.ts
+++ b/packages/web/src/js/utils/__tests__/index.test.ts
@@ -67,6 +67,22 @@ describe('Util', () => {
     });
   });
 
+  describe('getTargetElement', () => {
+    it('should try to parse element base on data-target', () => {
+      fixtureEl.innerHTML = [
+        '<div id="foo" class="test" data-target="#bar"></div>',
+        '<div id="bar" class="test"></div>',
+      ].join('');
+
+      const el = fixtureEl.querySelector('#foo');
+      const targetEl = fixtureEl.querySelector('#bar');
+
+      expect(Util.getTargetOrElement(el)).toEqual(targetEl);
+      expect(Util.getTargetOrElement('#foo')).toBe('#foo');
+      expect(Util.getTargetOrElement(null)).toBeNull();
+    });
+  });
+
   describe('reflow', () => {
     it('should return element offset height to force the reflow', () => {
       fixtureEl.innerHTML = '<div></div>';

--- a/packages/web/src/js/utils/index.ts
+++ b/packages/web/src/js/utils/index.ts
@@ -7,7 +7,7 @@ const isElement = (object: any): boolean => {
   return typeof object.nodeType !== 'undefined';
 };
 
-const getElement = (object?: any): Node | Element | HTMLElement | null => {
+const getElement = (object?: any): SpiritElement => {
   // it's a node element
   if (isElement(object)) {
     return object;
@@ -18,6 +18,16 @@ const getElement = (object?: any): Node | Element | HTMLElement | null => {
   }
 
   return null;
+};
+
+const getTargetOrElement = (element?: SpiritElement): SpiritElement => {
+  let target;
+
+  if (element?.dataset?.target) {
+    target = getElement(element.dataset.target);
+  }
+
+  return target || element;
 };
 
 const getSelector = (element: HTMLElement | null) => element?.getAttribute('data-target');
@@ -39,4 +49,4 @@ const reflow = (element: HTMLElement): void => {
   element.offsetHeight;
 };
 
-export { isElement, getElement, getSelector, getElementFromSelector, reflow };
+export { isElement, getElement, getSelector, getElementFromSelector, getTargetOrElement, reflow };

--- a/packages/web/src/js/utils/index.ts
+++ b/packages/web/src/js/utils/index.ts
@@ -20,14 +20,13 @@ const getElement = (object?: any): SpiritElement => {
   return null;
 };
 
-const getTargetOrElement = (element?: SpiritElement): SpiritElement => {
-  let target;
+type Aim = 'trigger' | 'target';
 
-  if (element?.dataset?.target) {
-    target = getElement(element.dataset.target);
-  }
+const getTriggerOrTarget = (element?: SpiritElement, aim: Aim = 'target'): SpiritElement => {
+  const trigger = element;
+  const target = trigger?.dataset?.target ? getElement(element.dataset.target) : null;
 
-  return target || element;
+  return aim === 'target' ? target : trigger;
 };
 
 const getSelector = (element: HTMLElement | null) => element?.getAttribute('data-target');
@@ -49,4 +48,5 @@ const reflow = (element: HTMLElement): void => {
   element.offsetHeight;
 };
 
-export { isElement, getElement, getSelector, getElementFromSelector, getTargetOrElement, reflow };
+export { isElement, getElement, getSelector, getElementFromSelector, getTriggerOrTarget, reflow };
+export type { Aim };


### PR DESCRIPTION
The goal is to pass the main component element to the component instance, eg. in the `this.element` of the BaseComponent should be the element targeted by `data-target` and not the toggle element as it was until now. If the `data-target` do not exist, still the toggle element will be passed as it is now.