### PR TITLE
Feat(web-react): Introduce on auto close callback prop for Dropdown

### DIFF
--- a/packages/web-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/web-react/src/components/Dropdown/Dropdown.tsx
@@ -20,13 +20,14 @@ const Dropdown = (props: SpiritDropdownProps) => {
     renderTrigger,
     enableAutoClose,
     breakpoint,
+    onAutoClose,
     ...rest
   } = props;
 
   const dropdownRef = useRef();
   const triggerRef = useRef();
 
-  const { isOpen, toggleHandler } = useDropdown({ dropdownRef, triggerRef, enableAutoClose });
+  const { isOpen, toggleHandler } = useDropdown({ dropdownRef, triggerRef, enableAutoClose, onAutoClose });
   const { classProps, props: modifiedProps } = useDropdownStyleProps({ isOpen, ...rest });
   const { triggerProps, contentProps } = useDropdownAriaProps({ id, isOpen, toggleHandler, breakpoint });
 

--- a/packages/web-react/src/components/Dropdown/README.md
+++ b/packages/web-react/src/components/Dropdown/README.md
@@ -21,6 +21,7 @@ import { Dropdown } from '@lmc-eu/spirit-web-react/components';
 | `id`               | `string`                                     | `<random>`    | no       | Component id                                                    |
 | `renderTrigger`    | `(render: DropdownRenderProps) => ReactNode` | -             | no       | Properties for trigger render                                   |
 | `enableAutoClose`  | `boolean`                                    | `true`        | no       | Enables close on click outside of Dropdown                      |
+| `onAutoClose` .    | `(event: Event) => void`                     |               | no       | Callback on close on click outside of Dropdown                  |
 | `isFullWidth`      | `boolean`                                    | `false`       | no       | Whether is component displayed in full width                    |
 | `placement`        | [`DropdownPlacement`][dropdownplacement]     | `bottom-left` | no       | Alignment of the component                                      |
 | `breakpoint`       | [`DropdownBreakpoint`][dropdownbreakpoint]   | -             | no       | Breakpoint to switch from the full-width to the auto-width mode |

--- a/packages/web-react/src/components/Dropdown/useDropdown.ts
+++ b/packages/web-react/src/components/Dropdown/useDropdown.ts
@@ -9,6 +9,8 @@ export interface UseDropdownProps {
   triggerRef: MutableRefObject<HTMLElement | undefined>;
   /** enabled click outside event */
   enableAutoClose?: boolean;
+  /** on close callback */
+  onAutoClose?: (event: Event) => void;
 }
 
 export interface UseDropdownReturn {
@@ -18,7 +20,12 @@ export interface UseDropdownReturn {
   isOpen: boolean;
 }
 
-export const useDropdown = ({ dropdownRef, triggerRef, enableAutoClose }: UseDropdownProps): UseDropdownReturn => {
+export const useDropdown = ({
+  dropdownRef,
+  triggerRef,
+  enableAutoClose,
+  onAutoClose,
+}: UseDropdownProps): UseDropdownReturn => {
   const [open, setOpen] = useState<boolean>(false);
 
   const collapseHandler = () => setOpen(!open);
@@ -34,6 +41,10 @@ export const useDropdown = ({ dropdownRef, triggerRef, enableAutoClose }: UseDro
     }
 
     if (!triggerRef?.current?.contains(event?.target as Node)) {
+      if (onAutoClose) {
+        onAutoClose(event);
+      }
+
       setOpen(false);
     }
   };

--- a/packages/web-react/src/types/dropdown.ts
+++ b/packages/web-react/src/types/dropdown.ts
@@ -43,4 +43,5 @@ export interface SpiritDropdownProps extends DropdownProps {
   isFullWidth?: boolean;
   placement?: DropdownPlacement;
   breakpoint?: DropdownBreakpoint;
+  onAutoClose?: (event: Event) => void;
 }


### PR DESCRIPTION
  * new prop `onAutoClose` that enables running callback when Dropdown is closed using click outside of the component