### PR TITLE
Feat(web): Introduction of Accordion CSS+JS

### DIFF
--- a/packages/web/src/js/Collapse.ts
+++ b/packages/web/src/js/Collapse.ts
@@ -6,6 +6,7 @@ import EventHandler from './dom/EventHandler';
 import {
   ARIA_EXPANDED_ATTRIBUTE,
   ARIA_CONTROLS_ATTRIBUTE,
+  NAME_DATA_TOGGLE,
   NAME_DATA_TARGET,
   CLASSNAME_OPEN,
   CLASSNAME_TRANSITION,
@@ -23,32 +24,30 @@ interface CollapseMeta {
   id: string | 'unknown';
   hideOnCollapse: boolean;
   parent: string | undefined;
+  triggerParent: HTMLElement | null | undefined;
 }
 interface CollapseState {
   open: boolean;
-  width: number;
 }
 
 class Collapse extends BaseComponent {
   target: HTMLElement | null | undefined;
-  parent: HTMLElement | null | undefined;
   meta: CollapseMeta;
   state: CollapseState;
 
   constructor(element: HTMLElement) {
     super(element);
     this.target = this.element.dataset.target ? SelectorEngine.findOne(`#${this.element.dataset.target}`) : null;
-    this.parent = this.element && this.element.parentElement;
     this.meta = {
       id: this.element.dataset.target,
       hideOnCollapse: !!(this.element.dataset.more || this.element.dataset.more === ''),
       parent: this.target?.dataset.parent,
+      triggerParent: this.element && this.element.parentElement,
     };
     this.state = {
       open:
         this.element.hasAttribute(ARIA_EXPANDED_ATTRIBUTE) &&
         this.element.getAttribute(ARIA_EXPANDED_ATTRIBUTE) === 'true',
-      width: window.innerWidth,
     };
 
     this.init();
@@ -62,7 +61,7 @@ class Collapse extends BaseComponent {
     return `${this.NAME}`;
   }
 
-  siblingsControlHandler(trigger: HTMLElement) {
+  hideParentSiblings(trigger: HTMLElement) {
     if (this.meta.parent) {
       const parentElement = SelectorEngine.findOne(this.meta.parent);
       const children = parentElement?.children;
@@ -72,7 +71,7 @@ class Collapse extends BaseComponent {
       }
 
       for (const item of children) {
-        const itemTrigger = SelectorEngine.findOne(`[data-toggle="${NAME}"]`, item);
+        const itemTrigger = SelectorEngine.findOne(`[${NAME_DATA_TOGGLE}="${NAME}"]`, item);
         const instance = Collapse.getInstance(itemTrigger);
 
         if (instance?.state?.open && itemTrigger !== trigger) {
@@ -82,20 +81,20 @@ class Collapse extends BaseComponent {
     }
   }
 
-  async appendNodeToParentHandler() {
+  appendNodeToParent() {
     if (this.state.open) {
       const contentEl = this.target?.children[0];
       const innerHtml = contentEl ? contentEl?.innerHTML : this.target?.innerHTML;
-      const originalHtml = this.parent?.innerHTML;
-      if (this.parent) {
-        this.parent.innerHTML = `${originalHtml}${innerHtml}`;
+      const originalHtml = this.meta.triggerParent?.innerHTML;
+      if (this.meta.triggerParent) {
+        this.meta.triggerParent.innerHTML = `${originalHtml}${innerHtml}`;
       }
 
-      await this.target?.remove();
+      this.target?.remove();
     }
   }
 
-  adjustCollapsibleChildrenHeightHandler(zeroHeight?: boolean) {
+  adjustCollapsibleChildrenHeight(zeroHeight?: boolean) {
     if (this.target) {
       const content = this.target.children[0];
       const bounds = content.getBoundingClientRect();
@@ -103,25 +102,27 @@ class Collapse extends BaseComponent {
     }
   }
 
-  adjustCollapsibleElementHeightHandler(open: boolean = this.state.open) {
-    this.adjustCollapsibleChildrenHeightHandler(!open);
+  adjustCollapsibleElementHeight(open: boolean = this.state.open) {
+    this.adjustCollapsibleChildrenHeight(!open);
     if (this.target) {
       EventHandler.trigger(this.target, open ? EVENT_SHOWN : EVENT_HIDDEN);
     }
   }
 
-  updateTriggerElementHandler(open: boolean = this.state.open) {
+  updateTriggerElement(open: boolean = this.state.open) {
     const triggers = SelectorEngine.findAll(`[${NAME_DATA_TARGET}="${this.meta.id}"]`);
     const updateElement = (element: Element | HTMLElement) => {
       element.setAttribute(ARIA_CONTROLS_ATTRIBUTE, this.meta.id);
       element.setAttribute(ARIA_EXPANDED_ATTRIBUTE, String(open));
       if (this.meta.hideOnCollapse && open) {
         element.remove();
-        this.appendNodeToParentHandler();
+        this.appendNodeToParent();
         this.onDestroy();
       }
     };
+
     this.state.open = open;
+
     if (triggers.length === 1) {
       updateElement(this.element);
     } else {
@@ -129,12 +130,12 @@ class Collapse extends BaseComponent {
     }
   }
 
-  updateCollapsibleElementHandler(open: boolean = this.state.open) {
+  updateCollapsibleElement(open: boolean = this.state.open) {
     if (this.target) {
       if (!open) {
-        this.adjustCollapsibleChildrenHeightHandler();
+        this.adjustCollapsibleChildrenHeight();
       }
-      this.adjustCollapsibleElementHeightHandler(open);
+      this.adjustCollapsibleElementHeight(open);
       this.target?.classList.add(CLASSNAME_TRANSITION);
       executeAfterTransition(this.target, () => {
         this.target?.classList.remove(CLASSNAME_TRANSITION);
@@ -148,21 +149,29 @@ class Collapse extends BaseComponent {
     }
   }
 
-  async show() {
-    this.siblingsControlHandler(this.element);
+  show() {
+    this.hideParentSiblings(this.element);
     EventHandler.trigger(this.target as HTMLElement, EVENT_SHOW);
-    this.updateTriggerElementHandler(true);
-    this.updateCollapsibleElementHandler(true);
+    this.updateTriggerElement(true);
+    this.updateCollapsibleElement(true);
 
-    await EventHandler.trigger(this.target as HTMLElement, EVENT_SHOWN);
+    if (this.target) {
+      executeAfterTransition(this.target, () => {
+        EventHandler.trigger(this.target as HTMLElement, EVENT_SHOWN);
+      });
+    }
   }
 
-  async hide() {
+  hide() {
     EventHandler.trigger(this.target as HTMLElement, EVENT_HIDE);
-    this.updateTriggerElementHandler(false);
-    this.updateCollapsibleElementHandler(false);
+    this.updateTriggerElement(false);
+    this.updateCollapsibleElement(false);
 
-    await EventHandler.trigger(this.target as HTMLElement, EVENT_HIDDEN);
+    if (this.target) {
+      executeAfterTransition(this.target, () => {
+        EventHandler.trigger(this.target as HTMLElement, EVENT_HIDDEN);
+      });
+    }
   }
 
   toggle() {
@@ -178,16 +187,16 @@ class Collapse extends BaseComponent {
     if (triggers.length === 1) {
       EventHandler.on(this.element, 'click', () => this.toggle());
     } else {
-      triggers.forEach((trigger) => EventHandler.on(trigger as HTMLElement, 'click', () => this.toggle()));
+      triggers.forEach((trigger) => EventHandler.on(trigger, 'click', () => this.toggle()));
     }
   }
 
   destroyEvents() {
-    const triggers = SelectorEngine.findAll(`[data-target="${this.meta.id}"]`);
+    const triggers = SelectorEngine.findAll(`[${NAME_DATA_TARGET}="${this.meta.id}"]`);
     if (triggers.length === 1) {
       EventHandler.off(this.element, 'click', () => this.toggle());
     } else {
-      triggers.forEach((trigger) => EventHandler.off(trigger as HTMLElement, 'click', () => this.toggle()));
+      triggers.forEach((trigger) => EventHandler.off(trigger, 'click', () => this.toggle()));
     }
   }
 
@@ -196,8 +205,8 @@ class Collapse extends BaseComponent {
   }
 
   init() {
-    this.updateTriggerElementHandler();
-    this.updateCollapsibleElementHandler();
+    this.updateTriggerElement();
+    this.updateCollapsibleElement();
     this.initEvents();
   }
 }

--- a/packages/web/src/js/__tests__/Collapse.test.ts
+++ b/packages/web/src/js/__tests__/Collapse.test.ts
@@ -1,6 +1,7 @@
 import { clearFixture, getFixture } from '../../../tests/helpers/fixture';
+import EventHandler from '../dom/EventHandler';
 import Collapse from '../Collapse';
-import { CLASSNAME_EXPANDED, CLASSNAME_COLLAPSED } from '../constants';
+import { CLASSNAME_OPEN, CLASSNAME_TRANSITION } from '../constants';
 
 describe('Collapse', () => {
   let fixtureEl: Element;
@@ -74,8 +75,10 @@ describe('Collapse', () => {
       await collapse.show();
 
       expect(element.getAttribute('aria-expanded')).toBe('true');
-      expect(element).toHaveClass(CLASSNAME_EXPANDED);
-      expect(target).toHaveClass(CLASSNAME_COLLAPSED);
+      expect(target).toHaveClass(CLASSNAME_TRANSITION);
+
+      EventHandler.trigger(target, 'transitionend');
+      expect(target).toHaveClass(CLASSNAME_OPEN);
     });
   });
 
@@ -96,6 +99,114 @@ describe('Collapse', () => {
       await collapse.hide();
 
       expect(element.getAttribute('aria-expanded')).toBe('false');
+    });
+  });
+
+  describe('accordion', () => {
+    it('should toggle a collapse with parent', async () => {
+      fixtureEl.innerHTML = `
+        <section
+          id="accordionExample1"
+          class="Accordion"
+          data-toggle="accordion"
+        >
+          <article
+            id="accordionExample1_article_0"
+            class="Accordion__item"
+          >
+            <h3
+              id="accordionExample1_article_0_header"
+              class="Accordion__itemHeader"
+            >
+              <button
+                type="button"
+                class="Accordion__itemToggle"
+                data-toggle="collapse"
+                data-target="accordionExample1_article_0_collapse"
+              >
+                header
+              </button>
+              <span class="Accordion__itemSide">
+                <span class="Accordion__itemSlot">
+                  slot
+                </span>
+                <span class="Accordion__itemIcon">
+                  <svg width="24" height="24" aria-hidden="true">
+                    <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+                  </svg>
+                </span>
+              </span>
+            </h3>
+            <div
+              id="accordionExample1_article_0_collapse"
+              class="Collapse"
+              data-parent="#accordionExample1"
+              aria-labelledby="accordionExample1_article_0_header"
+            >
+              <div class="Collapse__content">
+                <div class="Accordion__content">content</div>
+              </div>
+            </div>
+          </article>
+          <article
+            id="accordionExample1_article_1"
+            class="Accordion__item"
+          >
+            <h3
+              id="accordionExample1_article_1_header"
+              class="Accordion__itemHeader"
+            >
+              <button
+                type="button"
+                class="Accordion__itemToggle"
+                data-toggle="collapse"
+                data-target="accordionExample1_article_1_collapse"
+                aria-expanded="true"
+              >
+                header
+              </button>
+              <span class="Accordion__itemSide">
+                <span class="Accordion__itemSlot">
+                  slot
+                </span>
+                <span class="Accordion__itemIcon">
+                  <svg width="24" height="24" aria-hidden="true">
+                    <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+                  </svg>
+                </span>
+              </span>
+            </h3>
+            <div
+              id="accordionExample1_article_1_collapse"
+              class="Collapse is-open"
+              data-parent="#accordionExample1"
+              aria-labelledby="accordionExample1_article_1_header"
+            >
+              <div class="Collapse__content">
+                <div class="Accordion__content">content</div>
+              </div>
+            </div>
+          </article>
+        </section>
+      `;
+
+      const element0 = fixtureEl.querySelector('[data-target="accordionExample1_article_0_collapse"]') as HTMLElement;
+      const target0 = fixtureEl.querySelector('#accordionExample1_article_0_collapse') as HTMLElement;
+      const target1 = fixtureEl.querySelector('#accordionExample1_article_1_collapse') as HTMLElement;
+      const collapse0 = new Collapse(element0);
+
+      expect(target0).toHaveClass('Collapse');
+      expect(target1).toHaveClass(CLASSNAME_OPEN);
+
+      await collapse0.show();
+
+      expect(target0).toHaveClass(CLASSNAME_TRANSITION);
+
+      EventHandler.trigger(target0, 'transitionend');
+      EventHandler.trigger(target1, 'transitionend');
+
+      expect(target0).toHaveClass(CLASSNAME_OPEN);
+      expect(target1).toHaveClass('Collapse');
     });
   });
 });

--- a/packages/web/src/js/constants.ts
+++ b/packages/web/src/js/constants.ts
@@ -4,4 +4,5 @@ export const ARIA_CONTROLS_ATTRIBUTE = 'aria-controls';
 export const NAME_DATA_TARGET = 'data-target';
 
 export const CLASSNAME_EXPANDED = 'is-expanded';
-export const CLASSNAME_COLLAPSED = 'is-collapsed';
+export const CLASSNAME_OPEN = 'is-open';
+export const CLASSNAME_TRANSITION = 'is-transitioning';

--- a/packages/web/src/js/constants.ts
+++ b/packages/web/src/js/constants.ts
@@ -1,6 +1,7 @@
 export const ARIA_EXPANDED_ATTRIBUTE = 'aria-expanded';
 export const ARIA_CONTROLS_ATTRIBUTE = 'aria-controls';
 
+export const NAME_DATA_TOGGLE = 'data-toggle';
 export const NAME_DATA_TARGET = 'data-target';
 
 export const CLASSNAME_EXPANDED = 'is-expanded';

--- a/packages/web/src/js/utils/ComponentFunctions.ts
+++ b/packages/web/src/js/utils/ComponentFunctions.ts
@@ -53,4 +53,14 @@ const enableToggleAutoloader = (component: typeof BaseComponent, method = 'toggl
 
 const clickOutsideElement = (target: Element, event: Event) => !event.composedPath().includes(target);
 
-export { enableToggleTrigger, enableDismissTrigger, enableToggleAutoloader, clickOutsideElement };
+const debounce = (func: () => void, time: number) => {
+  const t: number = time || 100;
+  let timer: TimerHandler | number;
+
+  return (event: Event) => {
+    if (timer) clearTimeout(timer as unknown as ReturnType<typeof setTimeout>);
+    timer = setTimeout(func, t, event);
+  };
+};
+
+export { debounce, enableToggleTrigger, enableDismissTrigger, enableToggleAutoloader, clickOutsideElement };

--- a/packages/web/src/js/utils/ComponentFunctions.ts
+++ b/packages/web/src/js/utils/ComponentFunctions.ts
@@ -53,14 +53,4 @@ const enableToggleAutoloader = (component: typeof BaseComponent, method = 'toggl
 
 const clickOutsideElement = (target: Element, event: Event) => !event.composedPath().includes(target);
 
-const debounce = (func: () => void, time: number) => {
-  const t: number = time || 100;
-  let timer: TimerHandler | number;
-
-  return (event: Event) => {
-    if (timer) clearTimeout(timer as unknown as ReturnType<typeof setTimeout>);
-    timer = setTimeout(func, t, event);
-  };
-};
-
-export { debounce, enableToggleTrigger, enableDismissTrigger, enableToggleAutoloader, clickOutsideElement };
+export { enableToggleTrigger, enableDismissTrigger, enableToggleAutoloader, clickOutsideElement };

--- a/packages/web/src/js/utils/index.ts
+++ b/packages/web/src/js/utils/index.ts
@@ -1,3 +1,5 @@
+import EventHandler from '../dom/EventHandler';
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const isElement = (object: any): boolean => {
   if (!object || typeof object !== 'object') {
@@ -29,7 +31,7 @@ const getElementFromSelector = (element: HTMLElement | null): HTMLElement | null
 };
 
 const triggerTransitionEnd = (element: HTMLElement) => {
-  element.dispatchEvent(new Event('transitionend'));
+  EventHandler.trigger(element, 'transitionend');
 };
 
 const getTransitionDurationFromElement = (element: HTMLElement) => {

--- a/packages/web/src/scss/components/Accordion/README.md
+++ b/packages/web/src/scss/components/Accordion/README.md
@@ -1,0 +1,86 @@
+# Accordion
+
+Accordion is a wrapper for multiple **Collapse** items, and can be open one or more at time.
+
+## Usage
+
+### Default (Always open)
+
+```html
+<section class="Accordion" data-toggle="accordion">
+  <article id="accordionExample_article_0" class="Accordion__item">
+    <h3 id="accordionExample_article_0_header" class="Accordion__itemHeader">
+      <button
+        type="button"
+        class="Accordion__itemToggle"
+        data-toggle="collapse"
+        data-target="accordionExample_article_0_collapse"
+      >
+        toggle
+      </button>
+      <span class="Accordion__itemSide">
+        <span class="Accordion__itemSlot"> slot </span>
+        <span class="Accordion__itemIcon">
+          <svg width="24" height="24" aria-hidden="true">
+            <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+          </svg>
+        </span>
+      </span>
+    </h3>
+    <div id="accordionExample_article_0_collapse" class="Collapse" aria-labelledby="accordionExample_article_0_header">
+      <div class="Collapse__content">
+        <div class="Accordion__content">content</div>
+      </div>
+    </div>
+  </article>
+  ...
+</section>
+```
+
+### Open only one at time
+
+```html
+<section id="accordionExample" class="Accordion" data-toggle="accordion">
+  <article id="accordionExample_article_0" class="Accordion__item">
+    <h3 id="accordionExample_article_0_header" class="Accordion__itemHeader">
+      <button
+        type="button"
+        class="Accordion__itemToggle"
+        data-toggle="collapse"
+        data-target="accordionExample_article_0_collapse"
+      >
+        toggle
+      </button>
+      <span class="Accordion__itemSide">
+        <span class="Accordion__itemSlot"> slot </span>
+        <span class="Accordion__itemIcon">
+          <svg width="24" height="24" aria-hidden="true">
+            <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+          </svg>
+        </span>
+      </span>
+    </h3>
+    <div
+      id="accordionExample_article_0_collapse"
+      class="Collapse"
+      aria-labelledby="accordionExample_article_0_header"
+      data-parent="#accordionExample"
+    >
+      <div class="Collapse__content">
+        <div class="Accordion__content">content</div>
+      </div>
+    </div>
+  </article>
+  ...
+</section>
+```
+
+## Attributes
+
+Attributes are inherited from [**Collapse** component][collapse].
+
+## JavaScript Plugin
+
+The accordion uses [collapse][collapse] internally to make it collapsible.
+
+[collapse]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/scss/components/Collapse/README.md

--- a/packages/web/src/scss/components/Accordion/README.md
+++ b/packages/web/src/scss/components/Accordion/README.md
@@ -1,6 +1,6 @@
 # Accordion
 
-Accordion is a wrapper for multiple **Collapse** items, and can be open one or more at time.
+Accordion is a wrapper for multiple [**Collapse**][collapse] items, and can be open one or more at time.
 
 ## Usage
 
@@ -33,11 +33,13 @@ Accordion is a wrapper for multiple **Collapse** items, and can be open one or m
       </div>
     </div>
   </article>
-  ...
+  …
 </section>
 ```
 
-### Open only one at time
+### Open only one at a time
+
+Link individual **Collapse items** to their **Accordion parent** via `data-parent` attribute to allow just a single item being open at a time.
 
 ```html
 <section id="accordionExample" class="Accordion" data-toggle="accordion">
@@ -71,16 +73,16 @@ Accordion is a wrapper for multiple **Collapse** items, and can be open one or m
       </div>
     </div>
   </article>
-  ...
+  …
 </section>
 ```
 
 ## Attributes
 
-Attributes are inherited from [**Collapse** component][collapse].
+Attributes are inherited from the [**Collapse** component][collapse].
 
 ## JavaScript Plugin
 
-The accordion uses [collapse][collapse] internally to make it collapsible.
+Under the hood, the Accordion makes use of the [Collapse][collapse] JavaScript plugin for the collapsing functionality.
 
 [collapse]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/scss/components/Collapse/README.md

--- a/packages/web/src/scss/components/Accordion/_Accordion.scss
+++ b/packages/web/src/scss/components/Accordion/_Accordion.scss
@@ -25,8 +25,6 @@
         top: 0;
         right: theme.$accordion-header-padding-x;
         left: theme.$accordion-header-padding-x;
-        display: block;
-        height: 0;
         border-bottom: theme.$accordion-divider-width theme.$accordion-divider-style theme.$accordion-divider-color;
     }
 
@@ -46,10 +44,7 @@
         content: '';
         position: absolute;
         z-index: 0;
-        display: block;
         inset: 0;
-        width: 100%;
-        height: 100%;
         border-radius: theme.$accordion-border-radius;
     }
 
@@ -57,11 +52,10 @@
         @include typography.generate(theme.$accordion-header-typography-active);
     }
 
-    // stylelint-disable selector-max-class -- We have to control the state of the Icon
+    // stylelint-disable-next-line selector-max-class -- We have to control the state of the Icon
     &[aria-expanded='true'] + .Accordion__itemSide .Accordion__itemIcon {
         transform: rotate(180deg);
     }
-    // stylelint-enable
 
     &:active:first-of-type::before {
         background-color: theme.$accordion-item-background-color-active;
@@ -76,8 +70,7 @@
     justify-content: space-between;
 }
 
-.Accordion__itemSlot a,
-.Accordion__itemSlot button {
+.Accordion__itemSlot :is(a, button) {
     position: relative;
 }
 
@@ -91,8 +84,6 @@
         top: 100%;
         right: theme.$accordion-header-padding-x;
         left: theme.$accordion-header-padding-x;
-        display: block;
-        height: 1px;
         border-bottom: theme.$accordion-divider-width theme.$accordion-divider-style theme.$accordion-divider-color;
     }
 }

--- a/packages/web/src/scss/components/Accordion/_Accordion.scss
+++ b/packages/web/src/scss/components/Accordion/_Accordion.scss
@@ -1,0 +1,98 @@
+@use 'sass:map';
+@use 'theme';
+@use '../../tools/typography';
+@use '../../tools/reset';
+
+.Accordion__itemHeader {
+    position: relative;
+    display: flex;
+    gap: theme.$accordion-header-gap;
+    align-items: flex-start;
+    justify-content: space-between;
+    width: 100%;
+    padding: theme.$accordion-header-padding-y theme.$accordion-header-padding-x;
+    margin-bottom: 0;
+    border-radius: theme.$accordion-border-radius;
+    background-color: theme.$accordion-item-background-color-default;
+
+    &:hover {
+        background-color: theme.$accordion-item-background-color-hover;
+    }
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: theme.$accordion-header-padding-x;
+        left: theme.$accordion-header-padding-x;
+        display: block;
+        height: 0;
+        border-bottom: theme.$accordion-divider-width theme.$accordion-divider-style theme.$accordion-divider-color;
+    }
+
+    &:hover::before {
+        border-bottom-color: transparent;
+    }
+}
+
+.Accordion__itemToggle {
+    @include reset.button();
+    @include typography.generate(theme.$accordion-header-typography);
+
+    flex: initial;
+    text-align: left;
+
+    &:first-of-type::before {
+        content: '';
+        position: absolute;
+        z-index: 0;
+        display: block;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        border-radius: theme.$accordion-border-radius;
+    }
+
+    &[aria-expanded='true'] {
+        @include typography.generate(theme.$accordion-header-typography-active);
+    }
+
+    // stylelint-disable selector-max-class -- We have to control the state of the Icon
+    &[aria-expanded='true'] + .Accordion__itemSide .Accordion__itemIcon {
+        transform: rotate(180deg);
+    }
+    // stylelint-enable
+
+    &:active:first-of-type::before {
+        background-color: theme.$accordion-item-background-color-active;
+    }
+}
+
+.Accordion__itemSide,
+.Accordion__itemSlot {
+    display: flex;
+    gap: theme.$accordion-header-gap;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.Accordion__itemSlot a,
+.Accordion__itemSlot button {
+    position: relative;
+}
+
+.Accordion__content {
+    position: relative;
+    padding-bottom: theme.$accordion-content-bottom-offset;
+
+    &::after {
+        content: '';
+        position: absolute;
+        top: 100%;
+        right: theme.$accordion-header-padding-x;
+        left: theme.$accordion-header-padding-x;
+        display: block;
+        height: 1px;
+        border-bottom: theme.$accordion-divider-width theme.$accordion-divider-style theme.$accordion-divider-color;
+    }
+}

--- a/packages/web/src/scss/components/Accordion/_theme.scss
+++ b/packages/web/src/scss/components/Accordion/_theme.scss
@@ -1,0 +1,15 @@
+@use '@tokens' as tokens;
+
+$accordion-item-background-color-default: tokens.$background-interactive-default;
+$accordion-item-background-color-hover: tokens.$background-interactive-hover;
+$accordion-item-background-color-active: tokens.$background-interactive-active;
+$accordion-header-typography: tokens.$body-medium-text-regular;
+$accordion-header-typography-active: tokens.$body-medium-text-bold;
+$accordion-header-gap: tokens.$space-500;
+$accordion-header-padding-y: tokens.$space-700;
+$accordion-header-padding-x: tokens.$space-600;
+$accordion-border-radius: tokens.$radius-100;
+$accordion-divider-color: tokens.$action-tertiary-default;
+$accordion-divider-width: tokens.$border-width-100;
+$accordion-divider-style: tokens.$border-style-100;
+$accordion-content-bottom-offset: tokens.$space-600;

--- a/packages/web/src/scss/components/Accordion/index.html
+++ b/packages/web/src/scss/components/Accordion/index.html
@@ -1,0 +1,450 @@
+{{#> layout/plain }}
+
+<section class="docs-Section">
+
+  <h2 class="docs-Heading">Default accordion (Always open)</h2>
+
+  <div class="mb-400">
+
+    <section
+      class="Accordion"
+      data-toggle="accordion"
+    >
+
+      <!-- Accordion Item -->
+      <article
+        id="accordionExample_article_0"
+        class="Accordion__item"
+      >
+        <h3
+          id="accordionExample_article_0_header"
+          class="Accordion__itemHeader"
+        >
+          <button
+            type="button"
+            class="Accordion__itemToggle"
+            data-toggle="collapse"
+            data-target="accordionExample_article_0_collapse"
+          >
+            <!-- toggle -->
+            Accordion header #0
+            <!-- // toggle -->
+          </button>
+          <span class="Accordion__itemSide">
+            <span class="Accordion__itemSlot">
+              <!-- slot -->
+              <a href="#">Link</a>
+              <span class="Pill Pill--selected">3</span>
+              <!-- // slot -->
+            </span>
+            <span class="Accordion__itemIcon">
+              <svg width="24" height="24" aria-hidden="true">
+                <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+              </svg>
+            </span>
+          </span>
+        </h3>
+        <div
+          id="accordionExample_article_0_collapse"
+          class="Collapse"
+          aria-labelledby="accordionExample_article_0_header"
+        >
+          <div
+            class="Collapse__content"
+          >
+            <div
+              class="Accordion__content"
+            >
+              <!-- content -->
+              Accordion content #0
+              <!-- // content -->
+            </div>
+          </div>
+        </div>
+      </article>
+      <!-- // Accordion Item -->
+      <!-- Accordion Item -->
+      <article
+        id="accordionExample_article_1"
+        class="Accordion__item"
+      >
+        <h3
+          id="accordionExample_article_1_header"
+          class="Accordion__itemHeader"
+        >
+          <button
+            type="button"
+            class="Accordion__itemToggle"
+            data-toggle="collapse"
+            data-target="accordionExample_article_1_collapse"
+            aria-expanded="true"
+          >
+            <!-- toggle -->
+            Accordion header #1 (open)
+            <!-- // toggle -->
+          </button>
+          <span class="Accordion__itemSide">
+            <span class="Accordion__itemSlot">
+              <!-- slot -->
+              <span class="Pill Pill--selected">3</span>
+              <!-- // slot -->
+            </span>
+            <span class="Accordion__itemIcon">
+              <svg width="24" height="24" aria-hidden="true">
+                <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+              </svg>
+            </span>
+          </span>
+        </h3>
+        <div
+          id="accordionExample_article_1_collapse"
+          class="Collapse is-open"
+          aria-labelledby="accordionExample_article_1_header"
+        >
+          <div
+            class="Collapse__content"
+          >
+            <div
+              class="Accordion__content"
+            >
+              <!-- content -->
+              Accordion content #1
+              <!-- // content -->
+            </div>
+          </div>
+        </div>
+      </article>
+      <!-- // Accordion Item -->
+      <!-- Accordion Item -->
+      <article
+        id="accordionExample_article_2"
+        class="Accordion__item"
+      >
+        <h3
+          id="accordionExample_article_2_header"
+          class="Accordion__itemHeader"
+        >
+          <button
+            type="button"
+            class="Accordion__itemToggle"
+            data-toggle="collapse"
+            data-target="accordionExample_article_2_collapse"
+          >
+            <!-- toggle -->
+            Accordion header #2 with longer title and without slot
+            <!-- // toggle -->
+          </button>
+          <span class="Accordion__itemSide">
+            <span class="Accordion__itemIcon">
+              <svg width="24" height="24" aria-hidden="true">
+                <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+              </svg>
+            </span>
+          </span>
+        </h3>
+        <div
+          id="accordionExample_article_2_collapse"
+          class="Collapse"
+          aria-labelledby="accordionExample_article_2_header"
+        >
+          <div
+            class="Collapse__content"
+          >
+            <div
+              class="Accordion__content"
+            >
+              <!-- content -->
+              Accordion content #2
+              <!-- // content -->
+            </div>
+          </div>
+        </div>
+      </article>
+      <!-- // Accordion Item -->
+      <!-- Accordion Item -->
+      <article
+        id="accordionExample_article_3"
+        class="Accordion__item"
+      >
+        <h3
+          id="accordionExample_article_3_header"
+          class="Accordion__itemHeader"
+        >
+          <button
+            type="button"
+            class="Accordion__itemToggle"
+            data-toggle="collapse"
+            data-target="accordionExample_article_3_collapse"
+          >
+            <!-- toggle -->
+            Augue iaculis, quis ante sapien aliquam aliquam non cursus, vestibulum nunc ipsum maximus.
+            Libero sed non nulla, condimentum lorem ipsum molestie integer curabitur rutrum curabitur,
+            tellus pulvinar libero tempus
+            <!-- // toggle -->
+          </button>
+          <span class="Accordion__itemSide">
+            <span class="Accordion__itemSlot">
+              <!-- slot -->
+              <span class="Pill Pill--selected">3</span>
+              <!-- // slot -->
+            </span>
+            <span class="Accordion__itemIcon">
+              <svg width="24" height="24" aria-hidden="true">
+                <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+              </svg>
+            </span>
+          </span>
+        </h3>
+        <div
+          id="accordionExample_article_3_collapse"
+          class="Collapse"
+          aria-labelledby="accordionExample_article_3_header"
+        >
+          <div
+            class="Collapse__content"
+          >
+            <div
+              class="Accordion__content"
+            >
+              <!-- content -->
+              Accordion content #3
+              <!-- // content -->
+            </div>
+          </div>
+        </div>
+      </article>
+      <!-- // Accordion Item -->
+
+    </section>
+
+  </div>
+
+</section>
+
+<section class="docs-Section">
+
+  <h2 class="docs-Heading">Accordion with one item opened</h2>
+
+  <div class="mb-400">
+
+    <section
+      id="accordionExample1"
+      class="Accordion"
+      data-toggle="accordion"
+    >
+
+      <!-- Accordion Item -->
+      <article
+        id="accordionExample1_article_0"
+        class="Accordion__item"
+      >
+        <h3
+          id="accordionExample1_article_0_header"
+          class="Accordion__itemHeader"
+        >
+          <button
+            type="button"
+            class="Accordion__itemToggle"
+            data-toggle="collapse"
+            data-target="accordionExample1_article_0_collapse"
+          >
+            <!-- toggle -->
+            Accordion header #0
+            <!-- // toggle -->
+          </button>
+          <span class="Accordion__itemSide">
+            <span class="Accordion__itemSlot">
+              <!-- slot -->
+              <a href="#">Link</a>
+              <span class="Pill Pill--selected">3</span>
+              <!-- // slot -->
+            </span>
+            <span class="Accordion__itemIcon">
+              <svg width="24" height="24" aria-hidden="true">
+                <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+              </svg>
+            </span>
+          </span>
+        </h3>
+        <div
+          id="accordionExample1_article_0_collapse"
+          class="Collapse"
+          data-parent="#accordionExample1"
+          aria-labelledby="accordionExample1_article_0_header"
+        >
+          <div
+            class="Collapse__content"
+          >
+            <div
+              class="Accordion__content"
+            >
+              <!-- content -->
+              Accordion content #0
+              <!-- // content -->
+            </div>
+          </div>
+        </div>
+      </article>
+      <!-- // Accordion Item -->
+      <!-- Accordion Item -->
+      <article
+        id="accordionExample1_article_1"
+        class="Accordion__item"
+      >
+        <h3
+          id="accordionExample1_article_1_header"
+          class="Accordion__itemHeader"
+        >
+          <button
+            type="button"
+            class="Accordion__itemToggle"
+            data-toggle="collapse"
+            data-target="accordionExample1_article_1_collapse"
+            aria-expanded="true"
+          >
+            <!-- toggle -->
+            Accordion header #1 (open)
+            <!-- // toggle -->
+          </button>
+          <span class="Accordion__itemSide">
+            <span class="Accordion__itemSlot">
+              <!-- slot -->
+              <span class="Pill Pill--selected">3</span>
+              <!-- // slot -->
+            </span>
+            <span class="Accordion__itemIcon">
+              <svg width="24" height="24" aria-hidden="true">
+                <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+              </svg>
+            </span>
+          </span>
+        </h3>
+        <div
+          id="accordionExample1_article_1_collapse"
+          class="Collapse is-open"
+          data-parent="#accordionExample1"
+          aria-labelledby="accordionExample1_article_1_header"
+        >
+          <div
+            class="Collapse__content"
+          >
+            <div
+              class="Accordion__content"
+            >
+              <!-- content -->
+              Accordion content #1
+              <!-- // content -->
+            </div>
+          </div>
+        </div>
+      </article>
+      <!-- // Accordion Item -->
+      <!-- Accordion Item -->
+      <article
+        id="accordionExample1_article_2"
+        class="Accordion__item"
+      >
+        <h3
+          id="accordionExample1_article_2_header"
+          class="Accordion__itemHeader"
+        >
+          <button
+            type="button"
+            class="Accordion__itemToggle"
+            data-toggle="collapse"
+            data-target="accordionExample1_article_2_collapse"
+          >
+            <!-- toggle -->
+            Accordion header #2 with longer title and without slot
+            <!-- // toggle -->
+          </button>
+          <span class="Accordion__itemSide">
+            <span class="Accordion__itemIcon">
+              <svg width="24" height="24" aria-hidden="true">
+                <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+              </svg>
+            </span>
+          </span>
+        </h3>
+        <div
+          id="accordionExample1_article_2_collapse"
+          class="Collapse"
+          data-parent="#accordionExample1"
+          aria-labelledby="accordionExample1_article_2_header"
+        >
+          <div
+            class="Collapse__content"
+          >
+            <div
+              class="Accordion__content"
+            >
+              <!-- content -->
+              Accordion content #2
+              <!-- // content -->
+            </div>
+          </div>
+        </div>
+      </article>
+      <!-- // Accordion Item -->
+      <!-- Accordion Item -->
+      <article
+        id="accordionExample1_article_3"
+        class="Accordion__item"
+      >
+        <h3
+          id="accordionExample1_article_3_header"
+          class="Accordion__itemHeader"
+        >
+          <button
+            type="button"
+            class="Accordion__itemToggle"
+            data-toggle="collapse"
+            data-target="accordionExample1_article_3_collapse"
+          >
+            <!-- toggle -->
+            Augue iaculis, quis ante sapien aliquam aliquam non cursus, vestibulum nunc ipsum maximus.
+            Libero sed non nulla, condimentum lorem ipsum molestie integer curabitur rutrum curabitur,
+            tellus pulvinar libero tempus
+            <!-- // toggle -->
+          </button>
+          <span class="Accordion__itemSide">
+            <span class="Accordion__itemSlot">
+              <!-- slot -->
+              <span class="Pill Pill--selected">3</span>
+              <!-- // slot -->
+            </span>
+            <span class="Accordion__itemIcon">
+              <svg width="24" height="24" aria-hidden="true">
+                <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+              </svg>
+            </span>
+          </span>
+        </h3>
+        <div
+          id="accordionExample1_article_3_collapse"
+          class="Collapse"
+          data-parent="#accordionExample1"
+          aria-labelledby="accordionExample1_article_3_header"
+        >
+          <div
+            class="Collapse__content"
+          >
+            <div
+              class="Accordion__content"
+            >
+              <!-- content -->
+              Accordion content #3
+              <!-- // content -->
+            </div>
+          </div>
+        </div>
+      </article>
+      <!-- // Accordion Item -->
+
+    </section>
+
+  </div>
+
+</section>
+
+{{/layout/plain }}

--- a/packages/web/src/scss/components/Accordion/index.scss
+++ b/packages/web/src/scss/components/Accordion/index.scss
@@ -1,0 +1,1 @@
+@forward 'Accordion';

--- a/packages/web/src/scss/components/Collapse/README.md
+++ b/packages/web/src/scss/components/Collapse/README.md
@@ -55,13 +55,16 @@ Hide button when collapse
 
 ## Wrapper attributes
 
-| Prop name         | Type                   | Default | Required | Description                                                      |
-| ----------------- | ---------------------- | ------- | -------- | ---------------------------------------------------------------- |
-| `data-breakpoint` | `'tablet'`,`'desktop'` | -       | no       | Breakpoint on which the collapsed content is forced to reveal \* |
+| Prop name         | Type                   | Default | Required | Description                                                              |
+| ----------------- | ---------------------- | ------- | -------- | ------------------------------------------------------------------------ |
+| `data-breakpoint` | `'tablet'`,`'desktop'` | -       | no       | Breakpoint on which the collapsed content is forced to reveal \*         |
+| `data-parent`     | `string`               | -       | no       | A parent element selector that ensures that only one item is opened \*\* |
 
 There can be several triggers, the same rules apply to each.
 
 (\*) The mobile breakpoint rule doesn't exist because it doesn't make sense given the implementation because it always stays hidden.
+
+(\*\*) Attribute for Accordion implementation
 
 ## State classes
 

--- a/packages/web/src/scss/components/Collapse/_Collapse.scss
+++ b/packages/web/src/scss/components/Collapse/_Collapse.scss
@@ -6,9 +6,19 @@
     position: relative;
     height: 0;
     overflow: hidden;
+    visibility: hidden;
     transition-property: height;
     transition-duration: theme.$collapse-transition-duration;
     transition-timing-function: theme.$collapse-transition-timing;
+
+    &.is-open,
+    &.is-transitioning {
+        visibility: visible;
+    }
+
+    &.is-open:not(.is-transitioning) {
+        overflow: visible;
+    }
 
     @each $breakpoint-name, $breakpoint-value in theme.$breakpoints {
         @if $breakpoint-value > 0 {
@@ -17,6 +27,7 @@
                     /* stylelint-disable declaration-no-important -- This Important rule is important here because it overrides inline styles applied by JavaScript */
                     height: auto !important;
                     /* stylelint-enable declaration-no-important */
+                    visibility: visible;
                 }
             }
         }

--- a/packages/web/src/scss/components/Collapse/_Collapse.scss
+++ b/packages/web/src/scss/components/Collapse/_Collapse.scss
@@ -7,13 +7,16 @@
     height: 0;
     overflow: hidden;
     visibility: hidden;
-    transition-property: height;
-    transition-duration: theme.$collapse-transition-duration;
-    transition-timing-function: theme.$collapse-transition-timing;
 
     &.is-open,
     &.is-transitioning {
         visibility: visible;
+    }
+
+    &.is-transitioning {
+        transition-property: height;
+        transition-duration: theme.$collapse-transition-duration;
+        transition-timing-function: theme.$collapse-transition-timing;
     }
 
     &.is-open:not(.is-transitioning) {

--- a/packages/web/src/scss/components/Collapse/index.html
+++ b/packages/web/src/scss/components/Collapse/index.html
@@ -34,7 +34,7 @@
 
 <section class="docs-Section">
 
-  <h2 class="docs-Heading">Collapsed on init with aria or class</h2>
+  <h2 class="docs-Heading">Collapsed on init with 'aria' attribute</h2>
 
   <!--
     Collapse with auto open by aria
@@ -65,41 +65,12 @@
     </div>
   </div>
 
-  <br />
-
-  <!--
-    Collapse with auto open by class
-  -->
-  <div class="mb-400">
-    <div class="mb-400">
-      <button
-        type="button"
-        role="button"
-        data-toggle="collapse"
-        data-target="CollapseExampleII"
-        class="Button Button--primary Button--medium is-expanded"
-      >
-        Collapse trigger
-      </button>
-    </div>
-    <div
-      id="CollapseExampleII"
-      class="Collapse"
-    >
-      <div class="Collapse__content">
-        Nibh maximus sed ac, lorem ipsum dolor sit amet congue leo vitae condimentum molestie eget urna, magna at lectus quis purus. Euismod purus, egestas vestibulum in nisi et iaculis mauris
-        ullamcorper egestas, bibendum molestie auctor consectetur. Nisl vel purus a lacinia, sem lobortis consequat convallis felis scelerisque dui vel dolor suspendisse fermentum, vulputate
-        suspendisse consequat lacinia. Potenti et, quis orci fusce donec placerat phasellus proin quis odio, tempus a felis molestie et nisi. Nulla donec, neque quis neque augue porta urna
-        lorem, donec erat id duis id at sem. Libero sed congue,  fringilla consequat vestibulum finibus quis vitae at nullam, donec felis rhoncus non.
-      </div>
-    </div>
-  </div>
-
 </section>
 
 <section class="docs-Section">
 
-  <h2 class="docs-Heading">Tablet</h2>
+  <h2 class="docs-Heading">Change visibility with 'breakpoint' attribute</h2>
+  <h3>Tablet</h3>
 
   <!--
     Collapse with tablet breakpoint
@@ -128,11 +99,8 @@
     </div>
   </div>
 
-</section>
 
-<section class="docs-Section">
-
-  <h2 class="docs-Heading">Desktop</h2>
+  <h3 class="pt-300">Desktop</h3>
 
   <!--
     Collapse with desktop breakpoint

--- a/packages/web/src/scss/components/index.scss
+++ b/packages/web/src/scss/components/index.scss
@@ -1,3 +1,4 @@
+@forward 'Accordion';
 @forward 'Alert';
 @forward 'Breadcrumbs';
 @forward 'Button';


### PR DESCRIPTION
# Accordion component
This is CSS and JavaScript of Accordion component. 
This branch was created to merge [#580](https://github.com/lmc-eu/spirit-design-system/pull/580) and [#581](https://github.com/lmc-eu/spirit-design-system/pull/581) because there were duplicates and it was difficult to test.

## What was done:
1) Collapse updates and fixes
   - Utility class for open state
   - Accessibility fix for collapsed content
   - Aria attribute on initialization was not properly set for value
   - Removed class `is-expanded` for trigger, only `aria-expanded` attribute will be used
   - The `data-parent` attribute to control the opening of only one item at a time
   - Tests updates
   - Removed 'resize' handler
   - `setTimeout` replaced with async methods
   - Updated handling for finished transitions
2) Accordion component styles
3) Accordion component tests