### PR TITLE
Feat(web-react): Introduce React Accordion component #DS-447

### DIFF
--- a/.storybook/assets/stylesheets/index.scss
+++ b/.storybook/assets/stylesheets/index.scss
@@ -3,6 +3,7 @@
 @forward '../../../packages/web/src/scss/foundation';
 @forward '../../../packages/web/src/scss/helpers';
 
+@forward '../../../packages/web/src/scss/components/Accordion';
 @forward '../../../packages/web/src/scss/components/Alert';
 @forward '../../../packages/web/src/scss/components/Breadcrumbs';
 @forward '../../../packages/web/src/scss/components/Button';

--- a/.storybook/decorators/IconGlobalDecorator.js
+++ b/.storybook/decorators/IconGlobalDecorator.js
@@ -1,0 +1,12 @@
+// Because there is no `dist` directory during the CI run
+/* eslint-disable import/no-extraneous-dependencies, import/extensions, import/no-unresolved */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore: No declaration file
+import icons from '../../packages/icons/dist/icons';
+import { IconsProvider } from '@lmc-eu/spirit-web-react/src/context';
+
+export const IconGlobalDecorator = (Story) => (
+  <IconsProvider value={icons}>
+    <Story />
+  </IconsProvider>
+);

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,6 @@
 import SpiritTheme from './spirit.theme';
 import '../.storybook/assets/stylesheets/index.scss';
+import { IconGlobalDecorator } from './decorators/IconGlobalDecorator';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -19,3 +20,7 @@ export const parameters = {
   },
   viewMode: 'docs',
 };
+
+export const decorators = [
+  IconGlobalDecorator,
+];

--- a/packages/web-react/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/web-react/src/components/Accordion/Accordion.stories.tsx
@@ -1,0 +1,20 @@
+import { ComponentMeta } from '@storybook/react';
+import Accordion from './Accordion';
+
+export default {
+  title: 'Components/Accordion',
+  parameters: {
+    docs: {
+      description: {
+        component: `
+  [Spirit Accordion](https://spirit.supernova-docs.io/spirit/latest/components/accordion/overview.html)
+
+  Toggle the visibility of content across your project with Accordion.
+  `,
+      },
+    },
+  },
+} as ComponentMeta<typeof Accordion>;
+
+export { default as Accordion } from './stories/Accordion';
+export { default as AccordionStayOpen } from './stories/AccordionStayOpen';

--- a/packages/web-react/src/components/Accordion/Accordion.tsx
+++ b/packages/web-react/src/components/Accordion/Accordion.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import classNames from 'classnames';
+import { AccordionProps, AccordionContextProps } from '../../types';
+import { useStyleProps } from '../../hooks/styleProps';
+import { AccordionProvider } from './AccordionContext';
+import { useAccordionStyleProps } from './useAccordionStyleProps';
+
+const Accordion: React.FC<AccordionProps> = (props) => {
+  const { children, elementType: ElementTag = 'section', id, open, toggle, ...restProps } = props;
+
+  const { classProps } = useAccordionStyleProps();
+  const { styleProps, props: transferProps } = useStyleProps(restProps);
+
+  const contextValue: AccordionContextProps = {
+    open,
+    toggle,
+  };
+
+  return (
+    <ElementTag
+      {...transferProps}
+      {...styleProps}
+      id={id}
+      className={classNames(classProps.root, styleProps.className)}
+    >
+      <AccordionProvider value={contextValue}>{children}</AccordionProvider>
+    </ElementTag>
+  );
+};
+
+export default Accordion;

--- a/packages/web-react/src/components/Accordion/AccordionContent.tsx
+++ b/packages/web-react/src/components/Accordion/AccordionContent.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import classNames from 'classnames';
+import { Collapse } from '../Collapse';
+import { AccordionContentProps } from '../../types';
+import { useStyleProps } from '../../hooks/styleProps';
+import { useAccordionStyleProps } from './useAccordionStyleProps';
+import { useAccordionItemContext } from './AccordionItemContext';
+import { useAccordionAriaProps } from './useAccordionAriaProps';
+import { useOpenItem } from './useOpenItem';
+
+const AccordionContent: React.FC<AccordionContentProps> = ({ children, ...restProps }) => {
+  const { classProps } = useAccordionStyleProps();
+  const { id } = useAccordionItemContext();
+  const { styleProps, props: transferProps } = useStyleProps(restProps);
+  const { isOpen } = useOpenItem(id);
+  const { contentProps } = useAccordionAriaProps({ id, isOpen });
+
+  return (
+    <Collapse isOpen={isOpen} {...contentProps}>
+      <div {...transferProps} {...styleProps} className={classNames(classProps.content, styleProps.className)}>
+        {children}
+      </div>
+    </Collapse>
+  );
+};
+
+export default AccordionContent;

