### PR TITLE
Fix(web): FileUploader cannot remove files with same names

### DIFF
--- a/packages/web/src/js/FileUploader.ts
+++ b/packages/web/src/js/FileUploader.ts
@@ -43,6 +43,7 @@ class FileUploader extends BaseComponent {
   accept: string;
   isDragging: boolean;
   fileQueue: Map<string, File>;
+  instanceUid: string;
 
   constructor(element: HTMLElement) {
     super(element);
@@ -66,6 +67,7 @@ class FileUploader extends BaseComponent {
     this.accept = this.inputElement?.accept;
     this.isDragging = false;
     this.fileQueue = new Map();
+    this.instanceUid = FileUploader.getUid();
 
     this.init();
   }
@@ -86,8 +88,12 @@ class FileUploader extends BaseComponent {
     }
   }
 
-  static getUpdatedFileName(name: string): string {
-    return `file__${name.replace(/\./g, '_').replace(/\s/g, '_')}`;
+  static getUid(): string {
+    return Math.random().toString(36).slice(-6);
+  }
+
+  getUpdatedFileName(name: string): string {
+    return `${this.instanceUid}_file__${name.replace(/\./g, '_').replace(/\s/g, '_')}`;
   }
 
   dragReset() {
@@ -102,7 +108,7 @@ class FileUploader extends BaseComponent {
   }
 
   checkFileQueueDuplicity(file: File) {
-    if (this.fileQueue.has(FileUploader.getUpdatedFileName(file.name))) {
+    if (this.fileQueue.has(this.getUpdatedFileName(file.name))) {
       throw new Error(errorMessages.errorFileDuplicity);
     }
   }
@@ -239,7 +245,7 @@ class FileUploader extends BaseComponent {
       this.clearFileQueue();
     }
 
-    const id = FileUploader.getUpdatedFileName(file.name);
+    const id = this.getUpdatedFileName(file.name);
     const attachment = this.getAttachmentElement(file, id);
 
     if (!attachment) {
@@ -278,7 +284,7 @@ class FileUploader extends BaseComponent {
   removeFromQueue(name: string) {
     if (this.fileQueue.has(name)) {
       EventHandler.trigger(this.wrapper, EVENT_UNQUEUE_FILE, { fileQueue: this.fileQueue });
-      const itemElement = SelectorEngine.findOne(`li#${name}`);
+      const itemElement = SelectorEngine.findOne(`#\\${name}`);
       this.fileQueue.delete(name);
       itemElement?.remove();
       this.updateDropZoneVisibility();

--- a/packages/web/src/js/FileUploader.ts
+++ b/packages/web/src/js/FileUploader.ts
@@ -93,7 +93,9 @@ class FileUploader extends BaseComponent {
   }
 
   getUpdatedFileName(name: string): string {
-    return `${this.instanceUid}_file__${name.replace(/\./g, '_').replace(/\s/g, '_')}`;
+    // 1. use unique id for every file, even those with the same names
+    // 2. remove all special characters from file name
+    return `file_${this.instanceUid}_${name.replace(/[^a-zA-Z0-9]/g, '')}`;
   }
 
   dragReset() {
@@ -284,7 +286,7 @@ class FileUploader extends BaseComponent {
   removeFromQueue(name: string) {
     if (this.fileQueue.has(name)) {
       EventHandler.trigger(this.wrapper, EVENT_UNQUEUE_FILE, { fileQueue: this.fileQueue });
-      const itemElement = SelectorEngine.findOne(`#\\${name}`);
+      const itemElement = SelectorEngine.findOne(`#${name}`);
       this.fileQueue.delete(name);
       itemElement?.remove();
       this.updateDropZoneVisibility();


### PR DESCRIPTION


refs #DS-830

<!-- Thank you for contributing! -->

## Description

FileUploader cannot remove files with the same names

### Additional context

  * generate simple uuid for every instance of FileUploader and use it as a prefix for file id
  * this avoids having the same file ids on elements that we are querying when removing files from queue

### Issue reference

[<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->](https://jira.lmc.cz/browse/DS-830)

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md).
- [x] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
