### PR TITLE
Feat(web): Collapse toggle with variable content #DS-501

### DIFF
--- a/packages/web/src/scss/components/Collapse/_Collapse.scss
+++ b/packages/web/src/scss/components/Collapse/_Collapse.scss
@@ -23,6 +23,11 @@
         overflow: visible;
     }
 
+    /* When it should be as a hidden inline element */
+    &:is(span) {
+        display: none;
+    }
+
     @each $breakpoint-name, $breakpoint-value in theme.$breakpoints {
         @if $breakpoint-value > 0 {
             &[data-breakpoint='#{$breakpoint-name}'] {

--- a/packages/web/src/scss/components/Collapse/index.html
+++ b/packages/web/src/scss/components/Collapse/index.html
@@ -10,7 +10,6 @@
   <div class="mb-400">
     <button
       type="button"
-      role="button"
       data-toggle="collapse"
       data-target="CollapseExample0"
       class="Button Button--primary Button--medium"
@@ -43,7 +42,6 @@
     <div class="mb-400">
       <button
         type="button"
-        role="button"
         data-toggle="collapse"
         data-target="CollapseExampleI"
         aria-expanded="true"
@@ -152,19 +150,63 @@
     >
       ...more
     </a>
-    <div
+    <span
       id="CollapseExampleIII"
       class="Collapse"
     >
-      <div class="Collapse__content">
+      <span class="Collapse__content">
         Commodo metus a lorem, a aliquet vestibulum rutrum pharetra sapien sed, ullamcorper quis odio dolor ut aliquam. Rutrum suspendisse, fermentum tellus metus a lorem
         cursus volutpat proin bibendum, sed diam a duis id dui et tempus. Ligula non, sapien augue libero eget aliquam semper varius, posuere urna leo vitae ullamcorper.
         Venenatis posuere, sapien rhoncus dolor quis semper porttitor et vestibulum, odio leo ac nibh molestie placerat. Tellus suspendisse, dui lectus tellus quis eget
         sollicitudin dolor sit amet, dui ac nibh nulla mauris. Feugiat sollicitudin, integer bibendum at sem sapien non nullam sed id tortor, suscipit fusce gravida nec eget.
-      </div>
-    </div>
+      </span>
+    </span>
   </p>
 
+</section>
+
+<section class="docs-Section">
+
+  <h2 class="docs-Heading">Default with helper class for changing content inside toggle</h2>
+
+  <p>
+    Ante rhoncus, tristique nunc et elit id in ex sem consectetur id, consectetur et elit nibh sed ac. Sed ac convallis, sem lobortis convallis et nisi sapien in ex sem ullamcorper
+    iaculis, aliquet sem lobortis pellentesque sit amet. Congue nulla congue, porttitor quis orci quam elit rutrum scelerisque nibh maximus, felis a integer maximus praesent.
+    Metus varius, at sem dui vivamus elementum luctus nisl sit amet dolor sit amet, mauris et iaculis nec fermentum. Augue sapien, nisl vel purus nullam odio morbi a fusce vitae
+    mattis vitae, posuere tristique bibendum aliquam. In donec dolor ut, imperdiet quam fermentum molestie vulputate scelerisque ac nec, tortor mi orci sollicitudin elementum.
+  </p>
+  <div
+    id="CollapseExampleV"
+    class="Collapse"
+  >
+    <div class="Collapse__content">
+      Aliquam varius, consequat posuere a lacinia mauris eu tellus condimentum ut id ante, accumsan vehicula nulla neque. Mauris mi orci, in donec nullam odio leo sapien et vehicula nunc a
+      lacinia, fermentum arcu ullamcorper posuere. Mauris euismod, ac nec ante fermentum praesent nisi commodo neque placerat, vivamus dui et tempus pulvinar suspendisse. Porttitor eget,
+      sollicitudin hendrerit bibendum nulla aliquam sit amet leo vitae, eget consectetur diam a vestibulum. Adipiscing lorem ipsum, arcu condimentum posuere semper morbi condimentum dui,
+      bibendum nunc aenean facilisis. Phasellus euismod, donec sem odio ligula praesent finibus nibh convallis, tristique aliquam sed id tortor sem lobortis.
+    </div>
+  </div>
+  <div class="mb-400">
+    <button
+      type="button"
+      data-toggle="collapse"
+      data-target="CollapseExampleV"
+      class="Button Button--primary Button--medium"
+    >
+      <span class="accessibility-open">Show less</span>
+      <span class="accessibility-closed">Show more</span>
+    </button>
+    &nbsp;
+    <a
+      role="button"
+      href="javascript:void(0)"
+      data-toggle="collapse"
+      data-target="CollapseExampleV"
+    >
+      <span class="accessibility-open">Show less</span>
+      <span class="accessibility-closed">Show more</span>
+    </a>
+  </div>
 </section>
 
 <section class="docs-Section">
@@ -177,7 +219,6 @@
   <div class="mb-400">
     <button
       type="button"
-      role="button"
       data-toggle="collapse"
       data-target="CollapseExampleIV"
       class="Button Button--primary Button--medium"
@@ -199,7 +240,6 @@
   <div class="pt-400">
     <button
       type="button"
-      role="button"
       data-toggle="collapse"
       data-target="CollapseExampleIV"
       class="Button Button--secondary Button--medium"

--- a/packages/web/src/scss/helpers/_accessibility.scss
+++ b/packages/web/src/scss/helpers/_accessibility.scss
@@ -3,3 +3,13 @@
 .accessibility-hidden {
     @include accessibility.hide-text();
 }
+
+[aria-expanded='true'] .accessibility-open,
+[aria-expanded='false'] .accessibility-closed {
+    display: initial;
+}
+
+[aria-expanded='false'] .accessibility-open,
+[aria-expanded='true'] .accessibility-closed {
+    display: none;
+}

--- a/packages/web/src/scss/helpers/index.html
+++ b/packages/web/src/scss/helpers/index.html
@@ -3,11 +3,28 @@
   <section class="docs-Section">
 
     <h2 class="docs-Heading">Accessibility</h2>
-    <p>
-      The following element is visually hidden, but still accessible by AT (use dev tools to check it's really there!).
-    </p>
 
-    <p class="accessibility-hidden">This text is visually hidden</p>
+    <div class="mb-400">
+      <p>
+        The following element is visually hidden, but still accessible by AT (use dev tools to check it's really there!).
+      </p>
+
+      <p class="accessibility-hidden">This text is visually hidden</p>
+    </div>
+
+    <div class="mb-400">
+      <p>Toggle display of an element inside the toggle button depending on <code>aria-expanded</code>.</p>
+
+      <button type="button" aria-expanded="true">
+        <span class="accessibility-open">Show less</span>
+        <span class="accessibility-closed">Show more</span>
+      </button>
+
+      <button type="button" aria-expanded="false">
+        <span class="accessibility-open">Show less</span>
+        <span class="accessibility-closed">Show more</span>
+      </button>
+    </div>
 
   </section>
 


### PR DESCRIPTION
# Collapse - allow content to be expanded/hidden [DS-501](https://jira.lmc.cz/browse/DS-501)

## What was done:
* Added helper class for toggle content, which depends on `aria-expanded`
* Added example for Collapse use case, also with anchor element
* ~~Created test for Collapse~~
* Fixed implementation for `data-more` option