--- a/packages/web-react/src/components/Accordion/AccordionContext.ts
+++ b/packages/web-react/src/components/Accordion/AccordionContext.ts
@@ -1,0 +1,14 @@
+import { createContext, useContext } from 'react';
+import { AccordionContextProps } from '../../types';
+
+const defaultContext: AccordionContextProps = {
+  open: undefined,
+};
+
+const AccordionContext = createContext<AccordionContextProps>(defaultContext);
+const AccordionProvider = AccordionContext.Provider;
+const AccordionConsumer = AccordionContext.Consumer;
+const useAccordionContext = (): AccordionContextProps => useContext(AccordionContext);
+
+export default AccordionContext;
+export { AccordionProvider, AccordionConsumer, useAccordionContext };

--- a/packages/web-react/src/components/Accordion/AccordionHeader.tsx
+++ b/packages/web-react/src/components/Accordion/AccordionHeader.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import classNames from 'classnames';
+import { Icon } from '../Icon';
+import { AccordionHeaderProps } from '../../types';
+import { useStyleProps } from '../../hooks/styleProps';
+import { useAccordionStyleProps } from './useAccordionStyleProps';
+import { useAccordionContext } from './AccordionContext';
+import { useAccordionItemContext } from './AccordionItemContext';
+import { useAccordionAriaProps } from './useAccordionAriaProps';
+import { useOpenItem } from './useOpenItem';
+
+const AccordionHeader: React.FC<AccordionHeaderProps> = ({ children, slot, ...restProps }) => {
+  const { classProps } = useAccordionStyleProps();
+  const { toggle } = useAccordionContext();
+  const { id } = useAccordionItemContext();
+  const { styleProps, props: transferProps } = useStyleProps(restProps);
+  const { isOpen } = useOpenItem(id);
+  const { triggerProps, headerProps } = useAccordionAriaProps({ id, isOpen });
+
+  const itemToggle = () => {
+    if (toggle && id) {
+      toggle(id);
+    }
+  };
+
+  return (
+    <h3
+      {...transferProps}
+      {...styleProps}
+      {...headerProps}
+      className={classNames(classProps.header, styleProps.className)}
+    >
+      <button type="button" className={classProps.toggle} onClick={itemToggle} {...triggerProps}>
+        {children}
+      </button>
+      <span className={classProps.side}>
+        {slot && <span className={classProps.slot}>{slot}</span>}
+        <span className={classProps.icon}>
+          <Icon name="chevron-down" />
+        </span>
+      </span>
+    </h3>
+  );
+};
+
+export default AccordionHeader;

--- a/packages/web-react/src/components/Accordion/AccordionItem.tsx
+++ b/packages/web-react/src/components/Accordion/AccordionItem.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import classNames from 'classnames';
+import { AccordionItemProps } from '../../types';
+import { useStyleProps } from '../../hooks/styleProps';
+import { useAccordionStyleProps } from './useAccordionStyleProps';
+import { AccordionItemProvider } from './AccordionItemContext';
+
+const AccordionItem: React.FC<AccordionItemProps> = (props) => {
+  const { children, elementType: ElementTag = 'article', id, ...restProps } = props;
+
+  const { classProps } = useAccordionStyleProps();
+  const { styleProps, props: transferProps } = useStyleProps(restProps);
+
+  const contextValue = { id };
+
+  return (
+    <ElementTag
+      {...transferProps}
+      {...styleProps}
+      id={id}
+      className={classNames(classProps.item, styleProps.className)}
+    >
+      <AccordionItemProvider value={contextValue}>{children}</AccordionItemProvider>
+    </ElementTag>
+  );
+};
+
+export default AccordionItem;

--- a/packages/web-react/src/components/Accordion/AccordionItemContext.ts
+++ b/packages/web-react/src/components/Accordion/AccordionItemContext.ts
@@ -1,0 +1,14 @@
+import { createContext, useContext } from 'react';
+import { AccordionItemContextProps } from '../../types';
+
+const defaultContext: AccordionItemContextProps = {
+  id: undefined,
+};
+
+const AccordionItemContext = createContext(defaultContext);
+const AccordionItemProvider = AccordionItemContext.Provider;
+const AccordionItemConsumer = AccordionItemContext.Consumer;
+const useAccordionItemContext = (): AccordionItemContextProps => useContext(AccordionItemContext);
+
+export default AccordionItemContext;
+export { AccordionItemProvider, AccordionItemConsumer, useAccordionItemContext };

