### PR TITLE
Feat(web-react): ForwardRef for Button and ButtonLink #DS-445

### DIFF
--- a/packages/web-react/src/components/Button/Button.stories.ts
+++ b/packages/web-react/src/components/Button/Button.stories.ts
@@ -1,4 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import Button from './Button';
 
 export default {
@@ -11,6 +12,7 @@ export default {
       },
     },
   },
+  argTypes,
 } as ComponentMeta<typeof Button>;
 
 export { default as Button } from './stories/Button';

--- a/packages/web-react/src/components/Button/Button.tsx
+++ b/packages/web-react/src/components/Button/Button.tsx
@@ -1,5 +1,5 @@
+import React, { ElementType, ForwardedRef, forwardRef } from 'react';
 import classNames from 'classnames';
-import React, { ElementType } from 'react';
 import { useStyleProps } from '../../hooks';
 import { SpiritButtonProps } from '../../types';
 import { useButtonAriaProps } from './useButtonAriaProps';
@@ -15,25 +15,29 @@ const defaultProps = {
   size: 'medium',
 };
 
-export const Button = <T extends ElementType = 'button', C = void, S = void>(
-  props: SpiritButtonProps<T, C, S>,
-): JSX.Element => {
-  const { elementType: ElementTag = 'button', children, ...restProps } = props;
-  const { buttonProps } = useButtonAriaProps(props);
-  const { classProps, props: modifiedProps } = useButtonStyleProps(restProps);
-  const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
+export const Button = forwardRef<HTMLButtonElement, SpiritButtonProps>(
+  <T extends ElementType = 'button', C = void, S = void>(
+    props: SpiritButtonProps<T, C, S>,
+    ref: ForwardedRef<HTMLButtonElement>,
+  ): JSX.Element => {
+    const { elementType: ElementTag = 'button', children, ...restProps } = props;
+    const { buttonProps } = useButtonAriaProps(props);
+    const { classProps, props: modifiedProps } = useButtonStyleProps(restProps);
+    const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
 
-  return (
-    <ElementTag
-      {...otherProps}
-      {...styleProps}
-      {...buttonProps}
-      className={classNames(classProps, styleProps.className)}
-    >
-      {children}
-    </ElementTag>
-  );
-};
+    return (
+      <ElementTag
+        {...otherProps}
+        {...styleProps}
+        {...buttonProps}
+        ref={ref}
+        className={classNames(classProps, styleProps.className)}
+      >
+        {children}
+      </ElementTag>
+    );
+  },
+);
 
 Button.defaultProps = defaultProps;
 

--- a/packages/web-react/src/components/Button/ButtonLink.stories.tsx
+++ b/packages/web-react/src/components/Button/ButtonLink.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import ButtonLink from './ButtonLink';
 
 export default {
@@ -9,6 +10,15 @@ export default {
       description: {
         component: 'ButtonLinks allow users to take actions.',
       },
+    },
+  },
+  argTypes: {
+    ...argTypes,
+    href: {
+      control: {
+        type: 'text',
+      },
+      defaultValue: '#',
     },
   },
 } as ComponentMeta<typeof ButtonLink>;

--- a/packages/web-react/src/components/Button/ButtonLink.tsx
+++ b/packages/web-react/src/components/Button/ButtonLink.tsx
@@ -1,5 +1,5 @@
+import React, { ElementType, ForwardedRef, forwardRef } from 'react';
 import classNames from 'classnames';
-import React, { ElementType } from 'react';
 import { useStyleProps } from '../../hooks';
 import { SpiritButtonLinkProps } from '../../types';
 import { useButtonAriaProps } from './useButtonAriaProps';
@@ -15,25 +15,29 @@ const defaultProps = {
   size: 'medium',
 };
 
-export const ButtonLink = <T extends ElementType = 'a', C = void, S = void>(
-  props: SpiritButtonLinkProps<T, C, S>,
-): JSX.Element => {
-  const { elementType: ElementTag = 'a', children, ...restProps } = props;
-  const { buttonProps } = useButtonAriaProps(props);
-  const { classProps, props: modifiedProps } = useButtonStyleProps(restProps);
-  const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
+export const ButtonLink = forwardRef<HTMLAnchorElement, SpiritButtonLinkProps>(
+  <T extends ElementType = 'a', C = void, S = void>(
+    props: SpiritButtonLinkProps<T, C, S>,
+    ref: ForwardedRef<HTMLAnchorElement>,
+  ): JSX.Element => {
+    const { elementType: ElementTag = 'a', children, ...restProps } = props;
+    const { buttonProps } = useButtonAriaProps(props);
+    const { classProps, props: modifiedProps } = useButtonStyleProps(restProps);
+    const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
 
-  return (
-    <ElementTag
-      {...otherProps}
-      {...styleProps}
-      {...buttonProps}
-      className={classNames(classProps, styleProps.className)}
-    >
-      {children}
-    </ElementTag>
-  );
-};
+    return (
+      <ElementTag
+        {...otherProps}
+        {...styleProps}
+        {...buttonProps}
+        ref={ref}
+        className={classNames(classProps, styleProps.className)}
+      >
+        {children}
+      </ElementTag>
+    );
+  },
+);
 
 ButtonLink.defaultProps = defaultProps;
 

