### PR TITLE
Feat/web react uncontrolled collapse

### DIFF
--- a/packages/web-react/package.json
+++ b/packages/web-react/package.json
@@ -16,7 +16,8 @@
   "module": "./index.js",
   "types": "./index.d.ts",
   "dependencies": {
-    "classnames": "^2.3.1"
+    "classnames": "^2.3.1",
+    "react-transition-group": "^4.4.5"
   },
   "devDependencies": {
     "@babel/preset-env": "7.19.4",
@@ -35,6 +36,7 @@
     "@types/node": "17.0.23",
     "@types/react": "18.0.24",
     "@types/react-dom": "18.0.8",
+    "@types/react-transition-group": "^4.4.5",
     "@typescript-eslint/eslint-plugin": "5.42.0",
     "@typescript-eslint/parser": "5.42.0",
     "eslint": "8.26.0",

--- a/packages/web-react/src/components/Collapse/Collapse.stories.tsx
+++ b/packages/web-react/src/components/Collapse/Collapse.stories.tsx
@@ -1,111 +1,25 @@
-import React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import Collapse from './Collapse';
-import { Button } from '../Button';
-import { SpiritCollapseProps, CollapseRenderProps } from '../../types';
 
 export default {
   title: 'Components/Collapse',
-  argTypes: {},
+  parameters: {
+    docs: {
+      description: {
+        component: `
+  [Spirit Collapse](https://spirit.supernova-docs.io/spirit/latest/components/collapse/overview.html)
+
+  Toggle the visibility of content across your project with Collapse.
+  `,
+      },
+    },
+  },
 } as ComponentMeta<typeof Collapse>;
 
-const Template = (args: SpiritCollapseProps) => <Collapse {...args} />;
-const WrappredTemplate = (args: SpiritCollapseProps) => (
-  <div>
-    Condimentum odio, pulvinar et sollicitudin accumsan ac hendrerit vestibulum commodo, molestie laoreet dui sit amet.
-    Molestie consectetur, sed ac felis scelerisque lectus accumsan purus id dolor sed vitae, praesent aliquam dolor quis
-    ornare. Nulla sit amet, rhoncus at quis odio et iaculis lacinia suscipit vivamus sodales, nunc id condimentum felis.
-    Consectetur nec commodo, praesent et elit magna purus molestie cursus molestie, libero ut venenatis erat id et nisi.
-    Quam posuere, aliquam quam leo vitae tellus semper eget nunc, ultricies adipiscing sit amet accumsan. Lorem rutrum,
-    porttitor ante mauris suspendisse ultricies consequat purus, congue a commodo magna et.
-    <br />
-    Nunc potenti, mauris sollicitudin purus augue justo et condimentum, vivamus a ornare consequat. Aliquet ut, metus
-    libero vitae volutpat felis a iaculis sapien dolor quis, augue fermentum donec urna. Sem facilisis, finibus non
-    mauris suspendisse varius et nisi egestas potenti, praesent interdum nulla sem. Sodales dui, quam sagittis sapien
-    elit lorem fringilla hendrerit nunc, porttitor quis dolor ut sit amet. Scelerisque aliquet, maximus integer cursus
-    fusce vitae proin lacinia sed vitae, bibendum suspendisse nunc ut enim et at. Sem turpis, iaculis a eget non mauris
-    nulla vitae augue, molestie porttitor luctus bibendum.
-    <Collapse {...args} />
-  </div>
-);
-
-export const Default = Template.bind({});
-Default.args = {
-  id: 'DemoCollapse',
-  renderTrigger: ({ collapsed, trigger }: CollapseRenderProps) => (
-    <Button {...trigger}>Trigger ({collapsed ? 'open' : 'closed'})</Button>
-  ),
-  children: (
-    <>
-      <p>
-        Commodo urna, ultrices porta dolor sit amet morbi libero lorem ipsum venenatis, quam congue consectetur
-        pellentesque. Proin pharetra, accumsan ipsum cras dictum aliquam efficitur proin consectetur, viverra metus dui
-        a lacinia. Odio magna et, molestie aliquet at nullam praesent vitae semper mauris, congue sapien sollicitudin
-        pretium accumsan. Ac nec nulla a, turpis vulputate maximus aliquet et erat bibendum, non integer aliquam ut.
-        Mollis sollicitudin, convallis ut id ante auctor scelerisque augue lorem dui, bibendum libero sed commodo arcu.
-        Cursus consequat, tristique auctor suscipit dui vel dolor dui vel vitae placerat, fermentum sem cursus ut nisl
-        mauris.
-      </p>
-      <p>
-        Vitae sed, ullamcorper tristique vitae lectus quis mattis fringilla maximus, turpis cras dictum mi orci
-        adipiscing. Rutrum sollicitudin, volutpat rhoncus erat dui et tempus donec quam in donec nunc, urna molestie
-        dignissim phasellus. Metus ligula, sapien aliquet scelerisque vitae fringilla etiam nunc, nulla quam tristique
-        sed ac. Venenatis semper, dui id volutpat ullamcorper semper tortor ac hendrerit, iaculis lorem ipsum interdum
-        enim in. Efficitur suspendisse, ultricies aliquam venenatis purus imperdiet nullam ullamcorper, dui vel dolor
-        leo vitae nunc a. Pharetra laoreet, curabitur nec sem urna et nam integer, condimentum quam ipsum diam a.
-      </p>
-    </>
-  ),
-};
-
-export const Responsive = Template.bind({});
-Responsive.args = {
-  id: 'DemoCollapseResponsive',
-  renderTrigger: ({ collapsed, trigger: { className, ...rest } }: CollapseRenderProps) => (
-    <Button UNSAFE_className={[className, 'd-tablet-none'].join(' ')} {...rest}>
-      Trigger ({collapsed ? 'open' : 'closed'})
-    </Button>
-  ),
-  children: (
-    <>
-      <p>
-        Commodo urna, ultrices porta dolor sit amet morbi libero lorem ipsum venenatis, quam congue consectetur
-        pellentesque. Proin pharetra, accumsan ipsum cras dictum aliquam efficitur proin consectetur, viverra metus dui
-        a lacinia. Odio magna et, molestie aliquet at nullam praesent vitae semper mauris, congue sapien sollicitudin
-        pretium accumsan. Ac nec nulla a, turpis vulputate maximus aliquet et erat bibendum, non integer aliquam ut.
-        Mollis sollicitudin, convallis ut id ante auctor scelerisque augue lorem dui, bibendum libero sed commodo arcu.
-        Cursus consequat, tristique auctor suscipit dui vel dolor dui vel vitae placerat, fermentum sem cursus ut nisl
-        mauris.
-      </p>
-      <p>
-        Vitae sed, ullamcorper tristique vitae lectus quis mattis fringilla maximus, turpis cras dictum mi orci
-        adipiscing. Rutrum sollicitudin, volutpat rhoncus erat dui et tempus donec quam in donec nunc, urna molestie
-        dignissim phasellus. Metus ligula, sapien aliquet scelerisque vitae fringilla etiam nunc, nulla quam tristique
-        sed ac. Venenatis semper, dui id volutpat ullamcorper semper tortor ac hendrerit, iaculis lorem ipsum interdum
-        enim in. Efficitur suspendisse, ultricies aliquam venenatis purus imperdiet nullam ullamcorper, dui vel dolor
-        leo vitae nunc a. Pharetra laoreet, curabitur nec sem urna et nam integer, condimentum quam ipsum diam a.
-      </p>
-    </>
-  ),
-  collapsibleToBreakpoint: 'tablet',
-};
-
-export const HideOnClose = WrappredTemplate.bind({});
-HideOnClose.args = {
-  id: 'DemoCollapseHideOnClose',
-  renderTrigger: ({ collapsed, trigger }: CollapseRenderProps) => (
-    <Button {...trigger}>Trigger ({collapsed ? 'open' : 'closed'})</Button>
-  ),
-  children: (
-    <>
-      Commodo urna, ultrices porta dolor sit amet morbi libero lorem ipsum venenatis, quam congue consectetur
-      pellentesque. Proin pharetra, accumsan ipsum cras dictum aliquam efficitur proin consectetur, viverra metus dui a
-      lacinia. Odio magna et, molestie aliquet at nullam praesent vitae semper mauris, congue sapien sollicitudin
-      pretium accumsan. Ac nec nulla a, turpis vulputate maximus aliquet et erat bibendum, non integer aliquam ut.
-      Mollis sollicitudin, convallis ut id ante auctor scelerisque augue lorem dui, bibendum libero sed commodo arcu.
-      Cursus consequat, tristique auctor suscipit dui vel dolor dui vel vitae placerat, fermentum sem cursus ut nisl
-      mauris.
-    </>
-  ),
-  hideOnCollapse: true,
-};
+export { default as Collapse } from './stories/Collapse';
+export { default as CollapseBreakpoints } from './stories/CollapseBreakpoints';
+export { default as CollapseProps } from './stories/CollapseProps';
+export { default as CollapseHtml } from './stories/CollapseHtml';
+export { default as CollapseUncontrolled } from './stories/CollapseUncontrolled';
+export { default as CollapseUncontrolledHideOnClose } from './stories/CollapseUncontrolledHideOnClose';
+export { default as CollapseUncontrolledProps } from './stories/CollapseUncontrolledProps';

--- a/packages/web-react/src/components/Collapse/Collapse.tsx
+++ b/packages/web-react/src/components/Collapse/Collapse.tsx
@@ -1,92 +1,44 @@
-import React, { createElement } from 'react';
+import React, { useRef, MutableRefObject } from 'react';
 import classNames from 'classnames';
 import { SpiritCollapseProps } from '../../types';
 import { useStyleProps } from '../../hooks/styleProps';
-import { useCollapse } from './useCollapse';
 import { useCollapseStyleProps } from './useCollapseStyleProps';
 import { useCollapseAriaProps } from './useCollapseAriaProps';
+import { useResizeHeight } from './useResizeHeight';
+
+const defaultProps = {
+  isCollapsed: false,
+  collapsibleToBreakpoint: undefined,
+};
 
 const Collapse = (props: SpiritCollapseProps) => {
-  const {
-    id = Math.random().toString(36).slice(2, 7),
-    elementType = 'div',
-    contentElementType = 'div',
-    collapsibleToBreakpoint = undefined,
-    children,
-    isCollapsed,
-    hideOnCollapse,
-    renderTrigger,
-    ...rest
-  } = props;
+  const { elementType: ElementTag = 'div', children, ...restProps } = props;
 
-  const { collapsed, toggleHandler } = useCollapse({
-    isCollapsed,
-  });
-  const { wrapperClassName, contentClassName, triggerClassName } = useCollapseStyleProps({
-    isCollapsed: collapsed,
-  });
-  const { wrapperProps, contentProps, triggerProps } = useCollapseAriaProps({
-    id,
-    collapsibleToBreakpoint,
-    toggleHandler,
-    isCollapsed: collapsed,
-  });
+  const collapseElementRef: MutableRefObject<HTMLDivElement | null> = useRef(null);
+  const collapseHeight = useResizeHeight(collapseElementRef);
 
-  const { styleProps: wrapperStyleProps, props: wrapperOtherProps } = useStyleProps({ ...rest });
-  const { styleProps: triggerStyleProps } = useStyleProps({
-    UNSAFE_className: triggerClassName,
-  });
-
-  const content = createElement(
-    contentElementType,
-    {
-      ...contentProps,
-      className: contentClassName,
-    },
-    children,
-  );
-
-  const triggerRenderHandler = () => {
-    const show = hideOnCollapse ? !(hideOnCollapse && collapsed) : true;
-    if (renderTrigger && show)
-      return renderTrigger({
-        collapsed,
-        trigger: {
-          ...triggerStyleProps,
-          ...triggerProps,
-        },
-      });
-
-    return null;
-  };
-
-  const wrapperRenderHandler = () => {
-    if (hideOnCollapse && collapsed) {
-      return children;
-    }
-
-    return createElement(
-      elementType || 'div',
-      {
-        ...wrapperOtherProps,
-        ...wrapperStyleProps,
-        ...wrapperProps,
-        className: classNames(wrapperClassName, wrapperStyleProps.className),
-        style: {
-          ...wrapperProps.style,
-          ...wrapperStyleProps.style,
-        },
-      },
-      content,
-    );
+  const { classProps } = useCollapseStyleProps(restProps.isCollapsed);
+  const { ariaProps, props: otherProps } = useCollapseAriaProps(restProps);
+  const { styleProps, props: transferProps } = useStyleProps(otherProps);
+  const collapseStyleProps = {
+    className: styleProps.className,
+    ...{ style: { height: restProps.isCollapsed ? collapseHeight : 0, ...styleProps.style } },
   };
 
   return (
-    <>
-      {triggerRenderHandler()}
-      {wrapperRenderHandler()}
-    </>
+    <ElementTag
+      {...transferProps}
+      {...collapseStyleProps}
+      {...ariaProps.root}
+      className={classNames(classProps.root, styleProps.className)}
+    >
+      <div ref={collapseElementRef} className={classProps.content}>
+        {children}
+      </div>
+    </ElementTag>
   );
 };
+
+Collapse.defaultProps = defaultProps;
 
 export default Collapse;

--- a/packages/web-react/src/components/Collapse/Collapse.tsx
+++ b/packages/web-react/src/components/Collapse/Collapse.tsx
@@ -1,19 +1,31 @@
-import React, { useRef, MutableRefObject } from 'react';
 import classNames from 'classnames';
-import { SpiritCollapseProps } from '../../types';
+import React, { MutableRefObject, useRef } from 'react';
+import Transition, { TransitionStatus, ENTERED, ENTERING, EXITED, EXITING } from 'react-transition-group/Transition';
 import { useStyleProps } from '../../hooks/styleProps';
-import { useCollapseStyleProps } from './useCollapseStyleProps';
+import { SpiritCollapseProps } from '../../types';
 import { useCollapseAriaProps } from './useCollapseAriaProps';
+import { useCollapseStyleProps } from './useCollapseStyleProps';
 import { useResizeHeight } from './useResizeHeight';
+
+const TRANSITION_DURATION = 250;
+
+const transitioningStyles = {
+  [ENTERING]: 'is-transitioning',
+  [ENTERED]: '',
+  [EXITING]: 'is-transitioning',
+  [EXITED]: '',
+};
 
 const defaultProps = {
   isOpen: false,
   collapsibleToBreakpoint: undefined,
+  transitionDuration: TRANSITION_DURATION,
 };
 
 const Collapse = (props: SpiritCollapseProps) => {
-  const { elementType: ElementTag = 'div', children, ...restProps } = props;
+  const { elementType: ElementTag = 'div', children, transitionDuration = TRANSITION_DURATION, ...restProps } = props;
 
+  const rootElementRef: MutableRefObject<HTMLDivElement | null> = useRef(null);
   const collapseElementRef: MutableRefObject<HTMLDivElement | null> = useRef(null);
   const collapseHeight = useResizeHeight(collapseElementRef);
 
@@ -26,16 +38,24 @@ const Collapse = (props: SpiritCollapseProps) => {
   };
 
   return (
-    <ElementTag
-      {...transferProps}
-      {...collapseStyleProps}
-      {...ariaProps.root}
-      className={classNames(classProps.root, styleProps.className)}
-    >
-      <div ref={collapseElementRef} className={classProps.content}>
-        {children}
-      </div>
-    </ElementTag>
+    <Transition in={restProps.isOpen} nodeRef={rootElementRef} timeout={transitionDuration}>
+      {(transitionState: TransitionStatus) => (
+        <ElementTag
+          {...transferProps}
+          {...collapseStyleProps}
+          {...ariaProps.root}
+          // Element implicitly has an 'any' type because expression of type 'TransitionStatus' can't be used to index type '{ entering: string; entered: string; exiting: string; exited: string; }'.
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          className={classNames(classProps.root, styleProps.className, transitioningStyles[transitionState])}
+          ref={rootElementRef}
+        >
+          <div ref={collapseElementRef} className={classProps.content}>
+            {children}
+          </div>
+        </ElementTag>
+      )}
+    </Transition>
   );
 };
 

--- a/packages/web-react/src/components/Collapse/Collapse.tsx
+++ b/packages/web-react/src/components/Collapse/Collapse.tsx
@@ -7,7 +7,7 @@ import { useCollapseAriaProps } from './useCollapseAriaProps';
 import { useResizeHeight } from './useResizeHeight';
 
 const defaultProps = {
-  isCollapsed: false,
+  isOpen: false,
   collapsibleToBreakpoint: undefined,
 };
 
@@ -17,12 +17,12 @@ const Collapse = (props: SpiritCollapseProps) => {
   const collapseElementRef: MutableRefObject<HTMLDivElement | null> = useRef(null);
   const collapseHeight = useResizeHeight(collapseElementRef);
 
-  const { classProps } = useCollapseStyleProps(restProps.isCollapsed);
+  const { classProps } = useCollapseStyleProps(restProps.isOpen);
   const { ariaProps, props: otherProps } = useCollapseAriaProps(restProps);
   const { styleProps, props: transferProps } = useStyleProps(otherProps);
   const collapseStyleProps = {
     className: styleProps.className,
-    ...{ style: { height: restProps.isCollapsed ? collapseHeight : 0, ...styleProps.style } },
+    ...{ style: { height: restProps.isOpen ? collapseHeight : 0, ...styleProps.style } },
   };
 
   return (

--- a/packages/web-react/src/components/Collapse/README.md
+++ b/packages/web-react/src/components/Collapse/README.md
@@ -5,7 +5,17 @@
 ### Basic
 
 ```javascript
-<Collapse id="CollapseExample" renderToggle={({ trigger }) => <button {...trigger}>...</button>}>
+import React, { useState} from 'react';
+import { Button } from '@lmc-eu/spirit-web-react/components';
+
+// ...
+
+const [collapsed, setCollapsed] = useState<boolean>(true);
+
+// ...
+
+<Button onClick={() => setCollapsed(!collapsed)}>Collapse Trigger ({collapsed ? 'Open' : 'Closed'})</Button>
+<Collapse isCollapsed={collapsed}>
   ...
 </Collapse>
 ```
@@ -13,48 +23,86 @@
 ### Responsive
 
 ```javascript
-<Collapse
-  id="CollapseExample"
-  renderToggle={({ trigger }) => (
-    <button className="d-tablet-none" {...trigger}>
-      ...
-    </button>
-  )}
-  collapsibleToBreakpoint="tablet"
->
-  ...
-</Collapse>
-```
+import React, { useState} from 'react';
+import { Button, Collapse } from '@lmc-eu/spirit-web-react/components';
 
-### Hide on close
+// ...
 
-```javascript
-<Collapse id="CollapseExample" renderToggle={({ trigger }) => <button {...trigger}>...</button>} hideOnCollapse>
+const [collapsed, setCollapsed] = useState<boolean>(true);
+
+// ...
+
+<Button UNSAFE_className="d-tablet-none" onClick={() => setCollapsed(!collapsed)}>Collapse Trigger ({collapsed ? 'Open' : 'Closed'})</Button>
+<Collapse isCollapsed={collapsed} collapsibleToBreakpoint="tablet">
   ...
 </Collapse>
 ```
 
 ## Props
 
-| Prop name                 | Type                                                        | Default    | Required | Description                            |
-| ------------------------- | ----------------------------------------------------------- | ---------- | -------- | -------------------------------------- |
-| `id`                      | `string`                                                    | `<random>` | no       | Component id                           |
-| `isCollapsed`             | `boolean`                                                   | -          | no       | Is collapsed on init                   |
-| `renderTrigger`           | `(render: CollapseRenderProps) => ReactNode`                | -          | no       | Properties for trigger render          |
-| `elementType`             | `'div','article','section','main','header','footer','span'` | -          | no       | Wrapper element type                   |
-| `contentElementType`      | `'div','article','section','main','header','footer','span'` | -          | no       | Wrapper element type                   |
-| `collapsibleToBreakpoint` | `'mobile', 'tablet', 'desktop'`                             | -          | no       | Handle for responsive breakpoint       |
-| `hideOnCollapse`          | `boolean`                                                   | -          | no       | Hides button when content is collapsed |
-| `UNSAFE_className`        | `string`                                                    | -          | no       | Wrapper custom classname               |
-| `UNSAFE_style`            | `CSSProperties`                                             | -          | no       | Wrapper custom style                   |
+| Prop name                 | Type                            | Default    | Required | Description                      |
+| ------------------------- | ------------------------------- | ---------- | -------- | -------------------------------- |
+| `id`                      | `string`                        | `<random>` | no       | Component id                     |
+| `isCollapsed`             | `boolean`                       | -          | no       | Is collapsed on init             |
+| `collapsibleToBreakpoint` | `'mobile', 'tablet', 'desktop'` | -          | no       | Handle for responsive breakpoint |
+| `UNSAFE_className`        | `string`                        | -          | no       | Wrapper custom classname         |
+| `UNSAFE_style`            | `CSSProperties`                 | -          | no       | Wrapper custom style             |
 
-## CollapseRenderProps
+## Uncontrolled Collapse
 
-| Prop name                  | Type         | Description                |
-| -------------------------- | ------------ | -------------------------- |
-| `collapsed`                | `boolean`    | When collapse is collapsed |
-| `trigger`                  | `Object`     | Trigger properties         |
-| `trigger.onClick`          | `string`     | Trigger onClick event      |
-| `trigger.className`        | `string`     | Trigger state classname    |
-| `trigger['aria-expanded']` | `Booleanish` | Trigger aria expanded      |
-| `trigger['aria-controls']` | `string`     | Trigger aria controls      |
+### Basic
+
+```javascript
+import React, { useState } from 'react';
+import { Button, UncontrolledCollapse } from '@lmc-eu/spirit-web-react/components';
+
+// ...
+
+<UncontrolledCollapse
+  id="CollapseExample"
+  renderToggle={({ collapsed, ...restProps }) => (
+    <Button {...restProps}>Collapse Trigger ({collapsed ? 'Open' : 'Closed'})</Button>
+  )}
+>
+  ...
+</UncontrolledCollapse>;
+```
+
+```javascript
+import React, { useState } from 'react';
+import { Button, UncontrolledCollapse } from '@lmc-eu/spirit-web-react/components';
+
+// ...
+
+<UncontrolledCollapse
+  id="CollapseExample"
+  renderToggle={({ collapsed, ...restProps }) => (
+    <Button {...restProps}>Collapse Trigger ({collapsed ? 'Open' : 'Closed'})</Button>
+  )}
+  hideOnCollapse
+>
+  ...
+</UncontrolledCollapse>;
+```
+
+## Props
+
+| Prop name                 | Type                                         | Default    | Required | Description                            |
+| ------------------------- | -------------------------------------------- | ---------- | -------- | -------------------------------------- |
+| `id`                      | `string`                                     | `<random>` | no       | Component id                           |
+| `isCollapsed`             | `boolean`                                    | -          | no       | Is collapsed on init                   |
+| `renderTrigger`           | `(render: CollapseRenderProps) => ReactNode` | -          | no       | Properties for trigger render          |
+| `collapsibleToBreakpoint` | `'mobile', 'tablet', 'desktop'`              | -          | no       | Handle for responsive breakpoint       |
+| `hideOnCollapse`          | `boolean`                                    | -          | no       | Hides button when content is collapsed |
+| `UNSAFE_className`        | `string`                                     | -          | no       | Wrapper custom classname               |
+| `UNSAFE_style`            | `CSSProperties`                              | -          | no       | Wrapper custom style                   |
+
+## Render Toggle Props
+
+| Prop name       | Type         | Description                |
+| --------------- | ------------ | -------------------------- |
+| `collapsed`     | `boolean`    | When collapse is collapsed |
+| `onClick`       | `string`     | Trigger onClick event      |
+| `className`     | `string`     | Trigger state classname    |
+| `aria-expanded` | `Booleanish` | Trigger aria expanded      |
+| `aria-controls` | `string`     | Trigger aria controls      |

--- a/packages/web-react/src/components/Collapse/README.md
+++ b/packages/web-react/src/components/Collapse/README.md
@@ -76,13 +76,14 @@ const [isOpen, toggle] = useState<boolean>(true);
 
 ## Props
 
-| Prop name                 | Type                            | Default    | Required | Description                      |
-| ------------------------- | ------------------------------- | ---------- | -------- | -------------------------------- |
-| `id`                      | `string`                        | `<random>` | no       | Component id                     |
-| `isOpen`                  | `boolean`                       | -          | no       | Is open on initialization        |
-| `collapsibleToBreakpoint` | `'mobile', 'tablet', 'desktop'` | -          | no       | Handle for responsive breakpoint |
-| `UNSAFE_className`        | `string`                        | -          | no       | Wrapper custom class name        |
-| `UNSAFE_style`            | `CSSProperties`                 | -          | no       | Wrapper custom style             |
+| Prop name                 | Type                            | Default    | Required | Description                        |
+| ------------------------- | ------------------------------- | ---------- | -------- | ---------------------------------- |
+| `id`                      | `string`                        | `<random>` | no       | Component id                       |
+| `isOpen`                  | `boolean`                       | -          | no       | Is open on initialization          |
+| `collapsibleToBreakpoint` | `'mobile', 'tablet', 'desktop'` | -          | no       | Handle for responsive breakpoint   |
+| `transitionDuration`      | `number`                        | `250`      | no       | Transition duration in miliseconds |
+| `UNSAFE_className`        | `string`                        | -          | no       | Wrapper custom class name          |
+| `UNSAFE_style`            | `CSSProperties`                 | -          | no       | Wrapper custom style               |
 
 ## Uncontrolled Collapse
 

--- a/packages/web-react/src/components/Collapse/README.md
+++ b/packages/web-react/src/components/Collapse/README.md
@@ -10,12 +10,48 @@ import { Button } from '@lmc-eu/spirit-web-react/components';
 
 // ...
 
-const [collapsed, setCollapsed] = useState<boolean>(true);
+const [isOpen, toggle] = useState<boolean>(true);
 
 // ...
 
-<Button onClick={() => setCollapsed(!collapsed)}>Collapse Trigger ({collapsed ? 'Open' : 'Closed'})</Button>
-<Collapse isCollapsed={collapsed}>
+<Button onClick={() => toggle(!isOpen)}>Collapse Trigger ({ isOpen ? 'Open' : 'Closed' })</Button>
+<Collapse isOpen={isOpen}>
+  ...
+</Collapse>
+```
+
+### With toggle from hook
+
+```javascript
+import React, { useState} from 'react';
+import { Button, Collapse, useCollapse } from '@lmc-eu/spirit-web-react/components';
+
+// ...
+
+const { isOpen, toggle } = useCollapse(false);
+
+// ...
+
+<Button onClick={() => toggle(!isOpen)}>Collapse Trigger ({ isOpen ? 'Open' : 'Closed' })</Button>
+<Collapse isOpen={isOpen}>
+  ...
+</Collapse>
+```
+
+### With toggle handler from hook
+
+```javascript
+import React, { useState} from 'react';
+import { Button, Collapse, useCollapse } from '@lmc-eu/spirit-web-react/components';
+
+// ...
+
+const { isOpen, toggleHandler } = useCollapse(false);
+
+// ...
+
+<Button onClick={toggleHandler}>Collapse Trigger ({ isOpen ? 'Open' : 'Closed' })</Button>
+<Collapse isOpen={isOpen}>
   ...
 </Collapse>
 ```
@@ -28,12 +64,12 @@ import { Button, Collapse } from '@lmc-eu/spirit-web-react/components';
 
 // ...
 
-const [collapsed, setCollapsed] = useState<boolean>(true);
+const [isOpen, toggle] = useState<boolean>(true);
 
 // ...
 
-<Button UNSAFE_className="d-tablet-none" onClick={() => setCollapsed(!collapsed)}>Collapse Trigger ({collapsed ? 'Open' : 'Closed'})</Button>
-<Collapse isCollapsed={collapsed} collapsibleToBreakpoint="tablet">
+<Button UNSAFE_className="d-tablet-none" onClick={() => toggle(!isOpen)}>Collapse Trigger ({ isOpen ? 'Open' : 'Closed' })</Button>
+<Collapse isOpen={isOpen} collapsibleToBreakpoint="tablet">
   ...
 </Collapse>
 ```
@@ -43,9 +79,9 @@ const [collapsed, setCollapsed] = useState<boolean>(true);
 | Prop name                 | Type                            | Default    | Required | Description                      |
 | ------------------------- | ------------------------------- | ---------- | -------- | -------------------------------- |
 | `id`                      | `string`                        | `<random>` | no       | Component id                     |
-| `isCollapsed`             | `boolean`                       | -          | no       | Is collapsed on init             |
+| `isOpen`                  | `boolean`                       | -          | no       | Is open on initialization        |
 | `collapsibleToBreakpoint` | `'mobile', 'tablet', 'desktop'` | -          | no       | Handle for responsive breakpoint |
-| `UNSAFE_className`        | `string`                        | -          | no       | Wrapper custom classname         |
+| `UNSAFE_className`        | `string`                        | -          | no       | Wrapper custom class name        |
 | `UNSAFE_style`            | `CSSProperties`                 | -          | no       | Wrapper custom style             |
 
 ## Uncontrolled Collapse
@@ -60,8 +96,8 @@ import { Button, UncontrolledCollapse } from '@lmc-eu/spirit-web-react/component
 
 <UncontrolledCollapse
   id="CollapseExample"
-  renderToggle={({ collapsed, ...restProps }) => (
-    <Button {...restProps}>Collapse Trigger ({collapsed ? 'Open' : 'Closed'})</Button>
+  renderToggle={({ isOpen, ...restProps }) => (
+    <Button {...restProps}>Collapse Trigger ({isOpen ? 'Open' : 'Closed'})</Button>
   )}
 >
   ...
@@ -76,8 +112,8 @@ import { Button, UncontrolledCollapse } from '@lmc-eu/spirit-web-react/component
 
 <UncontrolledCollapse
   id="CollapseExample"
-  renderToggle={({ collapsed, ...restProps }) => (
-    <Button {...restProps}>Collapse Trigger ({collapsed ? 'Open' : 'Closed'})</Button>
+  renderToggle={({ isOpen, ...restProps }) => (
+    <Button {...restProps}>Collapse Trigger ({isOpen ? 'Open' : 'Closed'})</Button>
   )}
   hideOnCollapse
 >
@@ -90,19 +126,18 @@ import { Button, UncontrolledCollapse } from '@lmc-eu/spirit-web-react/component
 | Prop name                 | Type                                         | Default    | Required | Description                            |
 | ------------------------- | -------------------------------------------- | ---------- | -------- | -------------------------------------- |
 | `id`                      | `string`                                     | `<random>` | no       | Component id                           |
-| `isCollapsed`             | `boolean`                                    | -          | no       | Is collapsed on init                   |
+| `isOpen`                  | `boolean`                                    | -          | no       | Is open on initialization              |
 | `renderTrigger`           | `(render: CollapseRenderProps) => ReactNode` | -          | no       | Properties for trigger render          |
 | `collapsibleToBreakpoint` | `'mobile', 'tablet', 'desktop'`              | -          | no       | Handle for responsive breakpoint       |
-| `hideOnCollapse`          | `boolean`                                    | -          | no       | Hides button when content is collapsed |
+| `hideOnCollapse`          | `boolean`                                    | -          | no       | Hides button when content is displayed |
 | `UNSAFE_className`        | `string`                                     | -          | no       | Wrapper custom classname               |
 | `UNSAFE_style`            | `CSSProperties`                              | -          | no       | Wrapper custom style                   |
 
 ## Render Toggle Props
 
-| Prop name       | Type         | Description                |
-| --------------- | ------------ | -------------------------- |
-| `collapsed`     | `boolean`    | When collapse is collapsed |
-| `onClick`       | `string`     | Trigger onClick event      |
-| `className`     | `string`     | Trigger state classname    |
-| `aria-expanded` | `Booleanish` | Trigger aria expanded      |
-| `aria-controls` | `string`     | Trigger aria controls      |
+| Prop name       | Type         | Description           |
+| --------------- | ------------ | --------------------- |
+| `isOpen`        | `boolean`    | When collapse is open |
+| `onClick`       | `string`     | Trigger onClick event |
+| `aria-expanded` | `Booleanish` | Trigger aria expanded |
+| `aria-controls` | `string`     | Trigger aria controls |

--- a/packages/web-react/src/components/Collapse/UncontrolledCollapse.tsx
+++ b/packages/web-react/src/components/Collapse/UncontrolledCollapse.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Collapse from './Collapse';
+import { SpiritUncontrolledCollapseProps } from '../../types';
+import { useCollapse } from './useCollapse';
+import { useCollapseAriaProps } from './useCollapseAriaProps';
+import { useCollapseStyleProps } from './useCollapseStyleProps';
+
+const defaultProps = {
+  id: Math.random().toString(36).slice(2, 7),
+  isCollapsed: false,
+};
+
+const UncontrolledCollapse = (props: SpiritUncontrolledCollapseProps) => {
+  const { children, hideOnCollapse, renderTrigger, ...restProps } = props;
+  const { collapsed, toggleHandler } = useCollapse(restProps.isCollapsed);
+  const { classProps } = useCollapseStyleProps(collapsed);
+  const { ariaProps } = useCollapseAriaProps({ ...restProps, isCollapsed: collapsed });
+
+  const triggerRenderHandler = () => {
+    const showTrigger = hideOnCollapse ? !(hideOnCollapse && collapsed) : true;
+
+    return renderTrigger && showTrigger
+      ? renderTrigger({
+          collapsed,
+          onClick: toggleHandler,
+          ...ariaProps.trigger,
+          className: classProps.trigger,
+        })
+      : null;
+  };
+
+  return (
+    <>
+      {triggerRenderHandler()}
+      {hideOnCollapse && collapsed ? (
+        children
+      ) : (
+        <Collapse {...restProps} isCollapsed={collapsed}>
+          {children}
+        </Collapse>
+      )}
+    </>
+  );
+};
+
+UncontrolledCollapse.defaultProps = defaultProps;
+
+export default UncontrolledCollapse;

--- a/packages/web-react/src/components/Collapse/UncontrolledCollapse.tsx
+++ b/packages/web-react/src/components/Collapse/UncontrolledCollapse.tsx
@@ -3,28 +3,25 @@ import Collapse from './Collapse';
 import { SpiritUncontrolledCollapseProps } from '../../types';
 import { useCollapse } from './useCollapse';
 import { useCollapseAriaProps } from './useCollapseAriaProps';
-import { useCollapseStyleProps } from './useCollapseStyleProps';
 
 const defaultProps = {
   id: Math.random().toString(36).slice(2, 7),
-  isCollapsed: false,
+  isOpen: false,
 };
 
 const UncontrolledCollapse = (props: SpiritUncontrolledCollapseProps) => {
   const { children, hideOnCollapse, renderTrigger, ...restProps } = props;
-  const { collapsed, toggleHandler } = useCollapse(restProps.isCollapsed);
-  const { classProps } = useCollapseStyleProps(collapsed);
-  const { ariaProps } = useCollapseAriaProps({ ...restProps, isCollapsed: collapsed });
+  const { isOpen, toggleHandler } = useCollapse(restProps.isOpen);
+  const { ariaProps } = useCollapseAriaProps({ ...restProps, isOpen });
 
   const triggerRenderHandler = () => {
-    const showTrigger = hideOnCollapse ? !(hideOnCollapse && collapsed) : true;
+    const showTrigger = hideOnCollapse ? !(hideOnCollapse && isOpen) : true;
 
     return renderTrigger && showTrigger
       ? renderTrigger({
-          collapsed,
+          isOpen,
           onClick: toggleHandler,
           ...ariaProps.trigger,
-          className: classProps.trigger,
         })
       : null;
   };
@@ -32,10 +29,10 @@ const UncontrolledCollapse = (props: SpiritUncontrolledCollapseProps) => {
   return (
     <>
       {triggerRenderHandler()}
-      {hideOnCollapse && collapsed ? (
+      {hideOnCollapse && isOpen ? (
         children
       ) : (
-        <Collapse {...restProps} isCollapsed={collapsed}>
+        <Collapse {...restProps} isOpen={isOpen}>
           {children}
         </Collapse>
       )}

--- a/packages/web-react/src/components/Collapse/__tests__/UncontrolledCollapse.test.tsx
+++ b/packages/web-react/src/components/Collapse/__tests__/UncontrolledCollapse.test.tsx
@@ -4,26 +4,27 @@ import { render, fireEvent } from '@testing-library/react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
-import Collapse from '../Collapse';
+import UncontrolledCollapse from '../UncontrolledCollapse';
 
-describe('Collapse', () => {
-  classNamePrefixProviderTest(Collapse, 'Collapse');
+describe('UncontrolledCollapse', () => {
+  classNamePrefixProviderTest(UncontrolledCollapse, 'Collapse');
 
-  stylePropsTest(Collapse);
+  stylePropsTest(UncontrolledCollapse);
 
-  restPropsTest(Collapse, 'div');
+  restPropsTest(UncontrolledCollapse, 'div');
 
   it('should render text children', () => {
     const dom = render(
-      <Collapse
-        renderTrigger={({ trigger }) => (
-          <button type="button" {...trigger}>
+      <UncontrolledCollapse
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        renderTrigger={({ collapsed, ...rest }) => (
+          <button type="button" {...rest}>
             trigger
           </button>
         )}
       >
         Hello World
-      </Collapse>,
+      </UncontrolledCollapse>,
     );
     const element = dom.container.querySelector('div') as HTMLElement;
 
@@ -32,15 +33,16 @@ describe('Collapse', () => {
 
   it('should toggle a collapse', () => {
     const dom = render(
-      <Collapse
-        renderTrigger={({ trigger }) => (
-          <button type="button" {...trigger}>
+      <UncontrolledCollapse
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        renderTrigger={({ collapsed, ...rest }) => (
+          <button type="button" {...rest}>
             trigger
           </button>
         )}
       >
         Hello World
-      </Collapse>,
+      </UncontrolledCollapse>,
     );
     const element = dom.container.querySelector('div') as HTMLElement;
     const trigger = dom.container.querySelector('button') as HTMLElement;

--- a/packages/web-react/src/components/Collapse/__tests__/UncontrolledCollapse.test.tsx
+++ b/packages/web-react/src/components/Collapse/__tests__/UncontrolledCollapse.test.tsx
@@ -16,8 +16,9 @@ describe('UncontrolledCollapse', () => {
   it('should render text children', () => {
     const dom = render(
       <UncontrolledCollapse
+        // Normally we want to display state change, not in this test, prop is passed anyway
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        renderTrigger={({ collapsed, ...rest }) => (
+        renderTrigger={({ isOpen, ...rest }) => (
           <button type="button" {...rest}>
             trigger
           </button>
@@ -34,8 +35,9 @@ describe('UncontrolledCollapse', () => {
   it('should toggle a collapse', () => {
     const dom = render(
       <UncontrolledCollapse
+        // Normally we want to display state change, not in this test, prop is passed anyway
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        renderTrigger={({ collapsed, ...rest }) => (
+        renderTrigger={({ isOpen, ...rest }) => (
           <button type="button" {...rest}>
             trigger
           </button>
@@ -49,8 +51,7 @@ describe('UncontrolledCollapse', () => {
 
     fireEvent.click(trigger);
 
-    expect(element).toHaveClass('is-collapsed');
-    expect(trigger).toHaveClass('is-expanded');
+    expect(element).toHaveClass('is-open');
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
     fireEvent.click(trigger);

--- a/packages/web-react/src/components/Collapse/__tests__/useCollapse.test.ts
+++ b/packages/web-react/src/components/Collapse/__tests__/useCollapse.test.ts
@@ -2,16 +2,16 @@ import { act, renderHook } from '@testing-library/react-hooks';
 import { useCollapse } from '../useCollapse';
 
 describe('useCollapse', () => {
-  it.each([[true], [false]])('should return defaults', (isCollapsed) => {
-    const { result } = renderHook(() => useCollapse(isCollapsed));
+  it.each([[true], [false]])('should return defaults', (isOpen) => {
+    const { result } = renderHook(() => useCollapse(isOpen));
 
-    expect(result.current.collapsed).toBe(isCollapsed);
+    expect(result.current.isOpen).toBe(isOpen);
     expect(typeof result.current.toggleHandler).toBe('function');
   });
 
   it('should toggle state', () => {
-    const isCollapsed = true;
-    const { result } = renderHook(() => useCollapse(isCollapsed));
+    const isOpen = true;
+    const { result } = renderHook(() => useCollapse(isOpen));
     const { toggleHandler } = result.current;
 
     act(() => {
@@ -21,8 +21,6 @@ describe('useCollapse', () => {
       toggleHandler(new Event('click'));
     });
 
-    const { collapsed } = result.current;
-
-    expect(collapsed).toBe(!isCollapsed);
+    expect(result.current.isOpen).toBe(!isOpen);
   });
 });

--- a/packages/web-react/src/components/Collapse/__tests__/useCollapse.test.ts
+++ b/packages/web-react/src/components/Collapse/__tests__/useCollapse.test.ts
@@ -1,12 +1,28 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import { useCollapse } from '../useCollapse';
 
 describe('useCollapse', () => {
-  it('should return defaults', () => {
-    const props = { isCollapsed: true };
-    const { result } = renderHook(() => useCollapse(props));
+  it.each([[true], [false]])('should return defaults', (isCollapsed) => {
+    const { result } = renderHook(() => useCollapse(isCollapsed));
 
-    expect(result.current.collapsed).toBe(true);
+    expect(result.current.collapsed).toBe(isCollapsed);
     expect(typeof result.current.toggleHandler).toBe('function');
+  });
+
+  it('should toggle state', () => {
+    const isCollapsed = true;
+    const { result } = renderHook(() => useCollapse(isCollapsed));
+    const { toggleHandler } = result.current;
+
+    act(() => {
+      // Argument of type 'Event' is not assignable to parameter of type 'ClickEvent'.
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      toggleHandler(new Event('click'));
+    });
+
+    const { collapsed } = result.current;
+
+    expect(collapsed).toBe(!isCollapsed);
   });
 });

--- a/packages/web-react/src/components/Collapse/__tests__/useCollapseAriaProps.test.ts
+++ b/packages/web-react/src/components/Collapse/__tests__/useCollapseAriaProps.test.ts
@@ -7,7 +7,7 @@ describe('useCollapseAriaProps', () => {
     const props = {
       collapsibleToBreakpoint: undefined,
       id: 'test-collapse-id',
-      isCollapsed: true,
+      isOpen: true,
     };
     const { result } = renderHook(() => useCollapseAriaProps(props));
 
@@ -23,7 +23,7 @@ describe('useCollapseAriaProps', () => {
     const props = {
       collapsibleToBreakpoint: 'mobile',
       id: 'test-collapse-id',
-      isCollapsed: false,
+      isOpen: false,
     } as SpiritCollapseProps;
     const { result } = renderHook(() => useCollapseAriaProps(props));
 

--- a/packages/web-react/src/components/Collapse/__tests__/useCollapseAriaProps.test.ts
+++ b/packages/web-react/src/components/Collapse/__tests__/useCollapseAriaProps.test.ts
@@ -1,37 +1,32 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { useCollapseAriaProps, CollapseAriaPropsProps } from '../useCollapseAriaProps';
+import { SpiritCollapseProps } from '../../../types';
+import { useCollapseAriaProps } from '../useCollapseAriaProps';
 
 describe('useCollapseAriaProps', () => {
   it('should return defaults', () => {
     const props = {
+      collapsibleToBreakpoint: undefined,
       id: 'test-collapse-id',
       isCollapsed: true,
-      onClick: () => null,
-      toggleHandler: () => null,
     };
     const { result } = renderHook(() => useCollapseAriaProps(props));
 
-    expect(result.current.wrapperProps).toBeDefined();
-    expect(result.current.wrapperProps.style).toBeDefined();
-    expect(result.current.wrapperProps['data-breakpoint']).toBeUndefined();
-    expect(result.current.contentProps).toBeDefined();
-    expect(result.current.contentProps.ref).toBeDefined();
-    expect(result.current.triggerProps).toBeDefined();
-    expect(result.current.triggerProps['aria-expanded']).toBeDefined();
-    expect(result.current.triggerProps['aria-controls']).toBeDefined();
-    expect(result.current.triggerProps.onClick).toBeDefined();
+    expect(result.current.ariaProps).toBeDefined();
+    expect(result.current.ariaProps.root).toBeDefined();
+    expect(result.current.ariaProps.root['data-breakpoint']).toBeUndefined();
+    expect(result.current.ariaProps.trigger['aria-expanded']).toBeTruthy();
+    expect(result.current.ariaProps.trigger['aria-controls']).toBe(props.id);
+    expect(result.current.props.id).toBe(props.id);
   });
 
   it('should return breakpoints', () => {
     const props = {
+      collapsibleToBreakpoint: 'mobile',
       id: 'test-collapse-id',
       isCollapsed: false,
-      toggleHandler: () => null,
-      collapsibleToBreakpoint: 'mobile',
-    } as CollapseAriaPropsProps;
+    } as SpiritCollapseProps;
     const { result } = renderHook(() => useCollapseAriaProps(props));
 
-    expect(result.current.wrapperProps).toBeDefined();
-    expect(result.current.wrapperProps['data-breakpoint']).toBe('mobile');
+    expect(result.current.ariaProps.root['data-breakpoint']).toBe('mobile');
   });
 });

--- a/packages/web-react/src/components/Collapse/__tests__/useCollapseStyleProps.test.ts
+++ b/packages/web-react/src/components/Collapse/__tests__/useCollapseStyleProps.test.ts
@@ -2,12 +2,14 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useCollapseStyleProps } from '../useCollapseStyleProps';
 
 describe('useCollapseStyleProps', () => {
-  it('should return defaults', () => {
-    const props = { isCollapsed: true };
-    const { result } = renderHook(() => useCollapseStyleProps(props));
+  it.each([
+    [true, 'Collapse is-collapsed', 'is-expanded'],
+    [false, 'Collapse', ''],
+  ])('should return defaults', (isCollapsed, rootClass, triggerClass) => {
+    const { result } = renderHook(() => useCollapseStyleProps(isCollapsed));
 
-    expect(result.current.wrapperClassName).toBe('Collapse is-collapsed');
-    expect(result.current.contentClassName).toBe('Collapse__content');
-    expect(result.current.triggerClassName).toBe('is-expanded');
+    expect(result.current.classProps.root).toBe(rootClass);
+    expect(result.current.classProps.content).toBe('Collapse__content');
+    expect(result.current.classProps.trigger).toBe(triggerClass);
   });
 });

--- a/packages/web-react/src/components/Collapse/__tests__/useCollapseStyleProps.test.ts
+++ b/packages/web-react/src/components/Collapse/__tests__/useCollapseStyleProps.test.ts
@@ -3,13 +3,12 @@ import { useCollapseStyleProps } from '../useCollapseStyleProps';
 
 describe('useCollapseStyleProps', () => {
   it.each([
-    [true, 'Collapse is-collapsed', 'is-expanded'],
-    [false, 'Collapse', ''],
-  ])('should return defaults', (isCollapsed, rootClass, triggerClass) => {
+    [true, 'Collapse is-open'],
+    [false, 'Collapse'],
+  ])('should return defaults', (isCollapsed, rootClass) => {
     const { result } = renderHook(() => useCollapseStyleProps(isCollapsed));
 
     expect(result.current.classProps.root).toBe(rootClass);
     expect(result.current.classProps.content).toBe('Collapse__content');
-    expect(result.current.classProps.trigger).toBe(triggerClass);
   });
 });

--- a/packages/web-react/src/components/Collapse/__tests__/useResizeHeight.test.ts
+++ b/packages/web-react/src/components/Collapse/__tests__/useResizeHeight.test.ts
@@ -8,10 +8,9 @@ describe('useResizeHeight', () => {
       current: {
         offsetHeight: 500,
       },
-    };
-    const props = { contentRef: ref as MutableRefObject<HTMLElement | null | undefined> };
-    const { result } = renderHook(() => useResizeHeight(props));
+    } as MutableRefObject<HTMLElement | null | undefined>;
+    const { result } = renderHook(() => useResizeHeight(ref));
 
-    expect(result.current.height).toBe('500px');
+    expect(result.current).toBe('500px');
   });
 });

--- a/packages/web-react/src/components/Collapse/index.ts
+++ b/packages/web-react/src/components/Collapse/index.ts
@@ -1,5 +1,7 @@
 export * from './Collapse';
 export { default as Collapse } from './Collapse';
+export * from './UncontrolledCollapse';
+export { default as UncontrolledCollapse } from './UncontrolledCollapse';
 export * from './useCollapse';
-export * from './useCollapseStyleProps';
 export * from './useCollapseAriaProps';
+export * from './useCollapseStyleProps';

--- a/packages/web-react/src/components/Collapse/stories/Collapse.tsx
+++ b/packages/web-react/src/components/Collapse/stories/Collapse.tsx
@@ -1,0 +1,47 @@
+// Because there is no `dist` directory during the CI run
+/* eslint-disable import/no-extraneous-dependencies, import/extensions, import/no-unresolved */
+import { ComponentStory } from '@storybook/react';
+import React from 'react';
+import { Button } from '../../Button';
+import { useCollapse, Collapse } from '../index';
+
+export const content = (
+  <>
+    <p>
+      Condimentum odio, pulvinar et sollicitudin accumsan ac hendrerit vestibulum commodo, molestie laoreet dui sit
+      amet. Molestie consectetur, sed ac felis scelerisque lectus accumsan purus id dolor sed vitae, praesent aliquam
+      dolor quis ornare. Nulla sit amet, rhoncus at quis odio et iaculis lacinia suscipit vivamus sodales, nunc id
+      condimentum felis. Consectetur nec commodo, praesent et elit magna purus molestie cursus molestie, libero ut
+      venenatis erat id et nisi. Quam posuere, aliquam quam leo vitae tellus semper eget nunc, ultricies adipiscing sit
+      amet accumsan. Lorem rutrum, porttitor ante mauris suspendisse ultricies consequat purus, congue a commodo magna
+      et.
+    </p>
+    <p>
+      Nunc potenti, mauris sollicitudin purus augue justo et condimentum, vivamus a ornare consequat. Aliquet ut, metus
+      libero vitae volutpat felis a iaculis sapien dolor quis, augue fermentum donec urna. Sem facilisis, finibus non
+      mauris suspendisse varius et nisi egestas potenti, praesent interdum nulla sem. Sodales dui, quam sagittis sapien
+      elit lorem fringilla hendrerit nunc, porttitor quis dolor ut sit amet. Scelerisque aliquet, maximus integer cursus
+      fusce vitae proin lacinia sed vitae, bibendum suspendisse nunc ut enim et at. Sem turpis, iaculis a eget non
+      mauris nulla vitae augue, molestie porttitor luctus bibendum.
+    </p>
+  </>
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const CollapseTrigger = ({ collapsed, ...rest }: any) => {
+  return <Button {...rest}>Collapse Trigger ({collapsed ? 'Open' : 'Closed'})</Button>;
+};
+
+const Story: ComponentStory<typeof Collapse> = () => {
+  const { collapsed, toggleHandler } = useCollapse(false);
+
+  return (
+    <div>
+      {content}
+      <CollapseTrigger collapsed={collapsed} onClick={toggleHandler} />
+      <Collapse isCollapsed={collapsed}>{content}</Collapse>
+    </div>
+  );
+};
+
+export default Story;

--- a/packages/web-react/src/components/Collapse/stories/Collapse.tsx
+++ b/packages/web-react/src/components/Collapse/stories/Collapse.tsx
@@ -28,18 +28,18 @@ export const content = (
 );
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const CollapseTrigger = ({ collapsed, ...rest }: any) => {
-  return <Button {...rest}>Collapse Trigger ({collapsed ? 'Open' : 'Closed'})</Button>;
+export const CollapseTrigger = ({ isOpen, ...rest }: any) => {
+  return <Button {...rest}>Collapse Trigger ({isOpen ? 'Open' : 'Closed'})</Button>;
 };
 
 const Story: ComponentStory<typeof Collapse> = () => {
-  const { collapsed, toggleHandler } = useCollapse(false);
+  const { isOpen, toggleHandler } = useCollapse(false);
 
   return (
     <div>
       {content}
-      <CollapseTrigger collapsed={collapsed} onClick={toggleHandler} />
-      <Collapse isCollapsed={collapsed}>{content}</Collapse>
+      <CollapseTrigger isOpen={isOpen} onClick={toggleHandler} />
+      <Collapse isOpen={isOpen}>{content}</Collapse>
     </div>
   );
 };

--- a/packages/web-react/src/components/Collapse/stories/CollapseBreakpoints.tsx
+++ b/packages/web-react/src/components/Collapse/stories/CollapseBreakpoints.tsx
@@ -1,0 +1,23 @@
+// Because there is no `dist` directory during the CI run
+/* eslint-disable import/no-extraneous-dependencies, import/extensions, import/no-unresolved */
+import { ComponentStory } from '@storybook/react';
+import React from 'react';
+import Collapse from '../Collapse';
+import { useCollapse } from '../useCollapse';
+import { content, CollapseTrigger } from './Collapse';
+
+const Story: ComponentStory<typeof Collapse> = () => {
+  const { collapsed, toggleHandler } = useCollapse(false);
+
+  return (
+    <div>
+      {content}
+      <CollapseTrigger collapsed={collapsed} onClick={toggleHandler} UNSAFE_className="d-tablet-none" />
+      <Collapse isCollapsed={collapsed} collapsibleToBreakpoint="tablet">
+        {content}
+      </Collapse>
+    </div>
+  );
+};
+
+export default Story;

--- a/packages/web-react/src/components/Collapse/stories/CollapseBreakpoints.tsx
+++ b/packages/web-react/src/components/Collapse/stories/CollapseBreakpoints.tsx
@@ -7,13 +7,13 @@ import { useCollapse } from '../useCollapse';
 import { content, CollapseTrigger } from './Collapse';
 
 const Story: ComponentStory<typeof Collapse> = () => {
-  const { collapsed, toggleHandler } = useCollapse(false);
+  const { isOpen, toggleHandler } = useCollapse(false);
 
   return (
     <div>
       {content}
-      <CollapseTrigger collapsed={collapsed} onClick={toggleHandler} UNSAFE_className="d-tablet-none" />
-      <Collapse isCollapsed={collapsed} collapsibleToBreakpoint="tablet">
+      <CollapseTrigger isOpen={isOpen} onClick={toggleHandler} UNSAFE_className="d-tablet-none" />
+      <Collapse isOpen={isOpen} collapsibleToBreakpoint="tablet">
         {content}
       </Collapse>
     </div>

--- a/packages/web-react/src/components/Collapse/stories/CollapseHtml.tsx
+++ b/packages/web-react/src/components/Collapse/stories/CollapseHtml.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import Html from '../../../../docs/stories/Html';
+
+const Story = () => <Html storyId="collapse" groupId="components" />;
+
+export default Story;

--- a/packages/web-react/src/components/Collapse/stories/CollapseProps.tsx
+++ b/packages/web-react/src/components/Collapse/stories/CollapseProps.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import Collapse from '../Collapse';
+import Props from '../../../../docs/stories/Props';
+
+const Story = () => <Props component={Collapse} />;
+
+export default Story;

--- a/packages/web-react/src/components/Collapse/stories/CollapseUncontrolled.tsx
+++ b/packages/web-react/src/components/Collapse/stories/CollapseUncontrolled.tsx
@@ -1,0 +1,17 @@
+// Because there is no `dist` directory during the CI run
+/* eslint-disable import/no-extraneous-dependencies, import/extensions, import/no-unresolved */
+import { ComponentStory } from '@storybook/react';
+import React from 'react';
+import UncontrolledCollapse from '../UncontrolledCollapse';
+import { content, CollapseTrigger } from './Collapse';
+
+const Story: ComponentStory<typeof UncontrolledCollapse> = () => {
+  return (
+    <div>
+      {content}
+      <UncontrolledCollapse renderTrigger={CollapseTrigger}>{content}</UncontrolledCollapse>
+    </div>
+  );
+};
+
+export default Story;

--- a/packages/web-react/src/components/Collapse/stories/CollapseUncontrolledHideOnClose.tsx
+++ b/packages/web-react/src/components/Collapse/stories/CollapseUncontrolledHideOnClose.tsx
@@ -1,0 +1,19 @@
+// Because there is no `dist` directory during the CI run
+/* eslint-disable import/no-extraneous-dependencies, import/extensions, import/no-unresolved */
+import { ComponentStory } from '@storybook/react';
+import React from 'react';
+import UncontrolledCollapse from '../UncontrolledCollapse';
+import { content, CollapseTrigger } from './Collapse';
+
+const Story: ComponentStory<typeof UncontrolledCollapse> = () => {
+  return (
+    <div>
+      {content}
+      <UncontrolledCollapse hideOnCollapse renderTrigger={CollapseTrigger}>
+        {content}
+      </UncontrolledCollapse>
+    </div>
+  );
+};
+
+export default Story;

--- a/packages/web-react/src/components/Collapse/stories/CollapseUncontrolledProps.tsx
+++ b/packages/web-react/src/components/Collapse/stories/CollapseUncontrolledProps.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import UncontrolledCollapse from '../UncontrolledCollapse';
+import Props from '../../../../docs/stories/Props';
+
+const Story = () => <Props component={UncontrolledCollapse} />;
+
+export default Story;

--- a/packages/web-react/src/components/Collapse/useCollapse.ts
+++ b/packages/web-react/src/components/Collapse/useCollapse.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ClickEvent, SpiritCollapseProps } from '../../types';
+import { ClickEvent } from '../../types';
 
 export interface CollapseReturn {
   /** collapse handler */
@@ -8,7 +8,7 @@ export interface CollapseReturn {
   collapsed: boolean;
 }
 
-export const useCollapse = ({ isCollapsed }: SpiritCollapseProps): CollapseReturn => {
+export const useCollapse = (isCollapsed: boolean): CollapseReturn => {
   const [collapsed, setCollapsed] = useState<boolean>(!!isCollapsed);
 
   const collapseHandler = () => setCollapsed(!collapsed);

--- a/packages/web-react/src/components/Collapse/useCollapse.ts
+++ b/packages/web-react/src/components/Collapse/useCollapse.ts
@@ -2,24 +2,25 @@ import { useState } from 'react';
 import { ClickEvent } from '../../types';
 
 export interface CollapseReturn {
-  /** collapse handler */
+  /** collapse event handler */
   toggleHandler: (event: ClickEvent) => void;
+  /** collapse toggle */
+  toggle: (isOpen: boolean) => void;
   /** collapsed state */
-  collapsed: boolean;
+  isOpen: boolean;
 }
 
-export const useCollapse = (isCollapsed: boolean): CollapseReturn => {
-  const [collapsed, setCollapsed] = useState<boolean>(!!isCollapsed);
-
-  const collapseHandler = () => setCollapsed(!collapsed);
+export const useCollapse = (defaultOpenState: boolean): CollapseReturn => {
+  const [isOpen, toggle] = useState<boolean>(defaultOpenState);
 
   const toggleHandler = (event: ClickEvent) => {
     event.preventDefault();
-    collapseHandler();
+    toggle(!isOpen);
   };
 
   return {
     toggleHandler,
-    collapsed,
+    toggle,
+    isOpen,
   };
 };

--- a/packages/web-react/src/components/Collapse/useCollapseAriaProps.ts
+++ b/packages/web-react/src/components/Collapse/useCollapseAriaProps.ts
@@ -1,4 +1,4 @@
-import { SpiritCollapseProps, CollapseProps, Booleanish } from '../../types';
+import { CollapseProps, BaseCollapseProps, Booleanish } from '../../types';
 
 const ATTRIBUTE_ARIA_EXPANDED = 'aria-expanded';
 const ATTRIBUTE_ARIA_CONTROLS = 'aria-controls';
@@ -8,7 +8,7 @@ export interface CollapseAria {
   ariaProps: {
     /** wrapper returned props */
     root: {
-      [ATTRIBUTE_DATA_BREAKPOINT]: SpiritCollapseProps['collapsibleToBreakpoint'];
+      [ATTRIBUTE_DATA_BREAKPOINT]: CollapseProps['collapsibleToBreakpoint'];
     };
     /** trigger returned props */
     trigger: {
@@ -16,10 +16,10 @@ export interface CollapseAria {
       [ATTRIBUTE_ARIA_CONTROLS]: string;
     };
   };
-  props: CollapseProps;
+  props: BaseCollapseProps;
 }
 
-export const useCollapseAriaProps = (props: SpiritCollapseProps): CollapseAria => {
+export const useCollapseAriaProps = (props: CollapseProps): CollapseAria => {
   const { isOpen, collapsibleToBreakpoint, ...modifiedProps } = props;
 
   return {

--- a/packages/web-react/src/components/Collapse/useCollapseAriaProps.ts
+++ b/packages/web-react/src/components/Collapse/useCollapseAriaProps.ts
@@ -20,7 +20,7 @@ export interface CollapseAria {
 }
 
 export const useCollapseAriaProps = (props: SpiritCollapseProps): CollapseAria => {
-  const { isCollapsed, collapsibleToBreakpoint, ...modifiedProps } = props;
+  const { isOpen, collapsibleToBreakpoint, ...modifiedProps } = props;
 
   return {
     ariaProps: {
@@ -28,7 +28,7 @@ export const useCollapseAriaProps = (props: SpiritCollapseProps): CollapseAria =
         [ATTRIBUTE_DATA_BREAKPOINT]: collapsibleToBreakpoint,
       },
       trigger: {
-        [ATTRIBUTE_ARIA_EXPANDED]: isCollapsed,
+        [ATTRIBUTE_ARIA_EXPANDED]: isOpen,
         [ATTRIBUTE_ARIA_CONTROLS]: String(modifiedProps.id),
       },
     },

--- a/packages/web-react/src/components/Collapse/useCollapseAriaProps.ts
+++ b/packages/web-react/src/components/Collapse/useCollapseAriaProps.ts
@@ -1,60 +1,37 @@
-import { useRef, Ref, CSSProperties, MutableRefObject } from 'react';
-import { ClickEvent, CollapseResponsiveType, SpiritCollapseProps, Booleanish } from '../../types';
-import { useResizeHeight } from './useResizeHeight';
+import { SpiritCollapseProps, CollapseProps, Booleanish } from '../../types';
 
 const ATTRIBUTE_ARIA_EXPANDED = 'aria-expanded';
 const ATTRIBUTE_ARIA_CONTROLS = 'aria-controls';
 const ATTRIBUTE_DATA_BREAKPOINT = 'data-breakpoint';
 
-export interface CollapseAriaPropsProps {
-  id: string;
-  isCollapsed: boolean;
-  collapsibleToBreakpoint?: CollapseResponsiveType;
-  toggleHandler: (event: ClickEvent) => void;
+export interface CollapseAria {
+  ariaProps: {
+    /** wrapper returned props */
+    root: {
+      [ATTRIBUTE_DATA_BREAKPOINT]: SpiritCollapseProps['collapsibleToBreakpoint'];
+    };
+    /** trigger returned props */
+    trigger: {
+      [ATTRIBUTE_ARIA_EXPANDED]: Booleanish;
+      [ATTRIBUTE_ARIA_CONTROLS]: string;
+    };
+  };
+  props: CollapseProps;
 }
 
-export interface CollapseAriaPropsReturn {
-  /** wrapper returned props */
-  wrapperProps: {
-    style: CSSProperties;
-    [ATTRIBUTE_DATA_BREAKPOINT]: SpiritCollapseProps['collapsibleToBreakpoint'];
-  };
-  /** content returned props */
-  contentProps: {
-    ref: Ref<unknown>;
-  };
-  /** trigger returned props */
-  triggerProps: {
-    [ATTRIBUTE_ARIA_EXPANDED]: Booleanish;
-    [ATTRIBUTE_ARIA_CONTROLS]: string;
-    onClick: (event: ClickEvent) => void;
-  };
-}
-
-export const useCollapseAriaProps = (props: CollapseAriaPropsProps): CollapseAriaPropsReturn => {
-  const { id, isCollapsed, collapsibleToBreakpoint, toggleHandler } = props;
-
-  const contentElementRef: MutableRefObject<HTMLElement | null | undefined> = useRef();
-  const { height } = useResizeHeight({ contentRef: contentElementRef });
-
-  const wrapperProps = {
-    style: {
-      height: isCollapsed ? height : 0,
-    },
-    [ATTRIBUTE_DATA_BREAKPOINT]: collapsibleToBreakpoint,
-  };
-  const contentProps = {
-    ref: contentElementRef,
-  };
-  const triggerProps = {
-    [ATTRIBUTE_ARIA_EXPANDED]: isCollapsed,
-    [ATTRIBUTE_ARIA_CONTROLS]: String(id),
-    onClick: toggleHandler,
-  };
+export const useCollapseAriaProps = (props: SpiritCollapseProps): CollapseAria => {
+  const { isCollapsed, collapsibleToBreakpoint, ...modifiedProps } = props;
 
   return {
-    wrapperProps,
-    contentProps,
-    triggerProps,
+    ariaProps: {
+      root: {
+        [ATTRIBUTE_DATA_BREAKPOINT]: collapsibleToBreakpoint,
+      },
+      trigger: {
+        [ATTRIBUTE_ARIA_EXPANDED]: isCollapsed,
+        [ATTRIBUTE_ARIA_CONTROLS]: String(modifiedProps.id),
+      },
+    },
+    props: modifiedProps,
   };
 };

--- a/packages/web-react/src/components/Collapse/useCollapseStyleProps.ts
+++ b/packages/web-react/src/components/Collapse/useCollapseStyleProps.ts
@@ -6,22 +6,19 @@ export interface CollapseStyles {
   classProps: {
     root: string;
     content: string;
-    trigger: string;
   };
 }
 
-export const useCollapseStyleProps = (isCollapsed: boolean): CollapseStyles => {
+export const useCollapseStyleProps = (isOpen: boolean): CollapseStyles => {
   const collapseClass = useClassNamePrefix('Collapse');
   const collapseContentClass = `${collapseClass}__content`;
-  const collapsedClass = isCollapsed ? 'is-collapsed' : '';
-  const expandedClass = isCollapsed ? 'is-expanded' : '';
-  const rootClass = classNames(collapseClass, collapsedClass);
+  const openClass = isOpen ? 'is-open' : '';
+  const rootClass = classNames(collapseClass, openClass);
 
   return {
     classProps: {
       root: rootClass,
       content: collapseContentClass,
-      trigger: expandedClass,
     },
   };
 };

--- a/packages/web-react/src/components/Collapse/useCollapseStyleProps.ts
+++ b/packages/web-react/src/components/Collapse/useCollapseStyleProps.ts
@@ -1,28 +1,27 @@
 import classNames from 'classnames';
 import { useClassNamePrefix } from '../../hooks';
-import { SpiritCollapseProps } from '../../types';
 
-export interface CollapseStylePropsReturn {
+export interface CollapseStyles {
   /** className props */
-  wrapperClassName: string;
-  /** className props */
-  contentClassName: string;
-  /** className props */
-  triggerClassName: string;
+  classProps: {
+    root: string;
+    content: string;
+    trigger: string;
+  };
 }
 
-export const useCollapseStyleProps = ({ isCollapsed }: SpiritCollapseProps): CollapseStylePropsReturn => {
-  const wrapperClass = useClassNamePrefix('Collapse');
-  const contentClass = useClassNamePrefix('Collapse__content');
+export const useCollapseStyleProps = (isCollapsed: boolean): CollapseStyles => {
+  const collapseClass = useClassNamePrefix('Collapse');
+  const collapseContentClass = `${collapseClass}__content`;
   const collapsedClass = isCollapsed ? 'is-collapsed' : '';
   const expandedClass = isCollapsed ? 'is-expanded' : '';
-  const wrapperClassName = classNames(wrapperClass, collapsedClass);
-  const contentClassName = classNames(contentClass);
-  const triggerClassName = classNames(expandedClass);
+  const rootClass = classNames(collapseClass, collapsedClass);
 
   return {
-    wrapperClassName,
-    contentClassName,
-    triggerClassName,
+    classProps: {
+      root: rootClass,
+      content: collapseContentClass,
+      trigger: expandedClass,
+    },
   };
 };

--- a/packages/web-react/src/components/Collapse/useResizeHeight.ts
+++ b/packages/web-react/src/components/Collapse/useResizeHeight.ts
@@ -1,19 +1,10 @@
 import { useState, useEffect, MutableRefObject } from 'react';
 
-export interface ResizeHeightProps {
-  contentRef: MutableRefObject<HTMLElement | null | undefined>;
-}
-export interface ResizeHeightReturn {
-  height: string;
-}
-
-export const useResizeHeight = (props: ResizeHeightProps): ResizeHeightReturn => {
-  const { contentRef } = props;
-
+export const useResizeHeight = (ref: MutableRefObject<HTMLElement | null | undefined>): string => {
   const [height, setHeight] = useState<string>('0px');
 
   const adjustHeight = () => {
-    const currentHeight = contentRef?.current?.clientHeight || contentRef?.current?.offsetHeight;
+    const currentHeight = ref?.current?.clientHeight || ref?.current?.offsetHeight;
     setHeight(`${currentHeight}px`);
   };
 
@@ -24,7 +15,5 @@ export const useResizeHeight = (props: ResizeHeightProps): ResizeHeightReturn =>
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return {
-    height,
-  };
+  return height;
 };

--- a/packages/web-react/src/types/collapse.ts
+++ b/packages/web-react/src/types/collapse.ts
@@ -1,28 +1,29 @@
 import { ReactNode } from 'react';
 import { ChildrenProps, ClickEvent, StyleProps, Booleanish } from './shared';
 
-export type CollapseElementType = 'div' | 'article' | 'section' | 'main' | 'header' | 'footer' | 'span';
+export type CollapseElementType = 'div' | 'article' | 'section' | 'main' | 'header' | 'footer';
 
 export type CollapseResponsiveType = undefined | 'mobile' | 'tablet' | 'desktop';
 
-export type CollapseTriggerProps = {
+export type CollapseRenderProps = {
+  className: string;
+  collapsed: boolean;
   onClick: (event: ClickEvent) => void;
-  className?: string | undefined;
   'aria-expanded': Booleanish;
   'aria-controls': string;
 };
 
-export type CollapseRenderProps = {
-  collapsed: boolean;
-  trigger: CollapseTriggerProps;
-};
-
-export interface SpiritCollapseProps extends ChildrenProps, StyleProps {
+export interface CollapseProps extends ChildrenProps, StyleProps {
   id?: string;
-  isCollapsed?: boolean;
-  hideOnCollapse?: boolean;
+}
+
+export interface SpiritCollapseProps extends CollapseProps {
   collapsibleToBreakpoint?: CollapseResponsiveType;
-  renderTrigger?: (render: CollapseRenderProps) => ReactNode;
   elementType?: CollapseElementType;
-  contentElementType?: CollapseElementType;
+  isOpen: boolean;
+}
+
+export interface SpiritUncontrolledCollapseProps extends SpiritCollapseProps {
+  hideOnCollapse?: boolean;
+  renderTrigger?: (render: CollapseRenderProps) => ReactNode;
 }

--- a/packages/web-react/src/types/collapse.ts
+++ b/packages/web-react/src/types/collapse.ts
@@ -12,15 +12,20 @@ export type CollapseRenderProps = {
   'aria-controls': string;
 };
 
-export interface CollapseProps extends ChildrenProps, StyleProps {
+export interface BaseCollapseProps extends ChildrenProps, StyleProps {
   id?: string;
 }
 
-export interface SpiritCollapseProps extends CollapseProps {
+export interface CollapseProps extends BaseCollapseProps {
   collapsibleToBreakpoint?: CollapseResponsiveType;
   elementType?: CollapseElementType;
   isOpen: boolean;
 }
+export interface TransitionCollapseProps {
+  transitionDuration?: number;
+}
+
+export interface SpiritCollapseProps extends CollapseProps, TransitionCollapseProps {}
 
 export interface SpiritUncontrolledCollapseProps extends SpiritCollapseProps {
   hideOnCollapse?: boolean;

--- a/packages/web-react/src/types/collapse.ts
+++ b/packages/web-react/src/types/collapse.ts
@@ -6,8 +6,7 @@ export type CollapseElementType = 'div' | 'article' | 'section' | 'main' | 'head
 export type CollapseResponsiveType = undefined | 'mobile' | 'tablet' | 'desktop';
 
 export type CollapseRenderProps = {
-  className: string;
-  collapsed: boolean;
+  isOpen: boolean;
   onClick: (event: ClickEvent) => void;
   'aria-expanded': Booleanish;
   'aria-controls': string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2316,6 +2316,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.8.7":
+  version "7.20.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.6.tgz#facf4879bfed9b5326326273a64220f099b0fce3"
+  integrity sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.12.7", "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -7050,6 +7057,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-transition-group@^4.4.5":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
+  integrity sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@18.0.24":
   version "18.0.24"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.24.tgz#2f79ed5b27f08d05107aab45c17919754cc44c20"
@@ -11286,6 +11300,14 @@ dom-converter@^0.2.0:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
+
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@0:
   version "0.2.2"
@@ -20658,6 +20680,16 @@ react-textarea-autosize@^8.3.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
+react-transition-group@^4.4.5:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+
 react@16.14.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
@@ -20919,6 +20951,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.9"


### PR DESCRIPTION
Introducing `UncontrolledCollapse` component as an intermediate step between Collapse and Accordion, eg. we need to use `Collapse` as `AccordionItem` to make Accordion behave.

So I have split the current functionality into two separate components and used composition to make them work.

`Collapse` - controlled component, only template with HTML, styles and ARIA props, you must create state logic around it to make this work
`UncontrolledCollapse` - uncontrolled component with state logic around `Collapse` component