### PR TITLE
Fix(web): Fix FileUploader Drag and Drop and duplicated validation messages

### DIFF
--- a/packages/web/src/js/__tests__/FileUploader.test.ts
+++ b/packages/web/src/js/__tests__/FileUploader.test.ts
@@ -167,7 +167,7 @@ describe('FileUploader', () => {
     });
   });
 
-  describe('FileUploader: File Queue Limit', () => {
+  describe('File Queue Limit', () => {
     let fileUploader: FileUploader;
 
     beforeEach(() => {
@@ -287,6 +287,40 @@ describe('FileUploader', () => {
       expect(() => instance.checkFileQueueDuplicity(file)).toThrow(
         `${file.name}: ${instance.errors.errorFileDuplicity}`,
       );
+    });
+  });
+
+  describe('isValidationTextInElement', () => {
+    let listElement: HTMLElement;
+
+    beforeEach(() => {
+      listElement = document.createElement('div');
+      listElement.innerHTML = `
+      <ul>
+        <li>Validation Text 1</li>
+        <li>Validation Text 2</li>
+        <li>Validation Text 3</li>
+      </ul>`;
+    });
+
+    it('should return true if validation text is found in any <li> element', () => {
+      const validationText = 'Validation Text 2';
+
+      expect(FileUploader.isValidationTextInElement(validationText, listElement)).toBe(true);
+    });
+
+    it('should return false if validation text is not found in any <li> element', () => {
+      const validationText = 'Not Found';
+
+      expect(FileUploader.isValidationTextInElement(validationText, listElement)).toBe(false);
+    });
+
+    it('should return false for an empty element', () => {
+      const emptyElement = document.createElement('div');
+
+      const validationText = 'Validation Text';
+
+      expect(FileUploader.isValidationTextInElement(validationText, emptyElement)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Description

- It is not possible to drag and drop new files when input is disabled.
- If input is not disabled and you keep drag and drop files over limit, validation messages are not duplicated anymore.

### Issue reference

[Fixes #DS-848](https://jira.lmc.cz/browse/DS-848)

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-desing-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
