### PR TITLE
BREAKING CHANGE: Remove Tag deprecation #DS-648

### DIFF
--- a/packages/web-react/src/components/Tag/README.md
+++ b/packages/web-react/src/components/Tag/README.md
@@ -14,19 +14,16 @@ import { Tag } from '@lmc-eu/spirit-web-react';
 
 ## Available props
 
-| Prop name     | Type                                                                            | Default   | Required | Description                                                                                                      |
-| ------------- | ------------------------------------------------------------------------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
-| `children`    | `ReactNode`                                                                     | -         | ✔        | Content of the Tag                                                                                               |
-| `color`       | [Emotion Color dictionary][dictionary-color], `neutral`, `default` (deprecated) | `neutral` | ✕        | Color of the component; [**DEPRECATED**][deprecated] The value `default` will be replaced by the value `neutral` |
-| `elementType` | `React.Element`                                                                 | `span`    | ✕        | HTML tag                                                                                                         |
-| `isSubtle`    | `boolean`                                                                       | `false`   | ✕        | If is Subtle color variant used                                                                                  |
-| `ref`         | `ForwardedRef<HTMLSpanElement>`                                                 | -         | ✕        | Tag element reference                                                                                            |
-| `size`        | [Size Extended dictionary][dictionary-size]                                     | `medium`  | ✕        | Size of the Tag                                                                                                  |
-| `tag`         | `React.Element`                                                                 | `span`    | ✕        | [**DEPRECATED**][deprecated] in favor of `elementType`; HTML tag                                                 |
-| `theme`       | `light`, `dark`                                                                 | `null`    | ✕        | [**DEPRECATED**][deprecated] in favor of `isSubtle`; Theme of the component                                      |
+| Prop name     | Type                                                    | Default   | Required | Description                     |
+| ------------- | ------------------------------------------------------- | --------- | -------- | ------------------------------- |
+| `children`    | `ReactNode`                                             | -         | ✔        | Content of the Tag              |
+| `color`       | [Emotion Color dictionary][dictionary-color], `neutral` | `neutral` | ✕        | Color of the component          |
+| `elementType` | `React.Element`                                         | `span`    | ✕        | HTML tag                        |
+| `isSubtle`    | `boolean`                                               | `false`   | ✕        | If is Subtle color variant used |
+| `ref`         | `ForwardedRef<HTMLSpanElement>`                         | -         | ✕        | Tag element reference           |
+| `size`        | [Size Extended dictionary][dictionary-size]             | `medium`  | ✕        | Size of the Tag                 |
 
 For detailed information see [Tag](https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/scss/components/Tag/README.md) component
 
-[deprecated]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web-react/README.md#deprecations
 [dictionary-color]: https://github.com/lmc-eu/spirit-design-system/tree/main/docs/DICTIONARIES.md#color
 [dictionary-size]: https://github.com/lmc-eu/spirit-design-system/tree/main/docs/DICTIONARIES.md#size

--- a/packages/web-react/src/components/Tag/Tag.tsx
+++ b/packages/web-react/src/components/Tag/Tag.tsx
@@ -1,6 +1,6 @@
 import React, { ElementType, ForwardedRef, forwardRef } from 'react';
 import classNames from 'classnames';
-import { useDeprecationMessage, useStyleProps } from '../../hooks';
+import { useStyleProps } from '../../hooks';
 import { SpiritTagProps, StyleProps } from '../../types';
 import { useTagStyleProps } from './useTagStyleProps';
 
@@ -17,38 +17,9 @@ const _Tag = <T extends ElementType = 'span', C = void, S = void>(
   props: SpiritTagProps<T, C, S>,
   ref: ForwardedRef<HTMLSpanElement>,
 ): JSX.Element => {
-  const {
-    elementType,
-    /** @deprecated Will be removed in the next major version. */
-    tag,
-    children,
-    ...restProps
-  } = props;
+  const { elementType: ElementTag = 'span', children, ...restProps } = props;
   const { classProps, props: modifiedProps } = useTagStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps as StyleProps);
