### PR TITLE
Feat(web): Disable tap highlight on inputs in mobile Safari

### DIFF
--- a/packages/web/src/scss/foundation/_reset.scss
+++ b/packages/web/src/scss/foundation/_reset.scss
@@ -38,3 +38,7 @@ table {
     border-collapse: collapse;
     border-spacing: 0;
 }
+
+input {
+    -webkit-tap-highlight-color: transparent;
+}


### PR DESCRIPTION
(Is it a feature when it disables a native behavior…?)