### PR TITLE
Unescaped props in Twig docs

### DIFF
--- a/packages/web-twig/CONTRIBUTING.md
+++ b/packages/web-twig/CONTRIBUTING.md
@@ -44,6 +44,8 @@ This is an example of a typical file structure of a component:
 {% set _privateAttr = (props.attr is defined) ? pros.attr : '' %}
 ```
 
+### Boolean Props
+
 🚨 Do not use `default(true)` filter for setting default value of the prop to `true`.
 This will lead to unexpected behavior.
 The `false` value is never passed and is treated as empty/null, so the prop will be `true` every time.
@@ -61,6 +63,16 @@ Instead use:
 ```
 
 See [default filter does not work issue](https://github.com/twigphp/Twig/issues/769) and [Twig default filter documentation](https://twig.symfony.com/doc/2.x/filters/default.html) for more information
+
+### Unescaped Props
+
+🚨 All props that uses [raw](https://twig.symfony.com/doc/3.x/filters/raw.html) filter must be prefixed with `UNSAFE_`.
+These props are unescaped.
+For example we used this prefix for props that can accept HTML string.
+
+```twig
+<CheckboxField UNSAFE_helperText="<strong>Help!</strong>" />
+```
 
 ### Example of component definition
 

--- a/packages/web-twig/CONTRIBUTING.md
+++ b/packages/web-twig/CONTRIBUTING.md
@@ -21,6 +21,8 @@ This is an example of a typical file structure of a component:
     └── Resources
         └── components
             └── <ComponentName>
+                ├── stories - Component stories
+                ├── <ComponentName>.stories.twig - Template rendered in demo app
                 ├── <ComponentName>.twig — Twig component
                 └── README.md — documentation of the component
 ```

--- a/packages/web-twig/README.md
+++ b/packages/web-twig/README.md
@@ -60,43 +60,7 @@ spirit_web_twig:
 
 ## Usage
 
-Now you can use Twig components with JSX-like syntax in your Symfony project. You only need to remember that, unlike in HTML, component tags must always start with a capital letter:
-
-```html
-<ComponentName attr="value">Some other content</ComponentName>
-...
-<ComponentName attr="value" />
-```
-
-You can pass attributes like this:
-
-```html
-<ComponentName
-  :any="'any' ~ 'prop'" // this return as "any" prop with value "anyprop"
-  other="{{'this' ~ 'works' ~ 'too'}}"
-  anotherProp="or this still work"
-  not-this="{{'this' ~ 'does'}}{{ 'not work' }}" // this returns syntax as plain text but prop with dash work
-  ifCondition="{{ variable == 'success' ? 'true' : 'false' }}"  // condition can only be written via the ternary operator
-  jsXCondition={ variable == 'success' ? 'true' : 'false' }  // condition can only be written via the ternary operator
-  numberValue={11}  // if value is number 11
-  isOpen  // if value is not defined, it is set to true
-  isBoolean={false}  // if value is false
->
-Submit
-</ComponentName>
-```
-
-or pure original implementation
-
-```twig
-{% embed "@spirit/componentName.twig" with { props: {
-    attr: 'value'
-}} %}
-    {% block content %}
-        Some other content
-    {% endblock %}
-{% endembed %}
-```
+For detailed usage see [TwigX bundle](https://github.com/lmc-eu/twigx-bundle/blob/main/README.md#usage)
 
 ### Unescaped Props
 
@@ -109,29 +73,7 @@ This is considered a way how you can pass down HTML strings.
 
 # Spirit Components
 
-- [Alert](./src/Resources/components/Alert/README.md)
-- [Breadcrumbs](./src/Resources/components/Breadcrumbs/README.md)
-- [Button](./src/Resources/components/Button/README.md)
-- [ButtonLink](./src/Resources/components/ButtonLink/README.md)
-- [CheckboxField](./src/Resources/components/CheckboxField/README.md)
-- [Collapse](./src/Resources/components/Collapse/README.md)
-- [Container](./src/Resources/components/Container/README.md)
-- [Dropdown](./src/Resources/components/Dropdown/README.md)
-- [Grid](./src/Resources/components/Grid/README.md)
-- [Header](./src/Resources/components/Header/README.md)
-- [Heading](./src/Resources/components/Heading/README.md)
-- [Icon](./src/Resources/components/Icon/README.md)
-- [Link](./src/Resources/components/Link/README.md)
-- [Modal](./src/Resources/components/Modal/README.md)
-- [Pill](./src/Resources/components/Pill/README.md)
-- [RadioField](./src/Resources/components/RadioField/README.md)
-- [Stack](./src/Resources/components/Stack/README.md)
-- [Tabs](./src/Resources/components/Tabs/README.md)
-- [Tag](./src/Resources/components/Tag/README.md)
-- [Text](./src/Resources/components/Text/README.md)
-- [TextField](./src/Resources/components/TextField/README.md)
-- [TextFieldBase](./src/Resources/components/TextFieldBase/README.md)
-- [Tooltip](./src/Resources/components/Tooltip/README.md)
+For available components see the [components directory](https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web-twig/src/Resources/components).
 
 if you want to extend these components, an example guide is [here](./docs/extendComponents.md).
 if you want to contribute, read the guide [here](./CONTRIBUTING.md).

--- a/packages/web-twig/README.md
+++ b/packages/web-twig/README.md
@@ -98,6 +98,15 @@ or pure original implementation
 {% endembed %}
 ```
 
+### Unescaped Props
+
+All props that internally uses the [raw](https://twig.symfony.com/doc/3.x/filters/raw.html) filter are prefixed with `UNSAFE_`.
+This is considered a way how you can pass down HTML strings.
+
+```twig
+<CheckboxField UNSAFE_helperText="<strong>Help!</strong>" />
+```
+
 # Spirit Components
 
 - [Alert](./src/Resources/components/Alert/README.md)


### PR DESCRIPTION
Also, make the documentation a little bit maintainable.