### PR TITLE
Fix(web-react): Module `Transition` was not found while using Collapse

### DIFF
--- a/packages/web-react/src/components/Collapse/Collapse.tsx
+++ b/packages/web-react/src/components/Collapse/Collapse.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import React, { MutableRefObject, useRef } from 'react';
-import Transition, { TransitionStatus, ENTERED, ENTERING, EXITED, EXITING } from 'react-transition-group/Transition';
+import { Transition, TransitionStatus } from 'react-transition-group';
 import { useStyleProps } from '../../hooks/styleProps';
 import { SpiritCollapseProps } from '../../types';
 import { useCollapseAriaProps } from './useCollapseAriaProps';
@@ -10,10 +10,10 @@ import { useResizeHeight } from './useResizeHeight';
 const TRANSITION_DURATION = 250;
 
 const transitioningStyles = {
-  [ENTERING]: 'is-transitioning',
-  [ENTERED]: '',
-  [EXITING]: 'is-transitioning',
-  [EXITED]: '',
+  entering: 'is-transitioning',
+  entered: '',
+  exiting: 'is-transitioning',
+  exited: '',
 };
 
 const defaultProps = {


### PR DESCRIPTION
  * fixing Webpack error: Module build failed: Module not found: @lmc-eu/spirit-web-react/components/Collapse/Collapse.js" contains a reference to the file "react-transition-group/Transition".

```
> jobs-cz@1.0.0 build:prod

> encore production

Running webpack ...

 ERROR  Failed to compile with 1 errors9:36:56 AM

Module build failed: Module not found:

"./node_modules/@lmc-eu/spirit-web-react/components/Collapse/Collapse.js" contains a reference to the file "react-transition-group/Transition".

This file can not be found, please check it for typos or update it if the file got moved.
```

https://reactcommunity.org/react-transition-group/transition