### PR TITLE
Feat(web-react): Extension and modification of Button and ButtonLink

### DIFF
--- a/packages/web-react/src/components/Button/Button.stories.ts
+++ b/packages/web-react/src/components/Button/Button.stories.ts
@@ -12,7 +12,16 @@ export default {
       },
     },
   },
-  argTypes,
+  argTypes: {
+    ...argTypes,
+    type: {
+      control: {
+        type: 'select',
+        options: ['button', 'submit', 'reset'],
+      },
+      defaultValue: 'button',
+    },
+  },
 } as ComponentMeta<typeof Button>;
 
 export { default as Button } from './stories/Button';

--- a/packages/web-react/src/components/Button/Button.tsx
+++ b/packages/web-react/src/components/Button/Button.tsx
@@ -2,42 +2,42 @@ import React, { ElementType, ForwardedRef, forwardRef } from 'react';
 import classNames from 'classnames';
 import { useStyleProps } from '../../hooks';
 import { SpiritButtonProps } from '../../types';
-import { useButtonAriaProps } from './useButtonAriaProps';
 import { useButtonStyleProps } from './useButtonStyleProps';
+import { useButtonAriaProps } from './useButtonAriaProps';
 
 const defaultProps = {
   color: 'primary',
-  type: 'button',
   isBlock: false,
   isDisabled: false,
   isSquare: false,
-  elementType: 'button',
   size: 'medium',
+  type: 'button',
 };
 
-export const Button = forwardRef<HTMLButtonElement, SpiritButtonProps>(
-  <T extends ElementType = 'button', C = void, S = void>(
-    props: SpiritButtonProps<T, C, S>,
-    ref: ForwardedRef<HTMLButtonElement>,
-  ): JSX.Element => {
-    const { elementType: ElementTag = 'button', children, ...restProps } = props;
-    const { buttonProps } = useButtonAriaProps(props);
-    const { classProps, props: modifiedProps } = useButtonStyleProps(restProps);
-    const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
+/* We need an exception for components exported with forwardRef */
+/* eslint no-underscore-dangle: ['error', { allow: ['_Button'] }] */
+const _Button = <T extends ElementType = 'button', C = void, S = void>(
+  props: SpiritButtonProps<T, C, S>,
+  ref: ForwardedRef<HTMLButtonElement>,
+) => {
+  const { elementType: ElementTag = 'button', ...restProps } = props;
 
-    return (
-      <ElementTag
-        {...otherProps}
-        {...styleProps}
-        {...buttonProps}
-        ref={ref}
-        className={classNames(classProps, styleProps.className)}
-      >
-        {children}
-      </ElementTag>
-    );
-  },
-);
+  const { buttonProps } = useButtonAriaProps(restProps);
+  const { classProps, props: modifiedProps } = useButtonStyleProps(restProps);
+  const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
+
+  return (
+    <ElementTag
+      {...otherProps}
+      {...buttonProps}
+      ref={ref}
+      className={classNames(classProps, styleProps.className)}
+      style={styleProps.style}
+    />
+  );
+};
+
+export const Button = forwardRef<HTMLButtonElement, SpiritButtonProps<ElementType>>(_Button);
 
 Button.defaultProps = defaultProps;
 

--- a/packages/web-react/src/components/Button/ButtonLink.tsx
+++ b/packages/web-react/src/components/Button/ButtonLink.tsx
@@ -2,42 +2,41 @@ import React, { ElementType, ForwardedRef, forwardRef } from 'react';
 import classNames from 'classnames';
 import { useStyleProps } from '../../hooks';
 import { SpiritButtonLinkProps } from '../../types';
-import { useButtonAriaProps } from './useButtonAriaProps';
 import { useButtonStyleProps } from './useButtonStyleProps';
