### PR TITLE
Feat(web): Introduce `ScrollView` component #DS-449

### DIFF
--- a/packages/web/src/js/ScrollView.ts
+++ b/packages/web/src/js/ScrollView.ts
@@ -1,0 +1,139 @@
+// The `ScrollView` component is currently untested. This is because it is not possible to test it in a headless
+// environment (tests fail on `getBoundingClientRect` that we need to mock somehow).
+
+import BaseComponent from './BaseComponent';
+import { EventHandler, SelectorEngine } from './dom';
+import { debounce, enableToggleAutoloader } from './utils';
+
+export const Alignment = {
+  LEFT: 'left',
+  RIGHT: 'right',
+  TOP: 'top',
+  BOTTOM: 'bottom',
+} as const;
+
+export type AlignmentKeys = keyof typeof Alignment;
+export type AlignmentType = (typeof Alignment)[AlignmentKeys];
+
+export const Direction = {
+  HORIZONTAL: 'horizontal',
+  VERTICAL: 'vertical',
+} as const;
+
+export type DirectionKeys = keyof typeof Direction;
+export type DirectionType = (typeof Direction)[DirectionKeys];
+
+type CurrentPosition = {
+  [key in AlignmentType]: number;
+};
+
+const NAME = 'scrollView';
+const DEBOUNCE_DELAY_MS = 50;
+const DEFAULT_DIRECTION = Direction.VERTICAL;
+const SELECTOR_VIEWPORT = '[data-spirit-element="viewport"]';
+const SELECTOR_CONTENT = '[data-spirit-element="content"]';
+const CLASS_NAME_IS_SCROLLED_AT_START = 'is-scrolled-at-start';
+const CLASS_NAME_IS_SCROLLED_AT_END = 'is-scrolled-at-end';
+const EVENT_RESIZE = 'resize';
+const EVENT_SCROLL = 'scroll';
+
+// Method `getElementsPositionDifference` sometimes returns floating point values that results in inaccurate detection
+// of start/end. It is necessary to accept this inaccuracy and take every value less or equal to 1px as start/end.
+const EDGE_DETECTION_INACCURACY_PX = 1;
+
+class ScrollView extends BaseComponent {
+  content: SpiritElement;
+  currentPosition: CurrentPosition;
+  direction: DirectionType;
+  isScrolledAtEnd: boolean;
+  isScrolledAtStart: boolean;
+  scrollPositionEnd: AlignmentType;
+  scrollPositionStart: AlignmentType;
+  viewport: SpiritElement;
+
+  static get NAME(): string {
+    return NAME;
+  }
+
+  static get DATA_KEY(): string {
+    return `${this.NAME}`;
+  }
+
+  constructor(element: SpiritElement) {
+    super(element);
+
+    this.currentPosition = {
+      bottom: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+    };
+    this.direction = this.element.dataset?.spiritDirection
+      ? <DirectionType>String(this.element.dataset.spiritDirection)
+      : DEFAULT_DIRECTION;
+
+    this.content = SelectorEngine.findOne(SELECTOR_CONTENT, this.element);
+    this.viewport = SelectorEngine.findOne(SELECTOR_VIEWPORT, this.element);
+
+    this.scrollPositionStart = this.direction === Direction.HORIZONTAL ? Alignment.LEFT : Alignment.TOP;
+    this.scrollPositionEnd = this.direction === Direction.HORIZONTAL ? Alignment.RIGHT : Alignment.BOTTOM;
+
+    this.isScrolledAtStart = false;
+    this.isScrolledAtEnd = false;
+
+    this.init();
+  }
+
+  addEventListeners(): void {
+    EventHandler.on(this.viewport, EVENT_SCROLL, debounce(this.handleScrollViewState, DEBOUNCE_DELAY_MS));
+    EventHandler.on(window, EVENT_RESIZE, debounce(this.handleScrollViewState, DEBOUNCE_DELAY_MS));
+  }
+
+  getElementsPositionDifference = (): CurrentPosition => {
+    const contentPosition: DOMRect = this.content.getBoundingClientRect();
+    const viewportPosition: DOMRect = this.viewport.getBoundingClientRect();
+
+    return {
+      bottom: contentPosition.bottom - viewportPosition.bottom,
+      left: contentPosition.left - viewportPosition.left,
+      right: contentPosition.right - viewportPosition.right,
+      top: contentPosition.top - viewportPosition.top,
+    };
+  };
+
+  handleScrollViewState = (): void => {
+    this.currentPosition = this.getElementsPositionDifference();
+
+    const isScrolledAtStartActive = this.currentPosition[this.scrollPositionStart] <= -1 * EDGE_DETECTION_INACCURACY_PX;
+    const isScrolledAtEndActive = this.currentPosition[this.scrollPositionEnd] >= EDGE_DETECTION_INACCURACY_PX;
+
+    if (isScrolledAtStartActive !== this.isScrolledAtStart) {
+      this.isScrolledAtStart = isScrolledAtStartActive;
+    }
+
+    if (isScrolledAtEndActive !== this.isScrolledAtEnd) {
+      this.isScrolledAtEnd = isScrolledAtEndActive;
+    }
+
+    if (isScrolledAtStartActive) {
+      this.element.classList.add(CLASS_NAME_IS_SCROLLED_AT_START);
+    } else {
+      this.element.classList.remove(CLASS_NAME_IS_SCROLLED_AT_START);
+    }
+
+    if (isScrolledAtEndActive) {
+      this.element.classList.add(CLASS_NAME_IS_SCROLLED_AT_END);
+    } else {
+      this.element.classList.remove(CLASS_NAME_IS_SCROLLED_AT_END);
+    }
+  };
+
+  init(): void {
+    this.addEventListeners();
+    this.handleScrollViewState();
+  }
+}
+
+enableToggleAutoloader(ScrollView);
+
+export default ScrollView;

