### PR TITLE
Fix(web-twig): Escape value attributes in input components

### DIFF
--- a/packages/web-twig/src/Resources/components/CheckboxField/CheckboxField.twig
+++ b/packages/web-twig/src/Resources/components/CheckboxField/CheckboxField.twig
@@ -31,7 +31,7 @@
 {%- set _checkedAttr = _isChecked ? 'checked' : null -%}
 {%- set _disabledAttr = _isDisabled ? 'disabled' : null -%}
 {%- set _requiredAttr = _isRequired ? 'required' : null -%}
-{%- set _valueAttr = _value ? 'value="' ~ _value ~'"' : null -%}
+{%- set _valueAttr = _value ? 'value=' ~ _value : null -%}
 
 {# Miscellaneous #}
 {%- set _classNames = [ _rootClassName, _rootDisabledClassName, _rootItemClassName, _rootValidationStateClassName, _class ] -%}
@@ -53,7 +53,7 @@
         {{ _checkedAttr | raw }}
         {{ _disabledAttr | raw }}
         {{ _requiredAttr | raw }}
-        {{ _valueAttr | raw }}
+        {{ _valueAttr }}
     />
     <span class="{{ _textClassName }}">
         <span {{ classProp(_labelClassName) }}>{{ _label | raw }}</span>

--- a/packages/web-twig/src/Resources/components/RadioField/RadioField.twig
+++ b/packages/web-twig/src/Resources/components/RadioField/RadioField.twig
@@ -25,7 +25,7 @@
 {# Attributes #}
 {%- set _checkedAttr = _isChecked ? 'checked' : null -%}
 {%- set _disabledAttr = _isDisabled ? 'disabled' : null -%}
-{%- set _valueAttr = _value ? 'value="' ~ _value ~'"' : null -%}
+{%- set _valueAttr = _value ? 'value=' ~ _value : null -%}
 {%- set _idAttr = _id ? 'id="' ~ _id ~'"' : null -%}
 {%- set _labelForAttr = _id ? 'for="' ~ _id ~'"' : null -%}
 
@@ -43,7 +43,7 @@
         {{ _idAttr | raw }}
         {{ _checkedAttr | raw }}
         {{ _disabledAttr | raw }}
-        {{ _valueAttr | raw }}
+        {{ _valueAttr }}
     />
     <span class="{{ _textClassName }}">
         <span {{ classProp(_labelClassName) }}>{{ _label | raw }}</span>

--- a/packages/web-twig/src/Resources/components/TextFieldBase/TextFieldBase.twig
+++ b/packages/web-twig/src/Resources/components/TextFieldBase/TextFieldBase.twig
@@ -44,7 +44,7 @@
 {%- set _disabledAttr = _isDisabled ? 'disabled' : null -%}
 {%- set _placeholderAttr = _placeholder ? 'placeholder="' ~ _placeholder ~'"' : null -%}
 {%- set _requiredAttr = _isRequired ? 'required' : null -%}
-{%- set _valueAttr = _value ? 'value="' ~ _value ~'"' : null -%}
+{%- set _valueAttr = _value ? 'value=' ~ _value : null -%}
 
 {# Extended Attributes for TextArea #}
 {%- set _rowsAttr = _rows ? 'rows="' ~ _rows ~ '"' : null -%}
@@ -81,7 +81,7 @@
             {{ _disabledAttr | raw }}
             {{ _requiredAttr | raw }}
         >
-            {{ _value | raw }}
+            {{ _value }}
         </textarea>
     {% else %}
         {% if _hasPasswordToggle %}
@@ -125,7 +125,7 @@
                 {{ _inputWidthAttr | raw }}
                 {{ _placeholderAttr | raw }}
                 {{ _requiredAttr | raw }}
-                {{ _valueAttr | raw }}
+                {{ _valueAttr }}
             />
         {% endif %}
     {% endif %}


### PR DESCRIPTION
refs: #DS-645