+import { useButtonLinkAriaProps } from './useButtonAriaProps';
 
 const defaultProps = {
   color: 'primary',
-  href: '#',
   isBlock: false,
   isDisabled: false,
   isSquare: false,
-  elementType: 'a',
   size: 'medium',
 };
 
-export const ButtonLink = forwardRef<HTMLAnchorElement, SpiritButtonLinkProps>(
-  <T extends ElementType = 'a', C = void, S = void>(
-    props: SpiritButtonLinkProps<T, C, S>,
-    ref: ForwardedRef<HTMLAnchorElement>,
-  ): JSX.Element => {
-    const { elementType: ElementTag = 'a', children, ...restProps } = props;
-    const { buttonProps } = useButtonAriaProps(props);
-    const { classProps, props: modifiedProps } = useButtonStyleProps(restProps);
-    const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
+/* We need an exception for components exported with forwardRef */
+/* eslint no-underscore-dangle: ['error', { allow: ['_ButtonLink'] }] */
+const _ButtonLink = <T extends ElementType = 'a', C = void, S = void>(
+  props: SpiritButtonLinkProps<T, C, S>,
+  ref: ForwardedRef<HTMLAnchorElement>,
+) => {
+  const { elementType: ElementTag = 'a', ...restProps } = props;
 
-    return (
-      <ElementTag
-        {...otherProps}
-        {...styleProps}
-        {...buttonProps}
-        ref={ref}
-        className={classNames(classProps, styleProps.className)}
-      >
-        {children}
-      </ElementTag>
-    );
-  },
-);
+  const { buttonLinkProps } = useButtonLinkAriaProps(restProps);
+  const { classProps, props: modifiedProps } = useButtonStyleProps(restProps);
+  const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
+
+  return (
+    <ElementTag
+      {...otherProps}
+      {...buttonLinkProps}
+      ref={ref}
+      className={classNames(classProps, styleProps.className)}
+      style={styleProps.style}
+    />
+  );
+};
+
+export const ButtonLink = forwardRef<HTMLAnchorElement, SpiritButtonLinkProps<ElementType>>(_ButtonLink);
 
 ButtonLink.defaultProps = defaultProps;
 

