### PR TITLE
Feat(web): Enhance `ScrollView` scrolling indicators to be shadows, borders, or both #DS-796

### DIFF
--- a/packages/web/src/scss/components/ScrollView/README.md
+++ b/packages/web/src/scss/components/ScrollView/README.md
@@ -28,7 +28,7 @@ For vertical scrolling, you need to add the `ScrollView--vertical` class to the 
       <p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit…</p>
     </div>
   </div>
-  <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+  <div class="ScrollView__indicators ScrollView__indicators--shadows" aria-hidden="true"></div>
 </div>
 ```
 
@@ -47,7 +47,7 @@ content from wrapping.
       <p class="mb-700" style="white-space: nowrap">Lorem ipsum dolor sit amet, consectetuer adipiscing elit…</p>
     </div>
   </div>
-  <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+  <div class="ScrollView__indicators ScrollView__indicators--shadows" aria-hidden="true"></div>
 </div>
 ```
 
@@ -65,8 +65,32 @@ content from wrapping.
       </div>
     </div>
   </div>
-  <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+  <div class="ScrollView__indicators ScrollView__indicators--shadows" aria-hidden="true"></div>
 </div>
+```
+
+## Scrolling Indicators
+
+The ScrollView component provides indicators on its edges, showing that there is more content to scroll to. The default indicators
+use shadows:
+
+```html
+<div class="ScrollView__indicators ScrollView__indicators--shadows" aria-hidden="true"></div>
+```
+
+You can use borders instead:
+
+```html
+<div class="ScrollView__indicators ScrollView__indicators--borders" aria-hidden="true"></div>
+```
+
+Or both:
+
+```html
+<div
+  class="ScrollView__indicators ScrollView__indicators--borders ScrollView__indicators--shadows"
+  aria-hidden="true"
+></div>
 ```
 
 ## Scrollbar
@@ -84,7 +108,7 @@ class to your content, e.g. `mb-700` or `pb-700`.
       <p class="mb-700">…</p>
     </div>
   </div>
-  <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+  <div class="ScrollView__indicators ScrollView__indicators--shadows" aria-hidden="true"></div>
 </div>
 ```
 
@@ -105,7 +129,7 @@ To hide the scrollbar, add the `ScrollView--hideScrollbar` class to the containe
       <!-- … -->
     </div>
   </div>
