### PR TITLE
Fix(web): Escape attachment file name in FileUploader

### DIFF
--- a/packages/web/src/js/FileUploader.ts
+++ b/packages/web/src/js/FileUploader.ts
@@ -210,7 +210,7 @@ class FileUploader extends BaseComponent {
 
     item!.appendChild(attachmentInputElement);
     item!.setAttribute('id', id);
-    itemName!.innerHTML = file.name;
+    itemName!.appendChild(document.createTextNode(file.name));
     itemButton!.setAttribute(DATA_DISMISS_ATTRIBUTE, id);
     item!.removeAttribute(TEMPLATE_ELEMENT_SLOT_NAME);
     itemName!.removeAttribute(TEMPLATE_ELEMENT_SLOT_NAME);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

There is a XSS when file names like

```
<u>test</u>.txt
<iframe src="test"></iframe>.txt
```

are used and picked by FileUploader.

### Additional context

https://developer.mozilla.org/en-US/docs/Web/API/Document/createTextNode

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md).
- [x] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
