### PR TITLE
Feat(web-react): Controllable stories states

### DIFF
--- a/packages/web-react/src/components/Alert/Alert.stories.ts
+++ b/packages/web-react/src/components/Alert/Alert.stories.ts
@@ -1,4 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import Alert from './Alert';
 
 export default {
@@ -11,6 +12,7 @@ export default {
       },
     },
   },
+  argTypes,
 } as ComponentMeta<typeof Alert>;
 
 export { default as Alert } from './stories/Alert';

--- a/packages/web-react/src/components/Alert/stories/argTypes.ts
+++ b/packages/web-react/src/components/Alert/stories/argTypes.ts
@@ -1,0 +1,23 @@
+import { EmotionColors } from '../../../constants';
+
+export default {
+  color: {
+    control: {
+      type: 'select',
+      options: [...Object.values(EmotionColors)],
+    },
+    defaultValue: EmotionColors.SUCCESS,
+  },
+  isCentered: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  iconName: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: 'check-plain',
+  },
+};

--- a/packages/web-react/src/components/Alert/stories/argTypes.ts
+++ b/packages/web-react/src/components/Alert/stories/argTypes.ts
@@ -14,10 +14,4 @@ export default {
     },
     defaultValue: false,
   },
-  iconName: {
-    control: {
-      type: 'text',
-    },
-    defaultValue: 'check-plain',
-  },
 };

--- a/packages/web-react/src/components/Breadcrumbs/Breadcrumbs.stories.ts
+++ b/packages/web-react/src/components/Breadcrumbs/Breadcrumbs.stories.ts
@@ -1,4 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import Breadcrumbs from './Breadcrumbs';
 
 export default {
@@ -11,6 +12,7 @@ export default {
       },
     },
   },
+  argTypes,
 } as ComponentMeta<typeof Breadcrumbs>;
 
 export { default as Breadcrumbs } from './stories/Breadcrumbs';

--- a/packages/web-react/src/components/Breadcrumbs/stories/Breadcrumbs.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/stories/Breadcrumbs.tsx
@@ -16,7 +16,6 @@ const Story: ComponentStory<typeof Breadcrumbs> = <T extends ElementType = 'nav'
 );
 
 Story.args = {
-  goBackTitle: 'Back',
   items: [
     {
       title: 'Root',

--- a/packages/web-react/src/components/Breadcrumbs/stories/argTypes.ts
+++ b/packages/web-react/src/components/Breadcrumbs/stories/argTypes.ts
@@ -1,0 +1,8 @@
+export default {
+  goBackTitle: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: 'Back',
+  },
+};

--- a/packages/web-react/src/components/CheckboxField/CheckboxField.stories.ts
+++ b/packages/web-react/src/components/CheckboxField/CheckboxField.stories.ts
@@ -1,4 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import CheckboxField from './CheckboxField';
 
 export default {
@@ -11,6 +12,7 @@ export default {
       },
     },
   },
+  argTypes,
 } as ComponentMeta<typeof CheckboxField>;
 
 export { default as CheckboxField } from './stories/CheckboxField';

--- a/packages/web-react/src/components/CheckboxField/stories/CheckboxField.tsx
+++ b/packages/web-react/src/components/CheckboxField/stories/CheckboxField.tsx
@@ -5,14 +5,6 @@ import { SpiritCheckboxFieldProps } from '../../../types';
 
 const Story: ComponentStory<typeof CheckboxField> = (args: SpiritCheckboxFieldProps) => <CheckboxField {...args} />;
 
-Story.args = {
-  isChecked: true,
-  isDisabled: false,
-  isItem: false,
-  isLabelHidden: false,
-  isRequired: false,
-  label: 'Label',
-  name: 'example',
-};
+Story.args = {};
 
 export default Story;

--- a/packages/web-react/src/components/CheckboxField/stories/CheckboxField.tsx
+++ b/packages/web-react/src/components/CheckboxField/stories/CheckboxField.tsx
@@ -5,6 +5,4 @@ import { SpiritCheckboxFieldProps } from '../../../types';
 
 const Story: ComponentStory<typeof CheckboxField> = (args: SpiritCheckboxFieldProps) => <CheckboxField {...args} />;
 
