### PR TITLE
Fix(web-twig): Make Collapse components props optional according to its readme

### DIFF
--- a/packages/web-twig/src/Resources/components/Collapse/Collapse.twig
+++ b/packages/web-twig/src/Resources/components/Collapse/Collapse.twig
@@ -2,8 +2,8 @@
 {%- set props = props | default([]) -%}
 {%- set _class = props.class | default(null) -%}
 {%- set _id = props.id -%}
-{%- set _breakpoint = props.breakpoint -%}
-{%- set _parent = props.parent -%}
+{%- set _breakpoint = props.breakpoint | default(null) -%}
+{%- set _parent = props.parent | default(null) -%}
 {%- set _elementType = (props.elementType is defined) ? props.elementType : 'div' -%}
 
 {# Class names #}

--- a/packages/web-twig/src/Resources/components/Collapse/README.md
+++ b/packages/web-twig/src/Resources/components/Collapse/README.md
@@ -56,8 +56,8 @@ attributes to register trigger events.
 | Prop name     | Type     | Default | Required | Description                                                            |
 | ------------- | -------- | ------- | -------- | ---------------------------------------------------------------------- |
 | `id`          | `string` | -       | yes      | Collapse ID                                                            |
-| `breakpoint`  | `string` | -       | no       | Breakpoint level [mobile,tablet,desktop]                               |
-| `parent`      | `string` | -       | no       | A parent element selector that ensures that only one item is opened \* |
+| `breakpoint`  | `string` | `null`  | no       | Breakpoint level [mobile,tablet,desktop]                               |
+| `parent`      | `string` | `null`  | no       | A parent element selector that ensures that only one item is opened \* |
 | `class`       | `string` | `null`  | no       | Custom CSS class                                                       |
 | `elementType` | `string` | `'div'` | no       | Custom element type                                                    |
 


### PR DESCRIPTION
#DS-275

Event if the Collapse component didn't use `breakpoint` and `parent` properties along next in its logic and is using them as optional, it haven't had default value so it was still required. Otherways it blowes up with server error.