### PR TITLE
Docs(web-react): Fix renderToggle to renderTrigger

### DIFF
--- a/packages/web-react/src/components/Collapse/README.md
+++ b/packages/web-react/src/components/Collapse/README.md
@@ -98,7 +98,7 @@ import { Button, UncontrolledCollapse } from '@lmc-eu/spirit-web-react/component
 
 <UncontrolledCollapse
   id="CollapseExample"
-  renderToggle={({ isOpen, ...restProps }) => (
+  renderTrigger={({ isOpen, ...restProps }) => (
     <Button {...restProps}>Collapse Trigger ({isOpen ? 'Open' : 'Closed'})</Button>
   )}
 >
@@ -114,7 +114,7 @@ import { Button, UncontrolledCollapse } from '@lmc-eu/spirit-web-react/component
 
 <UncontrolledCollapse
   id="CollapseExample"
-  renderToggle={({ isOpen, ...restProps }) => (
+  renderTrigger={({ isOpen, ...restProps }) => (
     <Button {...restProps}>Collapse Trigger ({isOpen ? 'Open' : 'Closed'})</Button>
   )}
   hideOnCollapse


### PR DESCRIPTION
The example with undefined property renderToggle not work so its typo