-Story.args = {};
-
 export default Story;

--- a/packages/web-react/src/components/CheckboxField/stories/argTypes.ts
+++ b/packages/web-react/src/components/CheckboxField/stories/argTypes.ts
@@ -1,0 +1,77 @@
+import { ValidationStates } from '../../../constants';
+
+export default {
+  validationState: {
+    control: {
+      type: 'select',
+      options: [...Object.values(ValidationStates), undefined],
+    },
+    defaultValue: undefined,
+  },
+  isDisabled: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  isRequired: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  isChecked: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: true,
+  },
+  isLabelHidden: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  isItem: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  indeterminate: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  label: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: 'Field label',
+  },
+  name: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: 'example',
+  },
+  for: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: '',
+  },
+  message: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: '',
+  },
+  helperText: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: '',
+  },
+};

--- a/packages/web-react/src/components/Dropdown/Dropdown.stories.ts
+++ b/packages/web-react/src/components/Dropdown/Dropdown.stories.ts
@@ -1,9 +1,11 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import Dropdown from './Dropdown';
 
 export default {
   title: 'Components/Dropdown',
   component: Dropdown,
+  argTypes,
 } as ComponentMeta<typeof Dropdown>;
 
 export { default as Dropdown } from './stories/Dropdown';

--- a/packages/web-react/src/components/Dropdown/stories/argTypes.ts
+++ b/packages/web-react/src/components/Dropdown/stories/argTypes.ts
@@ -1,0 +1,21 @@
+export default {
+  fullWidthMode: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  enableAutoClose: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  placement: {
+    control: {
+      type: 'select',
+      options: ['bottom-left', 'bottom-right', 'top-left', 'top-right'],
+    },
+    defaultValue: 'bottom-left',
+  },
+};

--- a/packages/web-react/src/components/Header/Header.stories.ts
+++ b/packages/web-react/src/components/Header/Header.stories.ts
@@ -1,4 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import Header from './Header';
 
 export default {
@@ -11,6 +12,7 @@ export default {
       },
     },
   },
+  argTypes,
 } as ComponentMeta<typeof Header>;
 
 export { default as Header } from './stories/Header';

--- a/packages/web-react/src/components/Header/stories/Header.tsx
+++ b/packages/web-react/src/components/Header/stories/Header.tsx
@@ -13,8 +13,6 @@ Story.args = {
       <SpiritLogo />
     </Link>
   ),
-  color: 'inverted',
-  isSimple: false,
 };
 
 export default Story;

--- a/packages/web-react/src/components/Header/stories/argTypes.ts
+++ b/packages/web-react/src/components/Header/stories/argTypes.ts
@@ -1,0 +1,15 @@
+export default {
+  color: {
+    control: {
+      type: 'select',
+      options: ['inverted', 'transparent'],
+    },
+    defaultValue: 'inverted',
+  },
+  isSimple: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+};

--- a/packages/web-react/src/components/Heading/Heading.stories.ts
+++ b/packages/web-react/src/components/Heading/Heading.stories.ts
@@ -1,4 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import Heading from './Heading';
 
 export default {
@@ -11,6 +12,7 @@ export default {
       },
     },
   },
+  argTypes,
 } as ComponentMeta<typeof Heading>;
 
 export { default as Heading } from './stories/Heading';

--- a/packages/web-react/src/components/Heading/stories/argTypes.ts
+++ b/packages/web-react/src/components/Heading/stories/argTypes.ts
@@ -1,0 +1,11 @@
+import { SizesExtended } from '../../../constants';
+
+export default {
+  size: {
+    control: {
+      type: 'select',
+      options: [...Object.values(SizesExtended)],
+    },
+    defaultValue: SizesExtended.MEDIUM,
+  },
+};

