### PR TITLE
Render input and main props if the value is not `null` or empty

### DIFF
--- a/packages/web-twig/src/Resources/components/Accordion/Accordion.twig
+++ b/packages/web-twig/src/Resources/components/Accordion/Accordion.twig
@@ -12,7 +12,7 @@
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _styleProps.className ] -%}
-{%- set _mainPropsWithoutId = props | filter((value, prop) => prop != 'id') -%}
+{%- set _mainPropsWithoutId = props | filter((value, prop) => prop is not same as('id')) -%}
 
 <{{ _elementType }}
     {{ mainProps(_mainPropsWithoutId) }}

--- a/packages/web-twig/src/Resources/components/Accordion/AccordionContent.twig
+++ b/packages/web-twig/src/Resources/components/Accordion/AccordionContent.twig
@@ -20,7 +20,7 @@
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _collapseClassNames = [ _rootClassName, _isOpenClassName ] -%}
 {%- set _contentClassNames = [ _accordionClassName, _styleProps.className ] -%}
-{%- set _mainPropsWithoutId = props | filter((value, prop) => prop != 'id') -%}
+{%- set _mainPropsWithoutId = props | filter((value, prop) => prop is not same as('id')) -%}
 
 <div
     {{ mainProps(_mainPropsWithoutId) }}

--- a/packages/web-twig/src/Resources/components/Accordion/AccordionHeader.twig
+++ b/packages/web-twig/src/Resources/components/Accordion/AccordionHeader.twig
@@ -21,7 +21,7 @@
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _ariaExpanded = _isOpen ? 'true' : 'false' -%}
 {%- set _classNames = [ _rootClassName, _styleProps.className ] -%}
-{%- set _mainPropsWithoutId = props | filter((value, prop) => prop != 'id') -%}
+{%- set _mainPropsWithoutId = props | filter((value, prop) => prop is not same as('id')) -%}
 
 <{{ _elementType }}
     {{ mainProps(_mainPropsWithoutId) }}

--- a/packages/web-twig/src/Resources/components/Accordion/AccordionItem.twig
+++ b/packages/web-twig/src/Resources/components/Accordion/AccordionItem.twig
@@ -12,7 +12,7 @@
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _styleProps.className ] -%}
-{%- set _mainPropsWithoutId = props | filter((value, prop) => prop != 'id') -%}
+{%- set _mainPropsWithoutId = props | filter((value, prop) => prop is not same as('id')) -%}
 
 <{{ _elementType }}
     {{ mainProps(_mainPropsWithoutId) }}

--- a/packages/web-twig/src/Resources/components/Breadcrumbs/Breadcrumbs.twig
+++ b/packages/web-twig/src/Resources/components/Breadcrumbs/Breadcrumbs.twig
@@ -16,20 +16,20 @@
     {%- if _items|length > 0 -%}
         <ol>
             {% for item in _items %}
-                {% if loop.index is same as(_items|length - 1) and _goBackTitle != '' %}
+                {% if loop.index is same as(_items|length - 1) and _goBackTitle is not same as('') %}
                     <li class="d-tablet-none">
                         <Icon name="chevron-left" />
                         <Link href="{{ item.url }}" color="primary" isUnderlined>{{ _goBackTitle }}</Link>
                     </li>
                 {% endif %}
                 <li class="d-none d-tablet-flex">
-                    {% if loop.index0 != 0 %}
+                    {% if loop.index0 is not same as(0) %}
                         <Icon name="chevron-right" />
                     {% endif %}
                     <Link
                         href="{{ item.url }}"
                         color="{{ loop.last ? 'secondary' : 'primary' }}"
-                        isUnderlined="{{ loop.last != true }}"
+                        isUnderlined="{{ loop.last is not same as(true) }}"
                         aria-current="{{ loop.last ? 'page' : 'false' }}"
                     >
                         {{ item.title }}

--- a/packages/web-twig/src/Resources/components/CheckboxField/CheckboxField.twig
+++ b/packages/web-twig/src/Resources/components/CheckboxField/CheckboxField.twig
@@ -39,7 +39,7 @@
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _rootDisabledClassName, _rootItemClassName, _rootValidationStateClassName, _styleProps.className ] -%}
 {%- set _labelClassName = [ _labelClassName, _labelHiddenClassName, _labelRequiredClassName ] -%}