--- a/packages/web-react/src/components/Button/README.md
+++ b/packages/web-react/src/components/Button/README.md
@@ -33,6 +33,7 @@ import { Button } from '@lmc-eu/spirit-web-react';
 | `isSquare`   | `bool`                                                                                    | `false`   | no       | If true, Button is square, usually only with an icon |
 | `onClick`    | `string`                                                                                  | `null`    | no       | JS function to call on click                         |
 | `type`       | `string`                                                                                  | `button`  | no       | Type of the Button                                   |
+| `ref`        | `ForwardedRef<HTMLButtonElement>`                                                         | -         | no       | Button element reference                             |
 
 For more information see [Button] component.
 
@@ -68,6 +69,7 @@ import { ButtonLink } from '@lmc-eu/spirit-web-react';
 | `isSquare`   | `bool`                                                                                    | `false`   | no       | If true, ButtonLink is square, usually only with an icon |
 | `onClick`    | `string`                                                                                  | `null`    | no       | JS function to call on click                             |
 | `target`     | `string`                                                                                  | `null`    | no       | Link target                                              |
+| `ref`        | `ForwardedRef<HTMLAnchorElement>`                                                         | -         | no       | Anchor element reference                                 |
 
 For more information see [Button] component.
 

--- a/packages/web-react/src/components/Button/stories/argTypes.ts
+++ b/packages/web-react/src/components/Button/stories/argTypes.ts
@@ -1,0 +1,43 @@
+import { ActionColors, EmotionColors, Sizes } from '../../../constants';
+
+export default {
+  color: {
+    control: {
+      type: 'select',
+      options: [...Object.values(ActionColors), ...Object.values(EmotionColors)],
+    },
+    defaultValue: ActionColors.PRIMARY,
+  },
+  isDisabled: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  isBlock: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  isSquare: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  type: {
+    control: {
+      type: 'select',
+      options: ['button', 'submit', 'reset'],
+    },
+    defaultValue: 'button',
+  },
+  size: {
+    control: {
+      type: 'select',
+      options: [...Object.values(Sizes)],
+    },
+    defaultValue: Sizes.MEDIUM,
+  },
+};

--- a/packages/web-react/src/types/button.ts
+++ b/packages/web-react/src/types/button.ts
@@ -1,4 +1,4 @@
-import { ElementType, JSXElementConstructor, Ref } from 'react';
+import { ElementType, JSXElementConstructor } from 'react';
 import {
   ActionColorsDictionaryType,
   AriaLabelingProps,
@@ -6,13 +6,12 @@ import {
   ClickEvents,
   EmotionColorsDictionaryType,
   SizesDictionaryType,
-  SizeExtendedDictionaryType,
   StyleProps,
   TransferProps,
 } from './shared';
 
 export type ButtonColor<C> = ActionColorsDictionaryType | EmotionColorsDictionaryType | C;
-export type ButtonSize<S> = SizesDictionaryType | SizeExtendedDictionaryType | S;
+export type ButtonSize<S> = SizesDictionaryType | S;
 type ButtonType = 'button' | 'submit' | 'reset';
 
 interface ButtonProps<C = void, S = void> extends ChildrenProps, ClickEvents {
@@ -67,7 +66,6 @@ export interface SpiritButtonProps<T extends ElementType = 'button', C = void, S
     StyleProps,
     TransferProps {
   // tag?: ElementType;
-  innerRef?: Ref<HTMLButtonElement>;
 }
 
 export interface SpiritButtonLinkProps<T extends ElementType = 'a', C = void, S = void>


### PR DESCRIPTION
# ForwardRef for Button and ButtonLink [DS-445](https://jira.lmc.cz/browse/DS-445)

## ✅ What was done:
* **Button** wrapped with `React.forwardRef`
* **ButtonLink** wrapped with `React.forwardRef`

## ⁉️ Notice:
~~Adding `ref` properties for these components caused type whispering in the Typescript IDE to find no values ​​other than `ref` and `children`. So does Storybook.~~
