### PR TITLE
Extension of React components props

### DIFF
--- a/packages/web-react/src/components/TextFieldBase/TextFieldBase.tsx
+++ b/packages/web-react/src/components/TextFieldBase/TextFieldBase.tsx
@@ -36,8 +36,6 @@ export const TextFieldBase = (props: SpiritTextFieldBaseProps) => {
       <label htmlFor={id} className={classProps.label}>
         {label}
       </label>
-      {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-      {/* @ts-expect-error Property missing in the type */}
       <TextFieldBaseInputWithPasswordToggle id={id} {...otherProps} />
       {helperText && <div className={classProps.helperText}>{helperText}</div>}
       {message && <div className={classProps.message}>{message}</div>}

--- a/packages/web-react/src/types/checkboxField.ts
+++ b/packages/web-react/src/types/checkboxField.ts
@@ -1,20 +1,31 @@
-import { ChildrenProps, StyleProps, InputProps, ItemProps, TransferProps, HelperTextProps } from './shared';
+import {
+  ChildrenProps,
+  HelperTextProps,
+  InputBaseProps,
+  ItemProps,
+  SpiritInputElementProps,
+  Validation,
+} from './shared';
 import { LabelProps } from './label';
 import { MessageProps } from './message';
 
+export type CheckboxElementBaseProps = SpiritInputElementProps;
+
 export interface CheckboxFieldProps
-  extends ChildrenProps,
-    StyleProps,
+  extends CheckboxElementBaseProps,
+    ChildrenProps,
     LabelProps,
-    InputProps,
     ItemProps,
     MessageProps,
-    HelperTextProps,
-    TransferProps {
+    InputBaseProps,
+    Validation,
+    HelperTextProps {
   /** Whether the checkbox is indeterminate */
   indeterminate?: boolean;
   /** Whether the checkbox is checked */
   isChecked?: boolean;
+  /** Text of control label */
+  label: string;
 }
 
 export interface SpiritCheckboxFieldProps extends CheckboxFieldProps {}

--- a/packages/web-react/src/types/radioField.ts
+++ b/packages/web-react/src/types/radioField.ts
@@ -1,27 +1,27 @@
 import {
   ChildrenProps,
-  InputBase,
-  ItemProps,
-  StyleProps,
-  TransferProps,
-  ValueBase,
   HelperTextProps,
+  InputBaseProps,
+  ItemProps,
+  SpiritInputElementProps,
   Validation,
 } from './shared';
 import { LabelProps } from './label';
 
-interface InputProps extends InputBase, ValueBase<string | number>, Validation {}
+export type RadioElementBaseProps = SpiritInputElementProps;
 
 export interface RadioFieldProps
-  extends ChildrenProps,
+  extends RadioElementBaseProps,
+    ChildrenProps,
     LabelProps,
-    InputProps,
     ItemProps,
-    StyleProps,
     HelperTextProps,
-    TransferProps {
+    InputBaseProps,
+    Validation {
   /** Whether the checkbox is checked */
   isChecked?: boolean;
+  /** Text of control label */
+  label: string;
 }
 
 export interface SpiritRadioFieldProps extends RadioFieldProps {}

--- a/packages/web-react/src/types/shared/element.ts
+++ b/packages/web-react/src/types/shared/element.ts
@@ -1,12 +1,19 @@
-import { DetailedHTMLProps, HTMLAttributes } from 'react';
-import { OmittedUnsafeStyleProps, StyleProps } from './style';
+import { DetailedHTMLProps, HTMLAttributes, HTMLProps } from 'react';
+import { OverloadStyleProps } from './style';
 
+/** Returns all relevant attributes and their types from a given HTML Element */
 export type SpiritDetailedHTMLProps<E> = DetailedHTMLProps<HTMLAttributes<E>, E>;
+/** Returns all relevant attributes and their types, combined basic and detailed, from a given HTML Element */
+export type SpiritCombinedHTMLProps<E> = DetailedHTMLProps<HTMLAttributes<E>, E> & HTMLProps<E>;
 
 export type SpiritDivElementBaseProps = SpiritDetailedHTMLProps<HTMLDivElement>;
 export type SpiritDialogElementBaseProps = SpiritDetailedHTMLProps<HTMLDialogElement>;
 export type SpiritElementBaseProps = SpiritDetailedHTMLProps<HTMLElement>;
+export type SpiritInputElementBaseProps = SpiritCombinedHTMLProps<HTMLInputElement>;
+export type SpiritTextAreaElementBaseProps = SpiritCombinedHTMLProps<HTMLTextAreaElement>;
 
-export type SpiritDivElementProps = OmittedUnsafeStyleProps<SpiritDivElementBaseProps> & StyleProps;
-export type SpiritDialogElementProps = OmittedUnsafeStyleProps<SpiritDialogElementBaseProps> & StyleProps;
-export type SpiritElementProps = OmittedUnsafeStyleProps<SpiritElementBaseProps> & StyleProps;
+export type SpiritDivElementProps = OverloadStyleProps<SpiritDivElementBaseProps>;
+export type SpiritDialogElementProps = OverloadStyleProps<SpiritDialogElementBaseProps>;
+export type SpiritElementProps = OverloadStyleProps<SpiritElementBaseProps>;
+export type SpiritInputElementProps = Omit<OverloadStyleProps<SpiritInputElementBaseProps>, 'required' | 'type'>;
+export type SpiritTextAreaElementProps = Omit<OverloadStyleProps<SpiritTextAreaElementBaseProps>, 'required'>;

--- a/packages/web-react/src/types/shared/index.ts
+++ b/packages/web-react/src/types/shared/index.ts
@@ -1,5 +1,6 @@
 import { ReactNode, ElementType, JSXElementConstructor } from 'react';
 
+export * from './adornments';
 export * from './colors';
 export * from './dialogs';
 export * from './dictionaries';

--- a/packages/web-react/src/types/shared/inputs.ts
+++ b/packages/web-react/src/types/shared/inputs.ts
@@ -1,4 +1,3 @@
-import type { ChangeEventHandler, KeyboardEventHandler } from 'react';
 import { ValidationStatesDictionaryType } from './dictionaries';
 
 /* @deprecated: 'error' value will be removed in the next major version. */
@@ -13,44 +12,26 @@ export interface Validation {
   isRequired?: boolean;
 }
 
-export interface InputBase {
-  /** Text of control label */
-  label: string;
-  /** Identificator of input */
-  id: string;
-  /**
-   * The name of the input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
-   */
-  name?: string;
+export interface TextInputBase {
+  /** Temporary text that occupies the text input when it is empty. */
+  placeholder?: string;
+  /** The input width */
+  inputWidth?: number;
+}
+
+export type InputBaseProps = {
   /** Whether the label should be displayed */
   isLabelHidden?: boolean;
   /** Whether the input is disabled. */
   isDisabled?: boolean;
-  /** Handle action when the input is change. */
-  onChange?: ChangeEventHandler<HTMLInputElement>;
-  /** Handle action when key is pressed. */
-  onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
-}
+};
 
-export interface ValueBase<T> {
-  /** The current value (controlled). */
-  value?: T;
-  /** The default value (uncontrolled). */
-  defaultValue?: T;
-}
-
-export interface TextInputBase {
-  /** Temporary text that occupies the text input when it is empty. */
-  placeholder?: string;
-}
-
-export interface InputProps extends InputBase, Validation, ValueBase<string | number> {}
-
-export interface TextInputProps extends InputProps, TextInputBase {
+export interface TextInputProps extends TextInputBase {
   /** Whether the width should be controlled by container */
   isFluid?: boolean;
 }
 
 export interface HelperTextProps {
+  /** If I wanted some help text */
   helperText?: string;
 }

--- a/packages/web-react/src/types/shared/style.ts
+++ b/packages/web-react/src/types/shared/style.ts
@@ -10,6 +10,6 @@ export interface StyleProps {
 
 export type UnsafeStyleProps = 'style' | 'className';
 
-export type OmittedUnsafeStyleProps<E> = Omit<E, UnsafeStyleProps>;
-
 export type OmittedExtendedUnsafeStyleProps<E, P> = Omit<E, UnsafeStyleProps & P>;
+
+export type OverloadStyleProps<E> = Omit<E, UnsafeStyleProps> & StyleProps;

--- a/packages/web-react/src/types/textArea.ts
+++ b/packages/web-react/src/types/textArea.ts
@@ -1,19 +1,27 @@
-import { ChildrenProps, StyleProps, TextInputProps, TransferProps, HelperTextProps } from './shared';
+import {
+  ChildrenProps,
+  HelperTextProps,
+  InputBaseProps,
+  SpiritTextAreaElementProps,
+  TextInputProps,
+  Validation,
+} from './shared';
 import { LabelProps } from './label';
 import { MessageProps } from './message';
 
+export type TextAreaElementBaseProps = SpiritTextAreaElementProps;
+
 export interface TextAreaProps
-  extends ChildrenProps,
-    StyleProps,
+  extends TextAreaElementBaseProps,
+    InputBaseProps,
+    ChildrenProps,
     LabelProps,
     MessageProps,
     HelperTextProps,
     TextInputProps,
-    TransferProps {
+    Validation {
   /** Maximum characters length */
   maxLength?: number;
-  /** The number of visible rows */
-  rows?: number;
 }
 
 export interface SpiritTextAreaProps extends TextAreaProps {}

--- a/packages/web-react/src/types/textField.ts
+++ b/packages/web-react/src/types/textField.ts
@@ -1,23 +1,31 @@
-import { ChildrenProps, StyleProps, TextInputProps, TransferProps, HelperTextProps } from './shared';
+import {
+  ChildrenProps,
+  HelperTextProps,
+  InputBaseProps,
+  PasswordToggleAdornmentProp,
+  SpiritInputElementProps,
+  TextInputProps,
+  Validation,
+} from './shared';
 import { LabelProps } from './label';
 import { MessageProps } from './message';
-import { PasswordToggleAdornmentProp } from './shared/adornments';
 
 export type TextFieldType = 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url';
 
+export type TextFieldElementBaseProps = SpiritInputElementProps;
+
 export interface TextFieldProps
-  extends ChildrenProps,
-    StyleProps,
+  extends TextFieldElementBaseProps,
+    InputBaseProps,
+    PasswordToggleAdornmentProp,
+    ChildrenProps,
     LabelProps,
     MessageProps,
     HelperTextProps,
     TextInputProps,
-    TransferProps,
-    PasswordToggleAdornmentProp {
+    Validation {
   /** The type of text field */
   type?: TextFieldType;
-  /** The input width */
-  inputWidth?: number;
 }
 
 export interface SpiritTextFieldProps extends TextFieldProps {}

--- a/packages/web-react/src/types/textFieldBase.ts
+++ b/packages/web-react/src/types/textFieldBase.ts
@@ -1,23 +1,17 @@
-import { ChildrenProps, TextInputProps } from './shared';
+import { ChildrenProps, PasswordToggleAdornmentProp, TextInputProps } from './shared';
 import { TextAreaProps } from './textArea';
-import { TextFieldProps, TextFieldType } from './textField';
-import { PasswordToggleAdornmentProp } from './shared/adornments';
+import { TextFieldProps } from './textField';
 
 export interface TextFieldBaseMultiLineProps {
   /** Whether the input is TextArea. */
   isMultiline?: boolean;
 }
 
-export interface TextFieldBaseProps extends ChildrenProps, TextFieldProps, TextAreaProps, TextFieldBaseMultiLineProps {}
+export type TextFieldBaseProps = ChildrenProps & TextFieldBaseMultiLineProps & (TextFieldProps | TextAreaProps);
 
-export interface SpiritTextFieldBaseProps extends TextFieldBaseProps {}
+export type SpiritTextFieldBaseProps = TextFieldBaseProps;
 
-export interface TextFieldBaseInputProps extends TextInputProps, TextFieldBaseMultiLineProps {
-  /** The input width */
-  inputWidth?: number;
-  /** The type of text field */
-  type?: TextFieldType;
-}
+export type TextFieldBaseInputProps = TextInputProps & TextFieldBaseMultiLineProps;
 
 export interface SpiritTextFieldBaseInputProps extends TextFieldBaseInputProps {}
 


### PR DESCRIPTION
# Extension of TextField, TextArea, CheckboxField and RadioField props

Extension of components props from proper element type.

## ✅ What was done:
* Updating props for:
   *`types/checkbox.ts`  - uses `HTMLInputElement` as base props and then expand further
   *`types/radio.ts`  - uses `HTMLInputElement` as base props and then expand further
   *`types/textField.ts`  - uses `HTMLInputElement` as base props and then expand further
   *`types/textArea.ts`  - uses `HTMLTextAreaElement` as base props and then expand further
* Simplification of `types/textFieldBase.ts` and `types/shared/inputs.ts`