### PR TITLE
Make `Pagination` component inline to enable horizontal alignment #JALL-37

### DIFF
--- a/packages/web/src/scss/components/Pagination/_Pagination.scss
+++ b/packages/web/src/scss/components/Pagination/_Pagination.scss
@@ -2,7 +2,7 @@
 @use '../../settings/cursors';
 
 .Pagination {
-    display: flex;
+    display: inline-flex;
     gap: theme.$item-gap;
     list-style-type: none;
 }

--- a/packages/web/src/scss/components/Pagination/index.html
+++ b/packages/web/src/scss/components/Pagination/index.html
@@ -1,6 +1,6 @@
 {{#> layout/plain }}
 
-<nav role="navigation" aria-label="Pagination Navigation" class="mb-800">
+<nav class="mb-800" role="navigation" aria-label="Page navigation">
   <ul class="Pagination">
     <li class="Pagination__item">
       <a
@@ -48,7 +48,7 @@
   </ul>
 </nav>
 
-<nav role="navigation" aria-label="Pagination Navigation" class="mb-800">
+<nav class="mb-800" role="navigation" aria-label="Page navigation">
   <ul class="Pagination">
     <li class="Pagination__item">
       <a href="#" class="Button Button--secondary Button--square">
@@ -104,7 +104,7 @@
   </ul>
 </nav>
 
-<nav role="navigation" aria-label="Pagination Navigation" class="mb-800">
+<nav class="mb-800" role="navigation" aria-label="Page navigation">
   <ul class="Pagination">
     <li class="Pagination__item">
       <a href="#" class="Button Button--secondary Button--square">
@@ -147,6 +147,54 @@
       >
         <span class="accessibility-hidden">page</span>
         113
+      </a>
+    </li>
+  </ul>
+</nav>
+
+<nav class="mb-800 text-center" role="navigation" aria-label="Page navigation">
+  <ul class="Pagination">
+    <li class="Pagination__item">
+      <a
+        href="#"
+        class="Pagination__link Pagination__link--current"
+        aria-label="Current Page, Page 1"
+        aria-current="page"
+      >
+        <span class="accessibility-hidden">page</span>
+        1
+      </a>
+    </li>
+    <li class="Pagination__item">
+      <a href="#" class="Pagination__link" aria-label="Goto Page 2">
+        <span class="accessibility-hidden">page</span>
+        2
+      </a>
+    </li>
+    <li class="Pagination__item">
+      <a href="#" class="Pagination__link" aria-label="Goto Page 3">
+        <span class="accessibility-hidden">page</span>
+        3
+      </a>
+    </li>
+    <li class="Pagination__item">
+      <a href="#" class="Pagination__link" aria-label="Goto Page 4">
+        <span class="accessibility-hidden">page</span>
+        4
+      </a>
+    </li>
+    <li class="Pagination__item">
+      <a href="#" class="Pagination__link" aria-label="Goto Page 5">
+        <span class="accessibility-hidden">page</span>
+        5
+      </a>
+    </li>
+    <li class="Pagination__item">
+      <a href="#" class="Button Button--secondary Button--square">
+        <svg width="24" height="24" aria-hidden="true">
+          <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
+        </svg>
+        <span class="accessibility-hidden">Next</span>
       </a>
     </li>
   </ul>


### PR DESCRIPTION
Change value of the display property to `inline-flex` will enable horizontally center the Pagination using the utility class `text-center`.

This behavior is currently required from the Jobs UI team.