-{%- set _mainPropsWithoutId = props | filter((value, prop) => prop != 'id') -%}
+{%- set _mainPropsWithoutId = props | filter((value, prop) => prop is not same as('id')) -%}
 
 {# Deprecations #}
 {% if _validationState is same as('error') %}

--- a/packages/web-twig/src/Resources/components/Collapse/Collapse.twig
+++ b/packages/web-twig/src/Resources/components/Collapse/Collapse.twig
@@ -19,7 +19,7 @@
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _isOpenClassName, _styleProps.className ] -%}
-{%- set _mainPropsWithoutId = props | filter((value, prop) => prop != 'id') -%}
+{%- set _mainPropsWithoutId = props | filter((value, prop) => prop is not same as('id')) -%}
 
 <{{ _elementType }}
     {{ mainProps(_mainPropsWithoutId) }}

--- a/packages/web-twig/src/Resources/components/FileUploader/FileUploaderAttachment.twig
+++ b/packages/web-twig/src/Resources/components/FileUploader/FileUploaderAttachment.twig
@@ -11,7 +11,7 @@
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _styleProps.className ] -%}
-{%- set _mainPropsWithoutReservedAttributes = props | filter((value, prop) => prop != 'data-spirit-populate-field') -%}
+{%- set _mainPropsWithoutReservedAttributes = props | filter((value, prop) => prop is not same as('data-spirit-populate-field')) -%}
 
 <li
     {{ mainProps(_mainPropsWithoutReservedAttributes) }}

--- a/packages/web-twig/src/Resources/components/Icon/Icon.twig
+++ b/packages/web-twig/src/Resources/components/Icon/Icon.twig
@@ -9,7 +9,7 @@
 
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
-{%- set _mainProps = props | filter((value, prop) => prop != 'ariaHidden') | merge({
+{%- set _mainProps = props | filter((value, prop) => prop is not same as('ariaHidden')) | merge({
     'aria-hidden': _ariaHidden ? 'true' : 'false',
 }) -%}
 

--- a/packages/web-twig/src/Resources/components/Modal/Modal.twig
+++ b/packages/web-twig/src/Resources/components/Modal/Modal.twig
@@ -16,7 +16,7 @@
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _styleProps.className ] -%}
-{%- set _mainPropsWithoutId = props | filter((value, prop) => prop != 'id') -%}
+{%- set _mainPropsWithoutId = props | filter((value, prop) => prop is not same as('id')) -%}
 
 {# Deprecations #}
 {% deprecated 'Modal: The "Modal" component is deprecated, it will be replaced by implementation of "ModalComposed".' %}

--- a/packages/web-twig/src/Resources/components/Modal/ModalComposed.twig
+++ b/packages/web-twig/src/Resources/components/Modal/ModalComposed.twig
@@ -14,7 +14,7 @@
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _rootComposedClassName, _styleProps.className ] -%}
-{%- set _mainPropsWithoutId = props | filter((value, prop) => prop != 'id') -%}
+{%- set _mainPropsWithoutId = props | filter((value, prop) => prop is not same as('id')) -%}
 
 {# Deprecations #}
 {% deprecated 'ModalComposed: The "ModalComposed" component is deprecated, it will be renamed to "Modal".' %}

--- a/packages/web-twig/src/Resources/components/RadioField/RadioField.twig
+++ b/packages/web-twig/src/Resources/components/RadioField/RadioField.twig
@@ -35,7 +35,7 @@
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _rootDisabledClassName, _rootItemClassName, _rootValidationStateClassName, _styleProps.className ] -%}
 {%- set _labelClassName = [ _labelClassName, _labelHiddenClassName ] -%}
-{%- set _mainPropsWithoutId = props | filter((value, prop) => prop != 'id') -%}
+{%- set _mainPropsWithoutId = props | filter((value, prop) => prop is not same as('id')) -%}
 {%- set _allowedInputAttributes = [ 'autocomplete' ] -%}
 
 <label {{ _labelForAttr | raw }} {{ mainProps(_mainPropsWithoutId) }} {{ styleProp(_styleProps) }} {{ classProp(_classNames) }}>

