### PR TITLE
React dictionaries constants

### DIFF
--- a/packages/web-react/src/components/CheckboxField/__tests__/useCheckboxFieldStyleProps.test.ts
+++ b/packages/web-react/src/components/CheckboxField/__tests__/useCheckboxFieldStyleProps.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { SpiritCheckboxFieldProps, ValidationStates } from '../../../types';
+import { SpiritCheckboxFieldProps } from '../../../types';
+import { ValidationStates } from '../../../constants';
 import { useCheckboxFieldStyleProps } from '../useCheckboxFieldStyleProps';
 
 describe('useCheckboxFieldStyleProps', () => {

--- a/packages/web-react/src/components/Heading/__tests__/Heading.test.tsx
+++ b/packages/web-react/src/components/Heading/__tests__/Heading.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Heading from '../Heading';
 import headingSizeDataProvider from './headingSizeDataProvider';
-import { Size, SizeExtended } from '../../../types';
+import { SizesDictionaryType, SizeExtendedDictionaryType } from '../../../types';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { sizeExtendedPropsTest, sizePropsTest } from '../../../../tests/providerTests/dictionaryPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
@@ -21,7 +21,7 @@ describe('Heading', () => {
   restPropsTest(Heading, 'div');
 
   it.each(headingSizeDataProvider)('should have for size %s an expected class %s', (size, expectedClassName) => {
-    const dom = render(<Heading size={size as Size<string> as SizeExtended<string>} />);
+    const dom = render(<Heading size={size as SizesDictionaryType<string> as SizeExtendedDictionaryType<string>} />);
 
     expect(dom.container.querySelector('div')).toHaveClass(expectedClassName);
   });

--- a/packages/web-react/src/components/Link/__tests__/Link.test.tsx
+++ b/packages/web-react/src/components/Link/__tests__/Link.test.tsx
@@ -5,7 +5,7 @@ import { classNamePrefixProviderTest } from '../../../../tests/providerTests/cla
 import { textColorPropsTest } from '../../../../tests/providerTests/dictionaryPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
-import { TextColor } from '../../../types';
+import { TextColorsDictionaryType } from '../../../types';
 import Link from '../Link';
 import linkPropsDataProvider from './linkPropsDataProvider';
 
@@ -22,7 +22,7 @@ describe('Link', () => {
     const dom = render(
       <Link
         href="/"
-        color={color as TextColor<string>}
+        color={color as TextColorsDictionaryType<string>}
         isUnderlined={isUnderlined as boolean}
         isDisabled={isDisabled as boolean}
       />,

--- a/packages/web-react/src/components/RadioField/__tests__/useRadioFieldStyleProps.test.ts
+++ b/packages/web-react/src/components/RadioField/__tests__/useRadioFieldStyleProps.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { SpiritRadioFieldProps, ValidationStates } from '../../../types';
+import { SpiritRadioFieldProps } from '../../../types';
+import { ValidationStates } from '../../../constants';
 import { useRadioFieldStyleProps } from '../useRadioFieldStyleProps';
 
 describe('useRadioFieldStyleProps', () => {

--- a/packages/web-react/src/components/Text/__tests__/Text.test.tsx
+++ b/packages/web-react/src/components/Text/__tests__/Text.test.tsx
@@ -6,7 +6,7 @@ import { classNamePrefixProviderTest } from '../../../../tests/providerTests/cla
 import { sizeExtendedPropsTest, sizePropsTest } from '../../../../tests/providerTests/dictionaryPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
-import { Size, SizeExtended, TextEmphasis } from '../../../types';
+import { SizesDictionaryType, SizeExtendedDictionaryType, TextEmphasis } from '../../../types';
 import textPropsDataProvider from './textPropsDataProvider';
 
 describe('Text', () => {
@@ -22,7 +22,10 @@ describe('Text', () => {
 
   it.each(textPropsDataProvider)('should have classname', (size, emphasis, expectedClassName) => {
     const dom = render(
-      <Text size={size as Size<string> as SizeExtended<string>} emphasis={emphasis as TextEmphasis} />,
+      <Text
+        size={size as SizesDictionaryType<string> as SizeExtendedDictionaryType<string>}
+        emphasis={emphasis as TextEmphasis}
+      />,
     );
 
     expect(dom.container.querySelector('p')).toHaveClass(expectedClassName as string);

--- a/packages/web-react/src/constants/dictionaries.ts
+++ b/packages/web-react/src/constants/dictionaries.ts
@@ -1,0 +1,40 @@
+/* Colors */
+export const ActionColors = {
+  PRIMARY: 'primary',
+  SECONDARY: 'secondary',
+  TERTIARY: 'tertiary',
+  INVERTED: 'inverted',
+} as const;
+
+export const EmotionColors = {
+  SUCCESS: 'success',
+  INFORMATIVE: 'informative',
+  WARNING: 'warning',
+  DANGER: 'danger',
+} as const;
+
+export const TextColors = {
+  PRIMARY: 'primary',
+  SECONDARY: 'secondary',
+  INVERTED: 'inverted',
+} as const;
+
+/* Size */
+export const Sizes = {
+  SMALL: 'small',
+  MEDIUM: 'medium',
+  LARGE: 'large',
+} as const;
+
+export const SizesExtended = {
+  ...Sizes,
+  XSMALL: 'xsmall',
+  XLARGE: 'xlarge',
+} as const;
+
+/* Validation */
+export const ValidationStates = {
+  SUCCESS: 'success',
+  WARNING: 'warning',
+  DANGER: 'danger',
+} as const;

--- a/packages/web-react/src/constants/index.ts
+++ b/packages/web-react/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './dictionaries';

--- a/packages/web-react/src/index.ts
+++ b/packages/web-react/src/index.ts
@@ -1,4 +1,5 @@
 export * from './components';
+export * from './constants';
 export * from './context';
 export * from './hooks';
 export * from './types';

--- a/packages/web-react/src/types/alert.ts
+++ b/packages/web-react/src/types/alert.ts
@@ -1,5 +1,5 @@
 import { ElementType, JSXElementConstructor } from 'react';
-import { ChildrenProps, EmotionColor, StyleProps, TransferProps } from './shared';
+import { ChildrenProps, EmotionColorsDictionaryType, StyleProps, TransferProps } from './shared';
 
 export interface AriaAlertElementTypeProps<T extends ElementType = 'div'> {
   /**
@@ -16,7 +16,7 @@ export interface SpiritAlertProps<T extends ElementType = 'div', S = void>
   extends AriaAlertElementTypeProps<T>,
     AlertProps {
   /** The color of the alert. */
-  color?: EmotionColor<S>;
+  color?: EmotionColorsDictionaryType<S>;
   /** Icon used in Alert. */
   iconName?: string;
   /** Whether the alert should be centered. */

--- a/packages/web-react/src/types/button.ts
+++ b/packages/web-react/src/types/button.ts
@@ -1,17 +1,18 @@
 import { ElementType, JSXElementConstructor, Ref } from 'react';
 import {
-  ActionColor,
+  ActionColorsDictionaryType,
   AriaLabelingProps,
   ChildrenProps,
   ClickEvents,
-  EmotionColor,
-  Size,
+  EmotionColorsDictionaryType,
+  SizesDictionaryType,
+  SizeExtendedDictionaryType,
   StyleProps,
   TransferProps,
 } from './shared';
 
-export type ButtonColor<C> = ActionColor<void> | EmotionColor<void> | C;
-export type ButtonSize<S> = Size<void> | EmotionColor<void> | S;
+export type ButtonColor<C> = ActionColorsDictionaryType | EmotionColorsDictionaryType | C;
+export type ButtonSize<S> = SizesDictionaryType | SizeExtendedDictionaryType | S;
 type ButtonType = 'button' | 'submit' | 'reset';
 
 interface ButtonProps<C = void, S = void> extends ChildrenProps, ClickEvents {

--- a/packages/web-react/src/types/heading.ts
+++ b/packages/web-react/src/types/heading.ts
@@ -1,5 +1,5 @@
 import { ElementType, JSXElementConstructor } from 'react';
-import { ChildrenProps, SizeExtended, SizeProps, StyleProps, TransferProps } from './shared';
+import { ChildrenProps, SizeExtendedDictionaryType, SizeProps, StyleProps, TransferProps } from './shared';
 
 export interface HeadingElementTypeProps<T extends ElementType = 'div'> {
   /**
@@ -18,4 +18,4 @@ export interface HeadingProps<T extends ElementType = 'div'>
 
 export interface SpiritHeadingProps<T extends ElementType = 'div', S = void>
   extends HeadingProps<T>,
-    SizeProps<SizeExtended<S>> {}
+    SizeProps<SizeExtendedDictionaryType<S>> {}

--- a/packages/web-react/src/types/link.ts
+++ b/packages/web-react/src/types/link.ts
@@ -1,5 +1,5 @@
 import { ElementType, JSXElementConstructor } from 'react';
-import { ChildrenProps, StyleProps, TextColor, TransferProps } from './shared';
+import { ChildrenProps, StyleProps, TextColorsDictionaryType, TransferProps } from './shared';
 
 export type LinkTarget = '_blank' | '_self' | '_parent' | '_top';
 
@@ -25,7 +25,7 @@ export interface LinkProps<T extends ElementType = 'a'>
 
 export interface SpiritLinkProps<E extends ElementType = 'a', T = void> extends LinkProps<E> {
   /** Color of the Link */
-  color?: TextColor<T>;
+  color?: TextColorsDictionaryType<T>;
   /** Whether is the Link underlined */
   isUnderlined?: boolean;
   /** Whether is the Link disabled */

--- a/packages/web-react/src/types/pill.ts
+++ b/packages/web-react/src/types/pill.ts
@@ -1,7 +1,7 @@
 import { ElementType, JSXElementConstructor } from 'react';
-import { ActionColor, ChildrenProps, EmotionColor, TransferProps } from './shared';
+import { ActionColorsDictionaryType, ChildrenProps, EmotionColorsDictionaryType, TransferProps } from './shared';
 
-export type PillColor<C> = ActionColor<void> | EmotionColor<void> | 'selected' | 'unselected' | C;
+export type PillColor<C> = ActionColorsDictionaryType | EmotionColorsDictionaryType | 'selected' | 'unselected' | C;
 
 export interface AriaPillElementTypeProps<T extends ElementType = 'span'> {
   /**

--- a/packages/web-react/src/types/shared/dictionaries.ts
+++ b/packages/web-react/src/types/shared/dictionaries.ts
@@ -1,21 +1,21 @@
 import { ActionColors, EmotionColors, TextColors, Sizes, SizesExtended, ValidationStates } from '../../constants';
 
 /* Colors */
-export type ActionColorsKeys = keyof typeof ActionColors;
-export type ActionColor<T = undefined> = (typeof ActionColors)[ActionColorsKeys] | T;
+export type ActionColorsDictionaryKeys = keyof typeof ActionColors;
+export type ActionColorsDictionaryType<T = undefined> = (typeof ActionColors)[ActionColorsDictionaryKeys] | T;
 
-export type EmotionColorsKeys = keyof typeof EmotionColors;
-export type EmotionColor<T = undefined> = (typeof EmotionColors)[EmotionColorsKeys] | T;
+export type EmotionColorsDictionaryKeys = keyof typeof EmotionColors;
+export type EmotionColorsDictionaryType<T = undefined> = (typeof EmotionColors)[EmotionColorsDictionaryKeys] | T;
 
-export type TextColorsKeys = keyof typeof TextColors;
-export type TextColor<T = undefined> = (typeof TextColors)[TextColorsKeys] | T;
+export type TextColorsDictionaryKeys = keyof typeof TextColors;
+export type TextColorsDictionaryType<T = undefined> = (typeof TextColors)[TextColorsDictionaryKeys] | T;
 
 /* Size */
-export type SizesKeys = keyof typeof Sizes;
-export type Size<T = undefined> = (typeof Sizes)[SizesKeys] | T;
+export type SizesDictionaryKeys = keyof typeof Sizes;
+export type SizesDictionaryType<T = undefined> = (typeof Sizes)[SizesDictionaryKeys] | T;
 
-export type SizesExtendedKeys = keyof typeof SizesExtended;
-export type SizeExtended<T = undefined> = (typeof SizesExtended)[SizesExtendedKeys] | T;
+export type SizesExtendedDictionaryKeys = keyof typeof SizesExtended;
+export type SizeExtendedDictionaryType<T = undefined> = (typeof SizesExtended)[SizesExtendedDictionaryKeys] | T;
 
 export interface SizeProps<P> {
   /** Size of the text */
@@ -23,5 +23,7 @@ export interface SizeProps<P> {
 }
 
 /* Validation */
-export type ValidationStatesKeys = keyof typeof ValidationStates;
-export type ValidationStatesTypes<T = undefined> = (typeof ValidationStates)[ValidationStatesKeys] | T;
+export type ValidationStatesDictionaryKeys = keyof typeof ValidationStates;
+export type ValidationStatesDictionaryType<T = undefined> =
+  | (typeof ValidationStates)[ValidationStatesDictionaryKeys]
+  | T;

--- a/packages/web-react/src/types/shared/dictionaries.ts
+++ b/packages/web-react/src/types/shared/dictionaries.ts
@@ -1,60 +1,27 @@
-export const Sizes = {
-  SMALL: 'small',
-  MEDIUM: 'medium',
-  LARGE: 'large',
-} as const;
+import { ActionColors, EmotionColors, TextColors, Sizes, SizesExtended, ValidationStates } from '../../constants';
 
-export type SizesKeys = keyof typeof Sizes;
-export type Size<S> = (typeof Sizes)[SizesKeys] | S;
-
-export const SizesExtended = {
-  ...Sizes,
-  XSMALL: 'xsmall',
-  XLARGE: 'xlarge',
-} as const;
-
-export type SizesExtendedKeys = keyof typeof SizesExtended;
-export type SizeExtended<S> = (typeof SizesExtended)[SizesExtendedKeys] | S;
-
-export const ActionColors = {
-  PRIMARY: 'primary',
-  SECONDARY: 'secondary',
-  TERTIARY: 'tertiary',
-  INVERTED: 'inverted',
-} as const;
-
+/* Colors */
 export type ActionColorsKeys = keyof typeof ActionColors;
-export type ActionColor<A> = (typeof ActionColors)[ActionColorsKeys] | A;
-
-export const EmotionColors = {
-  SUCCESS: 'success',
-  INFORMATIVE: 'informative',
-  WARNING: 'warning',
-  DANGER: 'danger',
-} as const;
+export type ActionColor<T = undefined> = (typeof ActionColors)[ActionColorsKeys] | T;
 
 export type EmotionColorsKeys = keyof typeof EmotionColors;
-export type EmotionColor<E> = (typeof EmotionColors)[EmotionColorsKeys] | E;
-
-export const TextColors = {
-  PRIMARY: 'primary',
-  SECONDARY: 'secondary',
-  INVERTED: 'inverted',
-} as const;
+export type EmotionColor<T = undefined> = (typeof EmotionColors)[EmotionColorsKeys] | T;
 
 export type TextColorsKeys = keyof typeof TextColors;
-export type TextColor<T> = (typeof TextColors)[TextColorsKeys] | T;
+export type TextColor<T = undefined> = (typeof TextColors)[TextColorsKeys] | T;
 
-export interface SizeProps<S> {
+/* Size */
+export type SizesKeys = keyof typeof Sizes;
+export type Size<T = undefined> = (typeof Sizes)[SizesKeys] | T;
+
+export type SizesExtendedKeys = keyof typeof SizesExtended;
+export type SizeExtended<T = undefined> = (typeof SizesExtended)[SizesExtendedKeys] | T;
+
+export interface SizeProps<P> {
   /** Size of the text */
-  size?: S;
+  size?: P;
 }
 
-export const ValidationStates = {
-  SUCCESS: 'success',
-  WARNING: 'warning',
-  DANGER: 'danger',
-} as const;
-
+/* Validation */
 export type ValidationStatesKeys = keyof typeof ValidationStates;
-export type ValidationStatesTypes<T> = (typeof ValidationStates)[ValidationStatesKeys] | T;
+export type ValidationStatesTypes<T = undefined> = (typeof ValidationStates)[ValidationStatesKeys] | T;

--- a/packages/web-react/src/types/shared/inputs.ts
+++ b/packages/web-react/src/types/shared/inputs.ts
@@ -1,8 +1,8 @@
 import type { ChangeEventHandler, KeyboardEventHandler } from 'react';
-import { ValidationStatesTypes } from './dictionaries';
+import { ValidationStatesDictionaryType } from './dictionaries';
 
 /* @deprecated: 'error' value will be removed in the next major version. */
-export type ValidationState = ValidationStatesTypes<'error'>;
+export type ValidationState = ValidationStatesDictionaryType<'error'>;
 
 export interface Validation {
   /** Whether the input should display its "valid" or "invalid" visual styling. */

--- a/packages/web-react/src/types/tag.ts
+++ b/packages/web-react/src/types/tag.ts
@@ -1,10 +1,10 @@
 import { ElementType, JSXElementConstructor } from 'react';
-import { ChildrenProps, EmotionColor, Size, StyleProps, TransferProps } from './shared';
+import { ChildrenProps, EmotionColorsDictionaryType, SizesDictionaryType, StyleProps, TransferProps } from './shared';
 
 /* @deprecated: 'default' value will be removed in the next major version. */
-export type TagColor<C> = EmotionColor<void> | 'default' | 'neutral' | C;
+export type TagColor<C> = EmotionColorsDictionaryType | 'default' | 'neutral' | C;
 
-export type TagSize<S> = Size<void> | EmotionColor<void> | S;
+export type TagSize<S> = SizesDictionaryType | EmotionColorsDictionaryType | S;
 
 /** @deprecated Will be removed in next major version */
 export type TagTheme = 'light' | 'dark';

--- a/packages/web-react/src/types/text.ts
+++ b/packages/web-react/src/types/text.ts
@@ -1,5 +1,5 @@
 import { ElementType, JSXElementConstructor } from 'react';
-import { ChildrenProps, SizeExtended, SizeProps, StyleProps, TransferProps } from './shared';
+import { ChildrenProps, SizeExtendedDictionaryType, SizeProps, StyleProps, TransferProps } from './shared';
 
 export type TextEmphasis = 'bold' | 'italic';
 
@@ -20,7 +20,7 @@ export interface TextProps<T extends ElementType = 'p'>
 
 export interface SpiritTextProps<T extends ElementType = 'p', S = void>
   extends TextProps<T>,
-    SizeProps<SizeExtended<S>> {
+    SizeProps<SizeExtendedDictionaryType<S>> {
   /** Emphasis of the text */
   emphasis?: TextEmphasis | undefined | null;
 }

--- a/packages/web-react/tests/providerTests/dictionaryPropsTest.tsx
+++ b/packages/web-react/tests/providerTests/dictionaryPropsTest.tsx
@@ -1,20 +1,25 @@
 import React, { ComponentType } from 'react';
 import { render, waitFor } from '@testing-library/react';
 import {
-  ActionColor,
-  EmotionColor,
-  SizeExtended,
-  Size,
-  TextColor,
-  ValidationStatesTypes,
+  ActionColorsDictionaryType,
+  ActionColors,
+  EmotionColorsDictionaryType,
+  EmotionColors,
+  SizeExtendedDictionaryType,
+  SizesExtended,
+  SizesDictionaryType,
+  Sizes,
+  TextColorsDictionaryType,
+  TextColors,
+  ValidationStatesDictionaryType,
   ValidationStates,
 } from '../../src';
 import getElement from '../testUtils/getElement';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const sizePropsTest = (Component: ComponentType<any>, testId?: string) => {
-  it.each([['small'], ['medium'], ['large']])('should render size %s', async (size) => {
-    const dom = render(<Component size={size as Size<string>} />);
+  it.each([Object.values(Sizes)])('should render size %s', async (size) => {
+    const dom = render(<Component size={size as SizesDictionaryType<string>} />);
 
     await waitFor(() => {
       const element = getElement(dom, testId);
@@ -25,8 +30,8 @@ export const sizePropsTest = (Component: ComponentType<any>, testId?: string) =>
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const sizeExtendedPropsTest = (Component: ComponentType<any>, testId?: string) => {
-  it.each([['xsmall'], ['xlarge']])('should render extended size %s', async (size) => {
-    const dom = render(<Component size={size as SizeExtended<string>} />);
+  it.each([Object.values(SizesExtended)])('should render extended size %s', async (size) => {
+    const dom = render(<Component size={size as SizeExtendedDictionaryType<string>} />);
 
     await waitFor(() => {
       const element = getElement(dom, testId);
@@ -37,8 +42,8 @@ export const sizeExtendedPropsTest = (Component: ComponentType<any>, testId?: st
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const actionColorPropsTest = (Component: ComponentType<any>, prefix: string, testId?: string) => {
-  it.each([['primary'], ['secondary'], ['tertiary'], ['inverted']])('should render action color %s', async (color) => {
-    const dom = render(<Component color={color as ActionColor<string>} />);
+  it.each([Object.values(ActionColors)])('should render action color %s', async (color) => {
+    const dom = render(<Component color={color as ActionColorsDictionaryType<string>} />);
 
     await waitFor(() => {
       const element = getElement(dom, testId);
@@ -49,8 +54,8 @@ export const actionColorPropsTest = (Component: ComponentType<any>, prefix: stri
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const emotionColorPropsTest = (Component: ComponentType<any>, prefix: string, testId?: string) => {
-  it.each([['success'], ['informative'], ['warning'], ['danger']])('should render emotion color %s', async (color) => {
-    const dom = render(<Component color={color as EmotionColor<string>} />);
+  it.each([Object.values(EmotionColors)])('should render emotion color %s', async (color) => {
+    const dom = render(<Component color={color as EmotionColorsDictionaryType<string>} />);
 
     await waitFor(() => {
       const element = getElement(dom, testId);
@@ -61,8 +66,8 @@ export const emotionColorPropsTest = (Component: ComponentType<any>, prefix: str
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const textColorPropsTest = (Component: ComponentType<any>, prefix: string, testId?: string) => {
-  it.each([['primary'], ['secondary'], ['inverted']])('should render text color %s', async (color) => {
-    const dom = render(<Component color={color as TextColor<string>} />);
+  it.each([Object.values(TextColors)])('should render text color %s', async (color) => {
+    const dom = render(<Component color={color as TextColorsDictionaryType<string>} />);
 
     await waitFor(() => {
       const element = getElement(dom, testId);
@@ -74,7 +79,7 @@ export const textColorPropsTest = (Component: ComponentType<any>, prefix: string
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const validationStatePropsTest = (Component: ComponentType<any>, prefix: string, testId?: string) => {
   it.each([Object.values(ValidationStates)])('should have %s validation classname', async (state) => {
-    const dom = render(<Component validationState={state as ValidationStatesTypes<string>} />);
+    const dom = render(<Component validationState={state as ValidationStatesDictionaryType<string>} />);
 
     await waitFor(() => {
       const element = getElement(dom, testId);


### PR DESCRIPTION
# Separate constant folder
When editing one task, I thought if these constants were somewhere separately, for better maintenance of the structure and not to mix it with types.

## ✅ What was done:
* splitting existing constants from dictionaries and moving them to a separate folder with constants
* editing dictionary extensible types as an optional attribute
* renaming dictionary keys and types
* updated dictionaries test
* fixed bug in **Button** component props `export type ButtonSize<S> = Size<void> | EmotionColor<void> | S;`