-
-  const ElementTag = tag || elementType || 'span';
-
-  useDeprecationMessage({
-    method: 'property',
-    trigger: !!tag,
-    componentName: 'Tag',
-    propertyProps: {
-      deprecatedName: 'tag',
-      newName: 'elementType',
-    },
-  });
-
-  useDeprecationMessage({
-    method: 'property',
-    trigger: props?.color === 'default',
-    componentName: 'Tag',
-    propertyProps: {
-      deprecatedValue: 'default',
-      newValue: 'neutral',
-      propertyName: 'color',
-    },
-  });
 
   return (
     <ElementTag {...otherProps} {...styleProps} className={classNames(classProps, styleProps.className)} ref={ref}>

--- a/packages/web-react/src/components/Tag/__tests__/Tag.test.tsx
+++ b/packages/web-react/src/components/Tag/__tests__/Tag.test.tsx
@@ -32,10 +32,10 @@ describe('Tag', () => {
     expect(element.textContent).toBe('Tag');
   });
 
-  it.each([['neutral'], ['default']])('should render color %s', (color) => {
-    const dom = render(<Tag color={color}>333</Tag>);
+  it('should render neutral color', () => {
+    const dom = render(<Tag color="neutral">333</Tag>);
 
     const element = dom.container.querySelector('span') as HTMLElement;
-    expect(element).toHaveClass(`Tag--${color}`);
+    expect(element).toHaveClass('Tag--neutral');
   });
 });

--- a/packages/web-react/src/components/Tag/__tests__/useTagStyleProps.test.ts
+++ b/packages/web-react/src/components/Tag/__tests__/useTagStyleProps.test.ts
@@ -10,7 +10,7 @@ describe('useTagStyleProps', () => {
     expect(result.current.classProps).toBe('Tag');
   });
 
-  it.each([['neutral'], ['default'], ['success'], ['informative'], ['warning'], ['danger']])(
+  it.each([['neutral'], ['success'], ['informative'], ['warning'], ['danger']])(
     'should return color class %s',
     (color) => {
       const props = { color } as SpiritTagProps;
@@ -29,16 +29,5 @@ describe('useTagStyleProps', () => {
     const { result } = renderHook(() => useTagStyleProps(props));
 
     expect(result.current.classProps).toBe('Tag Tag--success Tag--small Tag--subtle');
-  });
-
-  it('should return large danger light', () => {
-    const props = {
-      color: 'danger',
-      size: 'large',
-      theme: 'light',
-    } as SpiritTagProps;
-    const { result } = renderHook(() => useTagStyleProps(props));
-
-    expect(result.current.classProps).toBe('Tag Tag--danger Tag--large Tag--light');
   });
 });

--- a/packages/web-react/src/components/Tag/stories/argTypes.ts
+++ b/packages/web-react/src/components/Tag/stories/argTypes.ts
@@ -4,7 +4,7 @@ export default {
   color: {
     control: {
       type: 'select',
-      options: [...Object.values(EmotionColors), 'default', 'neutral'],
+      options: [...Object.values(EmotionColors), 'neutral'],
     },
     defaultValue: 'neutral',
   },
@@ -14,13 +14,6 @@ export default {
       options: [...Object.values(Sizes)],
     },
     defaultValue: Sizes.MEDIUM,
-  },
-  theme: {
-    control: {
-      type: 'select',
-      options: ['dark', 'light', undefined],
-    },
-    defaultValue: undefined,
   },
   isSubtle: {
     control: {

--- a/packages/web-react/src/components/Tag/useTagStyleProps.ts
+++ b/packages/web-react/src/components/Tag/useTagStyleProps.ts
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { ElementType } from 'react';
-import { useClassNamePrefix, useDeprecationMessage } from '../../hooks';
+import { useClassNamePrefix } from '../../hooks';
 import { SpiritTagProps } from '../../types';
 
 export interface TagStyles {
@@ -13,30 +13,16 @@ export interface TagStyles {
 export function useTagStyleProps<T extends ElementType = 'span', C = void, S = void>(
   props: SpiritTagProps<T, C, S>,
 ): TagStyles {
-  const { color, isSubtle, size, theme, ...modifiedProps } = props;
+  const { color, isSubtle, size, ...modifiedProps } = props;
 
   const TagClass = useClassNamePrefix('Tag');
   const TagColorClass = `${TagClass}--${color}`;
   const TagSizeClass = `${TagClass}--${size}`;
   const TagSubtleClass = `${TagClass}--subtle`;
-  /** @deprecated Will be removed in the next major version. */
-  const TagThemeClass = `${TagClass}--${theme}`;
   const classProps = classNames(TagClass, {
     [TagColorClass]: color,
     [TagSizeClass]: size,
     [TagSubtleClass]: isSubtle,
-    /** @deprecated Will be removed in the next major version. */
-    [TagThemeClass]: !isSubtle && theme,
-  });
-
-  useDeprecationMessage({
-    method: 'property',
-    trigger: !!theme,
-    componentName: 'Tag',
-    propertyProps: {
-      deprecatedName: 'theme',
-      newName: 'isSubtle',
-    },
   });
 
   return {

--- a/packages/web-react/src/types/tag.ts
+++ b/packages/web-react/src/types/tag.ts
@@ -8,13 +8,9 @@ import {
   TransferProps,
 } from './shared';
 
-/* @deprecated: 'default' value will be removed in the next major version. */
-export type TagColor<C> = EmotionColorsDictionaryType | 'default' | 'neutral' | C;
+export type TagColor<C> = EmotionColorsDictionaryType | 'neutral' | C;
 
 export type TagSize<S> = SizesDictionaryType | S;
-
-/** @deprecated Will be removed in the next major version. */
-export type TagTheme = 'light' | 'dark';
 
 export interface TagProps<E extends ElementType = 'span', C = void, S = void>
   extends ChildrenProps,
@@ -24,10 +20,6 @@ export interface TagProps<E extends ElementType = 'span', C = void, S = void>
   elementType?: E;
   isSubtle?: boolean;
   size?: TagSize<S>;
-  /** @deprecated Will be removed in the next major version. */
-  tag?: E;
-  /** @deprecated Will be removed in the next major version. */
-  theme?: TagTheme;
 }
 
 export type SpiritTagProps<T extends ElementType = 'span', C = void, S = void> = TagProps<T, C, S> &

--- a/packages/web-twig/src/Resources/components/Tag/README.md
+++ b/packages/web-twig/src/Resources/components/Tag/README.md
@@ -31,13 +31,12 @@ Without lexer:
 
 ## API
 
-| Prop name     | Type                                                                            | Default   | Required | Description                                                                                                      |
-| ------------- | ------------------------------------------------------------------------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
-| `color`       | [Emotion Color dictionary][dictionary-color], `neutral`, `default` (deprecated) | `neutral` | no       | Color of the component; [**DEPRECATED**][deprecated] The value `default` will be replaced by the value `neutral` |
-| `isSubtle`    | `boolean`                                                                       | `false`   | no       | Whether is Tag displayed in subtle variant                                                                       |
-| `elementType` | `string`                                                                        | `span`    | no       | HTML tag to render                                                                                               |
-| `size`        | [Size Extended dictionary][dictionary-size]                                     | `medium`  | no       | Size of the Tag                                                                                                  |
-| `theme`       | `light`, `dark`                                                                 | `null`    | no       | [**DEPRECATED**][deprecated] in favor of `isSubtle`; Theme variant                                               |
+| Prop name     | Type                                                    | Default   | Required | Description                                    |
+| ------------- | ------------------------------------------------------- | --------- | -------- | ---------------------------------------------- |
+| `color`       | [Emotion Color dictionary][dictionary-color], `neutral` | `neutral` | no       | Color of the component                         |
+| `elementType` | `string`                                                | `span`    | no       | HTML tag to render                             |
+| `isSubtle`    | `boolean`                                               | `false`   | no       | Whether the Tag is displayed in subtle variant |
+| `size`        | [Size Extended dictionary][dictionary-size]             | `medium`  | no       | Size of the Tag                                |
 
 You can add `id`, `data-*` or `aria-*` attributes to further extend component's
 descriptiveness and accessibility. Also, UNSAFE styling props are available,
@@ -46,5 +45,4 @@ see the [Escape hatches][escape-hatches] section in README to learn how and when
 [tag]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web/src/scss/components/Tag
 [dictionary-color]: https://github.com/lmc-eu/spirit-design-system/tree/main/docs/DICTIONARIES.md#color
 [dictionary-size]: https://github.com/lmc-eu/spirit-design-system/tree/main/docs/DICTIONARIES.md#size
-[deprecated]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web-twig/README.md#deprecations
 [escape-hatches]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web-twig/README.md#escape-hatches

--- a/packages/web-twig/src/Resources/components/Tag/Tag.twig
+++ b/packages/web-twig/src/Resources/components/Tag/Tag.twig
@@ -4,26 +4,16 @@
 {%- set _elementType = props.elementType | default('span') -%}
 {%- set _isSubtle = props.isSubtle | default(false) -%}
 {%- set _size = props.size | default('medium') -%}
-{%- set _theme = props.theme | default(null) -%}
 
 {# Class names #}
 {%- set _rootClassName = _spiritClassPrefix ~ 'Tag' -%}
 {%- set _colorClassName = _spiritClassPrefix ~ 'Tag--' ~ _color -%}
 {%- set _sizeClassName = _spiritClassPrefix ~ 'Tag--' ~ _size -%}
 {%- set _subtleClassname = _isSubtle ? _spiritClassPrefix ~ 'Tag--subtle' : null -%}
-{%- set _themeClassName = _theme ? _spiritClassPrefix ~ 'Tag--' ~ _theme : null -%}
 
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
-{%- set _classNames = [ _rootClassName, _colorClassName, _sizeClassName, _subtleClassname, _themeClassName, _styleProps.className ] -%}
-
-{# Deprecations #}
-{% if _theme %}
-    {% deprecated 'Tag: The "theme" property is deprecated, use "isSubtle" instead.' %}
-{% endif %}
-{% if _color is same as('default') %}
-    {% deprecated 'Tag: The "default" value for "color" property will be removed in the next major version. Use "neutral" instead.' %}
-{% endif %}
+{%- set _classNames = [ _rootClassName, _colorClassName, _sizeClassName, _subtleClassname, _styleProps.className ] -%}
 
 <{{ _elementType }} {{ mainProps(props) }} {{ styleProp(_styleProps) }} {{ classProp(_classNames) }}>
 {%- block content %}{% endblock -%}

--- a/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set tagDefault.twig__1.html
+++ b/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set tagDefault.twig__1.html
@@ -5,21 +5,12 @@
     </title>
   </head>
   <body>
-    <span class="Tag Tag--neutral Tag--medium">Tag</span> <span class="Tag Tag--default Tag--medium">Tag</span>
-    <span class="Tag Tag--success Tag--medium">Tag</span>
+    <span class="Tag Tag--neutral Tag--medium">Tag</span> <span class="Tag Tag--success Tag--medium">Tag</span>
     <div class="Tag Tag--neutral Tag--medium">
       Tag
     </div>
     <span class="Tag Tag--neutral Tag--xlarge">Tag</span> <span class="Tag Tag--neutral Tag--medium Tag--subtle">Tag</span>
     <div class="Tag Tag--danger Tag--xsmall Tag--subtle">
-      Tag
-    </div>
-
-    <div class="Tag Tag--danger Tag--xsmall Tag--light">
-      Tag
-    </div>
-
-    <div class="Tag Tag--danger Tag--xsmall Tag--dark">
       Tag
     </div>
   </body>

--- a/packages/web-twig/tests/components-fixtures/tagDefault.twig
+++ b/packages/web-twig/tests/components-fixtures/tagDefault.twig
@@ -1,9 +1,6 @@
 <Tag>Tag</Tag>
-<Tag color="default">Tag</Tag>
 <Tag color="success">Tag</Tag>
 <Tag elementType="div">Tag</Tag>
 <Tag size="xlarge">Tag</Tag>
 <Tag isSubtle>Tag</Tag>
 <Tag color="danger" elementType="div" size="xsmall" isSubtle>Tag</Tag>
-<Tag color="danger" elementType="div" size="xsmall" theme="light">Tag</Tag>
-<Tag color="danger" elementType="div" size="xsmall" theme="dark">Tag</Tag>

--- a/packages/web/src/scss/components/Tag/README.md
+++ b/packages/web/src/scss/components/Tag/README.md
@@ -10,7 +10,7 @@ Subtle variants:
 <span class="Tag Tag--danger Tag--subtle Tag--small">Danger subtle tag</span>
 ```
 
-Dark variants:
+Default (non-subtle) variants:
 
 ```html
 <span class="Tag Tag--neutral Tag--small">neutral dark tag</span>

--- a/packages/web/src/scss/components/Tag/_Tag.scss
+++ b/packages/web/src/scss/components/Tag/_Tag.scss
@@ -30,18 +30,6 @@
     'tag-subtle'
 );
 
-// @deprecated Will be removed in the next major version.
-@include dictionaries.generate-colors(
-    'Tag--light.Tag',
-    theme.$color-dictionary,
-    theme.$subtle-color-dictionary-config,
-    null,
-    theme.$subtle-color-dictionary-overrides,
-    'tag-light'
-);
-
-.Tag--subtle.Tag--xsmall,
-// @deprecated Will be removed in the next major version.
-.Tag--light.Tag--xsmall {
+.Tag--subtle.Tag--xsmall {
     background-color: transparent;
 }

--- a/packages/web/src/scss/components/Tag/_theme.scss
+++ b/packages/web/src/scss/components/Tag/_theme.scss
@@ -2,12 +2,9 @@
 @use '@tokens' as tokens;
 @use '../../settings/dictionaries';
 
-/** @deprecated Will be removed in the next major version. */
-$_tag-colors-deprecated: default;
-
 $_tag-colors: neutral;
 
-$color-dictionary: list.join(dictionaries.$emotion-colors, list.join($_tag-colors-deprecated, $_tag-colors));
+$color-dictionary: list.join(dictionaries.$emotion-colors, $_tag-colors);
 
 $color-dictionary-config: (
     color: tokens.$text-primary-inverted-default,
@@ -15,15 +12,9 @@ $color-dictionary-config: (
 );
 
 $color-dictionary-overrides: (
-    // @deprecated Will be removed in the next major version
-    default:
-        (
-            background-color: tokens.$background-inverted,
-        ),
-
     neutral: (
         background-color: tokens.$background-inverted,
-    )
+    ),
 );
 
 $subtle-color-dictionary-config: (
@@ -32,17 +23,10 @@ $subtle-color-dictionary-config: (
 );
 
 $subtle-color-dictionary-overrides: (
-    // @deprecated Will be removed in the next major version
-    default:
-        (
-            color: tokens.$text-primary-default,
-            background-color: tokens.$background-cover,
-        ),
-
     neutral: (
         color: tokens.$text-primary-default,
         background-color: tokens.$background-cover,
-    )
+    ),
 );
 
 $border-radius: tokens.$radius-100;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Remove `light` and `default` modifiers in the `web` package. Use `subtle` and `neutral` instead.

Remove the `theme` prop in the `twig` package, use `isSubtle` instead. Remove color `default`, use `neutral instead.

Remove the `theme` prop in the `react` package, use `isSubtle` instead. Remove color `default`, use `neutral instead. Remove the `tag` prop, use `elementType` instead.

### Additional context

All removed props were deprecated. See each commit message for the migration guide.

### Issue reference

#DS-648

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md).
- [x] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
