### PR TITLE
BREAKING CHANGE: Rename `validator_message` to `validation_text` #DS-838

### DIFF
--- a/packages/form-validations/src/FormValidations.ts
+++ b/packages/form-validations/src/FormValidations.ts
@@ -44,7 +44,7 @@ const defaultConfig: Config = {
   validationTextParentSelector: `[${DATA_ATTR_PREFIX}-validate]`,
   validationTextTag: 'div',
   validationTextClass: '',
-  dataElementMessage: 'validator_message',
+  dataElementMessage: 'validation_text',
 };
 
 type HTMLAttribute = {

--- a/packages/web/src/scss/components/CheckboxField/_CheckboxField.scss
+++ b/packages/web/src/scss/components/CheckboxField/_CheckboxField.scss
@@ -52,7 +52,7 @@ $_field-name: 'CheckboxField';
 }
 
 .CheckboxField__validationText,
-.CheckboxField > .CheckboxField__text > [data-element='validator_message'] {
+.CheckboxField > .CheckboxField__text > [data-element='validation_text'] {
     @include form-fields-tools.validation-text();
 }
 

--- a/packages/web/src/scss/components/FileUploader/README.md
+++ b/packages/web/src/scss/components/FileUploader/README.md
@@ -225,7 +225,7 @@ or `is-disabled` to the `FileUploaderInput` subcomponent as well.
 
 When implementing client-side form validation, use JS interaction state classes
 (`has-success`, `has-warning`, `has-danger`) on the wrapping `<div>` element and
-render validation texts in a `<div>` with `data-spirit-element="validator_message"`
+render validation texts in a `<div>` with `data-spirit-element="validation_text"`
 attribute. This way your JS remains disconnected from CSS that may or may not be
 [prefixed].
 
@@ -237,7 +237,7 @@ own way.**
 <div class="FileUploaderInput has-success" data-spirit-element="wrapper">
   <!-- Label -->
   <!-- Drop zone with input -->
-  <div data-spirit-element="validator_message">Success message inserted by JS</div>
+  <div data-spirit-element="validation_text">Success message inserted by JS</div>
 </div>
 ```
 

--- a/packages/web/src/scss/components/FileUploader/_FileUploaderInput.scss
+++ b/packages/web/src/scss/components/FileUploader/_FileUploaderInput.scss
@@ -74,7 +74,7 @@ $_field-name: 'FileUploaderInput';
 }
 
 .FileUploaderInput__validationText,
-.FileUploaderInput > [data-element='validator_message'] {
+.FileUploaderInput > [data-element='validation_text'] {
     @include form-fields-tools.validation-text();
 }
 
@@ -103,7 +103,7 @@ $_field-name: 'FileUploaderInput';
 @include form-fields-tools.input-field-validation-states($_field-name); // 2.
 
 :is(.FileUploaderInput--disabled, .FileUploaderInput.is-disabled)
-    :is(.FileUploaderInput__validationText, [data-element='validator_message']) {
+    :is(.FileUploaderInput__validationText, [data-element='validation_text']) {
     @include form-fields-tools.validation-text-disabled();
 }
 

--- a/packages/web/src/scss/components/Select/README.md
+++ b/packages/web/src/scss/components/Select/README.md
@@ -204,7 +204,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
 
 When implementing client-side form validation, use JS interaction state classes
 (`has-success`, `has-warning`, `has-danger`) on the wrapping `<div>` element and
-render validation texts in a `<div>` with `data-spirit-element="validator_message"`
+render validation texts in a `<div>` with `data-spirit-element="validation_text"`
 attribute. This way your JS remains disconnected from CSS that may or may not be
 [prefixed].
 
@@ -225,7 +225,7 @@ components mix CSS with JS by design and handle prefixes their own way.**
       </svg>
     </div>
   </div>
-  <div data-spirit-element="validator_message">Validation text</div>
+  <div data-spirit-element="validation_text">Validation text</div>
 </div>
 ```
 

--- a/packages/web/src/scss/components/Select/_Select.scss
+++ b/packages/web/src/scss/components/Select/_Select.scss
@@ -70,7 +70,7 @@ $_field-name: 'Select';
 }
 
 .Select__validationText,
-.Select > [data-spirit-element='validator_message'] {
+.Select > [data-spirit-element='validation_text'] {
     @include form-fields-tools.validation-text();
 }
 
@@ -94,7 +94,7 @@ $_field-name: 'Select';
     color: theme.$icon-color-disabled;
 }
 