-  <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+  <div class="ScrollView__indicators ScrollView__indicators--shadows" aria-hidden="true"></div>
 </div>
 ```
 

--- a/packages/web/src/scss/components/ScrollView/_ScrollView.scss
+++ b/packages/web/src/scss/components/ScrollView/_ScrollView.scss
@@ -1,23 +1,23 @@
 // Based on React UI ScrollView ❤️:
 // https://react-ui.io/components/scroll-view
 
-// 1. Scrolling shadows are implemented as pseudo elements. This way we can customise them only with custom properties.
+// 1. Scrolling indicators are implemented as pseudo elements. This way we can transition their visibility easily.
 //
-// 2. Stack scrolling shadows over viewport content while keeping the content interactive.
+// 2. Stack scrolling indicators over viewport content while keeping the content interactive.
 //
-//    - `.ScrollView__scrollingShadows` is positioned absolutely over the `.ScrollView`, with auto `z-index` (this is
-//      important!), and with `overflow: hidden` to clip the shadows (ie. its pseudo elements).
-//    - The `.ScrollView__viewport` is in `.ScrollView`'s stacking context and remains interactive because its
-//      `z-index` is higher than the auto `z-index` of `.ScrollView__scrollingShadows`.
+//    - Scrolling indicators are positioned absolutely over the `.ScrollView`, with auto `z-index` (this is
+//      important!), and with `overflow: hidden` to clip the shadows (ie. its pseudo elements) when offset is applied.
+//    - The `.ScrollView__viewport` remains interactive thanks to `pointer-events: none` on scrolling indicators.
 //
 // 3. Make the `.ScrollView__content`'s bounding rectangle spread beyond the part visible through `.ScrollView__viewport`.
 //
 // 4. Prevent undesired vertical scrolling that may occur with tables inside.
 //
-// 5. Make `ScrollView` adjust to flexible layouts.
+// 5. Make `.ScrollView` adjust to flexible layouts.
 //
 // 6. Hide content overflowing in the other direction because scrollbars would be unreachable under scrolling shadows.
 
+@use '../../settings/transitions';
 @use 'theme';
 
 .ScrollView {
@@ -28,7 +28,7 @@
 }
 
 // 1.
-.ScrollView__scrollingShadows {
+.ScrollView__indicators {
     position: absolute; // 2.
     width: 100%; // 2.
     height: 100%; // 2.
@@ -44,9 +44,11 @@
         visibility: hidden;
         opacity: 0;
         transition-property: visibility, opacity, transform;
-        transition-duration: 250ms;
+        transition-duration: transitions.$duration-medium;
     }
+}
 
+.ScrollView__indicators--shadows {
     &::before {
         background: theme.$start-shadow-background;
     }
@@ -77,29 +79,6 @@
     min-width: 0; // 5.
 }
 
-.ScrollView--vertical > .ScrollView__scrollingShadows::before,
-.ScrollView--vertical > .ScrollView__scrollingShadows::after {
-    right: 0;
-    left: 0;
-    width: auto;
-}
-
-.ScrollView--vertical > .ScrollView__scrollingShadows::before {
-    --angle: 180deg;
-
-    top: 0;
-    height: theme.$start-shadow-size;
-    transform: translateY(#{theme.$start-shadow-initial-offset});
-}
-
-.ScrollView--vertical > .ScrollView__scrollingShadows::after {
-    --angle: 0;
-
-    bottom: 0;
-    height: theme.$end-shadow-size;
-    transform: translateY(#{-1 * theme.$end-shadow-initial-offset});
-}
-
 .ScrollView--horizontal > .ScrollView__viewport {
     overflow-x: auto; // 2.
     overflow-y: hidden; // 4., 6.
@@ -112,36 +91,87 @@
     vertical-align: top;
 }
 
-.ScrollView--horizontal > .ScrollView__scrollingShadows::before,
-.ScrollView--horizontal > .ScrollView__scrollingShadows::after {
+.ScrollView--vertical > .ScrollView__indicators::before,
+.ScrollView--vertical > .ScrollView__indicators::after {
+    right: 0;
+    left: 0;
+    width: auto;
+}
+
+.ScrollView--vertical > .ScrollView__indicators::before {
+    top: 0;
+}
+
+.ScrollView--vertical > .ScrollView__indicators::after {
+    bottom: 0;
+}
+
+.ScrollView--vertical > .ScrollView__indicators--borders::before {
+    border-top: theme.$border-width theme.$border-style theme.$border-color;
+}
+
+.ScrollView--vertical > .ScrollView__indicators--borders::after {
+    border-bottom: theme.$border-width theme.$border-style theme.$border-color;
+}
+
+.ScrollView--vertical > .ScrollView__indicators--shadows::before {
+    --angle: 180deg;
+
+    height: theme.$start-shadow-size;
+    transform: translateY(#{theme.$start-shadow-initial-offset});
+}
+
+.ScrollView--vertical > .ScrollView__indicators--shadows::after {
+    --angle: 0;
+
+    height: theme.$end-shadow-size;
+    transform: translateY(#{-1 * theme.$end-shadow-initial-offset});
+}
+
+.ScrollView--horizontal > .ScrollView__indicators::before,
+.ScrollView--horizontal > .ScrollView__indicators::after {
     top: 0;
     bottom: 0;
     height: auto;
 }
 
-.ScrollView--horizontal > .ScrollView__scrollingShadows::before {
+.ScrollView--horizontal > .ScrollView__indicators::before {
+    left: 0;
+}
+
+.ScrollView--horizontal > .ScrollView__indicators::after {
+    right: 0;
+}
+
+.ScrollView--horizontal > .ScrollView__indicators--borders::before {
+    border-left: theme.$border-width theme.$border-style theme.$border-color;
+}
+
+.ScrollView--horizontal > .ScrollView__indicators--borders::after {
+    border-right: theme.$border-width theme.$border-style theme.$border-color;
+}
+
+.ScrollView--horizontal > .ScrollView__indicators--shadows::before {
     --angle: 90deg;
 
-    left: 0;
     width: theme.$start-shadow-size;
     transform: translateX(#{theme.$start-shadow-initial-offset});
 }
 
-.ScrollView--horizontal > .ScrollView__scrollingShadows::after {
+.ScrollView--horizontal > .ScrollView__indicators--shadows::after {
     --angle: 270deg;
 
-    right: 0;
     width: theme.$end-shadow-size;
     transform: translateX(#{-1 * theme.$end-shadow-initial-offset});
 }
 
-.is-scrolled-at-start > .ScrollView__scrollingShadows::before {
+.is-scrolled-at-start > .ScrollView__indicators::before {
     visibility: visible;
     opacity: 1;
     transform: translate(0, 0);
 }
 
-.is-scrolled-at-end > .ScrollView__scrollingShadows::after {
+.is-scrolled-at-end > .ScrollView__indicators::after {
     visibility: visible;
     opacity: 1;
     transform: translate(0, 0);

--- a/packages/web/src/scss/components/ScrollView/_theme.scss
+++ b/packages/web/src/scss/components/ScrollView/_theme.scss
@@ -1,9 +1,14 @@
+@use '../../settings/transitions';
 @use '@tokens' as tokens;
 
+$border-width: tokens.$border-width-100;
+$border-style: tokens.$border-style-100;
+$border-color: tokens.$border-primary-default;
+
 $start-shadow-size: tokens.$space-600;
-$start-shadow-initial-offset: -1 * tokens.$space-600;
+$start-shadow-initial-offset: -1 * transitions.$shift-distance-medium;
 $start-shadow-background: tokens.$gradient-background-basic-overlay;
 
 $end-shadow-size: tokens.$space-600;
-$end-shadow-initial-offset: -1 * tokens.$space-600;
+$end-shadow-initial-offset: -1 * transitions.$shift-distance-medium;
 $end-shadow-background: tokens.$gradient-background-basic-overlay;

--- a/packages/web/src/scss/components/ScrollView/index.html
+++ b/packages/web/src/scss/components/ScrollView/index.html
@@ -20,7 +20,7 @@
 
         </div>
       </div>
-      <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+      <div class="ScrollView__indicators ScrollView__indicators--shadows" aria-hidden="true"></div>
     </div>
 
   </div>
@@ -44,7 +44,7 @@
 
       </div>
     </div>
-    <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+    <div class="ScrollView__indicators ScrollView__indicators--shadows" aria-hidden="true"></div>
   </div>
 
 </section>
@@ -70,8 +70,93 @@
 
         </div>
       </div>
-      <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+      <div class="ScrollView__indicators ScrollView__indicators--shadows" aria-hidden="true"></div>
     </div>
+  </div>
+
+</section>
+<section class="docs-Section">
+
+  <h2 class="docs-Heading">Scrolling Indicators</h2>
+
+  <h3>Borders</h3>
+
+  <div class="mb-1000" style="height: 160px">
+
+    <div
+      class="ScrollView ScrollView--vertical"
+      data-toggle="scrollView"
+      data-spirit-direction="vertical"
+    >
+      <div class="ScrollView__viewport" data-spirit-element="viewport">
+        <div class="ScrollView__content" data-spirit-element="content">
+
+          <p>
+            Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc.Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc.
+          </p>
+
+        </div>
+      </div>
+      <div class="ScrollView__indicators ScrollView__indicators--borders" aria-hidden="true"></div>
+    </div>
+
+  </div>
+
+  <div
+    class="ScrollView ScrollView--horizontal mb-1000"
+    data-toggle="scrollView"
+    data-spirit-direction="horizontal"
+  >
+    <div class="ScrollView__viewport" data-spirit-element="viewport">
+      <div class="ScrollView__content" data-spirit-element="content">
+
+        <p class="py-700" style="white-space: nowrap">
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.
+        </p>
+
+      </div>
+    </div>
+    <div class="ScrollView__indicators ScrollView__indicators--borders" aria-hidden="true"></div>
+  </div>
+
+  <h3>Borders and Shadows</h3>
+
+  <div class="mb-1000" style="height: 160px">
+
+    <div
+      class="ScrollView ScrollView--vertical"
+      data-toggle="scrollView"
+      data-spirit-direction="vertical"
+    >
+      <div class="ScrollView__viewport" data-spirit-element="viewport">
+        <div class="ScrollView__content" data-spirit-element="content">
+
+          <p>
+            Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc.Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc.
+          </p>
+
+        </div>
+      </div>
+      <div class="ScrollView__indicators ScrollView__indicators--borders ScrollView__indicators--shadows" aria-hidden="true"></div>
+    </div>
+
+  </div>
+
+  <div
+    class="ScrollView ScrollView--horizontal"
+    data-toggle="scrollView"
+    data-spirit-direction="horizontal"
+  >
+    <div class="ScrollView__viewport" data-spirit-element="viewport">
+      <div class="ScrollView__content" data-spirit-element="content">
+
+        <p class="py-700" style="white-space: nowrap">
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.
+        </p>
+
+      </div>
+    </div>
+    <div class="ScrollView__indicators ScrollView__indicators--borders ScrollView__indicators--shadows" aria-hidden="true"></div>
   </div>
 
 </section>
@@ -95,7 +180,7 @@
 
         </div>
       </div>
-      <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+      <div class="ScrollView__indicators ScrollView__indicators--shadows" aria-hidden="true"></div>
     </div>
 
   </div>
@@ -114,7 +199,7 @@
 
       </div>
     </div>
-    <div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
+    <div class="ScrollView__indicators ScrollView__indicators--shadows" aria-hidden="true"></div>
   </div>
 
 </section>


### PR DESCRIPTION
Previously:

```html
<div class="ScrollView__scrollingShadows" aria-hidden="true"></div>
```

Now:

```html
<div class="ScrollView__indicators ScrollView__indicators--shadows" aria-hidden="true"></div>
<div class="ScrollView__indicators ScrollView__indicators--borders" aria-hidden="true"></div>
<div
  class="ScrollView__indicators ScrollView__indicators--borders ScrollView__indicators--shadows"
  aria-hidden="true"
></div>
```