### PR TITLE
Chore(demo): Display only web-twig dirs where stories exists

### DIFF
--- a/apps/web-twig-demo/src/Controller/DefaultController.php
+++ b/apps/web-twig-demo/src/Controller/DefaultController.php
@@ -25,7 +25,8 @@ class DefaultController extends AbstractController
 
         /** @var SplFileInfo $file */
         foreach ($directories as $fileinfo) {
-            if ($fileinfo->isDir() && !$fileinfo->isDot()){
+            // display only directories where stories exists
+            if ($fileinfo->isDir() && !$fileinfo->isDot() && in_array('stories', scandir($fileinfo->getPathname()))) {
                 $components[] = $fileinfo->getBasename();
             }
         }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

In web-twig demo app list only components which have stories inside.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