--- a/packages/web-react/src/components/Icon/Icon.stories.ts
+++ b/packages/web-react/src/components/Icon/Icon.stories.ts
@@ -1,4 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import Icon from './Icon';
 
 export default {
@@ -11,6 +12,7 @@ export default {
       },
     },
   },
+  argTypes,
 } as ComponentMeta<typeof Icon>;
 
 export { default as Icon } from './stories/Icon';

--- a/packages/web-react/src/components/Icon/stories/Icon.tsx
+++ b/packages/web-react/src/components/Icon/stories/Icon.tsx
@@ -15,6 +15,4 @@ const Story: ComponentStory<typeof Icon> = (args: IconProps) => (
   </IconsProvider>
 );
 
-Story.args = {};
-
 export default Story;

--- a/packages/web-react/src/components/Icon/stories/Icon.tsx
+++ b/packages/web-react/src/components/Icon/stories/Icon.tsx
@@ -14,9 +14,7 @@ const Story: ComponentStory<typeof Icon> = (args: IconProps) => (
     <Icon {...args} />
   </IconsProvider>
 );
-Story.args = {
-  name: 'warning',
-  title: 'Warning',
-};
+
+Story.args = {};
 
 export default Story;

--- a/packages/web-react/src/components/Icon/stories/argTypes.ts
+++ b/packages/web-react/src/components/Icon/stories/argTypes.ts
@@ -1,0 +1,26 @@
+export default {
+  name: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: 'warning',
+  },
+  title: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: 'Warning',
+  },
+  boxSize: {
+    control: {
+      type: 'number',
+    },
+    defaultValue: 24,
+  },
+  ariaHidden: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: true,
+  },
+};

--- a/packages/web-react/src/components/Link/Link.stories.ts
+++ b/packages/web-react/src/components/Link/Link.stories.ts
@@ -1,4 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import Link from './Link';
 
 export default {
@@ -11,6 +12,7 @@ export default {
       },
     },
   },
+  argTypes,
 } as ComponentMeta<typeof Link>;
 
 export { default as Link } from './stories/Link';

--- a/packages/web-react/src/components/Link/stories/Link.tsx
+++ b/packages/web-react/src/components/Link/stories/Link.tsx
@@ -9,7 +9,6 @@ const Story: ComponentStory<typeof Link> = <E extends ElementType = 'a', T = voi
 
 Story.args = {
   children: 'Going somewhere?',
-  href: 'https://www.example.com',
 };
 
 export default Story;

--- a/packages/web-react/src/components/Link/stories/argTypes.ts
+++ b/packages/web-react/src/components/Link/stories/argTypes.ts
@@ -1,0 +1,36 @@
+import { TextColors } from '../../../constants';
+
+export default {
+  target: {
+    control: {
+      type: 'select',
+      options: ['_blank', '_self', '_parent', '_top', undefined],
+    },
+    defaultValue: undefined,
+  },
+  color: {
+    control: {
+      type: 'select',
+      options: [...Object.values(TextColors)],
+    },
+    defaultValue: TextColors.PRIMARY,
+  },
+  href: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: 'https://www.example.com',
+  },
+  isDisabled: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  isUnderlined: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+};

--- a/packages/web-react/src/components/Pill/Pill.stories.ts
+++ b/packages/web-react/src/components/Pill/Pill.stories.ts
@@ -1,4 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import Pill from './Pill';
 
 export default {
@@ -11,6 +12,7 @@ export default {
       },
     },
   },
+  argTypes,
 } as ComponentMeta<typeof Pill>;
 
 export { default as Pill } from './stories/Pill';

--- a/packages/web-react/src/components/Pill/stories/argTypes.ts
+++ b/packages/web-react/src/components/Pill/stories/argTypes.ts
@@ -1,0 +1,11 @@
+import { ActionColors, EmotionColors } from '../../../constants';
+
+export default {
+  color: {
+    control: {
+      type: 'select',
+      options: [...Object.values(ActionColors), ...Object.values(EmotionColors), 'selected', 'unselected'],
+    },
+    defaultValue: 'selected',
+  },
+};

