### PR TITLE
web-twig: Remove data-toggle attribute from TabLink

### DIFF
--- a/packages/web-twig/src/Resources/components/Tabs/README.md
+++ b/packages/web-twig/src/Resources/components/Tabs/README.md
@@ -7,10 +7,10 @@ Basic example usage:
 ```html
 <TabList>
   <TabItem>
-    <TabLink isSelected id="pane1-tab" target="pane1">Item selected</TabLink>
+    <TabLink isSelected id="pane1-tab" target="pane1" data-toggle="tabs">Item selected</TabLink>
   </TabItem>
   <TabItem>
-    <TabLink id="pane2-tab" target="pane2">Item</TabLink>
+    <TabLink id="pane2-tab" target="pane2" data-toggle="tabs">Item</TabLink>
   </TabItem>
   <TabItem>
     <TabLink href="https://www.example.com">Item link</TabLink>
@@ -74,5 +74,21 @@ You can add `id`, `data-*` or `aria-*` attributes to further extend component's
 descriptiveness and accessibility. Also, UNSAFE styling props are available,
 see the [Escape hatches][escape-hatches] section in README to learn how and when to use them.
 
+## JavaScript Plugin
+
+For full functionality, you need to provide Spirit JavaScript:
+
+```html
+<script src="node_modules/@lmc-eu/spirit-web/js/cjs/spirit-web.min.js" async></script>
+```
+
+Check the [component's docs in the web package][web-js-api] to see the full documentation of the plugin.
+
+Please consult the [main README][web-readme] for how to include JavaScript plugins.
+
+Or, feel free to write the controlling script yourself.
+
+[web-js-api]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/scss/components/Tabs/README.md#javascript-plugin-api
+[web-readme]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/README.md
 [tabs]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web/src/scss/components/Tabs
 [escape-hatches]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web-twig/README.md#escape-hatches

--- a/packages/web-twig/src/Resources/components/Tabs/TabLink.twig
+++ b/packages/web-twig/src/Resources/components/Tabs/TabLink.twig
@@ -12,7 +12,6 @@
 {# Attributes #}
 {%- set _ariaControlsAttr = _target ? 'aria-controls="' ~ _target | escape('html_attr') ~ '"' : null -%}
 {%- set _dataTargetAttr = _target ? 'data-target="#' ~ _target | escape('html_attr') ~ '"' : null -%}
-{%- set _dataToggleAttr = _href ? null : 'data-toggle="tabs"' -%}
 {%- set _roleAttr = _href ? 'role="tab"' : null -%}
 {%- set _typeAttr = _href ? null : 'type="button"' -%}
 
@@ -30,7 +29,6 @@
     aria-selected="{{ _ariaSelected }}"
     {{ _ariaControlsAttr | raw }}
     {{ _dataTargetAttr | raw }}
-    {{ _dataToggleAttr | raw }}
     {{ _roleAttr | raw }}
     {{ _typeAttr | raw }}
 >

--- a/packages/web-twig/src/Resources/components/Tabs/stories/TabsDefault.twig
+++ b/packages/web-twig/src/Resources/components/Tabs/stories/TabsDefault.twig
@@ -1,9 +1,9 @@
 <TabList>
     <TabItem>
-        <TabLink isSelected id="pane1-tab" target="pane1">Item 1</TabLink>
+        <TabLink isSelected id="pane1-tab" data-toggle="tabs" target="pane1">Item 1</TabLink>
     </TabItem>
     <TabItem>
-        <TabLink id="pane2-tab" target="pane2">Item 2</TabLink>
+        <TabLink id="pane2-tab" data-toggle="tabs" target="pane2">Item 2</TabLink>
     </TabItem>
     <TabItem>
         <TabLink href="https://www.example.com">Item link</TabLink>

--- a/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set tabsDefault.twig__1.html
+++ b/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set tabsDefault.twig__1.html
@@ -7,11 +7,11 @@
   <body>
     <ul class="Tabs" role="tablist">
       <li class="Tabs__item">
-        <button id="pane1-tab" class="Tabs__link is-selected" aria-selected="true" aria-controls="pane1" data-target="#pane1" data-toggle="tabs" type="button">Item selected</button>
+        <button id="pane1-tab" data-toggle="tabs" class="Tabs__link is-selected" aria-selected="true" aria-controls="pane1" data-target="#pane1" type="button">Item selected</button>
       </li>
 
       <li class="Tabs__item">
-        <button id="pane2-tab" class="Tabs__link" aria-selected="false" aria-controls="pane2" data-target="#pane2" data-toggle="tabs" type="button">Item</button>
+        <button id="pane2-tab" data-toggle="tabs" class="Tabs__link" aria-selected="false" aria-controls="pane2" data-target="#pane2" type="button">Item</button>
       </li>
 
       <li class="Tabs__item">

--- a/packages/web-twig/tests/components-fixtures/tabsDefault.twig
+++ b/packages/web-twig/tests/components-fixtures/tabsDefault.twig
@@ -1,23 +1,23 @@
 <TabList>
-  <TabItem>
-    <TabLink isSelected id="pane1-tab" data-toggle="tabs" target="pane1">
-      Item selected
-    </TabLink>
-  </TabItem>
-  <TabItem>
-    <TabLink id="pane2-tab" data-toggle="tabs" target="pane2">
-      Item
-    </TabLink>
-  </TabItem>
-  <TabItem>
-    <TabLink href="https://www.example.com">
-      Item link
-    </TabLink>
-  </TabItem>
+    <TabItem>
+        <TabLink isSelected id="pane1-tab" data-toggle="tabs" target="pane1">
+            Item selected
+        </TabLink>
+    </TabItem>
+    <TabItem>
+        <TabLink id="pane2-tab" data-toggle="tabs" target="pane2">
+            Item
+        </TabLink>
+    </TabItem>
+    <TabItem>
+        <TabLink href="https://www.example.com">
+            Item link
+        </TabLink>
+    </TabItem>
 </TabList>
 <TabPane id="pane1" isSelected label="pane1-tab">
-  Pane 1
+    Pane 1
 </TabPane>
 <TabPane id="pane2" label="pane2-tab">
-  Pane 2
+    Pane 2
 </TabPane>

--- a/packages/web-twig/tests/components-fixtures/tabsDefault.twig
+++ b/packages/web-twig/tests/components-fixtures/tabsDefault.twig
@@ -1,11 +1,11 @@
 <TabList>
   <TabItem>
-    <TabLink isSelected id="pane1-tab" target="pane1">
+    <TabLink isSelected id="pane1-tab" data-toggle="tabs" target="pane1">
       Item selected
     </TabLink>
   </TabItem>
   <TabItem>
-    <TabLink id="pane2-tab" target="pane2">
+    <TabLink id="pane2-tab" data-toggle="tabs" target="pane2">
       Item
     </TabLink>
   </TabItem>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Removing the data-toggle attribute which is automatically placed when the href attribute is missing. This causes an unwanted auto initialization of Tabs when a developer needs to do this yourself.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

https://jira.lmc.cz/browse/DS-840

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md).
- [x] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