-:is(.Select--disabled, .Select.is-disabled) > :is(.Select__validationText, [data-spirit-element='validator_message']) {
+:is(.Select--disabled, .Select.is-disabled) > :is(.Select__validationText, [data-spirit-element='validation_text']) {
     @include form-fields-tools.validation-text-disabled();
 }
 

--- a/packages/web/src/scss/components/TextArea/README.md
+++ b/packages/web/src/scss/components/TextArea/README.md
@@ -116,7 +116,7 @@ Filled</textarea
 
 When implementing client-side form validation, use JS interaction state classes
 (`has-success`, `has-warning`, `has-danger`) on the wrapping `<div>` element and
-render validation texts in a `<div>` with `data-element="validator_message"`
+render validation texts in a `<div>` with `data-element="validation_text"`
 attribute. This way your JS remains disconnected from CSS that may or may not be
 [prefixed].
 
@@ -129,7 +129,7 @@ components mix CSS with JS by design and handle prefixes their own way.**
   <textarea id="textAreaJSValidation" class="TextArea__input" name="jsValidation" placeholder="Placeholder">
 Filled</textarea
   >
-  <div data-element="validator_message">Error message inserted by JS</div>
+  <div data-element="validation_text">Error message inserted by JS</div>
 </div>
 ```
 

--- a/packages/web/src/scss/components/TextArea/_TextArea.scss
+++ b/packages/web/src/scss/components/TextArea/_TextArea.scss
@@ -42,7 +42,7 @@ $_field-name: 'TextArea';
 }
 
 .TextArea__validationText,
-.TextArea > [data-element='validator_message'] {
+.TextArea > [data-element='validation_text'] {
     @include form-fields-tools.validation-text();
 }
 
@@ -69,7 +69,7 @@ $_field-name: 'TextArea';
 }
 // stylelint-enable
 
-:is(.TextArea--disabled, .TextArea.is-disabled) > :is(.TextArea__validationText, [data-element='validator_message']) {
+:is(.TextArea--disabled, .TextArea.is-disabled) > :is(.TextArea__validationText, [data-element='validation_text']) {
     @include form-fields-tools.validation-text-disabled();
 }
 

--- a/packages/web/src/scss/components/TextField/README.md
+++ b/packages/web/src/scss/components/TextField/README.md
@@ -209,7 +209,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
 
 When implementing client-side form validation, use JS interaction state classes
 (`has-success`, `has-warning`, `has-danger`) on the wrapping `<div>` element and
-render validation texts in a `<div>` with `data-element="validator_message"`
+render validation texts in a `<div>` with `data-element="validation_text"`
 attribute. This way your JS remains disconnected from CSS that may or may not be
 [prefixed].
 
@@ -227,7 +227,7 @@ components mix CSS with JS by design and handle prefixes their own way.**
     placeholder="Placeholder"
     value="Filled"
   />
-  <div data-element="validator_message">Error message inserted by JS</div>
+  <div data-element="validation_text">Error message inserted by JS</div>
 </div>
 ```
 

--- a/packages/web/src/scss/components/TextField/_TextField.scss
+++ b/packages/web/src/scss/components/TextField/_TextField.scss
@@ -137,7 +137,7 @@ $_field-name: 'TextField';
 }
 
 .TextField__validationText,
-.TextField > [data-element='validator_message'] {
+.TextField > [data-element='validation_text'] {
     @include form-fields-tools.validation-text();
 }
 
@@ -194,8 +194,7 @@ $_field-name: 'TextField';
 }
 // stylelint-enable
 
-:is(.TextField--disabled, .TextField.is-disabled)
-    > :is(.TextField__validationText, [data-element='validator_message']) {
+:is(.TextField--disabled, .TextField.is-disabled) > :is(.TextField__validationText, [data-element='validation_text']) {
     @include form-fields-tools.validation-text-disabled();
 }
 

--- a/packages/web/src/scss/tools/_form-fields.scss
+++ b/packages/web/src/scss/tools/_form-fields.scss
@@ -149,7 +149,7 @@
                 :is(
                     .#{$field-name}__validationText,
                     .#{$field-name}__validationText,
-                    [data-element='validator_message']
+                    [data-element='validation_text']
                 ) {
                 color: map.get($validation-state-value, validation-text-color);
             }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Instead of the `validator_message` value of the `data-spirit-element` attribute, use
`validation_text`.

- `<div data-spirit-element="validator_message">…</div>` →
`<div data-spirit-element="validation_text">…</div>`

Please refer back to these instructions or reach out to our team
if you encounter any issues during migration.

### Issue reference

https://jira.lmc.cz/browse/DS-838