### PR TITLE
Fix(web-twig): Define native return type to "Twig\Extension\ExtensionInterface::getFilters()"

### DIFF
--- a/packages/web-twig/src/Twig/BoolpropExtension.php
+++ b/packages/web-twig/src/Twig/BoolpropExtension.php
@@ -9,7 +9,7 @@ use Twig\TwigFilter;
 
 class BoolpropExtension extends AbstractExtension
 {
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('boolprop', [$this, 'convert2Boolean'], [


### PR DESCRIPTION
because this is deprecation in symfony 
<img width="1096" alt="Snímek obrazovky 2023-01-19 v 12 49 54" src="https://user-images.githubusercontent.com/25146453/213435080-f1f52c1e-121e-4ea3-8510-e85231936341.png">
