### PR TITLE
Feat(web): TextArea (#DS-319)

### DIFF
--- a/packages/web/src/scss/components/CheckboxField/_CheckboxField.scss
+++ b/packages/web/src/scss/components/CheckboxField/_CheckboxField.scss
@@ -1,89 +1,76 @@
 @use 'theme';
-@use '../../tools/accessibility';
+@use '../../theme/form-fields' as form-fields-theme;
+@use '../../tools/form-fields' as form-fields-tools;
 @use '../../tools/svg';
-@use '../../tools/typography';
 
 .CheckboxField {
-    display: inline-flex;
-    margin-block: theme.$spacing;
+    @include form-fields-tools.inline-field-root();
 }
 
 .CheckboxField__text {
-    margin-left: theme.$text-offset;
+    margin-left: form-fields-theme.$spacing;
 }
 
 .CheckboxField__label {
-    @include typography.generate(theme.$label-typography);
-
-    display: inline-block;
-    color: theme.$label-color-default;
+    @include form-fields-tools.inline-field-label();
 }
 
 .CheckboxField__label--hidden {
-    @include accessibility.hide-text();
+    @include form-fields-tools.label-hidden();
 }
 
 .CheckboxField__label--required::after {
-    content: '*';
-    color: theme.$label-required-color;
+    @include form-fields-tools.label-required();
 }
 
 .CheckboxField__input {
-    appearance: none;
+    @include form-fields-tools.inline-field-input();
+
     flex-shrink: 0;
     width: theme.$input-width;
     height: theme.$input-width;
-    margin: 3px;
-    color: theme.$input-unselected-color;
-    border: 2px solid currentcolor;
-    border-radius: 2px;
+    border-radius: theme.$input-border-radius;
     background-position: center;
     background-size: contain;
     background-repeat: no-repeat;
 
     &:checked {
-        color: theme.$input-selected-color;
+        color: form-fields-theme.$inline-field-input-color-checked;
         background-image: svg.escape(theme.$input-checked-mark);
-        background-color: theme.$input-selected-color;
+        background-color: form-fields-theme.$inline-field-input-color-checked;
     }
 
     &:indeterminate {
-        color: theme.$input-selected-color;
+        color: form-fields-theme.$inline-field-input-color-checked;
         background-image: svg.escape(theme.$input-indeterminate-mark);
-        background-color: theme.$input-selected-color;
-    }
-
-    &:focus-visible {
-        outline: 0;
-        box-shadow: theme.$input-focus-shadow;
+        background-color: form-fields-theme.$inline-field-input-color-checked;
     }
 }
 
 .CheckboxField__message {
-    @include typography.generate(theme.$message-typography);
-
-    display: block;
-    margin-top: theme.$spacing;
-    color: theme.$message-color-default;
+    @include form-fields-tools.message();
 }
 
 .CheckboxField--error .CheckboxField__message {
-    color: theme.$message-color-error;
+    color: form-fields-theme.$message-color-error;
 }
 
-.CheckboxField--disabled .CheckboxField__label,
+.CheckboxField--disabled .CheckboxField__label {
+    @include form-fields-tools.label-disabled();
+}
+
 .CheckboxField--disabled .CheckboxField__message {
-    color: theme.$label-color-disabled;
+    @include form-fields-tools.message-disabled();
 }
 
 .CheckboxField--disabled > .CheckboxField__input,
 .CheckboxField > .CheckboxField__input:disabled {
-    color: theme.$input-disabled-color;
+    @include form-fields-tools.input-disabled();
 }
 
 .CheckboxField--disabled > .CheckboxField__input:checked,
 .CheckboxField--disabled > .CheckboxField__input:indeterminate,
 .CheckboxField > .CheckboxField__input:disabled:checked,
 .CheckboxField > .CheckboxField__input:disabled:indeterminate {
-    background-color: theme.$input-disabled-color;
+    background-color: form-fields-theme.$input-color-disabled;
 }

--- a/packages/web/src/scss/components/CheckboxField/_theme.scss
+++ b/packages/web/src/scss/components/CheckboxField/_theme.scss
@@ -1,23 +1,6 @@
 @use '@tokens' as tokens;
 
-$spacing: tokens.$space-400;
-
-$text-offset: tokens.$space-400;
-
-$label-typography: tokens.$body-medium-text-regular;
-$label-color-default: tokens.$text-primary-default;
-$label-color-disabled: tokens.$text-primary-disabled;
-$label-required-color: tokens.$emotion-danger-default;
-
+$input-border-radius: 2px;
 $input-width: 18px;
-$input-unselected-color: tokens.$action-unselected-default;
-$input-selected-color: tokens.$action-selected-default;
-$input-disabled-color: tokens.$text-primary-disabled;
-$input-focus-shadow: tokens.$focus;
 $input-checked-mark: url('data:image/svg+xml,<svg viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg" width="18" height="18"><path d="M7.71 13.29a.996.996 0 0 1-1.41 0L2.71 9.7a.996.996 0 1 1 1.41-1.41L7 11.17l6.88-6.88a.996.996 0 1 1 1.41 1.41l-7.58 7.59Z" style="fill:#fff"/></svg>');
 $input-indeterminate-mark: url('data:image/svg+xml,<svg viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg" width="18" height="18"><path style="fill:#fff" d="M4 8h10v2H4z"/></svg>');
-
-$message-typography: tokens.$body-medium-text-regular;
-$message-color-default: tokens.$text-primary-default;
-$message-color-disabled: tokens.$text-primary-disabled;
-$message-color-error: tokens.$emotion-danger-default;

--- a/packages/web/src/scss/components/RadioField/_RadioField.scss
+++ b/packages/web/src/scss/components/RadioField/_RadioField.scss
@@ -4,42 +4,34 @@
 //
 // See: https://moderncss.dev/pure-css-custom-styled-radio-buttons/
 
+@use '../../theme/form-fields' as form-fields-theme;
+@use '../../tools/form-fields' as form-fields-tools;
 @use 'theme';
-@use '../../tools/accessibility';
-@use '../../tools/typography';
 
 .RadioField {
-    display: inline-flex;
-    margin-block: theme.$spacing;
+    @include form-fields-tools.inline-field-root();
 }
 
 .RadioField__input {
-    appearance: none;
+    @include form-fields-tools.inline-field-input();
+
     display: grid;
-    width: theme.$input-width;
-    height: theme.$input-width;
-    margin: theme.$input-margin;
+    width: theme.$input-size;
+    height: theme.$input-size;
     font: inherit;
-    color: theme.$input-color-unchecked;
-    border: theme.$input-outline-width solid theme.$input-color-unchecked;
     border-radius: theme.$input-border-radius;
     background-color: transparent;
     transform: translateY(-0.075em);
     place-content: center;
 
     &:checked {
-        border-color: theme.$input-color-checked;
-    }
-
-    &:focus-visible {
-        outline: 0;
-        box-shadow: theme.$input-focus-shadow;
+        border-color: form-fields-theme.$inline-field-input-color-checked;
     }
 
     &::before {
         content: '';
-        width: theme.$input-inner-dot-width;
-        height: theme.$input-inner-dot-width;
+        width: theme.$input-inner-dot-size;
+        height: theme.$input-inner-dot-size;
         border-radius: theme.$input-border-radius;
         background-color: canvastext; // 2.
         box-shadow: theme.$input-box-shadow-before; // 1.
@@ -53,26 +45,25 @@
 }
 
 .RadioField__label {
-    display: inline-block;
-    margin-left: theme.$label-margin;
-    color: theme.$label-color-default;
-    @include typography.generate(theme.$label-typography);
+    @include form-fields-tools.inline-field-label();
+
+    margin-left: form-fields-theme.$spacing;
 }
 
 .RadioField__label--hidden {
-    @include accessibility.hide-text();
+    @include form-fields-tools.label-hidden();
 }
 
 .RadioField--disabled > .RadioField__label {
-    color: theme.$label-color-disabled;
+    @include form-fields-tools.label-disabled();
 }
 
 .RadioField--disabled > .RadioField__input,
 .RadioField > .RadioField__input:disabled {
-    border-color: theme.$input-color-disabled;
+    border-color: form-fields-theme.$input-color-disabled;
 
     &:checked {
-        border-color: theme.$input-color-disabled;
+        border-color: form-fields-theme.$input-color-disabled;
     }
 }
 

--- a/packages/web/src/scss/components/RadioField/_theme.scss
+++ b/packages/web/src/scss/components/RadioField/_theme.scss
@@ -1,22 +1,10 @@
 @use '@tokens' as tokens;
-
-$spacing: tokens.$space-400;
+@use '../../theme/form-fields' as form-fields-theme;
 
 $input-border-radius: 50%;
-$input-outline-width: 2px;
-$input-width: 20px;
-$input-inner-dot-width: 10px;
-$input-inner-dot-width: 10px;
-$input-margin: 3px;
-$input-color-unchecked: tokens.$text-primary-default;
-$input-color-checked: tokens.$action-primary-default;
-$input-color-disabled: tokens.$text-primary-disabled;
-$input-box-shadow-before: inset tokens.$space-600 tokens.$space-600 $input-color-checked;
-$input-box-shadow-disabled: inset tokens.$space-600 tokens.$space-600 $input-color-disabled;
+$input-size: 1.25em;
+$input-inner-dot-size: 0.625em;
+$input-box-shadow-before: inset tokens.$space-600 tokens.$space-600 form-fields-theme.$inline-field-input-color-checked;
+$input-box-shadow-disabled: inset tokens.$space-600 tokens.$space-600 form-fields-theme.$input-color-disabled;
 $input-transition: 0.12s transform ease-in-out;
 $input-focus-shadow: tokens.$focus;
-
-$label-typography: tokens.$body-medium-text-regular;
-$label-color-disabled: tokens.$text-primary-disabled;
-$label-color-default: tokens.$text-primary-default;
-$label-margin: tokens.$space-400;

--- a/packages/web/src/scss/components/TextArea/README.md
+++ b/packages/web/src/scss/components/TextArea/README.md
@@ -1,0 +1,135 @@
+# TextArea
+
+Basic usage:
+
+```html
+<div class="TextArea">
+  <label for="TextArea1" class="TextArea__label">Label</label>
+  <textarea id="TextArea1" class="TextArea__input" placeholder="Placeholder"></textarea>
+</div>
+```
+
+Required textarea:
+
+```html
+<div class="TextArea">
+  <label for="TextArea2" class="TextArea__label TextArea__label--required">Label of required textarea</label>
+  <textarea id="TextArea2" class="TextArea__input" placeholder="Placeholder" required></textarea>
+</div>
+```
+
+Additional message:
+
+```html
+<div class="TextArea">
+  <label for="TextArea3" class="TextArea__label">Label of textarea with message</label>
+  <textarea id="TextArea3" class="TextArea__input" placeholder="Placeholder"></textarea>
+  <div class="TextArea__message">Message</div>
+</div>
+```
+
+Hidden label:
+
+```html
+<div class="TextArea">
+  <label for="TextArea4" class="TextArea__label TextArea__label--hidden">Label hidden</label>
+  <textarea id="TextArea4" class="TextArea__input" placeholder="Placeholder">Filled</textarea>
+</div>
+```
+
+Fluid width:
+
+```html
+<div class="TextArea TextArea--fluid">
+  <label for="TextArea7" class="TextArea__label">Label of a fluid textarea</label>
+  <textarea id="TextArea7" class="TextArea__input" placeholder="Placeholder"></textarea>
+  <div class="TextArea__message">Message</div>
+</div>
+```
+
+## Input Width
+
+There are several ways to adjust the textarea width:
+
+### `rows` Attribute
+
+The number of visible text lines for the control. Supported values are positive integers from `3` up.
+
+```html
+<div class="TextArea">
+  <label for="TextArea-rows" class="TextArea__label">Label</label>
+  <textarea rows="3" id="TextArea-rows" class="TextArea__input"></textarea>
+</div>
+```
+
+### Grid
+
+For other use cases (wider textarea or textarea with unknown value length), we
+recommend placing them inside the Grid component and using `TextArea--fluid`
+modifier to fill the available space.
+
+## Validation States
+
+Validation states can be presented either by adding a CSS modifier class
+(`TextArea--success`, `TextArea--warning`, `TextArea--error`), or by adding
+a JS interaction class when controlled by JavaScript (`has-success`,
+`has-warning`, `has-error`).
+
+```html
+<div class="TextArea TextArea--error">
+  <label for="TextAreaValidation1" class="TextArea__label TextArea__label--required">
+    Label of textarea with error
+  </label>
+  <textarea id="TextAreaValidation1" class="TextArea__input" placeholder="Placeholder" required>Filled</textarea>
+  <div class="TextArea__message">Error message</div>
+</div>
+<div class="TextArea has-error">
+  <label for="TextAreaValidation2" class="TextArea__label TextArea__label--required">
+    Label of textarea with error
+  </label>
+  <textarea id="TextAreaValidation2" class="TextArea__input" placeholder="Placeholder" required>Filled</textarea>
+  <div class="TextArea__message">Error message</div>
+</div>
+```
+
+### JavaScript-Controlled Validation Message
+
+When implementing client-side form validation, use JS interaction state classes
+(`has-success`, `has-warning`, `has-error`) on the wrapping `<div>` element and
+render validation messages in a `<div>` with `data-element="validator_message"`
+attribute. This way your JS remains disconnected from CSS that may or may not be
+[prefixed].
+
+**Remember this approach is only valid for vanilla JS implementation. React
+components mix CSS with JS by design and handle prefixes their own way.**
+
+```html
+<div class="TextArea has-error">
+  <label for="TextAreaJSValidation1" class="TextArea__label TextArea__label--required">
+    Label of textarea with error
+  </label>
+  <textarea id="TextAreaJSValidation1" class="TextArea__input" placeholder="Placeholder" required>Filled</textarea>
+  <div data-element="validator_message">Error message inserted by JS</div>
+</div>
+```
+
+## Disabled State
+
+On top of adding the `disabled` attribute to the textarea, disabled TextArea can
+be marked by adding `TextArea--disabled` modifier class, or with `is-disabled`
+JS interaction class when controlled by JavaScript:
+
+```html
+<div class="TextArea TextArea--disabled">
+  <label for="TextAreaDisabled1" class="TextArea__label TextArea__label--required">Label of disabled textarea</label>
+  <textarea id="TextAreaDisabled1" class="TextArea__input" placeholder="Placeholder" disabled required></textarea>
+  <div class="TextArea__message">Message</div>
+</div>
+<div class="TextArea is-disabled">
+  <label for="TextAreaDisabled2" class="TextArea__label TextArea__label--required">Label of disabled textarea</label>
+  <textarea id="TextAreaDisabled2" class="TextArea__input" placeholder="Placeholder" disabled required></textarea>
+  <div class="TextArea__message">Message</div>
+</div>
+```
+
+[prefixed]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web#prefixing-css-class-names

--- a/packages/web/src/scss/components/TextArea/_TextArea.scss
+++ b/packages/web/src/scss/components/TextArea/_TextArea.scss
@@ -1,0 +1,58 @@
+@use '../../theme/form-fields' as form-fields-theme;
+@use '../../tools/form-fields' as form-fields-tools;
+@use 'theme';
+
+$_field-name: 'TextArea';
+
+.TextArea {
+    @include form-fields-tools.box-field-root();
+}
+
+.TextArea__label {
+    @include form-fields-tools.box-field-label();
+}
+
+.TextArea__label--hidden {
+    @include form-fields-tools.label-hidden();
+}
+
+.TextArea__label--required::after {
+    @include form-fields-tools.label-required();
+}
+
+.TextArea__input {
+    @include form-fields-tools.box-field-input();
+
+    min-height: calc(
+        #{theme.$input-min-height} + 2 * #{form-fields-theme.$box-field-input-padding-x} + 2 * #{form-fields-theme.$box-field-input-border-width}
+    );
+    resize: vertical;
+}
+
+.TextArea--fluid {
+    @include form-fields-tools.box-field-fluid();
+}
+
+.TextArea > .TextArea__input:focus-visible {
+    @include form-fields-tools.box-field-focus-visible();
+}
+
+.TextArea__message,
+.TextArea > [data-element='validator_message'] {
+    @include form-fields-tools.message();
+}
+
+@include form-fields-tools.box-field-variants($_field-name);
+
+.TextArea--disabled > .TextArea__label {
+    @include form-fields-tools.label-disabled();
+}
+
+.TextArea .TextArea__input:disabled,
+:is(.TextArea--disabled, .TextArea.is-disabled) .TextArea__input {
+    @include form-fields-tools.box-field-disabled-input();
+}
+
+:is(.TextArea--disabled, .TextArea.is-disabled) > :is(.TextArea__message, [data-element='validator_message']) {
+    @include form-fields-tools.message-disabled();
+}

--- a/packages/web/src/scss/components/TextArea/_theme.scss
+++ b/packages/web/src/scss/components/TextArea/_theme.scss
@@ -1,0 +1,1 @@
+$input-min-height: 3.375rem;

--- a/packages/web/src/scss/components/TextArea/index.html
+++ b/packages/web/src/scss/components/TextArea/index.html
@@ -1,0 +1,75 @@
+{{#> layout/plain }}
+
+<div class="docs-FormFieldGrid">
+  <div class="TextArea">
+    <label for="textareaSimple" class="TextArea__label TextArea__label--required">Label</label>
+    <textarea id="textareaSimple" class="TextArea__input" placeholder="Placeholder"></textarea>
+  </div>
+  <div class="TextArea">
+    <label for="textareaMessage" class="TextArea__label">Label</label>
+    <textarea id="textareaMessage" class="TextArea__input" placeholder="Placeholder"></textarea>
+    <div class="TextArea__message">Message</div>
+  </div>
+  <div class="TextArea">
+    <label for="textareaFilled" class="TextArea__label TextArea__label--required">Label</label>
+    <textarea id="textareaFilled" class="TextArea__input" placeholder="Placeholder">Filled</textarea>
+  </div>
+  <div class="TextArea">
+    <label for="textareaFilledMessage" class="TextArea__label TextArea__label--required">Label</label>
+    <textarea id="textareaFilledMessage" class="TextArea__input" placeholder="Placeholder">Filled</textarea>
+    <div class="TextArea__message">Message</div>
+  </div>
+  <div class="TextArea TextArea--error">
+    <label for="textareaError" class="TextArea__label TextArea__label--required">Label</label>
+    <textarea id="textareaError" class="TextArea__input" placeholder="Placeholder">Filled</textarea>
+  </div>
+  <div class="TextArea TextArea--error">
+    <label for="textareaErrorMessage" class="TextArea__label TextArea__label--required">Label</label>
+    <textarea id="textareaErrorMessage" class="TextArea__input" placeholder="Placeholder">Filled</textarea>
+    <div class="TextArea__message">Message</div>
+  </div>
+  <div class="TextArea TextArea--success">
+    <label for="textareaSuccess" class="TextArea__label TextArea__label--required">Label</label>
+    <textarea id="textareaSuccess" class="TextArea__input" placeholder="Placeholder">Filled</textarea>
+    <div class="TextArea__message">Message</div>
+  </div>
+  <div class="TextArea TextArea--warning">
+    <label for="textareaWarning" class="TextArea__label TextArea__label--required">Label</label>
+    <textarea id="textareaWarning" class="TextArea__input" placeholder="Placeholder">Filled</textarea>
+    <div class="TextArea__message">Message</div>
+  </div>
+  <div class="TextArea TextArea--disabled">
+    <label for="textareaDisabled" class="TextArea__label TextArea__label--required">Label</label>
+    <textarea id="textareaDisabled" class="TextArea__input" placeholder="Placeholder" disabled></textarea>
+    <div class="TextArea__message">Message</div>
+  </div>
+  <div class="TextArea TextArea--disabled">
+    <label for="textareaDisabledFilled" class="TextArea__label TextArea__label--required">Label</label>
+    <textarea
+      id="textareaDisabledFilled"
+      class="TextArea__input"
+      placeholder="Placeholder"
+      disabled
+   >Filled</textarea>
+    <div class="TextArea__message">Message</div>
+  </div>
+  <div class="TextArea TextArea--fluid">
+    <label for="textareaFluid" class="TextArea__label TextArea__label--required">Label</label>
+    <textarea id="textareaFluid" class="TextArea__input" placeholder="Placeholder">Filled</textarea>
+    <div class="TextArea__message">Message</div>
+  </div>
+
+  <div style="display: flex; gap: 1rem; align-items: flex-end;">
+    <div class="TextArea">
+      <label for="textareaInlineHiddenLabel" class="TextArea__label TextArea__label--hidden">Hidden Label</label>
+      <textarea
+        id="textareaInlineHiddenLabel"
+        class="TextArea__input"
+        placeholder="Placeholder"
+     >Filled</textarea>
+    </div>
+    <button type="button" class="Button Button--primary Button--medium">Button</button>
+  </div>
+</div>
+
+{{/layout/plain }}

--- a/packages/web/src/scss/components/TextArea/index.scss
+++ b/packages/web/src/scss/components/TextArea/index.scss
@@ -1,0 +1,1 @@
+@forward 'TextArea';

--- a/packages/web/src/scss/components/TextField/README.md
+++ b/packages/web/src/scss/components/TextField/README.md
@@ -4,8 +4,8 @@ Basic usage:
 
 ```html
 <div class="TextField">
-  <label for="textfield1" class="TextField__label">Label</label>
-  <input type="text" id="textfield1" class="TextField__input" placeholder="Placeholder" />
+  <label for="textfield" class="TextField__label">Label</label>
+  <input type="text" id="textfield" class="TextField__input" placeholder="Placeholder" />
 </div>
 ```
 
@@ -13,8 +13,8 @@ Required input:
 
 ```html
 <div class="TextField">
-  <label for="textfield2" class="TextField__label TextField__label--required">Label of required input</label>
-  <input type="text" id="textfield2" class="TextField__input" placeholder="Placeholder" required />
+  <label for="textfield-required" class="TextField__label TextField__label--required">Label of required input</label>
+  <input type="text" id="textfield-required" class="TextField__input" placeholder="Placeholder" required />
 </div>
 ```
 
@@ -22,8 +22,8 @@ Additional message:
 
 ```html
 <div class="TextField">
-  <label for="textfield3" class="TextField__label">Label of input with message</label>
-  <input type="text" id="textfield3" class="TextField__input" placeholder="Placeholder" />
+  <label for="textfield-message" class="TextField__label">Label of input with message</label>
+  <input type="text" id="textfield-message" class="TextField__input" placeholder="Placeholder" />
   <div class="TextField__message">Message</div>
 </div>
 ```
@@ -32,8 +32,8 @@ Hidden label:
 
 ```html
 <div class="TextField">
-  <label for="textfield4" class="TextField__label TextField__label--hidden">Label Hidden</label>
-  <input type="text" id="textfield4" class="TextField__input" placeholder="Placeholder" value="Filled" />
+  <label for="textfield-label-hidden" class="TextField__label TextField__label--hidden">Label Hidden</label>
+  <input type="text" id="textfield-label-hidden" class="TextField__input" placeholder="Placeholder" value="Filled" />
 </div>
 ```
 
@@ -41,8 +41,8 @@ Fluid width:
 
 ```html
 <div class="TextField TextField--fluid">
-  <label for="textfield7" class="TextField__label">Label of a fluid input</label>
-  <input type="text" id="textfield7" class="TextField__input" placeholder="Placeholder" />
+  <label for="textfield-fluid" class="TextField__label">Label of a fluid input</label>
+  <input type="text" id="textfield-fluid" class="TextField__input" placeholder="Placeholder" />
   <div class="TextField__message">Message</div>
 </div>
 ```
@@ -98,7 +98,7 @@ forget to change not only the input type but also `aria-pressed` and
 
 ```html
 <div class="TextField">
-  <label for="textfieldPasswordToggle" class="TextField__label TextField__label--required">Password Toggle</label>
+  <label for="textfield-password-toggle" class="TextField__label TextField__label--required">Password Toggle</label>
   <div class="TextField__passwordToggle">
     <button
       type="button"
@@ -121,7 +121,7 @@ forget to change not only the input type but also `aria-pressed` and
     </button>
     <input
       type="password"
-      id="textfieldPasswordToggle"
+      id="textfield-password-toggle"
       class="TextField__input"
       placeholder="Password must be at least 6 characters long"
     />
@@ -138,17 +138,17 @@ a JS interaction class when controlled by JavaScript (`has-success`,
 
 ```html
 <div class="TextField TextField--error">
-  <label for="textfieldValidation1" class="TextField__label TextField__label--required">
+  <label for="textfield-validation-1" class="TextField__label TextField__label--required">
     Label of input with error
   </label>
-  <input type="text" id="textfieldValidation1" class="TextField__input" placeholder="Placeholder" value="Filled" />
+  <input type="text" id="textfield-validation-1" class="TextField__input" placeholder="Placeholder" value="Filled" />
   <div class="TextField__message">Error message</div>
 </div>
 <div class="TextField has-error">
-  <label for="textfieldValidation2" class="TextField__label TextField__label--required">
+  <label for="textfield-validation-2" class="TextField__label TextField__label--required">
     Label of input with error
   </label>
-  <input type="text" id="textfieldValidation2" class="TextField__input" placeholder="Placeholder" value="Filled" />
+  <input type="text" id="textfield-validation-2" class="TextField__input" placeholder="Placeholder" value="Filled" />
   <div class="TextField__message">Error message</div>
 </div>
 ```
@@ -166,10 +166,10 @@ components mix CSS with JS by design and handle prefixes their own way.**
 
 ```html
 <div class="TextField has-error">
-  <label for="textfieldJSValidation1" class="TextField__label TextField__label--required">
+  <label for="textfield-js-validation" class="TextField__label TextField__label--required">
     Label of input with error
   </label>
-  <input type="text" id="textfieldJSValidation1" class="TextField__input" placeholder="Placeholder" value="Filled" />
+  <input type="text" id="textfield-js-validation" class="TextField__input" placeholder="Placeholder" value="Filled" />
   <div data-element="validator_message">Error message inserted by JS</div>
 </div>
 ```
@@ -182,13 +182,13 @@ JS interaction class when controlled by JavaScript:
 
 ```html
 <div class="TextField TextField--disabled">
-  <label for="textfieldDisabled1" class="TextField__label TextField__label--required">Label of disabled input</label>
-  <input type="text" id="textfieldDisabled1" class="TextField__input" placeholder="Placeholder" disabled />
+  <label for="textfield-disabled-1" class="TextField__label TextField__label--required">Label of disabled input</label>
+  <input type="text" id="textfield-disabled-1" class="TextField__input" placeholder="Placeholder" disabled />
   <div class="TextField__message">Message</div>
 </div>
 <div class="TextField is-disabled">
-  <label for="textfieldDisabled2" class="TextField__label TextField__label--required">Label of disabled input</label>
-  <input type="text" id="textfieldDisabled2" class="TextField__input" placeholder="Placeholder" disabled />
+  <label for="textfield-disabled-2" class="TextField__label TextField__label--required">Label of disabled input</label>
+  <input type="text" id="textfield-disabled-2" class="TextField__input" placeholder="Placeholder" disabled />
   <div class="TextField__message">Message</div>
 </div>
 ```

--- a/packages/web/src/scss/components/TextField/_TextField.scss
+++ b/packages/web/src/scss/components/TextField/_TextField.scss
@@ -1,48 +1,29 @@
-@use 'sass:map';
-@use 'theme';
 @use '../../settings/cursors';
-@use '../../tools/accessibility';
+@use '../../theme/form-fields' as form-fields-theme;
+@use '../../tools/form-fields' as form-fields-tools;
 @use '../../tools/reset';
-@use '../../tools/svg';
-@use '../../tools/typography';
+@use 'theme';
+
+$_field-name: 'TextField';
 
 .TextField {
-    display: inline-block;
-    width: theme.$width-default;
+    @include form-fields-tools.box-field-root();
 }
 
 .TextField__label {
-    @include typography.generate(theme.$label-typography);
-
-    display: block;
-    margin-bottom: theme.$spacing;
-    color: theme.$label-color-default;
+    @include form-fields-tools.box-field-label();
 }
 
 .TextField__label--hidden {
-    @include accessibility.hide-text();
+    @include form-fields-tools.label-hidden();
 }
 
 .TextField__label--required::after {
-    content: '*';
-    color: theme.$label-required-color;
+    @include form-fields-tools.label-required();
 }
 
 .TextField__input {
-    @include typography.generate(theme.$input-typography);
-
-    display: block;
-    width: 100%;
-    padding: theme.$input-padding-y theme.$input-padding-x;
-    color: theme.$input-color-default;
-    border: theme.$input-border-width theme.$input-border-style theme.$input-border-color-default;
-    border-radius: theme.$input-border-radius;
-    background: theme.$input-background;
-
-    &::placeholder {
-        color: theme.$input-placeholder-color-default;
-        opacity: 1;
-    }
+    @include form-fields-tools.box-field-input();
 
     &[type='email'],
     &[type='number'],
@@ -60,7 +41,8 @@
 
     &[size] {
         width: calc(
-            var(--width) + 2 * #{theme.$input-padding-x} + 2 * #{theme.$input-border-width} + var(--arrows-width, 0px)
+            var(--width) + 2 * #{form-fields-theme.$box-field-input-padding-x} + 2 * #{form-fields-theme.$box-field-input-border-width} +
+                var(--arrows-width, 0px)
         );
     }
 
@@ -72,7 +54,7 @@
 }
 
 .TextField--fluid {
-    width: 100%;
+    @include form-fields-tools.box-field-fluid();
 }
 
 .TextField__passwordToggle {
@@ -95,8 +77,8 @@
     align-items: center;
     justify-content: center;
     padding: theme.$input-password-toggle-padding;
-    color: theme.$input-color-default;
-    border-radius: theme.$input-border-radius;
+    color: form-fields-theme.$box-field-input-color-default;
+    border-radius: form-fields-theme.$box-field-input-border-radius;
 
     &::before {
         content: '';
@@ -105,8 +87,9 @@
         right: 0;
         bottom: 0;
         left: 0;
-        border: theme.$input-border-width theme.$input-border-style theme.$input-border-color-default;
-        border-radius: theme.$input-border-radius;
+        border: form-fields-theme.$box-field-input-border-width form-fields-theme.$box-field-input-border-style
+            form-fields-theme.$box-field-input-border-color-default;
+        border-radius: form-fields-theme.$box-field-input-border-radius;
         pointer-events: none;
     }
 }
@@ -129,9 +112,7 @@
 // stylelint-disable selector-max-specificity, selector-max-class, selector-max-compound-selectors -- We need high-specificity selectors here.
 .TextField > .TextField__input:focus-visible,
 .TextField > .TextField__passwordToggle > .TextField__input:focus-visible ~ .TextField__passwordToggle__button::before {
-    border-color: theme.$input-border-color-focus;
-    outline: 0;
-    box-shadow: theme.$input-focus-shadow;
+    @include form-fields-tools.box-field-focus-visible();
 }
 // stylelint-enable selector-max-specificity, selector-max-class, selector-max-compound-selectors
 
@@ -148,44 +129,24 @@
     z-index: 1;
     width: (2 * theme.$input-password-toggle-padding) + theme.$input-password-toggle-icon-size;
     height: 100%;
-    border-radius: theme.$input-border-radius;
-    box-shadow: theme.$input-focus-shadow;
+    border-radius: form-fields-theme.$box-field-input-border-radius;
+    box-shadow: form-fields-theme.$input-focus-shadow;
 }
 
 .TextField__message,
 .TextField > [data-element='validator_message'] {
-    @include typography.generate(theme.$message-typography);
-
-    margin-top: theme.$spacing;
-    color: theme.$message-color-default;
+    @include form-fields-tools.message();
 }
 
-@each $variant-name, $variant-value in theme.$variants {
-    :is(.TextField--#{$variant-name}, .TextField.has-#{$variant-name}) > .TextField__input,
-    :is(.TextField--#{$variant-name}, .TextField.has-#{$variant-name})
-        .TextField__passwordToggle
-        > .TextField__input
-        ~ .TextField__passwordToggle__button::before {
-        border-color: map.get($variant-value, input-border-color);
-    }
-
-    :is(.TextField--#{$variant-name}, .TextField.has-#{$variant-name})
-        > :is(.TextField__message, [data-element='validator_message']) {
-        color: map.get($variant-value, message-color);
-    }
-}
+@include form-fields-tools.box-field-variants($_field-name);
 
 .TextField--disabled > .TextField__label {
-    color: theme.$label-color-disabled;
+    @include form-fields-tools.label-disabled();
 }
 
 .TextField .TextField__input:disabled,
 :is(.TextField--disabled, .TextField.is-disabled) .TextField__input {
-    color: theme.$input-color-disabled;
-
-    &::placeholder {
-        color: theme.$input-placeholder-color-disabled;
-    }
+    @include form-fields-tools.box-field-disabled-input();
 }
 
 // stylelint-disable no-descending-specificity, selector-max-specificity, selector-max-class, selector-max-compound-selectors
@@ -205,11 +166,12 @@
 
 .TextField .TextField__input:disabled ~ .TextField__passwordToggle__button,
 :is(.TextField--disabled, .TextField.is-disabled) .TextField__passwordToggle__button {
-    color: theme.$input-color-disabled;
+    @include form-fields-tools.input-disabled();
+
     pointer-events: none;
     cursor: cursors.$disabled;
 }
 
 :is(.TextField--disabled, .TextField.is-disabled) > :is(.TextField__message, [data-element='validator_message']) {
-    color: theme.$message-color-disabled;
+    @include form-fields-tools.message-disabled();
 }

--- a/packages/web/src/scss/components/TextField/_theme.scss
+++ b/packages/web/src/scss/components/TextField/_theme.scss
@@ -1,56 +1,7 @@
 @use '@tokens' as tokens;
 
-$spacing: tokens.$space-300;
-$width-default: 18rem;
-
-$label-typography: tokens.$body-small-text-regular;
-$label-color-default: tokens.$text-primary-default;
-$label-color-disabled: tokens.$text-secondary-disabled;
-$label-required-color: tokens.$emotion-danger-default;
-
-$input-padding-x: tokens.$space-400;
-$input-padding-y: tokens.$space-400;
-$input-typography: tokens.$body-medium-text-regular;
-$input-color-default: tokens.$text-primary-default;
-$input-color-disabled: tokens.$text-primary-disabled;
-$input-border-width: tokens.$border-width-100;
-$input-border-style: tokens.$border-style-100;
-$input-border-color-default: tokens.$border-primary-default;
-$input-border-color-hover: tokens.$border-primary-hover;
-$input-border-color-focus: tokens.$focus-default;
 $input-border-color-disabled: tokens.$border-primary-disabled;
-$input-border-color-success: tokens.$emotion-success-default;
-$input-border-color-warning: tokens.$emotion-warning-default;
-$input-border-color-error: tokens.$emotion-danger-default;
-$input-border-radius: tokens.$radius-100;
-$input-background: tokens.$background-basic;
-$input-focus-shadow: tokens.$focus;
-$input-placeholder-color-default: tokens.$text-secondary-default;
-$input-placeholder-color-disabled: tokens.$text-secondary-disabled;
-$input-size-characters: (2, 3, 4);
 $input-number-arrows-width: 1.25rem;
-
 $input-password-toggle-padding: tokens.$space-400;
 $input-password-toggle-icon-size: tokens.$space-700;
-
-$message-typography: tokens.$body-medium-text-regular;
-$message-color-default: tokens.$text-secondary-default;
-$message-color-disabled: tokens.$text-secondary-disabled;
-$message-color-success: tokens.$emotion-success-default;
-$message-color-warning: tokens.$emotion-warning-default;
-$message-color-error: tokens.$emotion-danger-default;
-
-$variants: (
-    success: (
-        input-border-color: $input-border-color-success,
-        message-color: $input-border-color-success,
-    ),
-    warning: (
-        input-border-color: $input-border-color-warning,
-        message-color: $input-border-color-warning,
-    ),
-    error: (
-        input-border-color: $input-border-color-error,
-        message-color: $input-border-color-error,
-    ),
-);
+$input-size-characters: (2, 3, 4);

--- a/packages/web/src/scss/components/TextField/index.html
+++ b/packages/web/src/scss/components/TextField/index.html
@@ -205,6 +205,21 @@
     <button type="button" class="Button Button--primary Button--medium">Button</button>
   </div>
 
+  <div style="display: flex; align-items: start; gap: 1rem">
+    <div class="TextField TextField--error">
+      <label for="textfieldInlineErrorHiddenLabel" class="TextField__label TextField__label--hidden">Hidden Label</label>
+      <input
+        type="text"
+        id="textfieldInlineErrorHiddenLabel"
+        class="TextField__input"
+        placeholder="Placeholder"
+        value="Filled"
+      />
+      <div class="TextField__message">Message</div>
+    </div>
+    <button type="button" class="Button Button--primary Button--medium">Button</button>
+  </div>
+
   <div style="display: flex; gap: 1rem">
     <div class="TextField">
       <label for="textfieldInlineFirst" class="TextField__label TextField__label--hidden">Hidden Label</label>

--- a/packages/web/src/scss/components/index.scss
+++ b/packages/web/src/scss/components/index.scss
@@ -14,5 +14,6 @@
 @forward 'Stack';
 @forward 'Tabs';
 @forward 'Tag';
+@forward 'TextArea';
 @forward 'TextField';
 @forward 'Tooltip';

--- a/packages/web/src/scss/theme/_form-fields.scss
+++ b/packages/web/src/scss/theme/_form-fields.scss
@@ -1,0 +1,57 @@
+@use '@tokens' as tokens;
+
+// Common for all form components
+$spacing: tokens.$space-400;
+$input-typography: tokens.$body-medium-text-regular;
+$input-color-disabled: tokens.$text-primary-disabled;
+$input-focus-shadow: tokens.$focus;
+$label-color-default: tokens.$text-primary-default;
+$label-color-disabled: tokens.$text-primary-disabled;
+$label-required-color: tokens.$emotion-danger-default;
+$message-typography: tokens.$body-medium-text-regular;
+$message-margin-top: tokens.$space-300;
+$message-color-default: tokens.$text-secondary-default;
+$message-color-disabled: tokens.$text-secondary-disabled;
+$message-color-error: tokens.$emotion-danger-default;
+
+// Inline field form components – CheckboxField, RadioField, etc.
+$inline-field-input-color-unchecked: tokens.$action-unselected-default;
+$inline-field-input-color-checked: tokens.$action-selected-default;
+$inline-field-input-margin: 3px;
+$inline-field-input-outline-width: tokens.$border-width-200;
+
+// Box field form components – TextField, TextArea, etc.
+$box-field-input-color-default: tokens.$text-primary-default;
+$box-field-input-border-width: tokens.$border-width-100;
+$box-field-input-border-style: tokens.$border-style-100;
+$box-field-input-border-color-default: tokens.$border-primary-default;
+$box-field-input-border-color-focus: tokens.$focus-default;
+$box-field-input-border-color-success: tokens.$emotion-success-default;
+$box-field-input-border-color-warning: tokens.$emotion-warning-default;
+$box-field-input-border-color-error: tokens.$emotion-danger-default;
+$box-field-input-border-radius: tokens.$radius-100;
+$box-field-input-background: tokens.$background-basic;
+$box-field-input-placeholder-color-default: tokens.$text-secondary-default;
+$box-field-input-placeholder-color-disabled: tokens.$text-secondary-disabled;
+$box-field-input-padding-x: tokens.$space-400;
+$box-field-input-padding-y: calc(#{tokens.$space-400} - #{tokens.$border-width-100});
+$box-field-input-width: 18rem;
+$box-field-label-typography: tokens.$body-small-text-regular;
+$box-field-label-margin-bottom: tokens.$space-300;
+$box-field-message-color-success: tokens.$emotion-success-default;
+$box-field-message-color-warning: tokens.$emotion-warning-default;
+
+$box-field-variants: (
+    success: (
+        input-border-color: $box-field-input-border-color-success,
+        message-color: $box-field-message-color-success,
+    ),
+    warning: (
+        input-border-color: $box-field-input-border-color-warning,
+        message-color: $box-field-message-color-warning,
+    ),
+    error: (
+        input-border-color: $box-field-input-border-color-error,
+        message-color: $message-color-error,
+    ),
+);

--- a/packages/web/src/scss/tools/_form-fields.scss
+++ b/packages/web/src/scss/tools/_form-fields.scss
@@ -1,0 +1,128 @@
+@use 'sass:map';
+@use '../theme/form-fields' as form-fields-theme;
+@use 'accessibility';
+@use 'typography';
+
+@mixin label-disabled() {
+    color: form-fields-theme.$label-color-disabled;
+}
+
+@mixin label-hidden() {
+    @include accessibility.hide-text();
+}
+
+@mixin label-required() {
+    content: '*';
+    color: form-fields-theme.$label-required-color;
+}
+
+@mixin input-disabled() {
+    color: form-fields-theme.$input-color-disabled;
+}
+
+@mixin message() {
+    @include typography.generate(form-fields-theme.$message-typography);
+
+    display: block;
+    margin-top: form-fields-theme.$message-margin-top;
+    color: form-fields-theme.$message-color-default;
+}
+
+@mixin message-disabled() {
+    color: form-fields-theme.$message-color-disabled;
+}
+
+@mixin inline-field-root() {
+    display: inline-flex;
+    margin-block: form-fields-theme.$spacing;
+}
+
+@mixin box-field-root() {
+    display: inline-block;
+    width: form-fields-theme.$box-field-input-width;
+}
+
+@mixin inline-field-label() {
+    @include typography.generate(form-fields-theme.$input-typography);
+
+    display: inline-block;
+    color: form-fields-theme.$label-color-default;
+}
+
+@mixin box-field-label() {
+    @include typography.generate(form-fields-theme.$box-field-label-typography);
+
+    display: block;
+    margin-bottom: form-fields-theme.$box-field-label-margin-bottom;
+    color: form-fields-theme.$label-color-default;
+}
+
+@mixin inline-field-input() {
+    appearance: none;
+    margin: form-fields-theme.$inline-field-input-margin;
+    color: form-fields-theme.$inline-field-input-color-unchecked;
+    border: form-fields-theme.$inline-field-input-outline-width solid currentcolor;
+
+    &:focus-visible {
+        outline: 0;
+        box-shadow: form-fields-theme.$input-focus-shadow;
+    }
+}
+
+@mixin box-field-input() {
+    @include typography.generate(form-fields-theme.$input-typography);
+
+    display: block;
+    width: 100%;
+    padding: form-fields-theme.$box-field-input-padding-y form-fields-theme.$box-field-input-padding-x;
+    color: form-fields-theme.$box-field-input-color-default;
+    border: form-fields-theme.$box-field-input-border-width form-fields-theme.$box-field-input-border-style
+        form-fields-theme.$box-field-input-border-color-default;
+    border-radius: form-fields-theme.$box-field-input-border-radius;
+    background: form-fields-theme.$box-field-input-background;
+
+    &::placeholder {
+        color: form-fields-theme.$box-field-input-placeholder-color-default;
+        opacity: 1;
+    }
+}
+
+@mixin box-field-variants($field-name) {
+    @each $variant-name, $variant-value in form-fields-theme.$box-field-variants {
+        :is(.#{$field-name}--#{$variant-name}, .#{$field-name}.has-#{$variant-name}) > .#{$field-name}__input {
+            border-color: map.get($variant-value, input-border-color);
+        }
+
+        @if $field-name == 'TextField' {
+            :is(.#{$field-name}--#{$variant-name}, .#{$field-name}.has-#{$variant-name})
+                .#{$field-name}__passwordToggle
+                > .#{$field-name}__input
+                ~ .#{$field-name}__passwordToggle__button::before {
+                border-color: map.get($variant-value, input-border-color);
+            }
+        }
+
+        :is(.#{$field-name}--#{$variant-name}, .#{$field-name}.has-#{$variant-name})
+            > :is(.#{$field-name}__message, [data-element='validator_message']) {
+            color: map.get($variant-value, message-color);
+        }
+    }
+}
+
+@mixin box-field-fluid() {
+    width: 100%;
+}
+
+@mixin box-field-focus-visible() {
+    border-color: form-fields-theme.$box-field-input-border-color-focus;
+    outline: 0;
+    box-shadow: form-fields-theme.$input-focus-shadow;
+}
+
+@mixin box-field-disabled-input() {
+    @include input-disabled();
+
+    &::placeholder {
+        color: form-fields-theme.$box-field-input-placeholder-color-disabled;
+    }
+}


### PR DESCRIPTION
Introducing new component is great opportunity to unify form field theme and create mixins to reduce code duplicity between form components. 🙂 

I suppose there could be a better solution. Code switching according component name in mixins and sharing all variables no matter which component uses them doesn't look like easily scalable solution. 

I'll appreciate better ideas from @adamkudrna and @crishpeen. 🙏🏻 