--- a/packages/web-react/src/components/Accordion/README.md
+++ b/packages/web-react/src/components/Accordion/README.md
@@ -1,0 +1,111 @@
+# Accordion
+
+## Usage
+
+### Default (Always open)
+
+```javascript
+import React, { useState } from 'react';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionHeader,
+  AccordionContent,
+  AccordionOpenStateType,
+} from '@lmc-eu/spirit-web-react/components';
+```
+
+```
+const [openState, setOpenState] = useState<AccordionOpenStateType>(undefined);
+```
+
+```javascript
+const toggle = (id) => {
+  if (Array.isArray(openState)) {
+    if (open.includes(id)) {
+      setOpenState(open.filter((accordionId) => accordionId !== id));
+    } else {
+      setOpenState([...open, id]);
+    }
+  } else if (open === id) {
+    setOpenState(undefined);
+  } else {
+    setOpenState(id);
+  }
+};
+```
+
+```javascript
+<Accordion open={openState} toggle={toggle}>
+  <AccordionItem id="AccordionItemExample0">
+    <AccordionHeader>Accordion header #0</AccordionHeader>
+    <AccordionContent>{content}</AccordionContent>
+  </AccordionItem>
+  <AccordionItem id="AccordionItemExample1">
+    <AccordionHeader>Accordion header #1 (open)</AccordionHeader>
+    <AccordionContent>{content}</AccordionContent>
+  </AccordionItem>
+  <AccordionItem id="AccordionItemExample2">
+    <AccordionHeader>Accordion header #2</AccordionHeader>
+    <AccordionContent>{content}</AccordionContent>
+  </AccordionItem>
+  <AccordionItem id="AccordionItemExample3">
+    <AccordionHeader>Accordion header #3</AccordionHeader>
+    <AccordionContent>{content}</AccordionContent>
+  </AccordionItem>
+  ...
+</Accordion>
+```
+
+### Default with opened on init
+
+```
+const [openState, setOpenState] = useState<AccordionOpenStateType>(['AccordionItemExample1']);
+```
+
+### Open only one at a time
+
+```
+const [openState, setOpenState] = useState<AccordionOpenStateType>('');
+```
+
+## Accordion Props
+
+| Prop name          | Type                          | Default     | Required | Description                                      |
+| ------------------ | ----------------------------- | ----------- | -------- | ------------------------------------------------ |
+| `id`               | `string`                      | -           | no       | Accordion id                                     |
+| `children`         | `ReactNode`                   | -           | yes      | Accordion children node                          |
+| `elementType`      | `'section', 'article', 'div'` | `'section'` | no       | Type of element used as wrapper                  |
+| `open`             | `string, string[]`            | `[]`        | no       | Open state \*                                    |
+| `toggle`           | `(id: string) => void`        | -           | no       | A generic handler for a single **AccordionItem** |
+| `UNSAFE_className` | `string`                      | -           | no       | Wrapper custom class name                        |
+| `UNSAFE_style`     | `CSSProperties`               | -           | no       | Wrapper custom style                             |
+
+(\*) Depending on the type of default value, what is set as the default will affect whether one or more will be open at the same time.
+
+## AccordionItem Props
+
+| Prop name          | Type                          | Default     | Required | Description                                     |
+| ------------------ | ----------------------------- | ----------- | -------- | ----------------------------------------------- |
+| `id`               | `string`                      | -           | yes      | Item id                                         |
+| `children`         | `ReactNode`                   | -           | yes      | Item children node                              |
+| `elementType`      | `'article', 'section', 'div'` | `'article'` | no       | Type of element used as wrapper for single item |
+| `UNSAFE_className` | `string`                      | -           | no       | Item custom class name                          |
+| `UNSAFE_style`     | `CSSProperties`               | -           | no       | Item custom style                               |
+
+## AccordionHeader Props
+
+| Prop name          | Type            | Default | Required | Description              |
+| ------------------ | --------------- | ------- | -------- | ------------------------ |
+| `children`         | `ReactNode`     | -       | yes      | Header children node     |
+| `slot`             | `ReactNode`     | -       | no       | Side slot in the header  |
+| `UNSAFE_className` | `string`        | -       | no       | Header custom class name |
+| `UNSAFE_style`     | `CSSProperties` | -       | no       | Header custom style      |
+
+## AccordionContent Props
+
+| Prop name          | Type            | Default | Required | Description               |
+| ------------------ | --------------- | ------- | -------- | ------------------------- |
+| `children`         | `ReactNode`     | -       | yes      | Content children node     |
+| `UNSAFE_className` | `string`        | -       | no       | Content custom class name |
+| `UNSAFE_style`     | `CSSProperties` | -       | no       | Content custom style      |

