### PR TITLE
Docs(web-react): Fix Accordion and Modal code examples

### DIFF
--- a/packages/web-react/src/components/Accordion/README.md
+++ b/packages/web-react/src/components/Accordion/README.md
@@ -6,13 +6,8 @@
 
 ```javascript
 import React, { useState } from 'react';
-import {
-  Accordion,
-  AccordionItem,
-  AccordionHeader,
-  AccordionContent,
-  AccordionOpenStateType,
-} from '@lmc-eu/spirit-web-react/components';
+import { Accordion, AccordionItem, AccordionHeader, AccordionContent } from '@lmc-eu/spirit-web-react/components';
+import { AccordionOpenStateType } from '@lmc-eu/spirit-web-react/types';
 ```
 
 ```
@@ -22,12 +17,12 @@ const [openState, setOpenState] = useState<AccordionOpenStateType>(undefined);
 ```javascript
 const toggle = (id) => {
   if (Array.isArray(openState)) {
-    if (open.includes(id)) {
-      setOpenState(open.filter((accordionId) => accordionId !== id));
+    if (openState.includes(id)) {
+      setOpenState(openState.filter((accordionId) => accordionId !== id));
     } else {
-      setOpenState([...open, id]);
+      setOpenState([...openState, id]);
     }
-  } else if (open === id) {
+  } else if (openState === id) {
     setOpenState(undefined);
   } else {
     setOpenState(id);
@@ -77,8 +72,8 @@ import {
   AccordionItem,
   AccordionHeader,
   AccordionContent,
-  AccordionOpenStateType,
 } from '@lmc-eu/spirit-web-react/components';
+import { AccordionOpenStateType } from '@lmc-eu/spirit-web-react/types';
 ```
 
 ```javascript

--- a/packages/web-react/src/components/Modal/README.md
+++ b/packages/web-react/src/components/Modal/README.md
@@ -1,7 +1,7 @@
 # Modal
 
 ```jsx
-import { Modal, ModalHeader, ModalBody, ModalFooter } from '@lmc-eu/spirit-web-react/components';
+import { Button, Icon, Modal, ModalHeader, ModalBody, ModalFooter } from '@lmc-eu/spirit-web-react/components';
 ```
 
 ```jsx


### PR DESCRIPTION
I found out it wasn't possible to just copy-paste the code from docs and make it work. Here I fix few small errors I encountered. 