--- a/packages/web-twig/src/Resources/components/ScrollView/ScrollView.twig
+++ b/packages/web-twig/src/Resources/components/ScrollView/ScrollView.twig
@@ -18,7 +18,7 @@
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _rootDirectionClassName, _rootScrollbarDisabledClassName, _styleProps.className ] -%}
 {%- set _indicatorsClassNames = [ _indicatorsClassName, _indicatorsShadowsClassName, _indicatorsBordersClassName ] -%}
-{%- set _mainPropsWithoutReservedAttributes = props | filter((value, prop) => prop != 'data-spirit-direction') -%}
+{%- set _mainPropsWithoutReservedAttributes = props | filter((value, prop) => prop is not same as('data-spirit-direction')) -%}
 
 <div
     {{ mainProps(_mainPropsWithoutReservedAttributes) }}

--- a/packages/web-twig/src/Resources/components/Select/Select.twig
+++ b/packages/web-twig/src/Resources/components/Select/Select.twig
@@ -35,7 +35,7 @@
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _rootFluidClassName, _rootDisabledClassName, _rootValidationStateClassName, _styleProps.className ] -%}
 {%- set _labelClassName = [ _labelClassName, _labelHiddenClassName, _labelRequiredClassName ] -%}
-{%- set _mainPropsWithoutId = props | filter((value, prop) => prop != 'id') -%}
+{%- set _mainPropsWithoutId = props | filter((value, prop) => prop is not same as('id')) -%}
 
 <div {{ mainProps(_mainPropsWithoutId) }} {{ styleProp(_styleProps) }} {{ classProp(_classNames) }}>
     <label for="{{ _id }}" {{ classProp(_labelClassName) }}>{{ _label }}</label>

--- a/packages/web-twig/src/Resources/components/Spinner/Spinner.twig
+++ b/packages/web-twig/src/Resources/components/Spinner/Spinner.twig
@@ -10,7 +10,7 @@
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _rootAnimationClassName, _styleProps.className ] -%}
-{%- set _mainPropsWithoutLocal = props | filter((value, prop) => prop != 'color' and prop != 'class') -%}
+{%- set _mainPropsWithoutLocal = props | filter((value, prop) => prop is not same as('color') and prop is not same as('class')) -%}
 
 {% embed "@spirit/icon.twig" with { props: {
     name: 'spinner',

--- a/packages/web-twig/src/Resources/components/TextFieldBase/TextFieldBase.twig
+++ b/packages/web-twig/src/Resources/components/TextFieldBase/TextFieldBase.twig
@@ -53,7 +53,7 @@
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _rootClassNames = [ _rootClassName, _rootDisabledClassName, _rootFluidClassName, _rootValidationStateClassName, _styleProps.className ] -%}
 {%- set _labelClassNames = [ _labelClassName, _labelHiddenClassName, _labelRequiredClassName ] -%}
-{%- set _mainPropsWithoutReservedAttributes = props | filter((value, prop) => prop != 'id' and (_isAutoResizing and prop != 'data-toggle')) -%}
+{%- set _mainPropsWithoutReservedAttributes = props | filter((value, prop) => prop is not same as('id') and (_dataToggleAttr is null or prop is not same as('data-toggle'))) -%}
 {%- set _allowedAttributes = [ 'autocomplete', 'placeholder'] -%}
 {%- set _textFieldAllowedAttributes = _allowedAttributes | merge([ 'value' ]) -%}
 {%- set _textAreaAllowedAttributes = _allowedAttributes | merge([ 'rows' ]) -%}

--- a/packages/web-twig/src/Resources/components/Tooltip/Tooltip.twig
+++ b/packages/web-twig/src/Resources/components/Tooltip/Tooltip.twig
@@ -20,7 +20,7 @@
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _rootPlacementClassName, _rootDismissibleClassName, _styleProps.className ] -%}
-{%- set _mainPropsWithoutId = props | filter((value, prop) => prop != 'id') -%}
+{%- set _mainPropsWithoutId = props | filter((value, prop) => prop is not same as('id')) -%}
 
 <div
     {{ mainProps(_mainPropsWithoutId) }}

