### PR TITLE
Feat(web): Enable customization of `ScrollView` shadows via custom properties

### DIFF
--- a/packages/web/src/scss/components/ScrollView/README.md
+++ b/packages/web/src/scss/components/ScrollView/README.md
@@ -93,6 +93,15 @@ Or both:
 ></div>
 ```
 
+### Custom Shadows
+
+You can customize the shadows by overriding the following CSS variables:
+
+```css
+--scroll-view-start-shadow-background: linear-gradient(to bottom, #9400d3 0%, #9400d300 100%);
+--scroll-view-end-shadow-background: linear-gradient(to top, #9400d3 0%, #9400d300 100%);
+```
+
 ## Scrollbar
 
 Depending on user's operating system and browser, the scrollbar may be hidden by default, or take up space in the container element.

--- a/packages/web/src/scss/components/ScrollView/_ScrollView.scss
+++ b/packages/web/src/scss/components/ScrollView/_ScrollView.scss
@@ -64,11 +64,11 @@
 
 .ScrollView__indicators--shadows {
     &::before {
-        background: theme.$start-shadow-background;
+        background: var(--scroll-view-start-shadow-background, theme.$start-shadow-background);
     }
 
     &::after {
-        background: theme.$end-shadow-background;
+        background: var(--scroll-view-end-shadow-background, theme.$end-shadow-background);
     }
 }
 

--- a/packages/web/src/scss/components/ScrollView/index.html
+++ b/packages/web/src/scss/components/ScrollView/index.html
@@ -143,7 +143,7 @@
   </div>
 
   <div
-    class="ScrollView ScrollView--horizontal"
+    class="ScrollView ScrollView--horizontal mb-1000"
     data-toggle="scrollView"
     data-spirit-direction="horizontal"
   >
@@ -157,6 +157,67 @@
       </div>
     </div>
     <div class="ScrollView__indicators ScrollView__indicators--borders ScrollView__indicators--shadows" aria-hidden="true"></div>
+  </div>
+
+  <h3>Custom Shadows</h3>
+
+  <div
+    class="mb-1000 px-700 py-600"
+    style="height: 160px; color: white; background-color: #9400d3;"
+  >
+
+    <div
+      class="ScrollView ScrollView--vertical"
+      data-toggle="scrollView"
+      data-spirit-direction="vertical"
+    >
+      <div class="ScrollView__viewport" data-spirit-element="viewport">
+        <div class="ScrollView__content" data-spirit-element="content">
+
+          <p>
+            Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc.Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc.
+          </p>
+
+        </div>
+      </div>
+      <div
+        class="ScrollView__indicators ScrollView__indicators--shadows"
+        style="
+          --scroll-view-start-shadow-background: linear-gradient(to bottom, #9400d3 0%, #9400d300 100%);
+          --scroll-view-end-shadow-background: linear-gradient(to top, #9400d3 0%, #9400d300 100%);
+        "
+        aria-hidden="true"
+      ></div>
+    </div>
+
+  </div>
+
+  <div class="px-700 py-600" style="color: white; background-color: #9400d3;">
+
+    <div
+      class="ScrollView ScrollView--horizontal"
+      data-toggle="scrollView"
+      data-spirit-direction="horizontal"
+    >
+      <div class="ScrollView__viewport" data-spirit-element="viewport">
+        <div class="ScrollView__content" data-spirit-element="content">
+
+          <p class="py-700" style="white-space: nowrap">
+            Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.
+          </p>
+
+        </div>
+      </div>
+      <div
+        class="ScrollView__indicators ScrollView__indicators--shadows"
+        style="
+          --scroll-view-start-shadow-background: linear-gradient(to right, #9400d3 0%, #9400d300 100%);
+          --scroll-view-end-shadow-background: linear-gradient(to left, #9400d3 0%, #9400d300 100%);
+        "
+        aria-hidden="true"
+      ></div>
+    </div>
+
   </div>
 
 </section>


### PR DESCRIPTION
New custom properties:

- `--scroll-view-start-shadow-background`
- `--scroll-view-end-shadow-background`

<img width="1318" alt="image" src="https://github.com/lmc-eu/spirit-design-system/assets/5614085/3159e528-1b8c-4233-97a8-a3bbf2145286">