--- a/packages/web-react/src/components/Button/README.md
+++ b/packages/web-react/src/components/Button/README.md
@@ -21,22 +21,36 @@ import { Button } from '@lmc-eu/spirit-web-react';
   <Button color="danger">Click me</Button>
 ```
 
+### Example usage with third-party component
+
+So if you use a third-party component, the Button will take on all of its proper attributes.
+
+```jsx
+import { RouterLink } from 'react-router-dom';
+
+<Button elementType={RouterLink} to="/">
+  Link to home
+</Button>;
+```
+
 ### Available props
 
-| Prop name    | Type                                                                                      | Default   | Required | Description                                          |
-| ------------ | ----------------------------------------------------------------------------------------- | --------- | -------- | ---------------------------------------------------- |
-| `children`   | `ReactNode`                                                                               | `null`    | no       | Content of the Button                                |
-| `color`      | [Action Color dictionary][dictionary-color], [Emotion Color dictionary][dictionary-color] | `primary` | no       | Color variant                                        |
-| `isBlock`    | `bool`                                                                                    | `false`   | no       | Span the element to the full width of its parent     |
-| `isDisabled` | `bool`                                                                                    | `false`   | no       | If true, Button is disabled                          |
-| `isSquare`   | `bool`                                                                                    | `false`   | no       | If true, Button is square, usually only with an icon |
-| `name`       | `string`                                                                                  | -         | no       | For use a button as a form data reference            |
-| `onClick`    | `string`                                                                                  | `null`    | no       | JS function to call on click                         |
-| `ref`        | `ForwardedRef<HTMLButtonElement>`                                                         | -         | no       | Button element reference                             |
-| `size`       | [Size dictionary][dictionary-size]                                                        | `medium`  | no       | Size variant                                         |
-| `type`       | `string`                                                                                  | `button`  | no       | Type of the Button                                   |
+| Prop name     | Type                                                                                      | Default    | Required | Description                                          |
+| ------------- | ----------------------------------------------------------------------------------------- | ---------- | -------- | ---------------------------------------------------- |
+| `children`    | `ReactNode`                                                                               | `null`     | no       | Content of the Button                                |
+| `color`       | [Action Color dictionary][dictionary-color], [Emotion Color dictionary][dictionary-color] | `primary`  | no       | Color variant                                        |
+| `elementType` | `ElementType`                                                                             | `'button'` | no       | Type of element                                      |
+| `isBlock`     | `bool`                                                                                    | `false`    | no       | Span the element to the full width of its parent     |
+| `isDisabled`  | `bool`                                                                                    | `false`    | no       | If true, Button is disabled                          |
+| `isSquare`    | `bool`                                                                                    | `false`    | no       | If true, Button is square, usually only with an icon |
+| `name`        | `string`                                                                                  | -          | no       | For use a button as a form data reference            |
+| `onClick`     | `string`                                                                                  | `null`     | no       | JS function to call on click                         |
+| `ref`         | `ForwardedRef<HTMLButtonElement>`                                                         | -          | no       | Button element reference                             |
+| `size`        | [Size dictionary][dictionary-size]                                                        | `medium`   | no       | Size variant                                         |
+| `type`        | `string`                                                                                  | `button`   | no       | Type of the Button                                   |
 
-For more information see [Button] component.
+For more information see [Button] component. Button also contain all the appropriate
+attributes according to the type of element. The default element type for Button is `<button>`.
 
 ## ButtonLink
 
@@ -59,20 +73,22 @@ import { ButtonLink } from '@lmc-eu/spirit-web-react';
 
 ### Available props
 
-| Prop name    | Type                                                                                      | Default   | Required | Description                                              |
-| ------------ | ----------------------------------------------------------------------------------------- | --------- | -------- | -------------------------------------------------------- |
-| `children`   | `ReactNode`                                                                               | `null`    | no       | Content of the ButtonLink                                |
-| `color`      | [Action Color dictionary][dictionary-color], [Emotion Color dictionary][dictionary-color] | `primary` | no       | Color variant                                            |
-| `href`       | `string`                                                                                  | —         | yes      | Link URL                                                 |
-| `isBlock`    | `bool`                                                                                    | `false`   | no       | Span the element to the full width of its parent         |
-| `isDisabled` | `bool`                                                                                    | `false`   | no       | If true, ButtonLink is disabled                          |
-| `isSquare`   | `bool`                                                                                    | `false`   | no       | If true, ButtonLink is square, usually only with an icon |
-| `onClick`    | `string`                                                                                  | `null`    | no       | JS function to call on click                             |
-| `ref`        | `ForwardedRef<HTMLAnchorElement>`                                                         | -         | no       | Anchor element reference                                 |
-| `size`       | [Size dictionary][dictionary-size]                                                        | `medium`  | no       | Size variant                                             |
-| `target`     | `string`                                                                                  | `null`    | no       | Link target                                              |
+| Prop name     | Type                                                                                      | Default   | Required | Description                                              |
+| ------------- | ----------------------------------------------------------------------------------------- | --------- | -------- | -------------------------------------------------------- |
+| `children`    | `ReactNode`                                                                               | `null`    | no       | Content of the ButtonLink                                |
+| `color`       | [Action Color dictionary][dictionary-color], [Emotion Color dictionary][dictionary-color] | `primary` | no       | Color variant                                            |
+| `elementType` | `ElementType`                                                                             | `'a'`     | no       | Type of element                                          |
+| `href`        | `string`                                                                                  | —         | yes      | Link URL                                                 |
+| `isBlock`     | `bool`                                                                                    | `false`   | no       | Span the element to the full width of its parent         |
+| `isDisabled`  | `bool`                                                                                    | `false`   | no       | If true, ButtonLink is disabled                          |
+| `isSquare`    | `bool`                                                                                    | `false`   | no       | If true, ButtonLink is square, usually only with an icon |
+| `onClick`     | `string`                                                                                  | `null`    | no       | JS function to call on click                             |
+| `ref`         | `ForwardedRef<HTMLAnchorElement>`                                                         | -         | no       | Anchor element reference                                 |
+| `size`        | [Size dictionary][dictionary-size]                                                        | `medium`  | no       | Size variant                                             |
+| `target`      | `string`                                                                                  | `null`    | no       | Link target                                              |
 
-For more information see [Button] component.
+For more information see [Button] component. ButtonLink also contain all the appropriate
+attributes according to the type of element. The default element type for ButtonLink is `<a>`.
 
 [button]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web/src/scss/components/Button
 [dictionary-color]: https://github.com/lmc-eu/spirit-design-system/tree/main/docs/DICTIONARIES.md#color

--- a/packages/web-react/src/components/Button/stories/Button.tsx
+++ b/packages/web-react/src/components/Button/stories/Button.tsx
@@ -3,7 +3,7 @@ import { ComponentStory } from '@storybook/react';
 import Button from '../Button';
 import { SpiritButtonProps } from '../../../types';
 
-const Story: ComponentStory<typeof Button> = <T extends ElementType = 'div', C = void, S = void>(
+const Story: ComponentStory<typeof Button> = <T extends ElementType = 'button', C = void, S = void>(
   args: SpiritButtonProps<T, C, S>,
 ) => <Button {...args} />;
 

--- a/packages/web-react/src/components/Button/stories/ButtonLink.tsx
+++ b/packages/web-react/src/components/Button/stories/ButtonLink.tsx
@@ -3,7 +3,7 @@ import { ComponentStory } from '@storybook/react';
 import ButtonLink from '../ButtonLink';
 import { SpiritButtonLinkProps } from '../../../types';
 
-const Story: ComponentStory<typeof ButtonLink> = <T extends ElementType = 'div', C = void, S = void>(
+const Story: ComponentStory<typeof ButtonLink> = <T extends ElementType = 'a', C = void, S = void>(
   args: SpiritButtonLinkProps<T, C, S>,
 ) => <ButtonLink {...args} />;
 

--- a/packages/web-react/src/components/Button/stories/ButtonLinkHtml.tsx
+++ b/packages/web-react/src/components/Button/stories/ButtonLinkHtml.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Html from '../../../../docs/stories/Html';
 
-const Story = () => <Html storyId="buttonLink" groupId="components" />;
+const Story = () => <Html storyId="button-link" groupId="components" />;
 
 export default Story;

--- a/packages/web-react/src/components/Button/stories/ButtonLinkProps.tsx
+++ b/packages/web-react/src/components/Button/stories/ButtonLinkProps.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ButtonLink } from '../ButtonLink';
+import ButtonLink from '../ButtonLink';
 import Props from '../../../../docs/stories/Props';
 
 const Story = () => <Props component={ButtonLink} />;

--- a/packages/web-react/src/components/Button/stories/ButtonProps.tsx
+++ b/packages/web-react/src/components/Button/stories/ButtonProps.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '../Button';
+import Button from '../Button';
 import Props from '../../../../docs/stories/Props';
 
 const Story = () => <Props component={Button} />;

--- a/packages/web-react/src/components/Button/stories/argTypes.ts
+++ b/packages/web-react/src/components/Button/stories/argTypes.ts
@@ -26,13 +26,6 @@ export default {
     },
     defaultValue: false,
   },
-  type: {
-    control: {
-      type: 'select',
-      options: ['button', 'submit', 'reset'],
-    },
-    defaultValue: 'button',
-  },
   size: {
     control: {
       type: 'select',

--- a/packages/web-react/src/components/Button/useButtonAriaProps.ts
+++ b/packages/web-react/src/components/Button/useButtonAriaProps.ts
@@ -1,60 +1,60 @@
-import { AnchorHTMLAttributes, ButtonHTMLAttributes, ElementType, HTMLAttributes } from 'react';
-import { ClickEvent, AriaButtonProps } from '../../types';
+import { ClickEvent, SpiritButtonProps, SpiritButtonLinkProps } from '../../types';
 
-export interface ButtonAria<T> {
-  /** Props for the button element. */
-  buttonProps: T;
-}
+const handleClick = (event: ClickEvent, isDisabled?: boolean, onClick?: (event: ClickEvent) => void) => {
+  if (isDisabled) {
+    event.preventDefault();
 
-export function useButtonAriaProps<C = void, S = void>(
-  props: AriaButtonProps<'a', C, S>,
-): ButtonAria<AnchorHTMLAttributes<HTMLAnchorElement>>;
-export function useButtonAriaProps<C = void, S = void>(
-  props: AriaButtonProps<'button', C, S>,
-): ButtonAria<ButtonHTMLAttributes<HTMLButtonElement>>;
-export function useButtonAriaProps<C = void, S = void>(
-  props: AriaButtonProps<ElementType, C, S>,
-): ButtonAria<HTMLAttributes<HTMLElement>>;
-
-export function useButtonAriaProps<C = void, S = void>(
-  props: AriaButtonProps<ElementType, C, S>,
-): ButtonAria<HTMLAttributes<unknown>> {
-  const { elementType = 'button', isDisabled, onClick, href, target, rel, type = 'button', ariaLabel } = props;
-
-  let additionalProps;
-  if (elementType === 'button') {
-    additionalProps = {
-      type,
-      disabled: isDisabled,
-    };
-  } else {
-    additionalProps = {
-      role: 'button',
-      href: elementType === 'a' && isDisabled ? undefined : href,
-      target: elementType === 'a' ? target : undefined,
-      type: elementType === 'a' && type === 'button' ? undefined : type,
-      disabled: isDisabled,
-      rel: elementType === 'a' ? rel : undefined,
-    };
+    return;
   }
 
-  const handleClick = (event: ClickEvent) => {
-    if (isDisabled) {
-      event.preventDefault();
+  if (onClick) {
+    onClick(event);
+  }
+};
 
-      return;
-    }
+export type UseButtonAriaProps = Partial<SpiritButtonProps>;
+export type UseButtonAriaReturn = {
+  buttonProps: UseButtonAriaProps;
+};
 
-    if (onClick) {
-      onClick(event);
-    }
+export const useButtonAriaProps = (props: UseButtonAriaProps): UseButtonAriaReturn => {
+  const { isDisabled, onClick, type = 'button', ariaLabel } = props;
+
+  const additionalProps = {
+    type,
+    disabled: isDisabled,
   };
 
   return {
     buttonProps: {
       ...additionalProps,
-      onClick: handleClick,
+      onClick: (event) => handleClick(event, isDisabled, onClick),
       'aria-label': ariaLabel || undefined,
     },
   };
-}
+};
+
+export type UseButtonLinkAriaProps = Partial<SpiritButtonLinkProps>;
+export type UseButtonLinkAriaReturn = {
+  buttonLinkProps: UseButtonLinkAriaProps;
+};
+
+export const useButtonLinkAriaProps = (props: UseButtonLinkAriaProps): UseButtonLinkAriaReturn => {
+  const { elementType, isDisabled, onClick, href, target, rel, ariaLabel } = props;
+
+  const additionalProps = {
+    role: 'button',
+    href: elementType === 'a' && isDisabled ? undefined : href,
+    target: elementType === 'a' ? target : undefined,
+    disabled: isDisabled,
+    rel: elementType === 'a' ? rel : undefined,
+  };
+
+  return {
+    buttonLinkProps: {
+      ...additionalProps,
+      onClick: (event) => handleClick(event, isDisabled, onClick),
+      'aria-label': ariaLabel || undefined,
+    },
+  };
+};

--- a/packages/web-react/src/components/Button/useButtonStyleProps.ts
+++ b/packages/web-react/src/components/Button/useButtonStyleProps.ts
@@ -2,7 +2,7 @@ import { ElementType } from 'react';
 import classNames from 'classnames';
 import { compose } from '../../utils/compose';
 import { applyColor, applySize } from '../../utils/classname';
-import { useClassNamePrefix } from '../../hooks/useClassNamePrefix';
+import { useClassNamePrefix } from '../../hooks';
 import { ButtonColor, ButtonSize, SpiritButtonProps } from '../../types';
 
 // `${componentClassName}--${color}`;
@@ -12,16 +12,16 @@ const getButtonColorClassname = <C = void>(className: string, color: ButtonColor
 const getButtonSizeClassname = <S = void>(className: string, size: ButtonSize<S>): string =>
   compose(applySize<ButtonSize<S>>(size))(className);
 
-export interface ButtonStyles<T> {
+export interface ButtonStyles {
   /** className props */
   classProps: string;
   /** Props for the button element */
-  props: T;
+  props: SpiritButtonProps;
 }
 
 export function useButtonStyleProps<T extends ElementType = 'button', C = void, S = void>(
   props: SpiritButtonProps<T, C, S>,
-): ButtonStyles<Omit<SpiritButtonProps<T, C, S>, 'color'>> {
+): ButtonStyles {
   const { color, isBlock, isDisabled, isSquare, size, ...restProps } = props;
 
   const buttonClass = useClassNamePrefix('Button');

--- a/packages/web-react/src/types/button.ts
+++ b/packages/web-react/src/types/button.ts
@@ -1,24 +1,24 @@
-import { ElementType, JSXElementConstructor } from 'react';
+import { ElementType } from 'react';
 import {
   ActionColorsDictionaryType,
   AriaLabelingProps,
   ChildrenProps,
   ClickEvents,
   EmotionColorsDictionaryType,
+  SpiritPolymorphicElementPropsWithRef,
   SizesDictionaryType,
   StyleProps,
-  TransferProps,
 } from './shared';
 
 export type ButtonColor<C> = ActionColorsDictionaryType | EmotionColorsDictionaryType | C;
 export type ButtonSize<S> = SizesDictionaryType | S;
-type ButtonType = 'button' | 'submit' | 'reset';
+export type ButtonType = 'button' | 'submit' | 'reset';
 
-interface ButtonProps<C = void, S = void> extends ChildrenProps, ClickEvents {
-  /** Whether the button is disabled. */
-  isDisabled?: boolean;
+export interface ButtonBaseProps<C = void, S = void> extends ChildrenProps, StyleProps, AriaLabelingProps, ClickEvents {
   /** The color of the button. */
   color?: ButtonColor<C>;
+  /** Whether the button is disabled. */
+  isDisabled?: boolean;
   /** Whether the button should be displayed with a block style. */
   isBlock?: boolean;
   /** Whether the button should be displayed as a square. */
@@ -27,47 +27,32 @@ interface ButtonProps<C = void, S = void> extends ChildrenProps, ClickEvents {
   size?: ButtonSize<S>;
 }
 
-export interface AriaButtonElementTypeProps<T extends ElementType = 'button'> {
+export type ButtonProps<E extends ElementType, C = void, S = void> = {
   /**
    * The HTML element or React element used to render the button, e.g. 'div', 'a', or `RouterLink`.
    *
    * @default 'button'
    */
-  elementType?: T | JSXElementConstructor<unknown>;
-}
-
-export interface LinkButtonProps<T extends ElementType = 'a'> extends AriaButtonElementTypeProps<T> {
-  /** A URL to link to if elementType="a". */
-  href?: string;
-  /** The target window for the link. */
-  target?: string;
-  /** The relationship between the linked resource and the current page. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel). */
-  rel?: string;
-}
-
-interface AriaBaseButtonProps extends AriaLabelingProps {
+  elementType?: E;
   /**
    * The behavior of the button when used in an HTML form.
    *
    * @default 'button'
    */
   type?: ButtonType;
-}
+} & ButtonBaseProps<C, S>;
 
-export interface AriaButtonProps<T extends ElementType = 'button', C = void, S = void>
-  extends ButtonProps<C, S>,
-    LinkButtonProps<T>,
-    AriaBaseButtonProps {}
+export type ButtonLinkProps<E extends ElementType, C = void, S = void> = {
+  /**
+   * The HTML element or React element used to render the button, e.g. 'div', 'a', or `RouterLink`.
+   *
+   * @default 'a'
+   */
+  elementType?: E;
+} & ButtonBaseProps<C, S>;
 
-export interface SpiritButtonProps<T extends ElementType = 'button', C = void, S = void>
-  extends AriaBaseButtonProps,
-    AriaButtonElementTypeProps<T>,
-    ButtonProps<C, S>,
-    StyleProps,
-    TransferProps {
-  // tag?: ElementType;
-}
+export type SpiritButtonProps<E extends ElementType = 'button', C = void, S = void> = ButtonProps<E, C, S> &
+  SpiritPolymorphicElementPropsWithRef<E, ButtonProps<E, C, S>>;
 
-export interface SpiritButtonLinkProps<T extends ElementType = 'a', C = void, S = void>
-  extends SpiritButtonProps<T, C, S>,
-    LinkButtonProps<T> {}
+export type SpiritButtonLinkProps<E extends ElementType = 'a', C = void, S = void> = ButtonLinkProps<E, C, S> &
+  SpiritPolymorphicElementPropsWithRef<E, ButtonLinkProps<E, C, S>>;

--- a/packages/web-react/src/types/shared/element.ts
+++ b/packages/web-react/src/types/shared/element.ts
@@ -1,10 +1,12 @@
-import { DetailedHTMLProps, HTMLAttributes, HTMLProps } from 'react';
+import { ComponentPropsWithRef, DetailedHTMLProps, ElementType, HTMLAttributes, HTMLProps } from 'react';
 import { OverloadStyleProps } from './style';
 
 /** Returns all relevant attributes and their types from a given HTML Element */
 export type SpiritDetailedHTMLProps<E> = DetailedHTMLProps<HTMLAttributes<E>, E>;
 /** Returns all relevant attributes and their types, combined basic and detailed, from a given HTML Element */
 export type SpiritCombinedHTMLProps<E> = DetailedHTMLProps<HTMLAttributes<E>, E> & HTMLProps<E>;
+/** Returns the appropriate elementary props based on the element's polymorphic type and excludes any duplicates from it */
+export type SpiritPolymorphicElementPropsWithRef<E extends ElementType, P> = Omit<ComponentPropsWithRef<E>, keyof P>;
 
 export type SpiritElementBaseProps = SpiritDetailedHTMLProps<HTMLElement>;
 export type SpiritAnchorElementBaseProps = SpiritCombinedHTMLProps<HTMLButtonElement>;


### PR DESCRIPTION
# Extension and modification of Button and ButtonLink [DS-453](https://jira.lmc.cz/browse/DS-453)

## ✅ What was done:
* Thorough redesign and simplification of types for **Button** and **ButtonLink**
* Retaining `forwardRef` and tested with the **Tooltip** component
* **Button** and **ButtonLink** now contain more detailed props from the given element type. This resulted in the `useButtonAriaProps` modification. Because `HTMLAttributes` are already part of `ComponentPropsWithRef`
* Documentation mention of `elementType` and added one example
* Fixed HTML stories for **ButtonLink**
