### PR TITLE
Mark package as side-effect free

### DIFF
--- a/packages/web-react/package.json
+++ b/packages/web-react/package.json
@@ -3,6 +3,7 @@
   "version": "0.34.0",
   "description": "React implementation of Spirit Design System components",
   "license": "MIT",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public",
     "directory": "dist"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,6 +3,7 @@
   "version": "0.36.0",
   "description": "CSS and vanilla JS implementation of Spirit Design System",
   "license": "MIT",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public",
     "directory": "dist"


### PR DESCRIPTION
Helping Webpack with tree-shaking and thus removing unused parts of code.

For more information, please read https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

We are already using this in https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-react/scripts/prepareDist.js#L56. So this marks only main `package.json`.