### PR TITLE
Fix(web-twig): Do not render space after label #DS-842

### DIFF
--- a/packages/web-twig/src/Resources/components/TextFieldBase/TextFieldBase.twig
+++ b/packages/web-twig/src/Resources/components/TextFieldBase/TextFieldBase.twig
@@ -69,7 +69,11 @@
 
 <div {{ mainProps(_mainPropsWithoutReservedAttributes) }} {{ styleProp(_styleProps) }} {{ classProp(_rootClassNames) }} {{ _dataToggleAttr }}>
     <label for="{{ _id }}" {{ classProp(_labelClassNames) }}>
-        {% if _unsafeLabel %}{{ _unsafeLabel | raw }}{% else %}{{ _label }}{% endif %}
+        {%- if _unsafeLabel -%}
+            {{ _unsafeLabel | raw }}
+        {%- else -%}
+            {{ _label }}
+        {%- endif -%}
     </label>
     {% if _isMultiline %}
         <textarea


### PR DESCRIPTION
## Description

`TextArea` and `TextField` components, which comes from an abstract component `TextFieldBase`, contains unwanted blank space after `label` element.

Only Twig related and the other components look fine. :)

### Issue reference

#DS-842