### PR TITLE
Fix(web): Prevent from dropdown content overflow outside its container

### DIFF
--- a/packages/web/src/scss/components/Dropdown/_Dropdown.scss
+++ b/packages/web/src/scss/components/Dropdown/_Dropdown.scss
@@ -7,7 +7,6 @@
     z-index: 1;
     display: none;
     width: max-content;
-    max-width: 100%;
     padding: theme.$padding;
     border-radius: theme.$border-radius;
     background-color: theme.$background;


### PR DESCRIPTION
Fixing following problem:

![Screenshot 2022-11-09 at 11 54 18](https://user-images.githubusercontent.com/9672439/200811839-b8b09730-b534-4353-901e-97d41c18058b.png)
