### PR TITLE
Fix(web): Fix Accordion styles

### DIFF
--- a/packages/web/src/scss/components/Accordion/_Accordion.scss
+++ b/packages/web/src/scss/components/Accordion/_Accordion.scss
@@ -15,10 +15,6 @@
     border-radius: theme.$accordion-border-radius;
     background-color: theme.$accordion-item-background-color-default;
 
-    &:hover {
-        background-color: theme.$accordion-item-background-color-hover;
-    }
-
     &::before {
         content: '';
         position: absolute;
@@ -28,8 +24,14 @@
         border-bottom: theme.$accordion-divider-width theme.$accordion-divider-style theme.$accordion-divider-color;
     }
 
-    &:hover::before {
-        border-bottom-color: transparent;
+    @media (hover: hover) {
+        &:hover {
+            background-color: theme.$accordion-item-background-color-hover;
+        }
+
+        &:hover::before {
+            border-bottom-color: transparent;
+        }
     }
 }
 
@@ -39,6 +41,8 @@
 
     flex: initial;
     text-align: left;
+    color: theme.$accordion-header-typography-color;
+    -webkit-tap-highlight-color: transparent;
 
     &:first-of-type::before {
         content: '';
@@ -86,4 +90,9 @@
         left: theme.$accordion-header-padding-x;
         border-bottom: theme.$accordion-divider-width theme.$accordion-divider-style theme.$accordion-divider-color;
     }
+}
+
+// stylelint-disable-next-line selector-max-class, selector-max-specificity -- We want to hide the border above the header of the adjacent item
+.Accordion__item:not(:last-child) .is-open .Accordion__content::after {
+    border-bottom-color: transparent;
 }

--- a/packages/web/src/scss/components/Accordion/_theme.scss
+++ b/packages/web/src/scss/components/Accordion/_theme.scss
@@ -5,6 +5,7 @@ $accordion-item-background-color-hover: tokens.$background-interactive-hover;
 $accordion-item-background-color-active: tokens.$background-interactive-active;
 $accordion-header-typography: tokens.$body-medium-text-regular;
 $accordion-header-typography-active: tokens.$body-medium-text-bold;
+$accordion-header-typography-color: tokens.$text-primary-default;
 $accordion-header-gap: tokens.$space-500;
 $accordion-header-padding-y: tokens.$space-700;
 $accordion-header-padding-x: tokens.$space-600;

--- a/packages/web/src/scss/components/Accordion/index.html
+++ b/packages/web/src/scss/components/Accordion/index.html
@@ -27,7 +27,7 @@
             data-target="accordionExample_article_0_collapse"
           >
             <!-- toggle -->
-            Accordion header #0
+            Accordion Header
             <!-- // toggle -->
           </button>
           <span class="Accordion__itemSide">
@@ -56,7 +56,13 @@
               class="Accordion__content"
             >
               <!-- content -->
-              Accordion content #0
+              Sit amet interdum, accumsan dolor sit amet posuere vel arcu mauris placerat non mauris, non sed vitae curabitur odio
+              leo. Dignissim tristique, consequat vel arcu et nisi odio leo pretium accumsan condimentum at sem, mauris aenean
+              aliquet enim. Neque sapien, volutpat erat id nunc facilisis eget ipsum phasellus, tellus ultricies sollicitudin
+              ligula. Sem proin, nibh maximus donec nec commodo molestie nulla sapien nec commodo, commodo et fermentum et. Mauris
+              posuere, mi orci et nisi et iaculis lorem fringilla sed mauris auctor, lorem tempus a pulvinar felis scelerisque.
+              Suscipit vivamus, elit vel arcu lorem fringilla finibus quis sit amet ligula convallis, consectetur potenti aenean
+              efficitur.
               <!-- // content -->
             </div>
           </div>
@@ -80,7 +86,7 @@
             aria-expanded="true"
           >
             <!-- toggle -->