--- a/packages/web-twig/src/Resources/partials/inputProps.twig
+++ b/packages/web-twig/src/Resources/partials/inputProps.twig
@@ -1,1 +1,1 @@
-{%- for propName, propValue in transferringAttributes  %}{%- if propValue is not null and propValue != '' %} {{ propName }}="{{ propValue }}"{% endif -%}{% endfor -%}
+{%- for propName, propValue in transferringAttributes  %}{%- if propValue is not null and propValue is not same as('') %} {{ propName }}="{{ propValue }}"{% endif -%}{% endfor -%}

--- a/packages/web-twig/src/Resources/partials/inputProps.twig
+++ b/packages/web-twig/src/Resources/partials/inputProps.twig
@@ -1,1 +1,1 @@
-{%- for propName, propValue in transferringAttributes  %} {{ propName }}="{{ propValue }}"{% endfor -%}
+{%- for propName, propValue in transferringAttributes  %}{%- if propValue is not null and propValue != '' %} {{ propName }}="{{ propValue }}"{% endif -%}{% endfor -%}

--- a/packages/web-twig/src/Resources/partials/mainProps.twig
+++ b/packages/web-twig/src/Resources/partials/mainProps.twig
@@ -1,1 +1,1 @@
-{%- if id != null %} id="{{ id }}"{% endif -%}{%- for propName, propValue in transferringAttributes %} {{ propName }}="{{ propValue }}"{% endfor -%}
+{%- if id != null %} id="{{ id }}"{% endif -%}{%- for propName, propValue in transferringAttributes %}{%- if propValue is not null and propValue != '' %} {{ propName }}="{{ propValue }}"{% endif -%}{% endfor -%}

--- a/packages/web-twig/src/Resources/partials/mainProps.twig
+++ b/packages/web-twig/src/Resources/partials/mainProps.twig
@@ -1,1 +1,1 @@
-{%- if id != null %} id="{{ id }}"{% endif -%}{%- for propName, propValue in transferringAttributes %}{%- if propValue is not null and propValue != '' %} {{ propName }}="{{ propValue }}"{% endif -%}{% endfor -%}
+{%- if id is not same as(null) %} id="{{ id }}"{% endif -%}{%- for propName, propValue in transferringAttributes %}{%- if propValue is not null and propValue is not same as('') %} {{ propName }}="{{ propValue }}"{% endif -%}{% endfor -%}

--- a/packages/web-twig/src/Resources/partials/props.twig
+++ b/packages/web-twig/src/Resources/partials/props.twig
@@ -1,1 +1,1 @@
-{%- if id != null %} id="{{ id }}"{% endif -%}{%- for dataPropName, dataPropValue in dataAttributes  %} {{ dataPropName }}="{{ dataPropValue }}"{% endfor -%}
+{%- if id is not same as(null) %} id="{{ id }}"{% endif -%}{%- for dataPropName, dataPropValue in dataAttributes  %} {{ dataPropName }}="{{ dataPropValue }}"{% endfor -%}

--- a/packages/web-twig/src/Resources/partials/styleProp.twig
+++ b/packages/web-twig/src/Resources/partials/styleProp.twig
@@ -1,1 +1,1 @@
-{%- if style != null %}style="{{ style }}"{% endif -%}
+{%- if style is not same as(null) %}style="{{ style }}"{% endif -%}

