### PR TITLE
Fix(web-react): TextArea is using native maxlength attribute

### DIFF
--- a/packages/web-react/src/components/TextArea/stories/argTypes.ts
+++ b/packages/web-react/src/components/TextArea/stories/argTypes.ts
@@ -50,6 +50,13 @@ export default {
     },
     defaultValue: 'example',
   },
+  maxLength: {
+    control: {
+      type: 'number',
+    },
+    defaultValue: 100,
+    description: 'Maximum characters length',
+  },
   for: {
     control: {
       type: 'text',

--- a/packages/web-react/src/types/textArea.ts
+++ b/packages/web-react/src/types/textArea.ts
@@ -20,8 +20,6 @@ export interface TextAreaProps
     HelperTextProps,
     TextInputProps,
     Validation {
-  /** Maximum characters length */
-  maxLength?: number;
   /** Whether is field auto resizing which adjusts its height while typing */
   isAutoResizing?: boolean;
   /** Maximum field height with automatic height control */


### PR DESCRIPTION
  * the type is defined using DetailedHTMProps
  * the `maxLength` prop was not used anywhere

<!-- Thank you for contributing! -->

## Description

Base on this comment (https://github.com/lmc-eu/spirit-design-system/pull/894/files#r1234453108) about the usage of `maxLenght` in web-twig I have checked it in web-react as well and noticed that it is not used anywhere thus I can removed it and replace with native `maxlength`.

### Additional context

https://github.com/lmc-eu/spirit-design-system/pull/894/files#r1234453108

### Issue reference

No issue referenced.

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md).
- [x] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