--- a/packages/web-react/src/components/RadioField/RadioField.stories.ts
+++ b/packages/web-react/src/components/RadioField/RadioField.stories.ts
@@ -1,4 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import RadioField from './RadioField';
 
 export default {
@@ -12,6 +13,7 @@ export default {
       },
     },
   },
+  argTypes,
 } as ComponentMeta<typeof RadioField>;
 
 export { default as RadioField } from './stories/RadioField';

--- a/packages/web-react/src/components/RadioField/stories/RadioField.tsx
+++ b/packages/web-react/src/components/RadioField/stories/RadioField.tsx
@@ -5,12 +5,6 @@ import { SpiritRadioFieldProps } from '../../../types';
 
 const Story: ComponentStory<typeof RadioField> = (args: SpiritRadioFieldProps) => <RadioField {...args} />;
 
-Story.args = {
-  isChecked: true,
-  isDisabled: false,
-  isLabelHidden: false,
-  label: 'Label',
-  name: 'example',
-};
+Story.args = {};
 
 export default Story;

--- a/packages/web-react/src/components/RadioField/stories/RadioField.tsx
+++ b/packages/web-react/src/components/RadioField/stories/RadioField.tsx
@@ -5,6 +5,4 @@ import { SpiritRadioFieldProps } from '../../../types';
 
 const Story: ComponentStory<typeof RadioField> = (args: SpiritRadioFieldProps) => <RadioField {...args} />;
 
-Story.args = {};
-
 export default Story;

--- a/packages/web-react/src/components/RadioField/stories/argTypes.ts
+++ b/packages/web-react/src/components/RadioField/stories/argTypes.ts
@@ -1,0 +1,59 @@
+import { ValidationStates } from '../../../constants';
+
+export default {
+  validationState: {
+    control: {
+      type: 'select',
+      options: [...Object.values(ValidationStates), undefined],
+    },
+    defaultValue: undefined,
+  },
+  isDisabled: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  isChecked: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: true,
+  },
+  isLabelHidden: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  isItem: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  label: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: 'Field label',
+  },
+  name: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: 'example',
+  },
+  for: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: '',
+  },
+  helperText: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: '',
+  },
+};

--- a/packages/web-react/src/components/Tag/Tag.stories.ts
+++ b/packages/web-react/src/components/Tag/Tag.stories.ts
@@ -1,4 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import Tag from './Tag';
 
 export default {
@@ -11,6 +12,7 @@ export default {
       },
     },
   },
+  argTypes,
 } as ComponentMeta<typeof Tag>;
 
 export { default as Tag } from './stories/Tag';

--- a/packages/web-react/src/components/Tag/stories/argTypes.ts
+++ b/packages/web-react/src/components/Tag/stories/argTypes.ts
@@ -1,0 +1,31 @@
+import { EmotionColors, Sizes } from '../../../constants';
+
+export default {
+  color: {
+    control: {
+      type: 'select',
+      options: [...Object.values(EmotionColors), 'default', 'neutral'],
+    },
+    defaultValue: 'neutral',
+  },
+  size: {
+    control: {
+      type: 'select',
+      options: [...Object.values(Sizes)],
+    },
+    defaultValue: Sizes.MEDIUM,
+  },
+  theme: {
+    control: {
+      type: 'select',
+      options: ['dark', 'light', undefined],
+    },
+    defaultValue: undefined,
+  },
+  isSubtle: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+};

--- a/packages/web-react/src/components/Text/Text.stories.ts
+++ b/packages/web-react/src/components/Text/Text.stories.ts
@@ -1,4 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import Text from './Text';
 
 export default {
@@ -11,6 +12,7 @@ export default {
       },
     },
   },
+  argTypes,
 } as ComponentMeta<typeof Text>;
 
 export { default as Text } from './stories/Text';