--- a/packages/web-twig/src/Twig/PropsExtension.php
+++ b/packages/web-twig/src/Twig/PropsExtension.php
@@ -54,7 +54,7 @@ class PropsExtension extends AbstractExtension
                     // allow manually specified attributes
                     || in_array($propName, $allowedAttributes)
                 ) {
-                    if ($propValue !== '') {
+                    if (! is_null($propValue) && $propValue !== '') {
                         $transferringAttributes[$propName] = $propValue;
                     }
                 }
@@ -76,7 +76,9 @@ class PropsExtension extends AbstractExtension
         $transferringAttributes = [];
         foreach ($props as $propName => $propValue) {
             if (in_array($propName, self::VALIDATION_ATTRIBUTES, true) || in_array($propName, $allowedAttributes)) {
-                $transferringAttributes[$propName] = $propValue;
+                if (! is_null($propValue) && $propValue !== '') {
+                    $transferringAttributes[$propName] = $propValue;
+                }
             }
         }
 

--- a/packages/web-twig/tests/Twig/PropsExtensionTest.php
+++ b/packages/web-twig/tests/Twig/PropsExtensionTest.php
@@ -105,6 +105,23 @@ class PropsExtensionTest extends TestCase
                     'id' => 'testId',
                 ],
             ],
+            'filter only allowed attributes and skip null values' => [
+                [
+                    'test-id' => 'testDataId',
+                    'aria-label' => 'testAria',
+                    'data-label' => 'testData',
+                    'id' => 'testId',
+                    'name' => null,
+                ],
+                ['name'],
+                [
+                    'transferringAttributes' => [
+                        'aria-label' => 'testAria',
+                        'data-label' => 'testData',
+                    ],
+                    'id' => 'testId',
+                ],
+            ],
             'skip empty transferring attributes' => [
                 [
                     'test-id' => 'testDataId',
@@ -145,7 +162,7 @@ class PropsExtensionTest extends TestCase
     }
 
     /**
-     * @return array<string, array<int, array<int|string, array<string, string>|string>>>
+     * @return array<string, array<int, array<int|string, array<string, string>|string|null>>>
      */
     public function renderInputPropsDataProvider(): array
     {
@@ -158,7 +175,22 @@ class PropsExtensionTest extends TestCase
                 'min' => '1',
                 'max' => '6',
                 'autocomplete' => 'on',
-            ], ['autocomplete'], [
+                'placeholder' => 'Your name',
+            ], ['autocomplete', 'placeholder'], [
+                'transferringAttributes' => [
+                    'min' => '1',
+                    'max' => '6',
+                    'autocomplete' => 'on',
+                    'placeholder' => 'Your name',
+                ],
+            ]],
+            'filter only allowed attributes and skip null values' => [[
+                'test-id' => 'testDataId',
+                'min' => '1',
+                'max' => '6',
+                'autocomplete' => 'on',
+                'placeholder' => null,
+            ], ['autocomplete', 'placeholder'], [
                 'transferringAttributes' => [
                     'min' => '1',
                     'max' => '6',

--- a/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set modalComposedDefault.twig__1.html
+++ b/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set modalComposedDefault.twig__1.html
@@ -62,7 +62,7 @@
           <h2 class="ModalHeader__title" id="modal-composed-2-title">
             Title of the Modal
           </h2>
-          <button aria-controls="modal-composed-2" aria-expanded="false" data-dismiss="" data-target="" class="Button Button--tertiary Button--medium Button--square" type="button"><svg width="24" height="24" fill="none" viewbox="0 0 24 24" aria-hidden="true">
+          <button aria-controls="modal-composed-2" aria-expanded="false" class="Button Button--tertiary Button--medium Button--square" type="button"><svg width="24" height="24" fill="none" viewbox="0 0 24 24" aria-hidden="true">
           <use href="#a79dff7a255f69bbe6e39d594aa2275b">
           </use></svg> <span class="accessibility-hidden">Close form</span></button>
         </header>

--- a/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set textAreaWithAutoResize.twig__1.html
+++ b/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set textAreaWithAutoResize.twig__1.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>
+    </title>
+  </head>
+  <body>
+    <div data-test="test" class="TextArea TextArea--error" data-toggle="autoResize">
+      <label for="example" class="TextArea__label TextArea__label--required">TextArea</label> 
+
+      <textarea maxlength="10" minlength="6" rows="10" id="example" name="example" class="TextArea__input" required="">TextArea value</textarea>
+      <div class="TextArea__message">
+        validation failed
+      </div>
+    </div>
+  </body>
+</html>

--- a/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set textFieldBaseDefault.twig__1.html
+++ b/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set textFieldBaseDefault.twig__1.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div data-test="test" class="TextField TextField--error">
+    <div data-test="test" data-validate="1" data-spirit-validate="1" data-custom-validate="true" class="TextField TextField--error">
       <label for="example" class="TextField__label TextField__label--required">Text field</label> <input minlength="6" autocomplete="on" placeholder="Very long text" value="Some long value" type="text" id="example" name="example" class="TextField__input" size="10" required="">
       <div class="TextField__message">
         validation failed

--- a/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set textFieldBaseDefault.twig__1.html
+++ b/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set textFieldBaseDefault.twig__1.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="TextField TextField--error">
+    <div data-test="test" class="TextField TextField--error">
       <label for="example" class="TextField__label TextField__label--required">Text field</label> <input minlength="6" autocomplete="on" placeholder="Very long text" value="Some long value" type="text" id="example" name="example" class="TextField__input" size="10" required="">
       <div class="TextField__message">
         validation failed

--- a/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set textFieldBaseMultiline.twig__1.html
+++ b/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set textFieldBaseMultiline.twig__1.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="TextArea TextArea--error">
+    <div data-test="test" class="TextArea TextArea--error">
       <label for="example" class="TextArea__label TextArea__label--required">Textarea</label> 
 
       <textarea minlength="6" id="example" name="example" class="TextArea__input" required=""></textarea>

--- a/packages/web-twig/tests/components-fixtures/breadcrumbsCustom.twig
+++ b/packages/web-twig/tests/components-fixtures/breadcrumbsCustom.twig
@@ -30,7 +30,7 @@
                     <Link
                         href="{{ item.url }}"
                         color="{{ loop.last ? 'secondary' : 'primary' }}"
-                        isUnderlined="{{ loop.last != true }}"
+                        isUnderlined="{{ loop.last is not same as(true) }}"
                         aria-current="{{ loop.last ? 'page' : 'false' }}"
                     >{{ item.title }}</Link>
                 </li>

--- a/packages/web-twig/tests/components-fixtures/textAreaWithAutoResize.twig
+++ b/packages/web-twig/tests/components-fixtures/textAreaWithAutoResize.twig
@@ -1,0 +1,14 @@
+<TextArea
+    id="example"
+    isAutoResizing
+    isRequired
+    label="TextArea"
+    maxlength="10"
+    message="validation failed"
+    minlength="6"
+    name="example"
+    rows="10"
+    validationState="error"
+    value="TextArea value"
+    data-test="test"
+/>

--- a/packages/web-twig/tests/components-fixtures/textFieldBaseDefault.twig
+++ b/packages/web-twig/tests/components-fixtures/textFieldBaseDefault.twig
@@ -12,4 +12,7 @@
     placeholder="Very long text"
     value="Some long value"
     data-test="test"
+    data-validate={ true }
+    data-spirit-validate
+    data-custom-validate="true"
 />

--- a/packages/web-twig/tests/components-fixtures/textFieldBaseDefault.twig
+++ b/packages/web-twig/tests/components-fixtures/textFieldBaseDefault.twig
@@ -11,4 +11,5 @@
     autocomplete="on"
     placeholder="Very long text"
     value="Some long value"
+    data-test="test"
 />

--- a/packages/web-twig/tests/components-fixtures/textFieldBaseMultiline.twig
+++ b/packages/web-twig/tests/components-fixtures/textFieldBaseMultiline.twig
@@ -8,4 +8,5 @@
     validationState="error"
     message="validation failed"
     minlength="6"
+    data-test="test"
 />


### PR DESCRIPTION
In Jobs we use form fields without lexer syntax via customized Symfony Forms widgets.
We have defined the whole props array to the given component. If a `propValue` is not given, we pass to the props `null`, otherwise the given value. 

```
{% set props = {
    propName: attr.propValue ?? null,
    …
} %}
```

Since the last update the attribute is rendered even its value is `null`.

<img width="1289" alt="image" src="https://github.com/lmc-eu/spirit-design-system/assets/33354913/c9155e35-4aec-49fc-b4e2-3dd20a48fcc8">
