### PR TITLE
Feat(web): Display validation text on FileUploader

### DIFF
--- a/packages/web/src/js/FileUploader.ts
+++ b/packages/web/src/js/FileUploader.ts
@@ -28,7 +28,7 @@ const DATA_ELEMENT_VALIDATION_TEXT = 'validator_message';
 const SELECTOR_VALIDATION_TEXT = `[data-element="${DATA_ELEMENT_VALIDATION_TEXT}"]`;
 const DEFAULT_FILE_SIZE_LIMIT = 10000000; // = 10 MB
 const DEFAULT_FILE_QUEUE_LIMIT = 10;
-const errorMessages = {
+const DEFAULT_ERROR_MESSAGES = {
   errorMaxFileSize: 'The file size limit has been exceeded',
   errorFileDuplicity: 'This file already exists in the queue',
   errorMaxUploadedFiles: 'You have exceeded the number of files allowed in the queue',
@@ -50,6 +50,7 @@ class FileUploader extends BaseComponent {
   isDragging: boolean;
   fileQueue: Map<string, File>;
   instanceUid: string;
+  errors: Record<string, string>;
 
   constructor(element: HTMLElement) {
     super(element);
@@ -68,6 +69,15 @@ class FileUploader extends BaseComponent {
     this.queueLimitBehavior = this.wrapper?.dataset.spiritQueueLimitBehavior
       ? this.wrapper?.dataset.spiritQueueLimitBehavior
       : 'none';
+    this.errors = {};
+    this.errors.errorMaxFileSize =
+      this.element.dataset.spiritMessageMaxfilesize ?? DEFAULT_ERROR_MESSAGES.errorMaxFileSize;
+    this.errors.errorFileDuplicity =
+      this.element.dataset.spiritMessageDuplicity ?? DEFAULT_ERROR_MESSAGES.errorFileDuplicity;
+    this.errors.errorMaxUploadedFiles =
+      this.element.dataset.spiritMessageMaxuploadedfiles ?? DEFAULT_ERROR_MESSAGES.errorMaxUploadedFiles;
+    this.errors.errorFileNotSupported =
+      this.element.dataset.spiritMessageUnsupported ?? DEFAULT_ERROR_MESSAGES.errorFileNotSupported;
     this.inputName = this.inputElement?.name || 'attachment';
     this.isMultiple = this.inputElement?.multiple;
     this.accept = this.inputElement?.accept;
@@ -111,13 +121,13 @@ class FileUploader extends BaseComponent {
 
   checkAllowedFileSize(file: File) {
     if (file.size > this.fileSizeLimit) {
-      throw new Error(`${file.name}: ${errorMessages.errorMaxFileSize}`);
+      throw new Error(`${file.name}: ${this.errors.errorMaxFileSize}`);
     }
   }
 
   checkFileQueueDuplicity(file: File) {
     if (this.fileQueue.has(this.getUpdatedFileName(file.name))) {
-      throw new Error(`${file.name}: ${errorMessages.errorFileDuplicity}`);
+      throw new Error(`${file.name}: ${this.errors.errorFileDuplicity}`);
     }
   }
 
@@ -158,7 +168,7 @@ class FileUploader extends BaseComponent {
     }
 
     if (!isTypeSupported) {
-      throw new Error(`"${file.name}": ${errorMessages.errorFileNotSupported}`);
+      throw new Error(`"${file.name}": ${this.errors.errorFileNotSupported}`);
     }
   }
 

--- a/packages/web/src/js/__tests__/FileUploader.test.ts
+++ b/packages/web/src/js/__tests__/FileUploader.test.ts
@@ -30,6 +30,37 @@ describe('FileUploader', () => {
     expect(FileUploader.NAME).toBe('fileUploader');
   });
 
+  it('should generate unique id', () => {
+    jest.spyOn(global.Math, 'random').mockReturnValue(0.123456789);
+
+    expect(FileUploader.getUid()).toBe('xjylrx');
+
+    jest.spyOn(global.Math, 'random').mockRestore();
+  });
+
+  it('should generate updated filename', () => {
+    jest.spyOn(global.Math, 'random').mockReturnValue(0.123456789);
+
+    fixtureEl.innerHTML = `
+      <div class="FileUploader" data-toggle="fileUploader">
+        <template data-spirit-snippet="item"></template>
+        <div class="FileUploaderInput" data-spirit-element="wrapper">
+          <label for="fileUploadMultiple" class="FileUploaderInput__label">Label</label>
+          <div class="FileUploaderInput__dropZone" data-spirit-element="dropZone"></div>
+        </div>
+        <h3 id="attachments-multipleFile" hidden>Attachments</h3>
+        <ul class="FileUploaderList" aria-labelledby="attachments-multipleFile" data-spirit-element="list"></ul>
+      </div>
+    `;
+
+    const fileUploaderEl = fixtureEl.querySelector('[data-toggle="fileUploader"]') as HTMLElement;
+
+    const fileUploader = new FileUploader(fileUploaderEl);
+    expect(fileUploader.getUpdatedFileName('test')).toBe('file_xjylrx_test');
+
+    jest.spyOn(global.Math, 'random').mockRestore();
+  });
+
   it('isDraggable should be true', () => {
     expect(instance.isDragAndDropSupported).toBeTruthy();
   });

--- a/packages/web/src/scss/components/FileUploader/README.md
+++ b/packages/web/src/scss/components/FileUploader/README.md
@@ -241,9 +241,29 @@ own way.**
 </div>
 ```
 
+##### Localization
+
+There are four types of validation errors that have their default validation text.
+You can customize those validation texts using `data-spirit-message-*` that is passed to the components' root element.
+
+```html
+<div class="FileUploaderInput has-danger" data-spirit-element="wrapper" data-spirit-message-maxfilesize="Too big file!">
+  <!-- … -->
+</div>
+```
+
+Validation Errors:
+
+| Name                  | Usage                                      | Description                                 |
+| --------------------- | ------------------------------------------ | ------------------------------------------- |
+| File Duplicity        | `data-spirit-message-duplicity="…"`        | When file is already in the queue           |
+| Max File Size         | `data-spirit-message-maxfilesize="…"`      | When file size is over allowed limit        |
+| Max Uploaded Files    | `data-spirit-message-maxuploadedfiles="…"` | When the limit of uploaded files is reached |
+| Unsupported File Type | `data-spirit-message-unsupported="…"`      | When the file is of unsupported type        |
+
 ## FileUploaderList
 
-FileUploaderList is a simple wrapper which provides an accessible title and the
+FileUploaderList is a simple wrapper that provides an accessible title and the
 list semantics for the selected files.
 
 ```html

--- a/packages/web/src/scss/components/FileUploader/README.md
+++ b/packages/web/src/scss/components/FileUploader/README.md
@@ -225,7 +225,7 @@ or `is-disabled` to the `FileUploaderInput` subcomponent as well.
 
 When implementing client-side form validation, use JS interaction state classes
 (`has-success`, `has-warning`, `has-danger`) on the wrapping `<div>` element and
-render validation messages in a `<div>` with `data-spirit-element="validator_message"`
+render validation messages in a `<div>` with `data-element="validator_message"`
 attribute. This way your JS remains disconnected from CSS that may or may not be
 [prefixed].
 

--- a/packages/web/src/scss/components/FileUploader/index.html
+++ b/packages/web/src/scss/components/FileUploader/index.html
@@ -55,7 +55,7 @@
   <h2 class="docs-Heading">Input Multiple</h2>
 
   <!-- FileUploader: start -->
-  <div id="example_multiple" class="FileUploader" data-toggle="fileUploader">
+  <div id="example_multiple" class="FileUploader" data-toggle="fileUploader" data-spirit-message-maxfilesize="Too big file!">
 
     <!-- FileUploaderAttachment template: start -->
     <template data-spirit-snippet="item">
@@ -682,7 +682,7 @@
       <!-- FileUploaderAttachment template: end -->
 
       <!-- FileUploaderInput: start -->
-      <div class="FileUploaderInput" data-spirit-element="wrapper" data-file-queue-limit="2">
+      <div class="FileUploaderInput" data-spirit-element="wrapper" data-spirit-file-queue-limit="2">
         <label for="fileUploadInForm" class="FileUploaderInput__label">Label</label>
         <input type="file" id="fileUploadInForm" name="attachment10" class="FileUploaderInput__input" multiple data-spirit-element="input" />
         <div class="FileUploaderInput__dropZone" data-spirit-element="dropZone">


### PR DESCRIPTION
  * FileUploader displayes validation text when error happen

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
