### PR TITLE
Docs(web): Why is the event listener not passive by default

### DIFF
--- a/packages/web/src/js/dom/EventHandler.ts
+++ b/packages/web/src/js/dom/EventHandler.ts
@@ -7,6 +7,14 @@ const addHandler = (element: EventHandlerElement, eventType: string, handler: an
     return;
   }
 
+  /**
+   * Treat event listener as active by default
+   * Safari sets the event listeners as passive by default, other browsers the opposite
+   * This lead to the touch events were treated differently on Safari then on other devices
+   * and the touch on Modal's backdrop did not close it
+   * @see: https://chromestatus.com/feature/5093566007214080
+   * @see: https://github.com/lmc-eu/spirit-design-system/pull/892
+   */
   element.addEventListener(eventType, handler, { passive: false });
 };
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

For testing purposes on mobile devices only.

### Additional context

https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md).
- [x] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