-            Accordion header #1 (open)
+            Accordion Header
             <!-- // toggle -->
           </button>
           <span class="Accordion__itemSide">
@@ -108,7 +114,12 @@
               class="Accordion__content"
             >
               <!-- content -->
-              Accordion content #1
+              Non suspendisse, maximus suscipit tortor non mauris bibendum felis scelerisque bibendum, nam augue scelerisque non
+              nulla. Erat nec, integer nec egestas integer consequat cursus sed porttitor, dolor sit amet lorem ipsum consectetur
+              porta. Condimentum urna, suspendisse mauris ligula duis id vivamus quis odio eget, integer ornare fermentum et
+              vehicula. Consequat bibendum, dui fusce gravida iaculis urna integer vitae id, ante purus nullam et nisl. Accumsan
+              arcu, nunc nulla faucibus purus vivamus facilisis augue, volutpat convallis eget suscipit. Tellus nunc ut enim et,
+              urna fusce pulvinar fusce et mauris donec, vitae odio morbi risus aliquet. et.
               <!-- // content -->
             </div>
           </div>
@@ -154,7 +165,13 @@
               class="Accordion__content"
             >
               <!-- content -->
-              Accordion content #2
+              Sit amet interdum, accumsan dolor sit amet posuere vel arcu mauris placerat non mauris, non sed vitae curabitur odio
+              leo. Dignissim tristique, consequat vel arcu et nisi odio leo pretium accumsan condimentum at sem, mauris aenean
+              aliquet enim. Neque sapien, volutpat erat id nunc facilisis eget ipsum phasellus, tellus ultricies sollicitudin
+              ligula. Sem proin, nibh maximus donec nec commodo molestie nulla sapien nec commodo, commodo et fermentum et. Mauris
+              posuere, mi orci et nisi et iaculis lorem fringilla sed mauris auctor, lorem tempus a pulvinar felis scelerisque.
+              Suscipit vivamus, elit vel arcu lorem fringilla finibus quis sit amet ligula convallis, consectetur potenti aenean
+              efficitur.
               <!-- // content -->
             </div>
           </div>
@@ -207,7 +224,12 @@
               class="Accordion__content"
             >
               <!-- content -->
-              Accordion content #3
+              Non suspendisse, maximus suscipit tortor non mauris bibendum felis scelerisque bibendum, nam augue scelerisque non
+              nulla. Erat nec, integer nec egestas integer consequat cursus sed porttitor, dolor sit amet lorem ipsum consectetur
+              porta. Condimentum urna, suspendisse mauris ligula duis id vivamus quis odio eget, integer ornare fermentum et
+              vehicula. Consequat bibendum, dui fusce gravida iaculis urna integer vitae id, ante purus nullam et nisl. Accumsan
+              arcu, nunc nulla faucibus purus vivamus facilisis augue, volutpat convallis eget suscipit. Tellus nunc ut enim et,
+              urna fusce pulvinar fusce et mauris donec, vitae odio morbi risus aliquet. et.
               <!-- // content -->
             </div>
           </div>
@@ -249,7 +271,7 @@
             data-target="accordionExample1_article_0_collapse"
           >
             <!-- toggle -->
-            Accordion header #0
+            Accordion Header
             <!-- // toggle -->
           </button>
           <span class="Accordion__itemSide">
@@ -279,7 +301,13 @@
               class="Accordion__content"
             >
               <!-- content -->
-              Accordion content #0
+              Sit amet interdum, accumsan dolor sit amet posuere vel arcu mauris placerat non mauris, non sed vitae curabitur odio
+              leo. Dignissim tristique, consequat vel arcu et nisi odio leo pretium accumsan condimentum at sem, mauris aenean
+              aliquet enim. Neque sapien, volutpat erat id nunc facilisis eget ipsum phasellus, tellus ultricies sollicitudin
+              ligula. Sem proin, nibh maximus donec nec commodo molestie nulla sapien nec commodo, commodo et fermentum et. Mauris
+              posuere, mi orci et nisi et iaculis lorem fringilla sed mauris auctor, lorem tempus a pulvinar felis scelerisque.
+              Suscipit vivamus, elit vel arcu lorem fringilla finibus quis sit amet ligula convallis, consectetur potenti aenean
+              efficitur.
               <!-- // content -->
             </div>
           </div>
