### PR TITLE
Fix(web-react): Tabs transfer properties #DS-401

### DIFF
--- a/packages/web-react/src/components/Tabs/README.md
+++ b/packages/web-react/src/components/Tabs/README.md
@@ -66,20 +66,22 @@ const selectTab = useCallback((tabId) => {
 
 **Available props**
 
-| Name          | Type               | Description                                  |
-| ------------- | ------------------ | -------------------------------------------- |
-| `selectedTab` | `string`, `number` | Identification of the selected tab           |
-| `toogle`      | `Function`         | Toggle function which accept tab ID as input |
-| `children`    | `any`              | Child component                              |
+| Name                | Type                     | Description                                  |
+| ------------------- | ------------------------ | -------------------------------------------- |
+| `selectedTab`       | `string`, `number`       | Identification of the selected tab           |
+| `toogle`            | `Function`               | Toggle function which accept tab ID as input |
+| `children`          | `any`                    | Child component                              |
+| `onSelectionChange` | `(tabId: TabId) => void` | When the state of the selected panel changes |
 
 ### UncontrolledTabs
 
 **Available props**
 
-| Name                 | Type               | Description                            |
-| -------------------- | ------------------ | -------------------------------------- |
-| `defaultSelectedTab` | `string`, `number` | Identification of default selected tab |
-| `children`           | `any`              | Child component                        |
+| Name                 | Type                     | Description                                  |
+| -------------------- | ------------------------ | -------------------------------------------- |
+| `defaultSelectedTab` | `string`, `number`       | Identification of default selected tab       |
+| `children`           | `any`                    | Child component                              |
+| `onSelectionChange`  | `(tabId: TabId) => void` | When the state of the selected panel changes |
 
 ### TabList
 

--- a/packages/web-react/src/components/Tabs/TabContent.tsx
+++ b/packages/web-react/src/components/Tabs/TabContent.tsx
@@ -3,6 +3,6 @@ import { ChildrenProps, TransferProps } from '../../types';
 
 type TabContentProps = ChildrenProps & TransferProps;
 
-const TabContent = ({ children }: TabContentProps): JSX.Element => <div>{children}</div>;
+const TabContent = ({ children, ...restProps }: TabContentProps): JSX.Element => <div {...restProps}>{children}</div>;
 
 export default TabContent;

--- a/packages/web-react/src/components/Tabs/TabContext.tsx
+++ b/packages/web-react/src/components/Tabs/TabContext.tsx
@@ -6,12 +6,15 @@ type TabsToggler = (tabId: TabId) => void;
 type TabsContextType = {
   selectedTabId: TabId;
   selectTab: TabsToggler;
+  onSelectionChange?: (tabId: TabId) => void;
 };
 
 const defaultContext: TabsContextType = {
   selectedTabId: '',
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
   selectTab: (tabId: TabId) => {},
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+  onSelectionChange: (tabId: TabId) => {},
 };
 
 const TabsContext = createContext<TabsContextType>(defaultContext);

--- a/packages/web-react/src/components/Tabs/TabItem.tsx
+++ b/packages/web-react/src/components/Tabs/TabItem.tsx
@@ -1,15 +1,27 @@
 import React from 'react';
-import { ChildrenProps, TabId, TransferProps } from '../../types';
+import { ChildrenProps, TabId, TransferProps, ClickEvents, ClickEvent } from '../../types';
 import { useTabContext } from './TabContext';
 import { useTabsStyleProps } from './useTabsStyleProps';
 
-interface TabItemProps extends ChildrenProps, TransferProps {
+interface TabItemProps extends ChildrenProps, TransferProps, ClickEvents {
   forTab: TabId;
 }
 
-const TabItem = ({ children, forTab, ...restProps }: TabItemProps): JSX.Element => {
-  const { selectTab, selectedTabId } = useTabContext();
+const TabItem = ({ children, forTab, onClick, ...restProps }: TabItemProps): JSX.Element => {
+  const { selectTab, selectedTabId, onSelectionChange } = useTabContext();
   const { classProps } = useTabsStyleProps({ forTab, selectedTabId });
+
+  const handleClick = (event: ClickEvent) => {
+    selectTab(forTab);
+
+    if (onClick) {
+      onClick(event);
+    }
+
+    if (onSelectionChange) {
+      onSelectionChange(selectedTabId);
+    }
+  };
 
   return (
     <li className={classProps.item}>
@@ -21,7 +33,7 @@ const TabItem = ({ children, forTab, ...restProps }: TabItemProps): JSX.Element 
         aria-selected={selectedTabId === forTab}
         id={`${forTab}-tab`}
         aria-controls={forTab.toString()}
-        onClick={() => selectTab(forTab)}
+        onClick={handleClick}
       >
         {children}
       </button>

--- a/packages/web-react/src/components/Tabs/TabLink.tsx
+++ b/packages/web-react/src/components/Tabs/TabLink.tsx
@@ -6,12 +6,12 @@ interface TabLinkProps extends ChildrenProps, TransferProps {
   href: string;
 }
 
-const TabLink = ({ children, href }: TabLinkProps): JSX.Element => {
+const TabLink = ({ children, href, ...restProps }: TabLinkProps): JSX.Element => {
   const { classProps } = useTabsStyleProps();
 
   return (
     <li className={classProps.item}>
-      <a href={href} className={classProps.link} role="tab">
+      <a {...restProps} href={href} className={classProps.link} role="tab">
         {children}
       </a>
     </li>

--- a/packages/web-react/src/components/Tabs/TabList.tsx
+++ b/packages/web-react/src/components/Tabs/TabList.tsx
@@ -4,11 +4,11 @@ import { useTabsStyleProps } from './useTabsStyleProps';
 
 type TabListProps = ChildrenProps & TransferProps;
 
-const TabList = ({ children }: TabListProps): JSX.Element => {
+const TabList = ({ children, ...restProps }: TabListProps): JSX.Element => {
   const { classProps } = useTabsStyleProps();
 
   return (
-    <ul className={classProps.root} role="tablist">
+    <ul {...restProps} className={classProps.root} role="tablist">
       {children}
     </ul>
   );

--- a/packages/web-react/src/components/Tabs/Tabs.tsx
+++ b/packages/web-react/src/components/Tabs/Tabs.tsx
@@ -5,10 +5,12 @@ import { TabsProvider, TabsToggler } from './TabContext';
 interface TabsProps extends ChildrenProps, TransferProps {
   selectedTab: TabId;
   toggle: TabsToggler;
+  // eslint-disable-next-line react/require-default-props
+  onSelectionChange?: (tabId: TabId) => void;
 }
 
-const Tabs = ({ children, selectedTab, toggle: selectTab }: TabsProps): JSX.Element => (
-  <TabsProvider value={{ selectedTabId: selectedTab, selectTab }}>{children}</TabsProvider>
+const Tabs = ({ children, selectedTab, toggle: selectTab, onSelectionChange }: TabsProps): JSX.Element => (
+  <TabsProvider value={{ selectedTabId: selectedTab, selectTab, onSelectionChange }}>{children}</TabsProvider>
 );
 
 export default Tabs;

--- a/packages/web-react/src/components/Tabs/UncontrolledTabs.tsx
+++ b/packages/web-react/src/components/Tabs/UncontrolledTabs.tsx
@@ -5,12 +5,14 @@ import { useTab } from './useTabs';
 
 interface TabsProps extends ChildrenProps, TransferProps {
   defaultSelectedTab: TabId;
+  // eslint-disable-next-line react/require-default-props
+  onSelectionChange?: (tabId: TabId) => void;
 }
 
-const Tabs = ({ children, defaultSelectedTab }: TabsProps): JSX.Element => {
+const Tabs = ({ children, defaultSelectedTab, onSelectionChange }: TabsProps): JSX.Element => {
   const { selectedTabId, selectTab } = useTab(defaultSelectedTab);
 
-  return <TabsProvider value={{ selectedTabId, selectTab }}>{children}</TabsProvider>;
+  return <TabsProvider value={{ selectedTabId, selectTab, onSelectionChange }}>{children}</TabsProvider>;
 };
 
 export default Tabs;


### PR DESCRIPTION
# Adding transfer properties to Tabs sub-components

* Allows `restProps` for:
   * TabContent
   * TabLink
   * TabList
* Created `onSelectionChange` for trigger custom callback when panel changed. Applied for **Tabs** and **UncontrolledTabs**. Also add mention in docs
   