--- a/packages/web/src/js/index.esm.ts
+++ b/packages/web/src/js/index.esm.ts
@@ -7,6 +7,7 @@ export { default as Header } from './Header';
 export { default as Modal } from './Modal';
 export { default as Offcanvas } from './Offcanvas';
 export { default as Password } from './Password';
+export { default as ScrollView } from './ScrollView';
 export { default as Tabs } from './Tabs';
 export { default as Tooltip } from './Tooltip';
 export * from './constants';

--- a/packages/web/src/js/index.umd.ts
+++ b/packages/web/src/js/index.umd.ts
@@ -7,6 +7,7 @@ import Header from './Header';
 import Modal from './Modal';
 import Offcanvas from './Offcanvas';
 import Password from './Password';
+import ScrollView from './ScrollView';
 import Tabs from './Tabs';
 import Tooltip from './Tooltip';
 import * as constants from './constants';
@@ -23,6 +24,7 @@ export default {
   Modal,
   Offcanvas,
   Password,
+  ScrollView,
   Tabs,
   Tooltip,
   constants,

--- a/packages/web/src/js/utils/Debounce.ts
+++ b/packages/web/src/js/utils/Debounce.ts
@@ -1,0 +1,8 @@
+export const debounce = <T>(callback: (props: T) => void, delay: number) => {
+  let timeout: NodeJS.Timeout;
+
+  return (args: T): void => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => callback(args), delay);
+  };
+};

--- a/packages/web/src/js/utils/__tests__/Debounce.test.ts
+++ b/packages/web/src/js/utils/__tests__/Debounce.test.ts
@@ -1,0 +1,28 @@
+import { debounce } from '../Debounce';
+
+const DEBOUNCE_DELAY_MS = 100;
+
+describe('Behavior: Debounce', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should call the given callback function only after the debounce delay has passed', () => {
+    const callback = jest.fn();
+    const debouncedFunction = debounce(callback, DEBOUNCE_DELAY_MS);
+
+    debouncedFunction('test argument');
+
+    expect(callback).not.toHaveBeenCalled();
+
+    jest.runAllTimers();
+
+    expect(callback).toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith('test argument');
+  });
+});