--- a/packages/web-react/src/components/Accordion/__tests__/Accordion.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/Accordion.test.tsx
@@ -1,0 +1,25 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
+import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
+import Accordion from '../Accordion';
+
+describe('Accordion', () => {
+  classNamePrefixProviderTest(Accordion, 'Accordion');
+
+  stylePropsTest(
+    (props: Record<string, unknown>) => <Accordion {...props} id="AccordionExample" data-testid="test-accordion" />,
+    'test-accordion',
+  );
+
+  restPropsTest(Accordion, '.Accordion');
+
+  it('should render text children', () => {
+    const dom = render(<Accordion>Hello World</Accordion>);
+    const element = dom.container.querySelector('.Accordion') as HTMLElement;
+
+    expect(element.textContent).toBe('Hello World');
+  });
+});

--- a/packages/web-react/src/components/Accordion/__tests__/AccordionContent.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/AccordionContent.test.tsx
@@ -1,0 +1,30 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
+import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
+import AccordionItem from '../AccordionItem';
+import AccordionContent from '../AccordionContent';
+
+describe('AccordionContent', () => {
+  classNamePrefixProviderTest(AccordionContent, 'Collapse');
+
+  stylePropsTest(
+    (props: Record<string, unknown>) => (
+      <AccordionItem id="AccordionItemExample">
+        <AccordionContent {...props} data-testid="test-accordion-content" />
+      </AccordionItem>
+    ),
+    'test-accordion-content',
+  );
+
+  restPropsTest(AccordionContent, '.Accordion__content');
+
+  it('should render text children', () => {
+    const dom = render(<AccordionContent>Hello World</AccordionContent>);
+    const element = dom.container.querySelector('.Collapse') as HTMLElement;
+
+    expect(element.textContent).toBe('Hello World');
+  });
+});

--- a/packages/web-react/src/components/Accordion/__tests__/AccordionHeader.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/AccordionHeader.test.tsx
@@ -1,0 +1,30 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
+import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
+import AccordionItem from '../AccordionItem';
+import AccordionHeader from '../AccordionHeader';
+
+describe('AccordionHeader', () => {
+  classNamePrefixProviderTest(AccordionHeader, 'Accordion__itemHeader');
+
+  stylePropsTest(
+    (props: Record<string, unknown>) => (
+      <AccordionItem id="AccordionItemExample">
+        <AccordionHeader {...props} data-testid="test-accordion-header" />
+      </AccordionItem>
+    ),
+    'test-accordion-header',
+  );
+
+  restPropsTest(AccordionHeader, '.Accordion__itemHeader');
+
+  it('should render text children', () => {
+    const dom = render(<AccordionHeader>Hello World</AccordionHeader>);
+    const element = dom.container.querySelector('.Accordion__itemHeader') as HTMLElement;
+
+    expect(element.textContent).toBe('Hello World');
+  });
+});