--- a/packages/web-react/src/components/Text/stories/argTypes.ts
+++ b/packages/web-react/src/components/Text/stories/argTypes.ts
@@ -1,0 +1,18 @@
+import { SizesExtended } from '../../../constants';
+
+export default {
+  size: {
+    control: {
+      type: 'select',
+      options: [...Object.values(SizesExtended)],
+    },
+    defaultValue: SizesExtended.MEDIUM,
+  },
+  emphasis: {
+    control: {
+      type: 'select',
+      options: ['bold', 'italic', undefined],
+    },
+    defaultValue: undefined,
+  },
+};

--- a/packages/web-react/src/components/TextArea/TextArea.stories.ts
+++ b/packages/web-react/src/components/TextArea/TextArea.stories.ts
@@ -1,4 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import TextArea from './TextArea';
 
 export default {
@@ -11,6 +12,7 @@ export default {
       },
     },
   },
+  argTypes,
 } as ComponentMeta<typeof TextArea>;
 
 export { default as TextArea } from './stories/TextArea';

--- a/packages/web-react/src/components/TextArea/stories/TextArea.tsx
+++ b/packages/web-react/src/components/TextArea/stories/TextArea.tsx
@@ -11,7 +11,6 @@ const Story: ComponentStory<typeof TextArea> = (args: SpiritTextAreaProps) => <T
 
 Story.args = {
   id: 'textarea-example',
-  label: 'Label',
 };
 
 export default Story;

--- a/packages/web-react/src/components/TextArea/stories/argTypes.ts
+++ b/packages/web-react/src/components/TextArea/stories/argTypes.ts
@@ -1,0 +1,65 @@
+import { ValidationStates } from '../../../constants';
+
+export default {
+  validationState: {
+    control: {
+      type: 'select',
+      options: [...Object.values(ValidationStates), undefined],
+    },
+    defaultValue: undefined,
+  },
+  isDisabled: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  isRequired: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  isLabelHidden: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  isFluid: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  label: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: 'Field label',
+  },
+  name: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: 'example',
+  },
+  for: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: '',
+  },
+  message: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: '',
+  },
+  helperText: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: '',
+  },
+};

--- a/packages/web-react/src/components/TextField/TextField.stories.ts
+++ b/packages/web-react/src/components/TextField/TextField.stories.ts
@@ -1,4 +1,5 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import TextField from './TextField';
 
 export default {
@@ -11,6 +12,7 @@ export default {
       },
     },
   },
+  argTypes,
 } as ComponentMeta<typeof TextField>;
 
 export { default as TextField } from './stories/TextField';

--- a/packages/web-react/src/components/TextField/stories/TextField.tsx
+++ b/packages/web-react/src/components/TextField/stories/TextField.tsx
@@ -11,7 +11,6 @@ const Story: ComponentStory<typeof TextField> = (args: SpiritTextFieldProps) => 
 
 Story.args = {
   id: 'textfield-example',
-  label: 'Label',
 };
 
 export default Story;

--- a/packages/web-react/src/components/TextField/stories/argTypes.ts
+++ b/packages/web-react/src/components/TextField/stories/argTypes.ts
@@ -1,0 +1,78 @@
+import { ValidationStates } from '../../../constants';
+
+export default {
+  validationState: {
+    control: {
+      type: 'select',
+      options: [...Object.values(ValidationStates), undefined],
+    },
+    defaultValue: undefined,
+  },
+  type: {
+    control: {
+      type: 'select',
+      options: ['email', 'number', 'password', 'search', 'tel', 'text', 'url'],
+    },
+    defaultValue: 'text',
+  },
+  isDisabled: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  isRequired: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  isLabelHidden: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  isFluid: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  hasPasswordToggle: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  label: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: 'Field label',
+  },
+  name: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: 'example',
+  },
+  for: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: '',
+  },
+  message: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: '',
+  },
+  helperText: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: '',
+  },
+};

--- a/packages/web-react/src/components/Tooltip/Tooltip.stories.ts
+++ b/packages/web-react/src/components/Tooltip/Tooltip.stories.ts
@@ -1,9 +1,11 @@
 import { ComponentMeta } from '@storybook/react';
