### PR TITLE
Fix(web-react): Dropdown props are not required anymore

### DIFF
--- a/packages/web-react/src/components/Dropdown/useDropdownStyleProps.ts
+++ b/packages/web-react/src/components/Dropdown/useDropdownStyleProps.ts
@@ -17,9 +17,9 @@ export interface UseDropdownStylePropsReturn {
 }
 
 export const useDropdownStyleProps = (
-  props: UseDropdownStyleProps = { isOpen: false, isFullWidth: false, placement: DropdownPlacements.BOTTOM_LEFT },
+  props: UseDropdownStyleProps = { isOpen: false, isFullWidth: false },
 ): UseDropdownStylePropsReturn => {
-  const { isOpen, isFullWidth, placement, ...modifiedProps } = props;
+  const { isOpen, isFullWidth, placement = DropdownPlacements.BOTTOM_LEFT, ...modifiedProps } = props;
   const dropdownClass = useClassNamePrefix('Dropdown');
   const dropdownWrapperClass = `${dropdownClass}Wrapper`;
   const dropdownFullWidthClass = `${dropdownClass}--fullWidth`;

--- a/packages/web-react/src/types/dropdown.ts
+++ b/packages/web-react/src/types/dropdown.ts
@@ -40,7 +40,7 @@ export interface DropdownProps extends ChildrenProps, StyleProps {
 
 export interface SpiritDropdownProps extends DropdownProps {
   enableAutoClose?: boolean;
-  isFullWidth: boolean;
-  placement: DropdownPlacement;
+  isFullWidth?: boolean;
+  placement?: DropdownPlacement;
   breakpoint?: DropdownBreakpoint;
 }


### PR DESCRIPTION
  * make `isFullWidth` and `placement` props not required
  * both have default values

![image (4)](https://user-images.githubusercontent.com/2481010/205724441-bbb7e7c7-cb04-4400-8713-a8458514ce98.png)