--- a/packages/web-react/src/components/Accordion/__tests__/AccordionItem.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/AccordionItem.test.tsx
@@ -1,0 +1,51 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
+import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
+import Accordion from '../Accordion';
+import AccordionItem from '../AccordionItem';
+import AccordionHeader from '../AccordionHeader';
+import AccordionContent from '../AccordionContent';
+
+describe('AccordionItem', () => {
+  classNamePrefixProviderTest(AccordionItem, 'Accordion__item');
+
+  stylePropsTest(
+    (props: Record<string, unknown>) => (
+      <AccordionItem {...props} id="AccordionItemExample" data-testid="test-accordion-item" />
+    ),
+    'test-accordion-item',
+  );
+
+  restPropsTest(AccordionItem, '.Accordion__item');
+
+  it('should render text children', () => {
+    const dom = render(<AccordionItem id="AccordionItemExample">Hello World</AccordionItem>);
+    const element = dom.container.querySelector('.Accordion__item') as HTMLElement;
+
+    expect(element.textContent).toBe('Hello World');
+  });
+
+  it('accordion item should be opened', () => {
+    const dom = render(
+      <Accordion open={['AccordionItemExample1']}>
+        <AccordionItem id="AccordionItemExample1">
+          <AccordionHeader>header</AccordionHeader>
+          <AccordionContent>content</AccordionContent>
+        </AccordionItem>
+        <AccordionItem id="AccordionItemExample2">
+          <AccordionHeader>header</AccordionHeader>
+          <AccordionContent>content</AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+    const itemElement = dom.container.querySelector('#AccordionItemExample1') as HTMLElement;
+    const triggerElement = itemElement.querySelector('button') as HTMLElement;
+    const collapseElement = itemElement.querySelector('.Collapse') as HTMLElement;
+
+    expect(triggerElement).toHaveAttribute('aria-expanded', 'true');
+    expect(collapseElement).toHaveClass('is-open');
+  });
+});

--- a/packages/web-react/src/components/Accordion/__tests__/useAccordionAriaProps.test.ts
+++ b/packages/web-react/src/components/Accordion/__tests__/useAccordionAriaProps.test.ts
@@ -1,0 +1,26 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useAccordionAriaProps } from '../useAccordionAriaProps';
+
+describe('useAccordionAriaProps', () => {
+  it('should return defaults', () => {
+    const props = {
+      id: 'test-accordion-id',
+      isOpen: true,
+    };
+    const { result } = renderHook(() => useAccordionAriaProps(props));
+
+    expect(result.current.headerProps).toBeDefined();
+    expect(result.current.headerProps.id).toBeDefined();
+    expect(result.current.headerProps.id).toBe('test-accordion-id_Header');
+
+    expect(result.current.triggerProps).toBeDefined();
+    expect(result.current.triggerProps['aria-controls']).toBeDefined();
+    expect(result.current.triggerProps['aria-expanded']).toBeDefined();
+    expect(result.current.triggerProps['aria-expanded']).toBe(true);
+
+    expect(result.current.contentProps).toBeDefined();
+    expect(result.current.contentProps['aria-labelledby']).toBeDefined();
+    expect(result.current.contentProps.id).toBeDefined();
+    expect(result.current.contentProps.id).toBe('test-accordion-id_Content');
+  });
+});

--- a/packages/web-react/src/components/Accordion/__tests__/useAccordionStyleProps.test.ts
+++ b/packages/web-react/src/components/Accordion/__tests__/useAccordionStyleProps.test.ts
@@ -1,0 +1,18 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useAccordionStyleProps } from '../useAccordionStyleProps';
+
+describe('useAccordionStyleProps', () => {
+  it('should return defaults', () => {
+    const { result } = renderHook(() => useAccordionStyleProps());
+
+    expect(result.current.classProps).toBeDefined();
+    expect(result.current.classProps.root).toBe('Accordion');
+    expect(result.current.classProps.item).toBe('Accordion__item');
+    expect(result.current.classProps.header).toBe('Accordion__itemHeader');
+    expect(result.current.classProps.toggle).toBe('Accordion__itemToggle');
+    expect(result.current.classProps.side).toBe('Accordion__itemSide');
+    expect(result.current.classProps.slot).toBe('Accordion__itemSlot');
+    expect(result.current.classProps.icon).toBe('Accordion__itemIcon');
+    expect(result.current.classProps.content).toBe('Accordion__content');
+  });
+});

--- a/packages/web-react/src/components/Accordion/index.ts
+++ b/packages/web-react/src/components/Accordion/index.ts
@@ -1,0 +1,14 @@
+export * from './Accordion';
+export * from './AccordionItem';
+export * from './AccordionHeader';
+export * from './AccordionContent';
+export * from './AccordionContext';
+export * from './useAccordionAriaProps';
+export * from './useAccordionStyleProps';
+export * from './useOpenItem';
+export { default as Accordion } from './Accordion';
+export { default as AccordionItem } from './AccordionItem';
+export { default as AccordionHeader } from './AccordionHeader';
+export { default as AccordionContent } from './AccordionContent';
+export { default as AccordionContext } from './AccordionContext';
+export { default as AccordionItemContext } from './AccordionItemContext';