--- a/packages/web/src/js/utils/index.ts
+++ b/packages/web/src/js/utils/index.ts
@@ -11,6 +11,7 @@ const reflow = (element: HTMLElement): void => {
 
 export { reflow };
 export * from './ComponentFunctions';
+export * from './Debounce';
 export * from './Deprecations';
 export * from './Elements';
 export { default as ScrollControl } from './ScrollControl';

--- a/packages/web/src/scss/components/ScrollView/README.md
+++ b/packages/web/src/scss/components/ScrollView/README.md
@@ -1,0 +1,119 @@
+# ScrollView
+
+ScrollView makes long content scrollable. On its edges, it provides indication of whether there is more content to scroll to.
+
+## JavaScript Plugin
+
+For full functionality, you need to provide Spirit JavaScript, which will handle toggling of the FileUploader component:
+
+```html
+<script src="node_modules/@lmc-eu/spirit-web/js/cjs/spirit-web.min.js" async></script>
+```
+
+You will find the [full documentation](#javascript-plugin-api) of the plugin below on this page.
+
+Please consult the [main README][web-readme] for how to include JavaScript plugins.
+
+Or, feel free to write the controlling script yourself.
+
+## Vertical Scrolling
+
+For vertical scrolling, you need to add the `ScrollView--vertical` class to the container element and set the
+`data-spirit-direction` attribute to `vertical`.
+
+```html
+<div class="ScrollView ScrollView--vertical" data-toggle="scrollView" data-spirit-direction="vertical">
+  <div class="ScrollView__viewport" data-spirit-element="viewport">
+    <div class="ScrollView__content" data-spirit-element="content">
+      <p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit…</p>
+    </div>
+  </div>
+  <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+</div>
+```
+
+## Horizontal Scrolling
+
+Analogically, add the `ScrollView--horizontal` class to the container element and set the `data-spirit-direction` attribute to
+`horizontal` to achieve horizontal scrolling.
+
+👉 For text content, you may need to explicitly set the `white-space` CSS property to `nowrap` on the content element to prevent the
+content from wrapping.
+
+```html
+<div class="ScrollView ScrollView--horizontal" data-toggle="scrollView" data-spirit-direction="horizontal">
+  <div class="ScrollView__viewport" data-spirit-element="viewport">
+    <div class="ScrollView__content" data-spirit-element="content">
+      <p class="mb-700" style="white-space: nowrap">Lorem ipsum dolor sit amet, consectetuer adipiscing elit…</p>
+    </div>
+  </div>
+  <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+</div>
+```
+
+👉 For other content types, you may need to provide fixed width to the content element (or elements) to force scrolling.
+
+```html
+<div class="ScrollView ScrollView--horizontal" data-toggle="scrollView" data-spirit-direction="horizontal">
+  <div class="ScrollView__viewport" data-spirit-element="viewport">
+    <div class="ScrollView__content" data-spirit-element="content">
+      <div class="Grid Grid--cols-4 mb-700">
+        <div style="width: 20rem">1/4</div>
+        <div style="width: 20rem">1/4</div>
+        <div style="width: 20rem">1/4</div>
+        <div style="width: 20rem">1/4</div>
+      </div>
+    </div>
+  </div>
+  <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+</div>
+```
+
+## Scrollbar
+
+Depending on user's operating system and browser, the scrollbar may be hidden by default, or take up space in the container element.
+
+👉 Unless you decide to [hide the scrollbar](#hiding-the-scrollbar), you may need to provide spacing for the scrollbar, so it does
+not cover your content when visible. For example, having a horizontal ScrollView, you can do so by adding a margin or padding utility
+class to your content, e.g. `mb-700` or `pb-700`.
+
+```html
+<div class="ScrollView ScrollView--horizontal" data-toggle="scrollView" data-spirit-direction="horizontal">
+  <div class="ScrollView__viewport" data-spirit-element="viewport">
+    <div class="ScrollView__content" data-spirit-element="content">
+      <p class="mb-700">…</p>
+    </div>
+  </div>
+  <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+</div>
+```
+
+### Hiding the Scrollbar
+
+To hide the scrollbar, add the `ScrollView--hideScrollbar` class to the container element.
+
+⚠️ Make sure that the content is still accessible to users who don’t use a pointing device with support of horizontal scrolling, e.g. by providing keyboard navigation.
+
+```html
+<div
+  class="ScrollView ScrollView--horizontal ScrollView--scrollbarDisabled"
+  data-toggle="scrollView"
+  data-spirit-direction="horizontal"
+>
+  <div class="ScrollView__viewport" data-spirit-element="viewport">
+    <div class="ScrollView__content" data-spirit-element="content">
+      <!-- … -->
+    </div>
+  </div>
+  <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+</div>
+```
+
+## JavaScript Plugin API
+
+| Method                | Description                                                                                                                                       |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getInstance`         | _Static_ method which allows you to get the ScrollView instance associated with a DOM element.                                                    |
+| `getOrCreateInstance` | _Static_ method which allows you to get the ScrollView instance associated with a DOM element, or create a new one in case it wasn’t initialized. |
+
+[web-readme]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/README.md

--- a/packages/web/src/scss/components/ScrollView/_ScrollView.scss
+++ b/packages/web/src/scss/components/ScrollView/_ScrollView.scss
@@ -1,0 +1,156 @@
+// Based on React UI ScrollView ❤️:
+// https://react-ui.io/components/scroll-view
+
+// 1. Scrolling shadows are implemented as pseudo elements. This way we can customise them only with custom properties.
+//
+// 2. Stack scrolling shadows over viewport content while keeping the content interactive.
+//
+//    - `.ScrollView__scrollingShadows` is positioned absolutely over the `.ScrollView`, with auto `z-index` (this is
+//      important!), and with `overflow: hidden` to clip the shadows (ie. its pseudo elements).
+//    - The `.ScrollView__viewport` is in `.ScrollView`'s stacking context and remains interactive because its
+//      `z-index` is higher than the auto `z-index` of `.ScrollView__scrollingShadows`.
+//
+// 3. Make the `.ScrollView__content`'s bounding rectangle spread beyond the part visible through `.ScrollView__viewport`.
+//
+// 4. Prevent undesired vertical scrolling that may occur with tables inside.
+//
+// 5. Make `ScrollView` adjust to flexible layouts.
+//
+// 6. Hide content overflowing in the other direction because scrollbars would be unreachable under scrolling shadows.
+
+@use 'theme';
+
+.ScrollView {
+    position: relative; // 2.
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+// 1.
+.ScrollView__scrollingShadows {
+    position: absolute; // 2.
+    width: 100%; // 2.
+    height: 100%; // 2.
+    overflow: hidden; // 2.
+    pointer-events: none; // 2.
+
+    &::before,
+    &::after {
+        content: '';
+        position: absolute;
+        z-index: 2; // 2.
+        display: block;
+        visibility: hidden;
+        opacity: 0;
+        transition-property: visibility, opacity, transform;
+        transition-duration: 250ms;
+    }
+
+    &::before {
+        background: theme.$start-shadow-background;
+    }
+
+    &::after {
+        background: theme.$end-shadow-background;
+    }
+}
+
+.ScrollView__viewport {
+    z-index: 1; // 2.
+    width: 100%;
+    scroll-behavior: smooth;
+}
+
+.ScrollView--vertical {
+    height: 100%;
+    min-height: 0; // 5.
+}
+
+.ScrollView--vertical > .ScrollView__viewport {
+    height: 100%;
+    overflow-x: hidden; // 6.
+    overflow-y: auto; // 2.
+}
+
+.ScrollView--horizontal {
+    min-width: 0; // 5.
+}
+
+.ScrollView--vertical > .ScrollView__scrollingShadows::before,
+.ScrollView--vertical > .ScrollView__scrollingShadows::after {
+    right: 0;
+    left: 0;
+    width: auto;
+}
+
+.ScrollView--vertical > .ScrollView__scrollingShadows::before {
+    --angle: 180deg;
+
+    top: 0;
+    height: theme.$start-shadow-size;
+    transform: translateY(#{theme.$start-shadow-initial-offset});
+}
+
+.ScrollView--vertical > .ScrollView__scrollingShadows::after {
+    --angle: 0;
+
+    bottom: 0;
+    height: theme.$end-shadow-size;
+    transform: translateY(#{-1 * theme.$end-shadow-initial-offset});
+}
+
+.ScrollView--horizontal > .ScrollView__viewport {
+    overflow-x: auto; // 2.
+    overflow-y: hidden; // 4., 6.
+}
+
+// stylelint-disable-next-line selector-max-class -- We need to be specific here.
+.ScrollView--horizontal > .ScrollView__viewport > .ScrollView__content {
+    display: inline-flex; // 3.
+    min-width: 100%;
+    vertical-align: top;
+}
+
+.ScrollView--horizontal > .ScrollView__scrollingShadows::before,
+.ScrollView--horizontal > .ScrollView__scrollingShadows::after {
+    top: 0;
+    bottom: 0;
+    height: auto;
+}
+
+.ScrollView--horizontal > .ScrollView__scrollingShadows::before {
+    --angle: 90deg;
+
+    left: 0;
+    width: theme.$start-shadow-size;
+    transform: translateX(#{theme.$start-shadow-initial-offset});
+}
+
+.ScrollView--horizontal > .ScrollView__scrollingShadows::after {
+    --angle: 270deg;
+
+    right: 0;
+    width: theme.$end-shadow-size;
+    transform: translateX(#{-1 * theme.$end-shadow-initial-offset});
+}
+
+.is-scrolled-at-start > .ScrollView__scrollingShadows::before {
+    visibility: visible;
+    opacity: 1;
+    transform: translate(0, 0);
+}
+
+.is-scrolled-at-end > .ScrollView__scrollingShadows::after {
+    visibility: visible;
+    opacity: 1;
+    transform: translate(0, 0);
+}
+
+.ScrollView--scrollbarDisabled > .ScrollView__viewport {
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
+}

--- a/packages/web/src/scss/components/ScrollView/_theme.scss
+++ b/packages/web/src/scss/components/ScrollView/_theme.scss
@@ -1,0 +1,9 @@
+@use '@tokens' as tokens;
+
+$start-shadow-size: tokens.$space-600;
+$start-shadow-initial-offset: -1 * tokens.$space-600;
+$start-shadow-background: tokens.$gradient-background-basic-overlay;
+
+$end-shadow-size: tokens.$space-600;
+$end-shadow-initial-offset: -1 * tokens.$space-600;
+$end-shadow-background: tokens.$gradient-background-basic-overlay;

--- a/packages/web/src/scss/components/ScrollView/index.html
+++ b/packages/web/src/scss/components/ScrollView/index.html
@@ -1,0 +1,122 @@
+{{#> layout/plain }}
+
+<section class="docs-Section">
+
+  <h2 class="docs-Heading">Vertical Scrolling</h2>
+
+  <div style="height: 160px">
+
+    <div
+      class="ScrollView ScrollView--vertical"
+      data-toggle="scrollView"
+      data-spirit-direction="vertical"
+    >
+      <div class="ScrollView__viewport" data-spirit-element="viewport">
+        <div class="ScrollView__content" data-spirit-element="content">
+
+          <p>
+            Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc.Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc.
+          </p>
+
+        </div>
+      </div>
+      <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+    </div>
+
+  </div>
+
+</section>
+<section class="docs-Section">
+
+  <h2 class="docs-Heading">Horizontal Scrolling</h2>
+
+  <div
+    class="ScrollView ScrollView--horizontal"
+    data-toggle="scrollView"
+    data-spirit-direction="horizontal"
+  >
+    <div class="ScrollView__viewport" data-spirit-element="viewport">
+      <div class="ScrollView__content" data-spirit-element="content">
+
+        <p class="py-700" style="white-space: nowrap">
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.
+        </p>
+
+      </div>
+    </div>
+    <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+  </div>
+
+</section>
+<section class="docs-Section">
+
+  <h2 class="docs-Heading">Horizontal Scrolling with Container Breakout</h2>
+
+  <div class="breakout-container">
+    <div
+      class="ScrollView ScrollView--horizontal"
+      data-toggle="scrollView"
+      data-spirit-direction="horizontal"
+    >
+      <div class="ScrollView__viewport" data-spirit-element="viewport">
+        <div class="ScrollView__content" data-spirit-element="content">
+
+          <div class="Grid Grid--cols-4 mb-700" style="padding-inline: var(--container-padding-inline)">
+            <div class="docs-Box docs-Box--small" style="width: 20rem; aspect-ratio: 2/1">1/4</div>
+            <div class="docs-Box docs-Box--small" style="width: 20rem; aspect-ratio: 2/1">1/4</div>
+            <div class="docs-Box docs-Box--small" style="width: 20rem; aspect-ratio: 2/1">1/4</div>
+            <div class="docs-Box docs-Box--small" style="width: 20rem; aspect-ratio: 2/1">1/4</div>
+          </div>
+
+        </div>
+      </div>
+      <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+    </div>
+  </div>
+
+</section>
+<section class="docs-Section">
+
+  <h2 class="docs-Heading">Hidden Scrollbar</h2>
+
+  <div class="mb-1000" style="height: 160px">
+
+    <div
+      class="ScrollView ScrollView--vertical ScrollView--scrollbarDisabled"
+      data-toggle="scrollView"
+      data-spirit-direction="vertical"
+    >
+      <div class="ScrollView__viewport" data-spirit-element="viewport">
+        <div class="ScrollView__content" data-spirit-element="content">
+
+          <p>
+            Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc.Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc.
+          </p>
+
+        </div>
+      </div>
+      <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+    </div>
+
+  </div>
+
+  <div
+    class="ScrollView ScrollView--horizontal ScrollView--scrollbarDisabled"
+    data-toggle="scrollView"
+    data-spirit-direction="horizontal"
+  >
+    <div class="ScrollView__viewport" data-spirit-element="viewport">
+      <div class="ScrollView__content" data-spirit-element="content">
+
+        <p style="white-space: nowrap">
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.
+        </p>
+
+      </div>
+    </div>
+    <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+  </div>
+
+</section>
+
+{{/ layout/plain }}

--- a/packages/web/src/scss/components/ScrollView/index.scss
+++ b/packages/web/src/scss/components/ScrollView/index.scss
@@ -1,0 +1,1 @@
+@forward 'ScrollView';

--- a/packages/web/src/scss/components/index.scss
+++ b/packages/web/src/scss/components/index.scss
@@ -13,6 +13,7 @@
 @forward 'Pagination';
 @forward 'Pill';
 @forward 'RadioField';
+@forward 'ScrollView';
 @forward 'Stack';
 @forward 'Tabs';
 @forward 'Tag';


### PR DESCRIPTION
<img width="1283" alt="obrazek" src="https://github.com/lmc-eu/spirit-design-system/assets/5614085/ded13220-6444-4861-aef8-137494d0bc62">

## TODO

- [x] scrolling shadows according to the design
- [x] ~~`startPadding`, `endPadding`~~ Figma only
- [x] `README`
- [x] `debounce.ts` test

Offloaded to standalone issue:

- `ScrollView` test, see the comment at the top of the file
- Borders instead of shadows