### PR TITLE
Feat(web-react): Allow extension of size prop of Text component

### DIFF
--- a/docs/DICTIONARIES.md
+++ b/docs/DICTIONARIES.md
@@ -13,7 +13,7 @@ This project uses `dictionaries` to unify props between different components.
 
 ### Size
 
-| Dictionary    | Values                     | Code name    |
-| ------------- | -------------------------- | ------------ |
-| Size          | `small`, `medium`, `large` | Size         |
-| Size Extended | `xsmall`, `xlarge`         | SizeExtended |
+| Dictionary    | Values                               | Code name    |
+| ------------- | ------------------------------------ | ------------ |
+| Size          | `small`, `medium`, `large`           | Size         |
+| Size Extended | Size Dictionary + `xsmall`, `xlarge` | SizeExtended |

--- a/packages/web-react/src/components/Text/Text.tsx
+++ b/packages/web-react/src/components/Text/Text.tsx
@@ -8,7 +8,7 @@ const defaultProps = {
   size: 'medium',
 };
 
-export const Text = <T extends ElementType = 'p'>(props: SpiritTextProps<T>): JSX.Element => {
+export const Text = <T extends ElementType = 'p', S = void>(props: SpiritTextProps<T, S>): JSX.Element => {
   const { elementType: ElementTag = 'p', children, ...restProps } = props;
   const { classProps, props: modifiedProps } = useTextStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);

--- a/packages/web-react/src/components/Text/stories/Text.tsx
+++ b/packages/web-react/src/components/Text/stories/Text.tsx
@@ -3,7 +3,7 @@ import { ComponentStory } from '@storybook/react';
 import { SpiritTextProps } from '../../../types';
 import Text from '../Text';
 
-const Story: ComponentStory<typeof Text> = <T extends ElementType = 'div'>(args: SpiritTextProps<T>) => (
+const Story: ComponentStory<typeof Text> = <T extends ElementType = 'div', S = void>(args: SpiritTextProps<T, S>) => (
   <Text {...args} />
 );
 

--- a/packages/web-react/src/components/Text/useTextStyleProps.ts
+++ b/packages/web-react/src/components/Text/useTextStyleProps.ts
@@ -9,7 +9,7 @@ export interface TextStyles<T extends ElementType = 'p'> {
   props: TextProps<T>;
 }
 
-export function useTextStyleProps<T extends ElementType = 'p'>(props: SpiritTextProps<T>): TextStyles<T> {
+export function useTextStyleProps<T extends ElementType = 'p', S = void>(props: SpiritTextProps<T, S>): TextStyles<T> {
   const { size, emphasis, ...restProps } = props;
 
   const textClass = useClassNamePrefix('typography-body');

--- a/packages/web-react/src/types/shared/dictionaries.ts
+++ b/packages/web-react/src/types/shared/dictionaries.ts
@@ -5,12 +5,13 @@ export const Sizes = {
 } as const;
 
 export type SizesKeys = keyof typeof Sizes;
-export type Size<E> = typeof Sizes[SizesKeys] | E;
+export type Size<S> = typeof Sizes[SizesKeys] | S;
 
 export const SizesExtended = {
+  ...Sizes,
   XSMALL: 'xsmall',
   XLARGE: 'xlarge',
 } as const;
 
 export type SizesExtendedKeys = keyof typeof SizesExtended;
-export type SizeExtended<E> = typeof SizesExtended[SizesExtendedKeys] | E;
+export type SizeExtended<S> = typeof SizesExtended[SizesExtendedKeys] | S;

--- a/packages/web-react/src/types/text.ts
+++ b/packages/web-react/src/types/text.ts
@@ -1,5 +1,5 @@
 import { ElementType, JSXElementConstructor } from 'react';
-import { ChildrenProps, SizeExtended, Size, StyleProps, TransferProps } from './shared';
+import { ChildrenProps, SizeExtended, StyleProps, TransferProps } from './shared';
 
 export type TextEmphasis = 'bold' | 'italic';
 
@@ -18,9 +18,9 @@ export interface TextProps<T extends ElementType = 'p'>
     StyleProps,
     TransferProps {}
 
-export interface SpiritTextProps<T extends ElementType = 'p'> extends TextProps<T> {
+export interface SpiritTextProps<T extends ElementType = 'p', S = void> extends TextProps<T> {
   /** Size of the text */
-  size?: Size<string> | SizeExtended<string>;
+  size?: SizeExtended<S>;
   /** Emphasis of the text */
   emphasis?: TextEmphasis | undefined | null;
 }


### PR DESCRIPTION
Allow extension of a type via generic.
```jsx
const CustomText = <T extends ElementType = 'span', S ='xxlarge' | xxsmall>(args: SpiritTextProps<T, S>) => (
  <Text {...args} />
);
```

Consider creating a `SizeExtended` dictionary by really extending it. So the developer can use `SizeExtended` with all those values.