### PR TITLE
Fix(web): Fix Accordion arrow stacking context #DS-527

### DIFF
--- a/packages/web/src/scss/components/Accordion/_Accordion.scss
+++ b/packages/web/src/scss/components/Accordion/_Accordion.scss
@@ -35,6 +35,10 @@
     }
 }
 
+.Accordion__itemIcon {
+    pointer-events: none;
+}
+
 .Accordion__itemToggle {
     @include reset.button();
     @include typography.generate(theme.$accordion-header-typography);


### PR DESCRIPTION
Accordion in open state has a rotated arrow, where transformation creates a new stacking context and therefore overlays the toggle button preventing it from closing the Accordion.