### PR TITLE
Fix(web): Only show `Item` background during interactions on hover-enabled devices

### DIFF
--- a/packages/web/src/scss/tools/_form-fields.scss
+++ b/packages/web/src/scss/tools/_form-fields.scss
@@ -140,12 +140,14 @@
     border-radius: form-fields-theme.$item-border-radius;
     background-color: form-fields-theme.$item-background-color-default;
 
-    &:hover {
-        background-color: form-fields-theme.$item-background-color-hover;
-    }
+    @media (hover: hover) {
+        &:hover {
+            background-color: form-fields-theme.$item-background-color-hover;
+        }
 
-    &:active {
-        background-color: form-fields-theme.$item-background-color-active;
+        &:active {
+            background-color: form-fields-theme.$item-background-color-active;
+        }
     }
 }
 


### PR DESCRIPTION
This is to prevent "sticky" interactions on touch devices.

## Before

https://user-images.githubusercontent.com/5614085/210080543-d67f6afe-e293-4693-9490-542548b8c784.mp4

## After

https://user-images.githubusercontent.com/5614085/210080621-d06a6756-d095-47f5-adc7-a14d9f4456da.mp4
