### PR TITLE
Docs(web-twig): Explain why the `raw` filter is avoided for input `value`

### DIFF
--- a/packages/web-twig/src/Resources/components/CheckboxField/CheckboxField.twig
+++ b/packages/web-twig/src/Resources/components/CheckboxField/CheckboxField.twig
@@ -53,7 +53,7 @@
         {{ _checkedAttr | raw }}
         {{ _disabledAttr | raw }}
         {{ _requiredAttr | raw }}
-        {{ _valueAttr }}
+        {{ _valueAttr }} {# Intentionally without `raw` to prevent XSS. #}
     />
     <span class="{{ _textClassName }}">
         <span {{ classProp(_labelClassName) }}>{{ _label | raw }}</span>

--- a/packages/web-twig/src/Resources/components/RadioField/RadioField.twig
+++ b/packages/web-twig/src/Resources/components/RadioField/RadioField.twig
@@ -43,7 +43,7 @@
         {{ _idAttr | raw }}
         {{ _checkedAttr | raw }}
         {{ _disabledAttr | raw }}
-        {{ _valueAttr }}
+        {{ _valueAttr }} {# Intentionally without `raw` to prevent XSS. #}
     />
     <span class="{{ _textClassName }}">
         <span {{ classProp(_labelClassName) }}>{{ _label | raw }}</span>

--- a/packages/web-twig/src/Resources/components/TextFieldBase/TextFieldBase.twig
+++ b/packages/web-twig/src/Resources/components/TextFieldBase/TextFieldBase.twig
@@ -81,7 +81,7 @@
             {{ _disabledAttr | raw }}
             {{ _requiredAttr | raw }}
         >
-            {{ _value }}
+            {{ _value }} {# Intentionally without `raw` to prevent XSS. #}
         </textarea>
     {% else %}
         {% if _hasPasswordToggle %}
@@ -125,7 +125,7 @@
                 {{ _inputWidthAttr | raw }}
                 {{ _placeholderAttr | raw }}
                 {{ _requiredAttr | raw }}
-                {{ _valueAttr }}
+                {{ _valueAttr }} {# Intentionally without `raw` to prevent XSS. #}
             />
         {% endif %}
     {% endif %}


### PR DESCRIPTION
This is a followup of #744.