### PR TITLE
BREAKING CHANGE(web-react): Rename `message` prop to `validationText`…

### DIFF
--- a/packages/web-react/src/components/CheckboxField/CheckboxField.tsx
+++ b/packages/web-react/src/components/CheckboxField/CheckboxField.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, ForwardedRef } from 'react';
 import classNames from 'classnames';
-import { useDeprecationMessage, useStyleProps } from '../../hooks';
+import { useStyleProps } from '../../hooks';
 import { SpiritCheckboxFieldProps } from '../../types';
 import { useValidationText } from '../Field';
 import { useCheckboxFieldStyleProps } from './useCheckboxFieldStyleProps';
@@ -9,24 +9,25 @@ import { useCheckboxFieldStyleProps } from './useCheckboxFieldStyleProps';
 /* eslint no-underscore-dangle: ['error', { allow: ['_CheckboxField'] }] */
 const _CheckboxField = (props: SpiritCheckboxFieldProps, ref: ForwardedRef<HTMLInputElement>): JSX.Element => {
   const { classProps, props: modifiedProps } = useCheckboxFieldStyleProps(props);
-  const { id, label, message, helperText, validationState, value, isDisabled, isRequired, isChecked, ...restProps } =
-    modifiedProps;
+  const {
+    id,
+    label,
+    validationText,
+    helperText,
+    validationState,
+    value,
+    isDisabled,
+    isRequired,
+    isChecked,
+    ...restProps
+  } = modifiedProps;
   const { styleProps, props: otherProps } = useStyleProps(restProps);
 
-  useDeprecationMessage({
-    method: 'custom',
-    trigger: !!(props?.message && !validationState),
-    componentName: 'CheckboxField',
-    customText:
-      '`message` prop without `validationState` prop will be unsupported in the next version. Use `helperText` instead.',
-  });
-
   const renderValidationText = useValidationText({
-    validationTextClassName: classProps.message,
+    validationTextClassName: classProps.validationText,
     validationState,
-    validationText: message,
+    validationText,
     validationElementType: 'span',
-    requireValidationState: false,
   });
 
   return (

--- a/packages/web-react/src/components/CheckboxField/README.md
+++ b/packages/web-react/src/components/CheckboxField/README.md
@@ -1,16 +1,27 @@
 # CheckboxField
 
-CheckboxField enables the user to check/uncheck choice. It has input, a label, and an optional helperText.
-It could be disabled or have a validation state. The label could be hidden and show if the input is required.
+CheckboxField enables the user to check/uncheck choice.
+It has input, a label, and an optional helperText.
+It could be disabled or have a validation state.
+The label could be hidden and show if the input is required.
+
+Basic example usage:
+
+```jsx
+<CheckboxField id="checkboxfieldDefault" label="Label" name="checkboxfieldDefault" />
+```
+
+Advanced example usage:
 
 ```jsx
 <CheckboxField
-  id="example"
-  name="example"
-  isRequired
+  id="checkboxfieldAdvanced"
   isChecked
+  isRequired
+  name="checkboxfieldAdvanced"
+  validationText="validation text"
   validationState="danger"
-  validationText="validation failed"
+  helperText="Helper text"
 />
 ```
 

--- a/packages/web-react/src/components/CheckboxField/README.md
+++ b/packages/web-react/src/components/CheckboxField/README.md
@@ -19,17 +19,17 @@ It could be disabled or have a validation state. The label could be hidden and s
 | Prop name         | Type                                           | Default | Required | Description                    |
 | ----------------- | ---------------------------------------------- | ------- | -------- | ------------------------------ |
 | `id`              | `string`                                       | -       | yes      | Input and label identification |
-| `name`            | `string`                                       | -       | no       | Input name                     |
+| `isDisabled`      | `boolean`                                      | -       | no       | Whether is field disabled      |
+| `isChecked`       | `boolean`                                      | -       | no       | Whether is field checked       |
+| `isItem`          | `boolean`                                      | -       | no       | To render in [Item][item] mode |
+| `isLabelHidden`   | `boolean`                                      | -       | no       | Whether is label hidden        |
+| `isRequired`      | `boolean`                                      | -       | no       | Whether is field required      |
 | `label`           | `string`                                       | -       | no       | Label text                     |
-| `value`           | `string`                                       | -       | no       | Input value                    |
+| `name`            | `string`                                       | -       | no       | Input name                     |
+| `ref`             | `ForwardedRef<HTMLInputElement>`               | -       | no       | Input element reference        |
 | `validationState` | [Validation dictionary][dictionary-validation] | -       | no       | Type of validation state.      |
 | `validationText`  | `string`, `string[]`                           | -       | no       | Validation text                |
-| `isDisabled`      | `boolean`                                      | -       | no       | Whether is field disabled      |
-| `isItem`          | `boolean`                                      | -       | no       | To render in [Item][item] mode |
-| `isRequired`      | `boolean`                                      | -       | no       | Whether is field required      |
-| `isChecked`       | `boolean`                                      | -       | no       | Whether is field checked       |
-| `isLabelHidden`   | `boolean`                                      | -       | no       | Whether is label hidden        |
-| `ref`             | `ForwardedRef<HTMLInputElement>`               | -       | no       | Input element reference        |
+| `value`           | `string`                                       | -       | no       | Input value                    |
 
 ## Custom component
 

--- a/packages/web-react/src/components/CheckboxField/README.md
+++ b/packages/web-react/src/components/CheckboxField/README.md
@@ -1,11 +1,17 @@
 # CheckboxField
 
-CheckboxField enables the user to check/uncheck choice. It has input, a label,
-and an optional message. It could be disabled or have a validation state. The label could be hidden
-and show if the input is required.
+CheckboxField enables the user to check/uncheck choice. It has input, a label, and an optional helperText.
+It could be disabled or have a validation state. The label could be hidden and show if the input is required.
 
 ```jsx
-<CheckboxField id="example" name="example" isRequired isChecked validationState="danger" message="validation failed" />
+<CheckboxField
+  id="example"
+  name="example"
+  isRequired
+  isChecked
+  validationState="danger"
+  validationText="validation failed"
+/>
 ```
 
 ## Available props
@@ -16,8 +22,8 @@ and show if the input is required.
 | `name`            | `string`                                       | -       | no       | Input name                     |
 | `label`           | `string`                                       | -       | no       | Label text                     |
 | `value`           | `string`                                       | -       | no       | Input value                    |
-| `message`         | `string`, `string[]`                           | -       | no       | Validation or help message     |
 | `validationState` | [Validation dictionary][dictionary-validation] | -       | no       | Type of validation state.      |
+| `validationText`  | `string`, `string[]`                           | -       | no       | Validation text                |
 | `isDisabled`      | `boolean`                                      | -       | no       | Whether is field disabled      |
 | `isItem`          | `boolean`                                      | -       | no       | To render in [Item][item] mode |
 | `isRequired`      | `boolean`                                      | -       | no       | Whether is field required      |
@@ -39,7 +45,7 @@ const CustomCheckboxField = (props: SpiritCheckboxFieldProps): JSX.Element => {
       <span className={styleProps.text}>
         <span className={styleProps.label}>{props.label}</span>
         <span className={styleProps.helperText}>{props.helperText}</span>
-        <span className={styleProps.message}>{props.message}</span>
+        <span className={styleProps.validationText}>{props.validationText}</span>
       </span>
     </label>
   );

--- a/packages/web-react/src/components/CheckboxField/__tests__/CheckboxField.test.tsx
+++ b/packages/web-react/src/components/CheckboxField/__tests__/CheckboxField.test.tsx
@@ -20,7 +20,7 @@ describe('CheckboxField', () => {
 
   validationStatePropsTest(CheckboxField, 'CheckboxField--');
 
-  validationTextPropsTest(CheckboxField, '.CheckboxField__message');
+  validationTextPropsTest(CheckboxField, '.CheckboxField__validationText');
 
   it('should have text classname', () => {
     const dom = render(<CheckboxField id="checkbox" label="Label" />);

--- a/packages/web-react/src/components/CheckboxField/__tests__/useCheckboxFieldStyleProps.test.ts
+++ b/packages/web-react/src/components/CheckboxField/__tests__/useCheckboxFieldStyleProps.test.ts
@@ -13,7 +13,7 @@ describe('useCheckboxFieldStyleProps', () => {
       text: 'CheckboxField__text',
       input: 'CheckboxField__input',
       label: 'CheckboxField__label',
-      message: 'CheckboxField__message',
+      validationText: 'CheckboxField__validationText',
       helperText: 'CheckboxField__helperText',
     });
   });

--- a/packages/web-react/src/components/CheckboxField/stories/CheckboxFieldValidationState.tsx
+++ b/packages/web-react/src/components/CheckboxField/stories/CheckboxFieldValidationState.tsx
@@ -8,21 +8,21 @@ const Story = () => (
       label="Checkbox success"
       name="example"
       validationState="success"
-      message="Success validation message"
+      validationText="Success validation text"
     />
     <CheckboxField
       id="checkboxfield1"
       label="Checkbox warning"
       name="example"
       validationState="warning"
-      message="Warning validation message"
+      validationText="Warning validation text"
     />
     <CheckboxField
       id="checkboxfield2"
       label="Checkbox danger"
       name="example"
       validationState="danger"
-      message={['Danger validation message', 'Danger validation message']}
+      validationText={['Danger validation text', 'Danger validation text']}
     />
   </div>
 );

--- a/packages/web-react/src/components/CheckboxField/stories/argTypes.ts
+++ b/packages/web-react/src/components/CheckboxField/stories/argTypes.ts
@@ -62,13 +62,13 @@ export default {
     },
     defaultValue: '',
   },
-  message: {
+  validationText: {
     control: {
       type: 'object',
     },
     defaultValue: '',
     description:
-      'The validation message. Use a string `"foo"` for single message or an array for multiple messages `["foo", "bar"]`.',
+      'The validation text. Only visible if validationState is set. Use a string `"foo"` for single validation text or an array for multiple validation texts `["foo", "bar"]`.',
   },
   helperText: {
     control: {

--- a/packages/web-react/src/components/CheckboxField/useCheckboxFieldStyleProps.ts
+++ b/packages/web-react/src/components/CheckboxField/useCheckboxFieldStyleProps.ts
@@ -9,8 +9,8 @@ export interface CheckboxFieldStyles {
     text: string;
     label: string;
     input: string;
-    message: string;
     helperText: string;
+    validationText: string;
   };
   /** props to be passed to the input element */
   props: CheckboxFieldProps;
@@ -28,14 +28,14 @@ export function useCheckboxFieldStyleProps(props: SpiritCheckboxFieldProps): Che
   const checkboxFieldLabelClass = `${checkboxFieldClass}__label`;
   const checkboxFieldLabelRequiredClass = `${checkboxFieldClass}__label--required`;
   const checkboxFieldLabelHiddenClass = `${checkboxFieldClass}__label--hidden`;
-  const checkboxFieldMessageClass = `${checkboxFieldClass}__message`;
   const checkboxFieldHelperTextClass = `${checkboxFieldClass}__helperText`;
-  const checkboxValidationClass = `${checkboxFieldClass}--${validationState}`;
+  const checkboxFieldValidationTextClass = `${checkboxFieldClass}__validationText`;
+  const checkboxFieldValidationClass = `${checkboxFieldClass}--${validationState}`;
 
   const rootStyles = classNames(checkboxFieldClass, {
     [checkboxFieldDisabledClass]: isDisabled,
     [checkboxFieldItemClass]: isItem,
-    [checkboxValidationClass]: validationState,
+    [checkboxFieldValidationClass]: validationState,
   });
   const labelStyles = classNames(checkboxFieldLabelClass, {
     [checkboxFieldLabelRequiredClass]: isRequired,
@@ -48,9 +48,12 @@ export function useCheckboxFieldStyleProps(props: SpiritCheckboxFieldProps): Che
       text: checkboxFieldTextClass,
       label: labelStyles,
       input: checkboxFieldInputClass,
-      message: checkboxFieldMessageClass,
       helperText: checkboxFieldHelperTextClass,
+      validationText: checkboxFieldValidationTextClass,
     },
-    props: restProps,
+    props: {
+      ...restProps,
+      validationState,
+    },
   };
 }

--- a/packages/web-react/src/components/Field/README.md
+++ b/packages/web-react/src/components/Field/README.md
@@ -1,21 +1,23 @@
-# ValidationText
+# Field
 
-The validationText subcomponent displays validation messages for Field components like TextField, TextArea, CheckboxField, FileUploader, etc.
+## ValidationText
+
+The ValidationText subcomponent displays validation texts for Field components like TextField, TextArea, CheckboxField, FileUploader, etc.
 
 ```jsx
 import { ValidationText } from '@lmc-eu/spirit-web-react/components';
 ```
 
 ```jsx
-<ValidationText elementType="div" className="TextField__message" validationText="This field is required" />
+<ValidationText elementType="div" className="TextField__validationText" validationText="This field is required" />
 ```
 
 ## ValidationText
 
 **Available props**
 
-| Name             | Type                 | Default | Required | Description                                                                                       |
-| ---------------- | -------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `elementType`    | `span`, `div`        | `div`   | no       | Type of element used as main wrapper (applied only for single validation message, otherwise `ul`) |
-| `className`      | `string`             | -       | yes      | Wrapper custom class name                                                                         |
-| `validationText` | `string`, `string[]` | -       | yes      | Validation message                                                                                |
+| Name             | Type                 | Default | Required | Description                                                                                    |
+| ---------------- | -------------------- | ------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `elementType`    | `span`, `div`        | `div`   | no       | Type of element used as main wrapper (applied only for single validation text, otherwise `ul`) |
+| `className`      | `string`             | -       | yes      | Wrapper custom class name                                                                      |
+| `validationText` | `string`, `string[]` | -       | yes      | Validation text                                                                                |

--- a/packages/web-react/src/components/Field/README.md
+++ b/packages/web-react/src/components/Field/README.md
@@ -18,6 +18,6 @@ import { ValidationText } from '@lmc-eu/spirit-web-react/components';
 
 | Name             | Type                 | Default | Required | Description                                                                                    |
 | ---------------- | -------------------- | ------- | -------- | ---------------------------------------------------------------------------------------------- |
-| `elementType`    | `span`, `div`        | `div`   | no       | Type of element used as main wrapper (applied only for single validation text, otherwise `ul`) |
 | `className`      | `string`             | -       | yes      | Wrapper custom class name                                                                      |
+| `elementType`    | `span`, `div`        | `div`   | no       | Type of element used as main wrapper (applied only for single validation text, otherwise `ul`) |
 | `validationText` | `string`, `string[]` | -       | yes      | Validation text                                                                                |

--- a/packages/web-react/src/components/Field/README.md
+++ b/packages/web-react/src/components/Field/README.md
@@ -8,8 +8,16 @@ The ValidationText subcomponent displays validation texts for Field components l
 import { ValidationText } from '@lmc-eu/spirit-web-react/components';
 ```
 
+Basic example usage:
+
 ```jsx
-<ValidationText elementType="div" className="TextField__validationText" validationText="This field is required" />
+<ValidationText className="Component__validationText" validationText="Danger validation text" />
+```
+
+Advanced example:
+
+```jsx
+<ValidationText className="Component__validationText" elementType="span" validationState="danger" />
 ```
 
 ## ValidationText

--- a/packages/web-react/src/components/Field/ValidationText.tsx
+++ b/packages/web-react/src/components/Field/ValidationText.tsx
@@ -1,9 +1,8 @@
 import React, { ElementType } from 'react';
-import { ValidationTextType } from '../../types';
+import { ValidationTextProp } from '../../types';
 
-export interface ValidationTextProps {
+export interface ValidationTextProps extends ValidationTextProp {
   className?: string;
-  validationText: ValidationTextType;
   elementType?: ElementType;
 }
 

--- a/packages/web-react/src/components/Field/ValidationText.tsx
+++ b/packages/web-react/src/components/Field/ValidationText.tsx
@@ -7,8 +7,8 @@ export interface ValidationTextProps extends ValidationTextProp {
 }
 
 const defaultProps = {
-  elementType: 'div',
   className: undefined,
+  elementType: 'div',
 };
 
 export const ValidationText = (props: ValidationTextProps) => {

--- a/packages/web-react/src/components/Field/__tests__/ValidationText.test.tsx
+++ b/packages/web-react/src/components/Field/__tests__/ValidationText.test.tsx
@@ -5,22 +5,22 @@ import ValidationText from '../ValidationText';
 
 describe('ValidationText', () => {
   it('should render single validation text', () => {
-    const dom = render(<ValidationText className="ValidationText__message" validationText="validation message" />);
+    const dom = render(<ValidationText className="ValidationText__validationText" validationText="validation text" />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
-    expect(element.textContent).toBe('validation message');
+    expect(element.textContent).toBe('validation text');
   });
 
-  it('should render multiple validation messages', () => {
+  it('should render multiple validation texts', () => {
     const dom = render(
       <ValidationText
-        className="ValidationText__message"
-        validationText={['validation message', 'another validation message']}
+        className="ValidationText__validationText"
+        validationText={['validation text', 'another validation text']}
       />,
     );
 
     const elements = dom.container.querySelectorAll('li') as NodeListOf<HTMLLIElement>;
-    expect(elements[0].textContent).toBe('validation message');
-    expect(elements[1].textContent).toBe('another validation message');
+    expect(elements[0].textContent).toBe('validation text');
+    expect(elements[1].textContent).toBe('another validation text');
   });
 });

--- a/packages/web-react/src/components/Field/__tests__/useValidationText.test.ts
+++ b/packages/web-react/src/components/Field/__tests__/useValidationText.test.ts
@@ -2,16 +2,16 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useValidationText } from '../useValidationText';
 
 describe('useValidationText', () => {
-  it('should return null', () => {
+  it('should return undefined', () => {
     const { result } = renderHook(() => useValidationText({ validationTextClassName: '', validationState: undefined }));
 
-    expect(result.current).toBeNull();
+    expect(result.current).toBeUndefined();
   });
 
   it('should return ValidationText component', () => {
     const { result } = renderHook(() =>
       useValidationText({
-        validationTextClassName: 'TextField__message',
+        validationTextClassName: 'TextField__validationText',
         validationState: 'danger',
         validationText: 'required',
       }),
@@ -19,7 +19,7 @@ describe('useValidationText', () => {
 
     expect(result.current).toMatchInlineSnapshot(`
       <ValidationText
-        className="TextField__message"
+        className="TextField__validationText"
         elementType="div"
         validationText="required"
       />

--- a/packages/web-react/src/components/Field/useValidationText.tsx
+++ b/packages/web-react/src/components/Field/useValidationText.tsx
@@ -3,14 +3,14 @@ import { ValidationState, ValidationTextType } from '../../types';
 import ValidationText from './ValidationText';
 
 export interface UseValidationTextProps {
-  validationTextClassName?: string;
+  validationElementType?: ElementType;
   validationState?: ValidationState;
   validationText?: ValidationTextType;
-  validationElementType?: ElementType;
+  validationTextClassName?: string;
 }
 
 export const useValidationText = (props: UseValidationTextProps): ReactNode => {
-  const { validationTextClassName, validationState, validationText, validationElementType } = props;
+  const { validationElementType, validationState, validationText, validationTextClassName } = props;
 
   return useMemo(
     () =>
@@ -18,10 +18,10 @@ export const useValidationText = (props: UseValidationTextProps): ReactNode => {
       validationText && (
         <ValidationText
           className={validationTextClassName}
-          validationText={validationText}
           elementType={validationElementType}
+          validationText={validationText}
         />
       ),
-    [validationState, validationText, validationElementType, validationTextClassName],
+    [validationElementType, validationState, validationText, validationTextClassName],
   );
 };

--- a/packages/web-react/src/components/Field/useValidationText.tsx
+++ b/packages/web-react/src/components/Field/useValidationText.tsx
@@ -7,29 +7,21 @@ export interface UseValidationTextProps {
   validationState?: ValidationState;
   validationText?: ValidationTextType;
   validationElementType?: ElementType;
-  /** @deprecated Will be removed in the next major version. */
-  requireValidationState?: boolean;
 }
 
 export const useValidationText = (props: UseValidationTextProps): ReactNode => {
-  const {
-    validationTextClassName,
-    validationState,
-    validationText,
-    validationElementType,
-    /** @deprecated Will be removed in the next major version. */
-    requireValidationState = true,
-  } = props;
+  const { validationTextClassName, validationState, validationText, validationElementType } = props;
 
   return useMemo(
     () =>
-      (requireValidationState && !validationState) || !validationText ? null : (
+      validationState &&
+      validationText && (
         <ValidationText
           className={validationTextClassName}
           validationText={validationText}
           elementType={validationElementType}
         />
       ),
-    [validationState, validationText, validationElementType, validationTextClassName, requireValidationState],
+    [validationState, validationText, validationElementType, validationTextClassName],
   );
 };

--- a/packages/web-react/src/components/RadioField/README.md
+++ b/packages/web-react/src/components/RadioField/README.md
@@ -1,9 +1,28 @@
 # RadioField
 
-Use RadioField when you have a group of mutually exclusive choices and only one selection from the group is allowed. It has input and label. It can be disabled or have a validation state. The label can be hidden.
+Use RadioField when you have a group of mutually exclusive choices and only one selection from the group is allowed.
+It has input and label.
+It can be disabled or have a validation state.
+The label can be hidden.
+
+Basic example usage:
 
 ```jsx
-<RadioField id="example" name="example" label="Label text" isChecked />
+<RadioField id="radiofieldDefault" isChecked label="Label" name="radiofieldDefault" />
+```
+
+Advanced example usage:
+
+```jsx
+<RadioField
+  autocomplete="off"
+  helperText="Helper text"
+  id="radiofieldAdvanced"
+  isChecked
+  label="some label"
+  name="radiofieldAdvanced"
+  validationState="danger"
+/>
 ```
 
 ## Available props

--- a/packages/web-react/src/components/RadioField/README.md
+++ b/packages/web-react/src/components/RadioField/README.md
@@ -11,15 +11,15 @@ Use RadioField when you have a group of mutually exclusive choices and only one 
 | Prop name         | Type                                           | Default | Required | Description                    |
 | ----------------- | ---------------------------------------------- | ------- | -------- | ------------------------------ |
 | `id`              | string                                         | -       | yes      | Input and label identification |
-| `name`            | string                                         | -       | no       | Input name                     |
-| `label`           | string                                         | -       | no       | Label text                     |
-| `value`           | string                                         | -       | no       | Input value                    |
 | `isDisabled`      | boolean                                        | -       | no       | Whether is field disabled      |
 | `isChecked`       | boolean                                        | -       | no       | Whether is field checked       |
 | `isItem`          | boolean                                        | -       | no       | To render in [Item][item] mode |
 | `isLabelHidden`   | boolean                                        | -       | no       | Whether is label hidden        |
+| `label`           | string                                         | -       | no       | Label text                     |
+| `name`            | string                                         | -       | no       | Input name                     |
 | `ref`             | `ForwardedRef<HTMLInputElement>`               | -       | no       | Input element reference        |
 | `validationState` | [Validation dictionary][dictionary-validation] | -       | no       | Type of validation state       |
+| `value`           | string                                         | -       | no       | Input value                    |
 
 ## Custom component
 

--- a/packages/web-react/src/components/Select/README.md
+++ b/packages/web-react/src/components/Select/README.md
@@ -14,18 +14,18 @@
 
 | Prop name         | Type                                           | Default | Required | Description                     |
 | ----------------- | ---------------------------------------------- | ------- | -------- | ------------------------------- |
+| `helperText`      | `string`                                       | -       | no       | Custom helper text              |
 | `children`        | `ReactNode`                                    | `null`  | no       | Content of the Select           |
 | `id`              | `string`                                       | -       | yes      | Select and label identification |
-| `name`            | `string`                                       | -       | no       | Select name                     |
+| `isDisabled`      | `boolean`                                      | -       | no       | Whether is field disabled       |
+| `isFluid`         | `boolean`                                      | -       | no       | Whether is field is fluid       |
+| `isLabelHidden`   | `boolean`                                      | -       | no       | Whether is label hidden         |
+| `isRequired`      | `boolean`                                      | -       | no       | Whether is field required       |
 | `label`           | `string`                                       | -       | no       | Label text                      |
-| `validationText`  | `string`, `string[]`                           | -       | no       | Validation text                 |
+| `name`            | `string`                                       | -       | no       | Select name                     |
 | `ref`             | `ForwardedRef<HTMLSelectElement>`              | -       | no       | Select element reference        |
 | `validationState` | [Validation dictionary][dictionary-validation] | -       | no       | Type of validation state        |
-| `isDisabled`      | `boolean`                                      | -       | no       | Whether is field disabled       |
-| `isRequired`      | `boolean`                                      | -       | no       | Whether is field required       |
-| `isLabelHidden`   | `boolean`                                      | -       | no       | Whether is label hidden         |
-| `isFluid`         | `boolean`                                      | -       | no       | Whether is field is fluid       |
-| `helperText`      | `string`                                       | -       | no       | Custom helper text              |
+| `validationText`  | `string`, `string[]`                           | -       | no       | Validation text                 |
 
 ## Icons Provider
 

--- a/packages/web-react/src/components/Select/README.md
+++ b/packages/web-react/src/components/Select/README.md
@@ -1,7 +1,29 @@
 # Select
 
+This is React implementation of the [Select][select] component.
+
+Basic example usage:
+
 ```jsx
-<Select id="example" name="example" validationState="danger" validationText="validation failed" isRequired>
+<Select id="selectDefault" label="Label" name="selectDefault">
+  <option value="" selected>
+    Placeholder
+  </option>
+  <option value="1">Option 1</option>
+  <option value="2">Option 2</option>
+</Select>
+```
+
+Advanced example usage:
+
+```jsx
+<Select
+  id="selectAdvanced"
+  name="selectAdvanced"
+  validationState="danger"
+  validationText="validation failed"
+  isRequired
+>
   <option value="" selected disabled>
     Placeholder
   </option>

--- a/packages/web-react/src/components/TextArea/README.md
+++ b/packages/web-react/src/components/TextArea/README.md
@@ -1,11 +1,11 @@
 # TextArea
 
-TextArea enables the user to add longer text to a form. It has textarea, label,
-and an optional message. It could be disabled or have a validation state. The label could be hidden
-and show if the textarea is required.
+TextArea enables the user to add longer text to a form.
+It could be disabled or have a validation state with validation text.
+The label could be hidden and show if the textarea is required.
 
 ```jsx
-<TextArea id="example" name="example" validationState="danger" message="validation failed" isRequired />
+<TextArea id="example" name="example" validationState="danger" validationText="validation failed" isRequired />
 ```
 
 ## Textarea with Auto-Height Adjustment
@@ -24,10 +24,10 @@ and show if the textarea is required.
 | `placeholder`           | `string`                                       | -       | no       | Textarea placeholder                                                 |
 | `value`                 | `string`                                       | -       | no       | Textarea value                                                       |
 | `maxLength`             | `number`                                       | -       | no       | Maximum number of characters                                         |
-| `message`               | `string`, `string[]`                           | -       | no       | Validation message                                                   |
 | `rows`                  | `number`                                       | -       | no       | Number of visible rows                                               |
 | `ref`                   | `ForwardedRef<HTMLTextAreaElement>`            | -       | no       | Textarea element reference                                           |
-| `validationState`       | [Validation dictionary][dictionary-validation] | -       | no       | Type of validation state.                                            |
+| `validationState`       | [Validation dictionary][dictionary-validation] | -       | no       | Type of validation state                                             |
+| `validationText`        | `string`, `string[]`                           | -       | no       | Validation text                                                      |
 | `isAutoResizing`        | `boolean`                                      | -       | no       | Whether is field auto resizing which adjusts its height while typing |
 | `isDisabled`            | `boolean`                                      | -       | no       | Whether is field disabled                                            |
 | `isRequired`            | `boolean`                                      | -       | no       | Whether is field required                                            |

--- a/packages/web-react/src/components/TextArea/README.md
+++ b/packages/web-react/src/components/TextArea/README.md
@@ -1,14 +1,34 @@
 # TextArea
 
 TextArea enables the user to add longer text to a form.
-It could be disabled or have a validation state with validation text.
+It could be disabled or have a validation state with optional validation text.
 The label could be hidden and show if the textarea is required.
 
+Basic example usage:
+
 ```jsx
-<TextArea id="example" name="example" validationState="danger" validationText="validation failed" isRequired />
+<TextArea id="textAreaDefault" label="Label" name="textAreaDefault" />
 ```
 
-## Textarea with Auto-Height Adjustment
+Advanced example usage:
+
+```jsx
+<TextArea
+  helperText="custom helper text"
+  id="textAreaAdvanced"
+  isRequired
+  label="Label"
+  maxlength="180"
+  name="textAreaAdvanced"
+  placeholder="Placeholder"
+  rows="10"
+  validationState="danger"
+  validationText="validation failed"
+  value="TextArea"
+/>
+```
+
+Example with Auto-Height Adjustment
 
 ```jsx
 <TextArea id="example" name="example" isAutoResizing autoResizingMaxHeight={500} />

--- a/packages/web-react/src/components/TextArea/README.md
+++ b/packages/web-react/src/components/TextArea/README.md
@@ -18,22 +18,22 @@ The label could be hidden and show if the textarea is required.
 
 | Prop name               | Type                                           | Default | Required | Description                                                          |
 | ----------------------- | ---------------------------------------------- | ------- | -------- | -------------------------------------------------------------------- |
+| `autoResizingMaxHeight` | `number`                                       | `400`   | no       | Maximum field height with automatic height control                   |
+| `helperText`            | `string`                                       | -       | no       | Custom helper text                                                   |
 | `id`                    | `string`                                       | -       | yes      | Textarea and label identification                                    |
-| `name`                  | `string`                                       | -       | no       | Textarea name                                                        |
-| `label`                 | `string`                                       | -       | no       | Label text                                                           |
-| `placeholder`           | `string`                                       | -       | no       | Textarea placeholder                                                 |
-| `value`                 | `string`                                       | -       | no       | Textarea value                                                       |
-| `maxLength`             | `number`                                       | -       | no       | Maximum number of characters                                         |
-| `rows`                  | `number`                                       | -       | no       | Number of visible rows                                               |
-| `ref`                   | `ForwardedRef<HTMLTextAreaElement>`            | -       | no       | Textarea element reference                                           |
-| `validationState`       | [Validation dictionary][dictionary-validation] | -       | no       | Type of validation state                                             |
-| `validationText`        | `string`, `string[]`                           | -       | no       | Validation text                                                      |
 | `isAutoResizing`        | `boolean`                                      | -       | no       | Whether is field auto resizing which adjusts its height while typing |
 | `isDisabled`            | `boolean`                                      | -       | no       | Whether is field disabled                                            |
-| `isRequired`            | `boolean`                                      | -       | no       | Whether is field required                                            |
 | `isLabelHidden`         | `boolean`                                      | -       | no       | Whether is label hidden                                              |
-| `helperText`            | `string`                                       | -       | no       | Custom helper text                                                   |
-| `autoResizingMaxHeight` | `number`                                       | `400`   | no       | Maximum field height with automatic height control                   |
+| `isRequired`            | `boolean`                                      | -       | no       | Whether is field required                                            |
+| `label`                 | `string`                                       | -       | no       | Label text                                                           |
+| `maxLength`             | `number`                                       | -       | no       | Maximum number of characters                                         |
+| `name`                  | `string`                                       | -       | no       | Textarea name                                                        |
+| `placeholder`           | `string`                                       | -       | no       | Textarea placeholder                                                 |
+| `ref`                   | `ForwardedRef<HTMLTextAreaElement>`            | -       | no       | Textarea element reference                                           |
+| `rows`                  | `number`                                       | -       | no       | Number of visible rows                                               |
+| `validationState`       | [Validation dictionary][dictionary-validation] | -       | no       | Type of validation state                                             |
+| `validationText`        | `string`, `string[]`                           | -       | no       | Validation text                                                      |
+| `value`                 | `string`                                       | -       | no       | Textarea value                                                       |
 
 ## Custom component
 

--- a/packages/web-react/src/components/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/web-react/src/components/TextArea/__tests__/TextArea.test.tsx
@@ -17,7 +17,7 @@ describe('TextArea', () => {
 
   validationStatePropsTest(TextArea, 'TextArea--');
 
-  validationTextPropsTest(TextArea, '.TextArea__message');
+  validationTextPropsTest(TextArea, '.TextArea__validationText');
 
   it('should have label classname', () => {
     const dom = render(<TextArea id="textarea" label="Label" />);

--- a/packages/web-react/src/components/TextArea/stories/TextAreaValidationState.tsx
+++ b/packages/web-react/src/components/TextArea/stories/TextAreaValidationState.tsx
@@ -9,22 +9,22 @@ const Story = (props: unknown) => (
       id="textarea-success"
       label="Validation success"
       name="textarea-success"
-      message="Success message"
       validationState="success"
+      validationText="Success validationText"
     />
     <TextArea
       id="textarea-warning"
       label="Validation warning"
-      message="Warning message"
       name="textarea-warning"
       validationState="warning"
+      validationText="Warning validationText"
     />
     <TextArea
       id="textarea-danger"
       label="Validation danger"
-      message={['Danger message', 'Second Danger message']}
       name="textarea-danger"
       validationState="danger"
+      validationText={['Danger validationText', 'Second Danger validationText']}
     />
   </div>
 );

--- a/packages/web-react/src/components/TextArea/stories/TextAreaValidationState.tsx
+++ b/packages/web-react/src/components/TextArea/stories/TextAreaValidationState.tsx
@@ -10,21 +10,21 @@ const Story = (props: unknown) => (
       label="Validation success"
       name="textarea-success"
       validationState="success"
-      validationText="Success validationText"
+      validationText="Validation text"
     />
     <TextArea
       id="textarea-warning"
       label="Validation warning"
       name="textarea-warning"
       validationState="warning"
-      validationText="Warning validationText"
+      validationText="Validation text"
     />
     <TextArea
       id="textarea-danger"
       label="Validation danger"
       name="textarea-danger"
       validationState="danger"
-      validationText={['Danger validationText', 'Second Danger validationText']}
+      validationText={['Validation text', 'Second validation text']}
     />
   </div>
 );

--- a/packages/web-react/src/components/TextArea/stories/argTypes.ts
+++ b/packages/web-react/src/components/TextArea/stories/argTypes.ts
@@ -63,13 +63,13 @@ export default {
     },
     defaultValue: '',
   },
-  message: {
+  validationText: {
     control: {
       type: 'object',
     },
     defaultValue: '',
     description:
-      'The validation message. Use a string `"foo"` for single message or an array for multiple messages `["foo", "bar"]`.',
+      'The validation text. Only visible if validationState is set. Use a string `"foo"` for single validation text or an array for multiple validation texts `["foo", "bar"]`.',
   },
   helperText: {
     control: {

--- a/packages/web-react/src/components/TextField/README.md
+++ b/packages/web-react/src/components/TextField/README.md
@@ -5,10 +5,41 @@ label, and an optional helper text. It supports several input types like `text` 
 `password` etc. It can be disabled or have a validation state. The label can be
 hidden or show if the input is required.
 
+Basic example usage:
+
 ```jsx
-<TextField id="example-text" name="example" validationState="danger" validationText="validation failed" isRequired />
-<TextField id="example-password" type="password" name="example" validationState="danger" validationText="validation failed" isRequired />
-<TextField id="example-password-toggle" name="example" validationState="danger" validationText="validation failed" hasPasswordToggle isRequired />
+<TextField id="textFieldDefault" name="textFieldDefault" />
+```
+
+Advanced example usage:
+
+```jsx
+<TextField
+  helperText="custom helper text"
+  id="textFieldAdvanced"
+  isRequired
+  label="Label"
+  name="textFieldAdvanced"
+  placeholder="Placeholder"
+  type="text"
+  validationState="danger"
+  validationText="validation failed"
+/>
+```
+
+TextField with password toggle (button to reveal the password):
+
+```jsx
+<TextField
+  hasPasswordToggle
+  id="textFieldPasswordToggle"
+  isRequired
+  label="Password"
+  name="textFieldPasswordToggle"
+  placeholder="Placeholder"
+  validationState="danger"
+  validationText="validation failed"
+/>
 ```
 
 ## Available props

--- a/packages/web-react/src/components/TextField/README.md
+++ b/packages/web-react/src/components/TextField/README.md
@@ -1,14 +1,14 @@
 # TextField
 
 TextField enables the user to type in text information. It has an input, a
-label, and an optional message. It supports several input types like `text` or
+label, and an optional helper text. It supports several input types like `text` or
 `password` etc. It can be disabled or have a validation state. The label can be
 hidden or show if the input is required.
 
 ```jsx
-<TextField id="example-text" name="example" validationState="danger" message="validation failed" isRequired />
-<TextField id="example-password" type="password" name="example" validationState="danger" message="validation failed" isRequired />
-<TextField id="example-password-toggle" name="example" validationState="danger" message="validation failed" hasPasswordToggle isRequired />
+<TextField id="example-text" name="example" validationState="danger" validationText="validation failed" isRequired />
+<TextField id="example-password" type="password" name="example" validationState="danger" validationText="validation failed" isRequired />
+<TextField id="example-password-toggle" name="example" validationState="danger" validationText="validation failed" hasPasswordToggle isRequired />
 ```
 
 ## Available props
@@ -24,13 +24,13 @@ hidden or show if the input is required.
 | `isLabelHidden`     | `boolean`                                                     | -       | no       | Whether is label hidden                                                 |
 | `isRequired`        | `boolean`                                                     | -       | no       | Whether is field required                                               |
 | `label`             | `string`                                                      | -       | no       | Label text                                                              |
-| `message`           | `string`, `string[]`                                          | -       | no       | Validation message                                                      |
 | `name`              | `string`                                                      | -       | no       | Input name                                                              |
 | `pattern`           | `string`                                                      | -       | no       | Defines regular expressions for allowed value types                     |
 | `placeholder`       | `string`                                                      | -       | no       | Input placeholder                                                       |
 | `ref`               | `ForwardedRef<HTMLInputElement>`                              | -       | no       | Input element reference                                                 |
 | `type`              | `email`, `number`, `password`, `search`, `tel`, `text`, `url` | -       | no       | Input type                                                              |
-| `validationState`   | [Validation dictionary][dictionary-validation]                | -       | no       | Type of validation state.                                               |
+| `validationState`   | [Validation dictionary][dictionary-validation]                | -       | no       | Type of validation state                                                |
+| `validationText`    | `string`, `string[]`                                          | -       | no       | Validation text                                                         |
 | `value`             | `string`                                                      | -       | no       | Input value                                                             |
 
 ## Custom component

--- a/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
+++ b/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
@@ -19,7 +19,7 @@ describe('TextField', () => {
 
     validationStatePropsTest(TextField, 'TextField--');
 
-    validationTextPropsTest(TextField, '.TextField__message', type as TextFieldType);
+    validationTextPropsTest(TextField, '.TextField__validationText', type as TextFieldType);
 
     it('should have label classname', () => {
       const dom = render(<TextField id="textfield" label="Label" type={type as TextFieldType} />);

--- a/packages/web-react/src/components/TextField/stories/TextFieldValidationState.tsx
+++ b/packages/web-react/src/components/TextField/stories/TextFieldValidationState.tsx
@@ -9,22 +9,22 @@ const Story = (props: unknown) => (
       id="textfield-success"
       label="Validation success"
       name="textfield-success"
-      message="Success message"
       validationState="success"
+      validationText="Success validationText"
     />
     <TextField
       id="textfield-warning"
       label="Validation warning"
-      message="Warning message"
       name="textfield-warning"
       validationState="warning"
+      validationText="Warning validationText"
     />
     <TextField
       id="textfield-danger"
       label="Validation danger"
-      message={['Danger message', 'Second Danger message']}
       name="textfield-danger"
       validationState="danger"
+      validationText={['Danger validationText', 'Second Danger validationText']}
     />
   </div>
 );

--- a/packages/web-react/src/components/TextField/stories/TextFieldValidationState.tsx
+++ b/packages/web-react/src/components/TextField/stories/TextFieldValidationState.tsx
@@ -10,21 +10,21 @@ const Story = (props: unknown) => (
       label="Validation success"
       name="textfield-success"
       validationState="success"
-      validationText="Success validationText"
+      validationText="Validation text"
     />
     <TextField
       id="textfield-warning"
       label="Validation warning"
       name="textfield-warning"
       validationState="warning"
-      validationText="Warning validationText"
+      validationText="Validation text"
     />
     <TextField
       id="textfield-danger"
       label="Validation danger"
       name="textfield-danger"
       validationState="danger"
-      validationText={['Danger validationText', 'Second Danger validationText']}
+      validationText={['Validation text', 'Second validation text']}
     />
   </div>
 );

--- a/packages/web-react/src/components/TextField/stories/argTypes.ts
+++ b/packages/web-react/src/components/TextField/stories/argTypes.ts
@@ -63,13 +63,13 @@ export default {
     },
     defaultValue: '',
   },
-  message: {
+  validationText: {
     control: {
       type: 'object',
     },
     defaultValue: '',
     description:
-      'The validation message. Use a string `"foo"` for single message or an array for multiple messages `["foo", "bar"]`.',
+      'The validation text. Only visible if validationState is set. Use a string `"foo"` for single validation text or an array for multiple validation texts `["foo", "bar"]`.',
   },
   helperText: {
     control: {

--- a/packages/web-react/src/components/TextFieldBase/README.md
+++ b/packages/web-react/src/components/TextFieldBase/README.md
@@ -3,8 +3,8 @@
 This is React implementation of the abstract component TextFieldBase for the purposes of the form components [TextField] and [TextArea].
 
 ```jsx
-<TextFieldBase id="example" label="Example TextFieldBase" name="example" isRequired validationState="danger" message="validation failed" />
-<TextFieldBase id="example" label="Example multiline TextFieldBase" name="example" isMultiline isRequired validationState="danger" message="validation failed" />
+<TextFieldBase id="example" label="Example TextFieldBase" name="example" isRequired validationState="danger" validationText="validation failed" />
+<TextFieldBase id="example" label="Example multiline TextFieldBase" name="example" isMultiline isRequired validationState="danger" validationText="validation failed" />
 ```
 
 ## Available props
@@ -20,13 +20,13 @@ This is React implementation of the abstract component TextFieldBase for the pur
 | `isMultiline`       | `boolean`                                                     | -       | no       | Whether is DOM element `textarea`                                       |
 | `isRequired`        | `boolean`                                                     | -       | no       | Whether is field required                                               |
 | `label`             | `string`                                                      | -       | no       | Label text                                                              |
-| `message`           | `string`, `string[]`                                          | -       | no       | Validation message                                                      |
 | `name`              | `string`                                                      | -       | no       | Input name                                                              |
 | `pattern`           | `string`                                                      | -       | no       | Defines regular expressions for allowed value types                     |
 | `placeholder`       | `string`                                                      | -       | no       | Input placeholder                                                       |
 | `ref`               | `ForwardedRef<HTMLInputElement or HTMLTextAreaElement>`       | -       | no       | Field element reference                                                 |
 | `type`              | `email`, `number`, `password`, `search`, `tel`, `text`, `url` | -       | no       | Input type                                                              |
 | `validationState`   | [Validation dictionary][dictionary-validation]                | -       | no       | Type of validation state.                                               |
+| `validationText`    | `string`, `string[]`                                          | -       | no       | Validation text                                                         |
 | `value`             | `string`                                                      | -       | no       | Input value                                                             |
 
 [dictionary-validation]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation

--- a/packages/web-react/src/components/TextFieldBase/README.md
+++ b/packages/web-react/src/components/TextFieldBase/README.md
@@ -2,9 +2,41 @@
 
 This is React implementation of the abstract component TextFieldBase for the purposes of the form components [TextField] and [TextArea].
 
+Basic example usage:
+
 ```jsx
-<TextFieldBase id="example" label="Example TextFieldBase" name="example" isRequired validationState="danger" validationText="validation failed" />
-<TextFieldBase id="example" label="Example multiline TextFieldBase" name="example" isMultiline isRequired validationState="danger" validationText="validation failed" />
+<TextFieldBase id="textFieldBaseDefault" label="Example TextFieldBase" name="textFieldBaseDefault" />
+```
+
+Advanced example usage:
+
+```jsx
+<TextFieldBase
+  helperText="custom helper text"
+  id="textFieldBaseAdvanced"
+  isMultiline
+  isRequired
+  label="Example multiline TextFieldBase"
+  name="textFieldBaseAdvanced"
+  placeholder="Placeholder"
+  validationState="danger"
+  validationText="validation failed"
+/>
+```
+
+TextFieldBase with password toggle (button to reveal the password):
+
+```jsx
+<TextFieldBase
+  hasPasswordToggle
+  id="textFieldBasePasswordToggle"
+  isRequired
+  label="Password"
+  name="textFieldBasePasswordToggle"
+  placeholder="Placeholder"
+  validationState="danger"
+  validationText="validation failed"
+/>
 ```
 
 ## Available props

--- a/packages/web-react/src/components/TextFieldBase/TextFieldBase.tsx
+++ b/packages/web-react/src/components/TextFieldBase/TextFieldBase.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, ForwardedRef } from 'react';
 import classNames from 'classnames';
-import { useStyleProps, useDeprecationMessage } from '../../hooks';
+import { useStyleProps } from '../../hooks';
 import { useValidationText } from '../Field';
 import { SpiritTextFieldBaseProps, TextFieldBasePasswordToggleProps } from '../../types';
 import { useTextFieldBaseStyleProps } from './useTextFieldBaseStyleProps';
@@ -15,22 +15,13 @@ const TextFieldBaseInputWithPasswordToggle = forwardRef(
 /* eslint no-underscore-dangle: ['error', { allow: ['_TextFieldBase'] }] */
 const _TextFieldBase = (props: SpiritTextFieldBaseProps, ref: ForwardedRef<HTMLInputElement | HTMLTextAreaElement>) => {
   const { classProps, props: modifiedProps } = useTextFieldBaseStyleProps(props);
-  const { id, label, message, helperText, validationState, ...restProps } = modifiedProps;
+  const { id, label, validationText, helperText, validationState, ...restProps } = modifiedProps;
   const { styleProps, props: otherProps } = useStyleProps(restProps);
 
-  useDeprecationMessage({
-    method: 'custom',
-    trigger: !!(props?.message && !validationState),
-    componentName: props?.isMultiline ? 'TextArea' : 'TextField',
-    customText:
-      '`message` prop without `validationState` prop will be unsupported in the next version. Use `helperText` instead.',
-  });
-
   const renderValidationText = useValidationText({
-    validationTextClassName: classProps.message,
+    validationTextClassName: classProps.validationText,
     validationState,
-    validationText: message,
-    requireValidationState: false,
+    validationText,
   });
 
   return (

--- a/packages/web-react/src/components/TextFieldBase/useTextFieldBaseStyleProps.ts
+++ b/packages/web-react/src/components/TextFieldBase/useTextFieldBaseStyleProps.ts
@@ -8,8 +8,8 @@ export interface TextFieldBaseStyles {
     root: string;
     label: string;
     input: string;
-    message: string;
     helperText: string;
+    validationText: string;
     passwordToggle: string;
     passwordToggleButton: string;
     passwordToggleIcon: string;
@@ -30,7 +30,7 @@ export function useTextFieldBaseStyleProps(props: SpiritTextFieldBaseProps): Tex
   const TextFieldBaseLabelClass = `${TextFieldBaseClass}__label`;
   const TextFieldBaseLabelRequiredClass = `${TextFieldBaseClass}__label--required`;
   const TextFieldBaseLabelHiddenClass = `${TextFieldBaseClass}__label--hidden`;
-  const TextFieldBaseMessageClass = `${TextFieldBaseClass}__message`;
+  const TextFieldBaseValidationTextClass = `${TextFieldBaseClass}__validationText`;
   const TextFieldBasePasswordToggleClass = `${TextFieldBaseClass}__passwordToggle`;
   const TextFieldBasePasswordToggleButtonClass = `${TextFieldBaseClass}__passwordToggle__button`;
   const TextFieldBasePasswordToggleIconClass = `${TextFieldBaseClass}__passwordToggle__icon`;
@@ -51,8 +51,8 @@ export function useTextFieldBaseStyleProps(props: SpiritTextFieldBaseProps): Tex
       root: rootStyles,
       label: labelStyles,
       input: TextFieldBaseInputClass,
-      message: TextFieldBaseMessageClass,
       helperText: TextFieldBaseHelperTextClass,
+      validationText: TextFieldBaseValidationTextClass,
       passwordToggle: TextFieldBasePasswordToggleClass,
       passwordToggleButton: TextFieldBasePasswordToggleButtonClass,
       passwordToggleIcon: TextFieldBasePasswordToggleIconClass,
@@ -60,6 +60,7 @@ export function useTextFieldBaseStyleProps(props: SpiritTextFieldBaseProps): Tex
     props: {
       ...restProps,
       isMultiline,
+      validationState,
     },
   };
 }

--- a/packages/web-react/src/types/checkboxField.ts
+++ b/packages/web-react/src/types/checkboxField.ts
@@ -5,9 +5,9 @@ import {
   ItemProps,
   SpiritInputElementPropsWithRef,
   Validation,
+  ValidationTextProp,
 } from './shared';
 import { LabelProps } from './label';
-import { MessageProps } from './message';
 
 export type CheckboxElementBaseProps = SpiritInputElementPropsWithRef;
 
@@ -16,9 +16,9 @@ export interface CheckboxFieldProps
     ChildrenProps,
     LabelProps,
     ItemProps,
-    MessageProps,
     InputBaseProps,
     Validation,
+    ValidationTextProp,
     HelperTextProps {
   /** Whether the checkbox is indeterminate */
   indeterminate?: boolean;

--- a/packages/web-react/src/types/index.ts
+++ b/packages/web-react/src/types/index.ts
@@ -12,7 +12,6 @@ export * from './heading';
 export * from './icon';
 export * from './label';
 export * from './link';
-export * from './message';
 export * from './modal';
 export * from './pagination';
 export * from './pill';

--- a/packages/web-react/src/types/message.ts
+++ b/packages/web-react/src/types/message.ts
@@ -1,6 +1,0 @@
-import { ValidationTextType } from './shared';
-
-export interface MessageProps {
-  /** The validation or other message to display. */
-  message?: ValidationTextType;
-}

--- a/packages/web-react/src/types/shared/inputs.ts
+++ b/packages/web-react/src/types/shared/inputs.ts
@@ -36,3 +36,8 @@ export interface HelperTextProps {
   /** If I wanted some help text */
   helperText?: string;
 }
+
+export interface ValidationTextProp {
+  /** The validation text to display. */
+  validationText?: ValidationTextType;
+}

--- a/packages/web-react/src/types/textArea.ts
+++ b/packages/web-react/src/types/textArea.ts
@@ -5,9 +5,9 @@ import {
   SpiritTextAreaElementPropsWithRef,
   TextInputProps,
   Validation,
+  ValidationTextProp,
 } from './shared';
 import { LabelProps } from './label';
-import { MessageProps } from './message';
 
 export type TextAreaElementBaseProps = SpiritTextAreaElementPropsWithRef;
 
@@ -16,8 +16,8 @@ export interface TextAreaProps
     InputBaseProps,
     ChildrenProps,
     LabelProps,
-    MessageProps,
     HelperTextProps,
+    ValidationTextProp,
     TextInputProps,
     Validation {
   /** Whether is field auto resizing which adjusts its height while typing */

--- a/packages/web-react/src/types/textField.ts
+++ b/packages/web-react/src/types/textField.ts
@@ -6,9 +6,9 @@ import {
   SpiritInputElementPropsWithRef,
   TextInputProps,
   Validation,
+  ValidationTextProp,
 } from './shared';
 import { LabelProps } from './label';
-import { MessageProps } from './message';
 
 export type TextFieldType = 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url';
 
@@ -20,8 +20,8 @@ export interface TextFieldProps
     PasswordToggleAdornmentProp,
     ChildrenProps,
     LabelProps,
-    MessageProps,
     HelperTextProps,
+    ValidationTextProp,
     TextInputProps,
     Validation {
   /** The type of text field */


### PR DESCRIPTION
… in Form Fields #DS-676

 ## Migration Guide

- Instead of the `message` prop, use `validationText`.
- The `validationState` prop is now required when using `validationText`.
  If `validationState` is not set, `validationText` won't render.
- To show a permanent helper, use `helperText`.

- `<… validationState="danger" message="error" …>`
   → `<… validationState="danger" validationText="error" …>`
- `<… message="Check this field" …>` → `<… helperText="Check this field" …>`

List of affected components:
- Checkbox
- TextField
- TextArea
- TextFieldBase
- Select

Please refer back to these instructions or reach out to our team
if you encounter any issues during migration.

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md).
- [x] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