--- a/packages/web-react/src/components/Accordion/stories/Accordion.tsx
+++ b/packages/web-react/src/components/Accordion/stories/Accordion.tsx
@@ -1,0 +1,71 @@
+// Because there is no `dist` directory during the CI run
+/* eslint-disable import/no-extraneous-dependencies, import/extensions, import/no-unresolved */
+import { ComponentStory } from '@storybook/react';
+import React from 'react';
+import { AccordionOpenStateType } from '../../../types';
+import Accordion from '../Accordion';
+import AccordionItem from '../AccordionItem';
+import AccordionHeader from '../AccordionHeader';
+import AccordionContent from '../AccordionContent';
+import toggleValueByType from './toggleValueByType';
+import { Link } from '../../Link';
+import { Pill } from '../../Pill';
+
+export const content = (
+  <p>
+    Sit amet interdum, accumsan dolor sit amet posuere vel arcu mauris placerat non mauris, non sed vitae curabitur odio
+    leo. Dignissim tristique, consequat vel arcu et nisi odio leo pretium accumsan condimentum at sem, mauris aenean
+    aliquet enim. Neque sapien, volutpat erat id nunc facilisis eget ipsum phasellus, tellus ultricies sollicitudin
+    ligula. Sem proin, nibh maximus donec nec commodo molestie nulla sapien nec commodo, commodo et fermentum et. Mauris
+    posuere, mi orci et nisi et iaculis lorem fringilla sed mauris auctor, lorem tempus a pulvinar felis scelerisque.
+    Suscipit vivamus, elit vel arcu lorem fringilla finibus quis sit amet ligula convallis, consectetur potenti aenean
+    efficitur.
+    <br />
+    Non suspendisse, maximus suscipit tortor non mauris bibendum felis scelerisque bibendum, nam augue scelerisque non
+    nulla. Erat nec, integer nec egestas integer consequat cursus sed porttitor, dolor sit amet lorem ipsum consectetur
+    porta. Condimentum urna, suspendisse mauris ligula duis id vivamus quis odio eget, integer ornare fermentum et
+    vehicula. Consequat bibendum, dui fusce gravida iaculis urna integer vitae id, ante purus nullam et nisl. Accumsan
+    arcu, nunc nulla faucibus purus vivamus facilisis augue, volutpat convallis eget suscipit. Tellus nunc ut enim et,
+    urna fusce pulvinar fusce et mauris donec, vitae odio morbi risus aliquet. et.
+  </p>
+);
+
+const Story: ComponentStory<typeof Accordion> = () => {
+  const [openState, setOpenState] = React.useState<AccordionOpenStateType>('AccordionItemExample1');
+
+  const toggle = (id: string) => {
+    setOpenState(toggleValueByType(id, openState));
+  };
+
+  return (
+    <Accordion open={openState} toggle={toggle}>
+      <AccordionItem id="AccordionItemExample0">
+        <AccordionHeader
+          slot={
+            <>
+              <Link href="#">Link</Link>
+              <Pill>3</Pill>
+            </>
+          }
+        >
+          Accordion header #0
+        </AccordionHeader>
+        <AccordionContent>{content}</AccordionContent>
+      </AccordionItem>
+      <AccordionItem id="AccordionItemExample1">
+        <AccordionHeader slot={<Pill>3</Pill>}>Accordion header #1 (open)</AccordionHeader>
+        <AccordionContent>{content}</AccordionContent>
+      </AccordionItem>
+      <AccordionItem id="AccordionItemExample2">
+        <AccordionHeader>Accordion header #2</AccordionHeader>
+        <AccordionContent>{content}</AccordionContent>
+      </AccordionItem>
+      <AccordionItem id="AccordionItemExample3">
+        <AccordionHeader slot={<Pill>3</Pill>}>Accordion header #3</AccordionHeader>
+        <AccordionContent>{content}</AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};
+
+export default Story;

--- a/packages/web-react/src/components/Accordion/stories/AccordionStayOpen.tsx
+++ b/packages/web-react/src/components/Accordion/stories/AccordionStayOpen.tsx
@@ -1,0 +1,63 @@
+// Because there is no `dist` directory during the CI run
+/* eslint-disable import/no-extraneous-dependencies, import/extensions, import/no-unresolved */
+import { ComponentStory } from '@storybook/react';
+import React from 'react';
+import { AccordionOpenStateType } from '../../../types';
+import Accordion from '../Accordion';
+import AccordionItem from '../AccordionItem';
+import AccordionHeader from '../AccordionHeader';
+import AccordionContent from '../AccordionContent';
+import toggleValueByType from './toggleValueByType';
+import { Link } from '../../Link';
+import { Pill } from '../../Pill';
+
+export const content = (
+  <p>
+    Condimentum odio, pulvinar et sollicitudin accumsan ac hendrerit vestibulum commodo, molestie laoreet dui sit amet.
+    Molestie consectetur, sed ac felis scelerisque lectus accumsan purus id dolor sed vitae, praesent aliquam dolor quis
+    ornare. Nulla sit amet, rhoncus at quis odio et iaculis lacinia suscipit vivamus sodales, nunc id condimentum felis.
+    Consectetur nec commodo, praesent et elit magna purus molestie cursus molestie, libero ut venenatis erat id et nisi.
+    Quam posuere, aliquam quam leo vitae tellus semper eget nunc, ultricies adipiscing sit amet accumsan. Lorem rutrum,
+    porttitor ante mauris suspendisse ultricies consequat purus, congue a commodo magna et.
+  </p>
+);
+
+const Story: ComponentStory<typeof Accordion> = () => {
+  const [openState, setOpenState] = React.useState<AccordionOpenStateType>(['AccordionItemExample1']);
+
+  const toggle = (id: string) => {
+    setOpenState(toggleValueByType(id, openState));
+  };
+
+  return (
+    <Accordion open={openState} toggle={toggle}>
+      <AccordionItem id="AccordionItemExample0">
+        <AccordionHeader
+          slot={
+            <>
+              <Link href="#">Link</Link>
+              <Pill>3</Pill>
+            </>
+          }
+        >
+          Accordion header #0
+        </AccordionHeader>
+        <AccordionContent>{content}</AccordionContent>
+      </AccordionItem>
+      <AccordionItem id="AccordionItemExample1">
+        <AccordionHeader slot={<Pill>3</Pill>}>Accordion header #1 (open)</AccordionHeader>
+        <AccordionContent>{content}</AccordionContent>
+      </AccordionItem>
+      <AccordionItem id="AccordionItemExample2">
+        <AccordionHeader>Accordion header #2</AccordionHeader>
+        <AccordionContent>{content}</AccordionContent>
+      </AccordionItem>
+      <AccordionItem id="AccordionItemExample3">
+        <AccordionHeader slot={<Pill>3</Pill>}>Accordion header #3</AccordionHeader>
+        <AccordionContent>{content}</AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};
+
+export default Story;

--- a/packages/web-react/src/components/Accordion/stories/toggleValueByType.ts
+++ b/packages/web-react/src/components/Accordion/stories/toggleValueByType.ts
@@ -1,0 +1,21 @@
+import { AccordionOpenStateType } from '../../../types';
+
+const toggleValueByType = (id: string, state: AccordionOpenStateType | undefined) => {
+  let value;
+
+  if (Array.isArray(state)) {
+    if (state.includes(id)) {
+      value = state.filter((accordionId) => accordionId !== id);
+    } else {
+      value = [...state, id];
+    }
+  } else if (state === id) {
+    value = undefined;
+  } else {
+    value = id;
+  }
+
+  return value;
+};
+
+export default toggleValueByType;

--- a/packages/web-react/src/components/Accordion/useAccordionAriaProps.ts
+++ b/packages/web-react/src/components/Accordion/useAccordionAriaProps.ts
@@ -1,0 +1,52 @@
+import { Booleanish } from '../../types';
+
+const NAME_ARIA_EXPANDED = 'aria-expanded';
+const NAME_ARIA_CONTROLS = 'aria-controls';
+const NAME_ARIA_LABELEDBY = 'aria-labelledby';
+
+export interface AccordionAriaProps {
+  /** AccordionItem ID */
+  id: string | undefined;
+  /** open state */
+  isOpen: boolean;
+}
+
+export interface AccordionAriaPropsReturn {
+  /** item header returned props */
+  headerProps: {
+    id: string;
+  };
+  /** item header trigger returned props */
+  triggerProps: {
+    [NAME_ARIA_EXPANDED]: Booleanish;
+    [NAME_ARIA_CONTROLS]: string;
+  };
+  /** item content returned props */
+  contentProps: {
+    id: string;
+    [NAME_ARIA_LABELEDBY]: string;
+  };
+}
+
+export const useAccordionAriaProps = ({ id, isOpen }: AccordionAriaProps): AccordionAriaPropsReturn => {
+  const headerId = `${id}_Header`;
+  const contentId = `${id}_Content`;
+
+  const headerProps = {
+    id: headerId,
+  };
+  const triggerProps = {
+    [NAME_ARIA_EXPANDED]: isOpen,
+    [NAME_ARIA_CONTROLS]: contentId,
+  };
+  const contentProps = {
+    id: contentId,
+    [NAME_ARIA_LABELEDBY]: headerId,
+  };
+
+  return {
+    headerProps,
+    triggerProps,
+    contentProps,
+  };
+};

--- a/packages/web-react/src/components/Accordion/useAccordionStyleProps.ts
+++ b/packages/web-react/src/components/Accordion/useAccordionStyleProps.ts
@@ -1,0 +1,39 @@
+import { useClassNamePrefix } from '../../hooks';
+
+export interface AccordionStyleReturn {
+  /** className props */
+  classProps: {
+    root: string;
+    item: string;
+    header: string;
+    toggle: string;
+    side: string;
+    slot: string;
+    icon: string;
+    content: string;
+  };
+}
+
+export const useAccordionStyleProps = (): AccordionStyleReturn => {
+  const accordionClass = useClassNamePrefix('Accordion');
+  const accordionItemClass = `${accordionClass}__item`;
+  const accordionItemHeaderClass = `${accordionClass}__itemHeader`;
+  const accordionItemToggleClass = `${accordionClass}__itemToggle`;
+  const accordionItemSideClass = `${accordionClass}__itemSide`;
+  const accordionItemSlotClass = `${accordionClass}__itemSlot`;
+  const accordionItemIconClass = `${accordionClass}__itemIcon`;
+  const accordionItemContentClass = `${accordionClass}__content`;
+
+  return {
+    classProps: {
+      root: accordionClass,
+      item: accordionItemClass,
+      header: accordionItemHeaderClass,
+      toggle: accordionItemToggleClass,
+      side: accordionItemSideClass,
+      slot: accordionItemSlotClass,
+      icon: accordionItemIconClass,
+      content: accordionItemContentClass,
+    },
+  };
+};

--- a/packages/web-react/src/components/Accordion/useOpenItem.ts
+++ b/packages/web-react/src/components/Accordion/useOpenItem.ts
@@ -1,0 +1,21 @@
+import { useAccordionContext } from './AccordionContext';
+
+export const useOpenItem = (
+  id: string | undefined,
+): {
+  isOpen: boolean;
+} => {
+  const { open } = useAccordionContext();
+
+  const isOpen = (iid: string | undefined): boolean => {
+    if (iid) {
+      return !!(iid === open || open?.includes(iid));
+    }
+
+    return false;
+  };
+
+  return {
+    isOpen: isOpen(id),
+  };
+};

--- a/packages/web-react/src/components/index.ts
+++ b/packages/web-react/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './Accordion';
 export * from './Alert';
 export * from './Breadcrumbs';
 export * from './Button';

--- a/packages/web-react/src/types/accordion.ts
+++ b/packages/web-react/src/types/accordion.ts
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ChildrenProps, StyleProps, TransferProps } from './shared';
+
+export type AccordionElementType = 'section' | 'article' | 'div';
+
+export type AccordionOpenStateType = string | string[] | undefined;
+
+export interface AccordionContextProps {
+  open: AccordionOpenStateType;
+  toggle?: (id: string) => void;
+}
+
+export interface AccordionItemContextProps {
+  id: string | undefined;
+}
+
+export interface AccordionProps
+  extends ChildrenProps,
+    StyleProps,
+    TransferProps,
+    Pick<AccordionContextProps, 'toggle'> {
+  elementType?: AccordionElementType;
+  id?: string;
+  open?: AccordionOpenStateType;
+}
+
+export interface AccordionItemProps extends ChildrenProps, StyleProps, TransferProps {
+  id: string;
+  elementType?: AccordionElementType;
+}
+
+export interface AccordionHeaderProps extends ChildrenProps, StyleProps, TransferProps {
+  slot?: React.ReactNode;
+}
+
+export interface AccordionContentProps extends ChildrenProps, StyleProps, TransferProps {}

--- a/packages/web-react/src/types/index.ts
+++ b/packages/web-react/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './accordion';
 export * from './alert';
 export * from './breadcrumbs';
 export * from './button';


### PR DESCRIPTION
# React Accordion component [#DS-447](https://jira.lmc.cz/browse/DS-447)

## What is done:
1) **React Accordion**
   - Accordion
   - AccordionContext
   - AccordionItem
   - AccordionItemContext
   - AccordionHeader
   - AccordionContent
   - useAccordionAriaProps
   - useAccordionStyleProps
   - useOpenItem
2) **Accordion stories**
   - Accordion (default)
   - AccordionStayOpen
   - common toggle function
3) Storybook global Icon provider
   - `IconGlobalDecorator` - No longer need to define an IconProvider every time icons are used
4) Accordion tests
   - Accordion.test
   - AccordionItem.test
   - AccordionHeader.test
   - AccordionContent.test
   - useAccordionAriaProps.test  
   - useAccordionStyleProps.test 
