### PR TITLE
Fix(web): Accordion(Collapse) content flashing #DS-538

### DIFF
--- a/packages/web/src/js/Collapse.ts
+++ b/packages/web/src/js/Collapse.ts
@@ -28,6 +28,7 @@ interface CollapseMeta {
 }
 interface CollapseState {
   open: boolean;
+  init: boolean;
 }
 
 class Collapse extends BaseComponent {
@@ -48,6 +49,7 @@ class Collapse extends BaseComponent {
       open:
         this.element.hasAttribute(ARIA_EXPANDED_ATTRIBUTE) &&
         this.element.getAttribute(ARIA_EXPANDED_ATTRIBUTE) === 'true',
+      init: false,
     };
 
     this.init();
@@ -136,7 +138,9 @@ class Collapse extends BaseComponent {
         this.adjustCollapsibleChildrenHeight();
       }
       this.adjustCollapsibleElementHeight(open);
-      this.target?.classList.add(CLASSNAME_TRANSITION);
+      if (this.state.init) {
+        this.target?.classList.add(CLASSNAME_TRANSITION);
+      }
       executeAfterTransition(this.target, () => {
         this.target?.classList.remove(CLASSNAME_TRANSITION);
         this.target?.classList.toggle(CLASSNAME_OPEN, open);
@@ -208,6 +212,7 @@ class Collapse extends BaseComponent {
     this.updateTriggerElement();
     this.updateCollapsibleElement();
     this.initEvents();
+    this.state.init = true;
   }
 }
 

--- a/packages/web/src/scss/components/Collapse/README.md
+++ b/packages/web/src/scss/components/Collapse/README.md
@@ -15,10 +15,13 @@ Usage with link:
 <a role="button" href="javascript:void(0)" data-toggle="collapse" data-target="CollapseExample"> trigger </a> ...
 ```
 
-Open on load example (by aria-expanded):
+Open on load example:
 
 ```html
-<button ... aria-expanded="true">trigger</button> ...
+<button ... aria-expanded="true">trigger</button>
+<div id="CollapseExample" class="Collapse is-open">
+  <div class="Collapse__content">content</div>
+</div>
 ```
 
 Responsive usage for tablet

--- a/packages/web/src/scss/components/Collapse/_Collapse.scss
+++ b/packages/web/src/scss/components/Collapse/_Collapse.scss
@@ -20,6 +20,7 @@
     }
 
     &.is-open:not(.is-transitioning) {
+        height: 100%;
         overflow: visible;
     }
 

--- a/packages/web/src/scss/components/Collapse/index.html
+++ b/packages/web/src/scss/components/Collapse/index.html
@@ -33,7 +33,7 @@
 
 <section class="docs-Section">
 
-  <h2 class="docs-Heading">Open on init using the 'aria-expanded' attribute</h2>
+  <h2 class="docs-Heading">Open on init</h2>
 
   <!--
     Collapse with auto open by aria
@@ -52,7 +52,7 @@
     </div>
     <div
       id="CollapseExampleI"
-      class="Collapse"
+      class="Collapse is-open"
     >
       <div class="Collapse__content">
         Cras dictum ante, mollis ollicitudin proin bibendum nec commodo consequat fusce ante, consequat venenatis suscipit odio morbi. Dolor sit amet porta, placerat tristique sit amet


### PR DESCRIPTION
# Accordion(Collapse) flash of content when loading DS-538
It did two things. One of them was the animation and the second problem was that the flickering was caused by setting the class and css attribute after loading the script.

## What was done:
* `Collapse.ts`: Added `state.init` for prevent animation before content is shown
* Updated examples for both components