### PR TITLE
Chore(web-react): Set correct path according to the base directory

### DIFF
--- a/packages/web-react/netlify.toml
+++ b/packages/web-react/netlify.toml
@@ -23,4 +23,4 @@
 
 [context.deploy-preview]
   # Deploy preview only if there are changes in some directories
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./packages/web-react/src/"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./src/"


### PR DESCRIPTION
  * problem during Netlify builds
  * fatal: ambiguous argument './packages/web-react/src/'
  * unknown revision or path not in the working tree.

<!-- Thank you for contributing! -->

## Description

Netlify is building web-react package while the change is only in the web-twig. Thus the web-react package should not be built.

### Additional context

We want to build only packages according to the changes in the file structure.

```
3:26:10 PM: Custom publish path detected. Proceeding with the specified path: 'packages/web-react/build'
3:26:10 PM: Custom build command detected. Proceeding with the specified command: 'cd ../../ && yarn lerna run --scope @lmc-eu/spirit-icons build && yarn lerna run --scope @lmc-eu/spirit-web-react examples:build'
3:26:10 PM: Custom ignore command detected. Proceeding with the specified command: 'git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./packages/web-react/src/'
3:26:10 PM: fatal: ambiguous argument './packages/web-react/src/': unknown revision or path not in the working tree.
3:26:10 PM: Use '--' to separate paths from revisions, like this:
3:26:10 PM: 'git <command> [<revision>...] -- [<file>...]'
```

https://app.netlify.com/sites/spirit-design-system-react/deploys/6491a7822b1ff4000872bde7

### Issue reference

See https://github.com/lmc-eu/spirit-design-system/pull/882

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md).
- [x] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