@@ -303,7 +331,7 @@
             aria-expanded="true"
           >
             <!-- toggle -->
-            Accordion header #1 (open)
+            Accordion Header
             <!-- // toggle -->
           </button>
           <span class="Accordion__itemSide">
@@ -332,7 +360,12 @@
               class="Accordion__content"
             >
               <!-- content -->
-              Accordion content #1
+              Non suspendisse, maximus suscipit tortor non mauris bibendum felis scelerisque bibendum, nam augue scelerisque non
+              nulla. Erat nec, integer nec egestas integer consequat cursus sed porttitor, dolor sit amet lorem ipsum consectetur
+              porta. Condimentum urna, suspendisse mauris ligula duis id vivamus quis odio eget, integer ornare fermentum et
+              vehicula. Consequat bibendum, dui fusce gravida iaculis urna integer vitae id, ante purus nullam et nisl. Accumsan
+              arcu, nunc nulla faucibus purus vivamus facilisis augue, volutpat convallis eget suscipit. Tellus nunc ut enim et,
+              urna fusce pulvinar fusce et mauris donec, vitae odio morbi risus aliquet. et.
               <!-- // content -->
             </div>
           </div>
@@ -379,7 +412,13 @@
               class="Accordion__content"
             >
               <!-- content -->
-              Accordion content #2
+              Sit amet interdum, accumsan dolor sit amet posuere vel arcu mauris placerat non mauris, non sed vitae curabitur odio
+              leo. Dignissim tristique, consequat vel arcu et nisi odio leo pretium accumsan condimentum at sem, mauris aenean
+              aliquet enim. Neque sapien, volutpat erat id nunc facilisis eget ipsum phasellus, tellus ultricies sollicitudin
+              ligula. Sem proin, nibh maximus donec nec commodo molestie nulla sapien nec commodo, commodo et fermentum et. Mauris
+              posuere, mi orci et nisi et iaculis lorem fringilla sed mauris auctor, lorem tempus a pulvinar felis scelerisque.
+              Suscipit vivamus, elit vel arcu lorem fringilla finibus quis sit amet ligula convallis, consectetur potenti aenean
+              efficitur.
               <!-- // content -->
             </div>
           </div>
@@ -433,7 +472,12 @@
               class="Accordion__content"
             >
               <!-- content -->
-              Accordion content #3
+              Non suspendisse, maximus suscipit tortor non mauris bibendum felis scelerisque bibendum, nam augue scelerisque non
+              nulla. Erat nec, integer nec egestas integer consequat cursus sed porttitor, dolor sit amet lorem ipsum consectetur
+              porta. Condimentum urna, suspendisse mauris ligula duis id vivamus quis odio eget, integer ornare fermentum et
+              vehicula. Consequat bibendum, dui fusce gravida iaculis urna integer vitae id, ante purus nullam et nisl. Accumsan
+              arcu, nunc nulla faucibus purus vivamus facilisis augue, volutpat convallis eget suscipit. Tellus nunc ut enim et,
+              urna fusce pulvinar fusce et mauris donec, vitae odio morbi risus aliquet. et.
               <!-- // content -->
             </div>
           </div>


### PR DESCRIPTION
# Fix Accordion styles

Fix issues for Accordion styles [[DS-494](https://jira.lmc.cz/browse/DS-494), [DS-499](https://jira.lmc.cz/browse/DS-499), [DS-500](https://jira.lmc.cz/browse/DS-500)]

## What was done:
* Preview example content
* Border on heading below opened item
* Preview example "open" text has been deleted
* Text color of heading
* (iOS) Blinking rectangle when click on heading
* (iOS) After click on heading, `:hover` state remains
