### PR TITLE
BREAKING CHANGE(web): Add underline to hover and active states to def…

### DIFF
--- a/packages/web/src/scss/foundation/_links.scss
+++ b/packages/web/src/scss/foundation/_links.scss
@@ -1,6 +1,3 @@
-// 1. Enable fixed default link underline on hover and active states using `spirit-v1-link-underlined` on the root element, eg. body.
-//    This will be removed in v1 and the new default link underline will be the default.
-
 @use '@tokens' as tokens;
 @use '../settings/links';
 
@@ -14,23 +11,14 @@ a {
     color: tokens.$action-link-primary-default;
 
     &:active {
+        text-decoration: underline;
         color: tokens.$action-link-primary-active;
     }
 
     @media (hover: hover) {
         &:hover {
+            text-decoration: underline;
             color: tokens.$action-link-primary-hover;
         }
-    }
-}
-
-// 1.
-:where(.spirit-v1-links-underlined) a:active {
-    text-decoration: underline;
-}
-
-@media (hover: hover) {
-    :where(.spirit-v1-links-underlined) a:hover {
-        text-decoration: underline;
     }
 }

--- a/packages/web/src/scss/helpers/links/index.html
+++ b/packages/web/src/scss/helpers/links/index.html
@@ -54,60 +54,6 @@
     Heading XSmall Text with <a href="#">link without underlined class, behaves the same as the one before</a>
   </h3>
 
-  <div class="spirit-v1-links-underlined mt-1200">
-    <h3 class="docs-Heading">V1 Feature &mdash; correct link underline</h3>
-
-    <p>
-      <a href="#" class="link-primary">Primary Link</a>
-    </p>
-    <p>
-      <a href="#" class="link-secondary">Secondary Link</a>
-    </p>
-    <p class="docs-Box">
-      <a href="#" class="link-inverted">Inverted Link</a>
-    </p>
-    <p>
-      <a href="#" class="link-primary link-disabled">Primary Disabled Link</a>
-    </p>
-    <p>
-      <a href="#" class="link-secondary link-disabled">Secondary Disabled Link</a>
-    </p>
-    <p class="docs-Box">
-      <a href="#" class="link-inverted link-disabled">Inverted Disabled Link</a>
-    </p>
-    <p>
-      <a href="#" class="link-primary link-underlined">Primary Underlined Link</a>
-    </p>
-    <p>
-      <a href="#" class="link-secondary link-underlined">Secondary Underlined Link</a>
-    </p>
-    <p class="docs-Box">
-      <a href="#" class="link-inverted link-underlined">Inverted Underlined Link</a>
-    </p>
-    <p>
-      <a href="#" class="link-primary link-disabled link-underlined">Primary Disabled Underlined Link</a>
-    </p>
-    <p>
-      <a href="#" class="link-secondary link-disabled link-underlined">Secondary Disabled Underlined Link</a>
-    </p>
-    <p class="docs-Box mb-1000">
-      <a href="#" class="link-inverted link-disabled link-underlined">Inverted Disabled Underlined Link</a>
-    </p>
-
-    <h3 class="typography-heading-xsmall-text">
-      Heading XSmall Text with <a href="#">link (default style), obtains visited state</a>
-    </h3>
-    <h3 class="typography-heading-xsmall-text">
-      Heading XSmall Text with <a href="#" class="link-primary">link (primary), obtains visited state</a>
-    </h3>
-    <h3 class="typography-heading-xsmall-text">
-      Heading XSmall Text with <a href="#" class="link-underlined">link with underlined class, obtains visited state, gets underlined only on hover and active</a>
-    </h3>
-    <h3 class="typography-heading-xsmall-text">
-      Heading XSmall Text with <a href="#">link without underlined class, behaves the same as the one before</a>
-    </h3>
-  </div>
-
 </section>
 
 {{/layout/plain}}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Added underlined to hover and active states of default links.

### Additional context

Also, removed the feature class enabling the behaviour by default.

### Issue reference

#DS-650

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md).
- [x] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