+import argTypes from './stories/argTypes';
 import Tooltip from './Tooltip';
 
 export default {
   title: 'Components/Tooltip',
   component: Tooltip,
+  argTypes,
 } as ComponentMeta<typeof Tooltip>;
 
 export { default as Tooltip } from './stories/Tooltip';

--- a/packages/web-react/src/components/Tooltip/stories/Tooltip.tsx
+++ b/packages/web-react/src/components/Tooltip/stories/Tooltip.tsx
@@ -6,8 +6,8 @@ import Tooltip from '../Tooltip';
 import TooltipWrapper from '../TooltipWrapper';
 import { Button } from '../../Button';
 
-const Story: ComponentStory<typeof Tooltip> = () => (
-  <TooltipWrapper UNSAFE_className="d-inline-block">
+const Story: ComponentStory<typeof Tooltip> = (args) => (
+  <TooltipWrapper UNSAFE_className="d-inline-block" {...args}>
     <Button UNSAFE_className="TooltipTarget">Tooltip on bottom</Button>
     <Tooltip>Hello there!</Tooltip>
   </TooltipWrapper>

--- a/packages/web-react/src/components/Tooltip/stories/Tooltip.tsx
+++ b/packages/web-react/src/components/Tooltip/stories/Tooltip.tsx
@@ -13,6 +13,4 @@ const Story: ComponentStory<typeof Tooltip> = (args) => (
   </TooltipWrapper>
 );
 
-Story.args = {};
-
 export default Story;

--- a/packages/web-react/src/components/Tooltip/stories/argTypes.ts
+++ b/packages/web-react/src/components/Tooltip/stories/argTypes.ts
@@ -1,0 +1,27 @@
+export default {
+  placement: {
+    control: {
+      type: 'select',
+      options: ['top', 'right', 'bottom', 'left', 'off'],
+    },
+    defaultValue: 'bottom',
+  },
+  isDismissible: {
+    control: {
+      type: 'boolean',
+    },
+    defaultValue: false,
+  },
+  label: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: '',
+  },
+  closeLabel: {
+    control: {
+      type: 'text',
+    },
+    defaultValue: 'Close',
+  },
+};

--- a/packages/web-react/src/types/radioField.ts
+++ b/packages/web-react/src/types/radioField.ts
@@ -17,7 +17,7 @@ export interface RadioFieldProps
     ItemProps,
     HelperTextProps,
     InputBaseProps,
-    Validation {
+    Omit<Validation, 'isRequired'> {
   /** Whether the checkbox is checked */
   isChecked?: boolean;
   /** Text of control label */

--- a/packages/web-react/src/types/tag.ts
+++ b/packages/web-react/src/types/tag.ts
@@ -4,7 +4,7 @@ import { ChildrenProps, EmotionColorsDictionaryType, SizesDictionaryType, StyleP
 /* @deprecated: 'default' value will be removed in the next major version. */
 export type TagColor<C> = EmotionColorsDictionaryType | 'default' | 'neutral' | C;
 
-export type TagSize<S> = SizesDictionaryType | EmotionColorsDictionaryType | S;
+export type TagSize<S> = SizesDictionaryType | S;
 
 /** @deprecated Will be removed in next major version */
 export type TagTheme = 'light' | 'dark';


### PR DESCRIPTION
# Controllable stories states and values ​​according to dictionaries [DS-622](https://jira.lmc.cz/browse/DS-622)

## ✅ What was done:
* Argument types for controllable stories:
   * Alert
   * Breadcrumbs
   * Button
   * CheckboxField
   * RadioField
   * TextArea
   * TextField
   * HeaderModern
   * Heading
   * Link
   * Pill
   * Text
   * Tag
   * Tooltip
   * Dropdown
   * Icon
* Minor fixes for:
   * RadioField 🐞 we don't need `isRequired` in props
   * Tag 🐞 mixing size props with color props
   
 ## NOTICE:
CheckboxField indeterminate state is not working. Will be done in [next issue](https://jira.lmc.cz/browse/DS-644)
 