### PR TITLE
Revert: Chore(ci): Test builds also on Node.js v20

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # supporting primarily LTS
-        node-version: [16, 18, 20]
+        node-version: [16, 18]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Fails on installing eslint-config-jsdoc.