### PR TITLE
Feat(web-twig): Allow pass `translate` attribute to the `Heading` and `Text` components

### DIFF
--- a/packages/web-twig/src/Resources/components/Heading/Heading.twig
+++ b/packages/web-twig/src/Resources/components/Heading/Heading.twig
@@ -9,7 +9,8 @@
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _styleProps.className ] -%}
+{%- set _allowedAttributes = [ 'translate' ] -%}
 
-<{{ _elementType }} {{ mainProps(props) }} {{ styleProp(_styleProps) }} {{ classProp(_classNames) }}>
+<{{ _elementType }} {{ mainProps(props, _allowedAttributes) }} {{ styleProp(_styleProps) }} {{ classProp(_classNames) }}>
 {%- block content %}{% endblock -%}
 </{{ _elementType }}>

--- a/packages/web-twig/src/Resources/components/Text/Text.twig
+++ b/packages/web-twig/src/Resources/components/Text/Text.twig
@@ -10,7 +10,8 @@
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _styleProps.className ] -%}
+{%- set _allowedAttributes = [ 'translate' ] -%}
 
-<{{ _elementType }} {{ mainProps(props) }} {{ styleProp(_styleProps) }} {{ classProp(_classNames) }}>
+<{{ _elementType }} {{ mainProps(props, _allowedAttributes) }} {{ styleProp(_styleProps) }} {{ classProp(_classNames) }}>
 {%- block content %}{% endblock -%}
 </{{ _elementType }}>

--- a/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set headingDefault.twig__1.html
+++ b/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set headingDefault.twig__1.html
@@ -13,7 +13,7 @@
       Example heading
     </h1>
 
-    <div class="typography-heading-large-text">
+    <div translate="no" class="typography-heading-large-text">
       Example heading
     </div>
   </body>

--- a/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set textDefault.twig__1.html
+++ b/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set textDefault.twig__1.html
@@ -9,7 +9,7 @@
       Example text
     </p>
 
-    <div class="typography-body-medium-text-regular">
+    <div translate="no" class="typography-body-medium-text-regular">
       Example text
     </div>
 

--- a/packages/web-twig/tests/components-fixtures/headingDefault.twig
+++ b/packages/web-twig/tests/components-fixtures/headingDefault.twig
@@ -4,6 +4,6 @@
 <Heading elementType="h1">
     Example heading
 </Heading>
-<Heading size="large">
+<Heading size="large" translate="no">
     Example heading
 </Heading>

--- a/packages/web-twig/tests/components-fixtures/textDefault.twig
+++ b/packages/web-twig/tests/components-fixtures/textDefault.twig
@@ -1,7 +1,7 @@
 <Text>
     Example text
 </Text>
-<Text elementType="div">
+<Text elementType="div" translate="no">
     Example text
 </Text>
 <Text size="large" emphasis="bold">


### PR DESCRIPTION
## Description

Allow pass `translate` attribute to the `Heading` and `Text` components.

### Additional context

For product purposes we would like to be able use text components as well as set them attribute `translate` to prevent text translation.

### Issue reference

Upcoming issue that will set global attributes across all components: https://jira.lmc.cz/browse/DS-836. 
