### PR TITLE
Feat(web-react): FileUploader Image attachment preview #DS-852

### DIFF
--- a/packages/web-react/docs/stories/examples/FileUploaderWithImagePreview.stories.tsx
+++ b/packages/web-react/docs/stories/examples/FileUploaderWithImagePreview.stories.tsx
@@ -1,0 +1,111 @@
+import React, { useState, MouseEvent } from 'react';
+import { SpiritFileUploaderAttachmentProps } from '../../../src/types';
+import { useFileQueue } from '../../../src/components/FileUploader/useFileQueue';
+import FileUploader from '../../../src/components/FileUploader/FileUploader';
+import FileUploaderInput from '../../../src/components/FileUploader/FileUploaderInput';
+import FileUploaderList from '../../../src/components/FileUploader/FileUploaderList';
+import FileUploaderAttachment from '../../../src/components/FileUploader/FileUploaderAttachment';
+import { Button, Modal, ModalBody, ModalDialog, ModalFooter } from '../../../src/components';
+
+export default {
+  title: 'Examples/Compositions',
+};
+
+export const FileUploaderWithModalImagePreview = (args) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [base64File, setBase64File] = useState<string>('');
+  const [fileToPreview, setFileToPreview] = useState<File | null>(null);
+  const { fileQueue, addToQueue, clearQueue, onDismiss, updateQueue } = useFileQueue();
+
+  const imagePreview = (key: string, file: File) => {
+    if (file.type.includes('image')) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        // FileReader.result contains the file content as a base64 encoded string
+        setBase64File(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+
+      setFileToPreview(file);
+      setIsModalOpen(true);
+
+      return;
+    }
+
+    return addToQueue(key, file);
+  };
+
+  const resetCropImageState = () => {
+    setIsModalOpen(false);
+    setFileToPreview(null);
+    setBase64File('');
+  };
+
+  const handleClose = () => {
+    resetCropImageState();
+  };
+
+  const confirmPreview = () => {
+    setIsModalOpen(false);
+    addToQueue(fileToPreview?.name || '', fileToPreview as File);
+  };
+
+  const onEdit = (event: MouseEvent, file: File) => {
+    imagePreview(file.name, file);
+  };
+
+  const attachmentComponent = ({ id, ...props }: SpiritFileUploaderAttachmentProps) => (
+    <FileUploaderAttachment key={id} id={id} onEdit={onEdit} {...props} />
+  );
+
+  return (
+    <>
+      <FileUploader
+        {...args}
+        id="fileUploaderExample"
+        onDismiss={onDismiss}
+        fileQueue={fileQueue}
+        addToQueue={imagePreview}
+        clearQueue={clearQueue}
+        updateQueue={updateQueue}
+      >
+        <FileUploaderInput
+          id="fileUploaderExampleInput"
+          name="attachments"
+          label="Label"
+          linkText="Upload your file(s)"
+          labelText="or drag and drop here"
+          helperText="Max file size is 10 MB"
+          validationText="Validation message"
+          /* eslint-disable-next-line no-console */
+          onError={(error) => console.error('My error log', error)}
+        />
+        <FileUploaderList
+          id="fileUploaderExampleList"
+          label="Attachments"
+          inputName="attachments"
+          attachmentComponent={attachmentComponent}
+          hasImagePreview
+        />
+      </FileUploader>
+
+      <Modal id="ModalExample" isOpen={isModalOpen} onClose={handleClose}>
+        <ModalDialog>
+          <ModalBody>
+            <div className="pt-400 pt-tablet-600">
+              <img src={base64File} style={{ width: '100%', height: 'auto' }} alt="fileToPreview" />
+            </div>
+          </ModalBody>
+          <ModalFooter>
+            <Button color="primary" onClick={confirmPreview}>
+              Confirm
+            </Button>
+            <Button color="tertiary" onClick={handleClose}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        </ModalDialog>
+      </Modal>
+    </>
+  );
+};

--- a/packages/web-react/src/components/FileUploader/AttachmentActionButton.tsx
+++ b/packages/web-react/src/components/FileUploader/AttachmentActionButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import classNames from 'classnames';
+import { SpiritAttachmentActionButtonProps } from '../../types';
+import { Icon } from '../Icon';
+import { useFileUploaderStyleProps } from './useFileUploaderStyleProps';
+import { useStyleProps } from '../../hooks';
+
+const AttachmentActionButton = (props: SpiritAttachmentActionButtonProps) => {
+  const { name = 'edit', children, ...restProps } = props;
+
+  const { classProps } = useFileUploaderStyleProps();
+  const { styleProps, props: transferProps } = useStyleProps(restProps);
+
+  return (
+    <button
+      type="button"
+      {...transferProps}
+      {...styleProps}
+      className={classNames(classProps.attachment.button, styleProps.className)}
+    >
+      <span className="accessibility-hidden">{children}</span>
+      <Icon name={name} aria-hidden="true" />
+    </button>
+  );
+};
+
+export default AttachmentActionButton;

--- a/packages/web-react/src/components/FileUploader/AttachmentImagePreview.tsx
+++ b/packages/web-react/src/components/FileUploader/AttachmentImagePreview.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useFileUploaderStyleProps } from './useFileUploaderStyleProps';
+import { IMAGE_DIMENSION } from './constants';
+
+type AttachmentImagePreviewProps = {
+  label: string;
+  imagePreview: string;
+};
+
+const AttachmentImagePreview = ({ label, imagePreview }: AttachmentImagePreviewProps) => {
+  const { classProps } = useFileUploaderStyleProps();
+
+  return (
+    <span className={classProps.attachment.image}>
+      <img src={imagePreview} width={IMAGE_DIMENSION} height={IMAGE_DIMENSION} alt={label} />
+    </span>
+  );
+};
+
+export default AttachmentImagePreview;

--- a/packages/web-react/src/components/FileUploader/FileUploader.stories.ts
+++ b/packages/web-react/src/components/FileUploader/FileUploader.stories.ts
@@ -8,6 +8,7 @@ export default {
 
 export { default as FileUploader } from './stories/FileUploader';
 export { default as FileUploaderAccept } from './stories/FileUploaderAccept';
+export { default as FileUploaderWithImagePreview } from './stories/FileUploaderWithImagePreview';
 export { default as FileUploaderDismissible } from './stories/FileUploaderDismissible';
 export { default as FileUploaderFluid } from './stories/FileUploaderFluid';
 export { default as FileUploaderValidationState } from './stories/FileUploaderValidationState';

--- a/packages/web-react/src/components/FileUploader/FileUploader.tsx
+++ b/packages/web-react/src/components/FileUploader/FileUploader.tsx
@@ -12,7 +12,19 @@ import {
 } from './constants';
 
 const FileUploader = (props: SpiritFileUploaderProps) => {
-  const { children, id, fileQueue, onDismiss, addToQueue, clearQueue, errorMessages, isFluid, ...restProps } = props;
+  const {
+    children,
+    id,
+    fileQueue,
+    onDismiss,
+    addToQueue,
+    clearQueue,
+    findInQueue,
+    updateQueue,
+    errorMessages,
+    isFluid,
+    ...restProps
+  } = props;
 
   const { classProps } = useFileUploaderStyleProps({ isFluid });
   const { styleProps, props: transferProps } = useStyleProps(restProps);
@@ -22,6 +34,8 @@ const FileUploader = (props: SpiritFileUploaderProps) => {
     clearQueue,
     fileQueue,
     onDismiss,
+    findInQueue,
+    updateQueue,
     errorMessages: {
       errorFileDuplicity: DEFAULT_ERROR_MESSAGE_QUEUE_DUPLICITY,
       errorFileNotSupported: DEFAULT_ERROR_MESSAGE_UNSUPPORTED_FILE,

--- a/packages/web-react/src/components/FileUploader/FileUploaderAttachment.tsx
+++ b/packages/web-react/src/components/FileUploader/FileUploaderAttachment.tsx
@@ -1,17 +1,37 @@
-import React, { useRef, RefObject } from 'react';
+import React, { useRef, RefObject, MouseEvent, useState } from 'react';
 import classNames from 'classnames';
 import { SpiritFileUploaderAttachmentProps } from '../../types';
 import { useStyleProps } from '../../hooks';
 import { useFileUploaderStyleProps } from './useFileUploaderStyleProps';
 import { useFileUploaderAttachment } from './useFileUploaderAttachment';
-import AttachmentDismissButton from './AttachmentDismissButton';
+import AttachmentImagePreview from './AttachmentImagePreview';
 import { Icon } from '../Icon';
+import { DEFAULT_ICON_NAME, DEFAULT_BUTTON_LABEL, DEFAULT_EDIT_BUTTON_LABEL } from './constants';
+import { image2Base64Preview } from './utils';
+import AttachmentActionButton from './AttachmentActionButton';
+import AttachmentDismissButton from './AttachmentDismissButton';
 
 const FileUploaderAttachment = (props: SpiritFileUploaderAttachmentProps) => {
-  const { label, name, iconName = 'file', id, onDismiss, buttonLabel = 'Remove', file, onError, ...restProps } = props;
+  const {
+    file,
+    hasImagePreview,
+    id,
+    label,
+    name,
+    onDismiss,
+    onError,
+    onEdit,
+    iconName = DEFAULT_ICON_NAME,
+    buttonLabel = DEFAULT_BUTTON_LABEL,
+    editButtonLabel = DEFAULT_EDIT_BUTTON_LABEL,
+    ...restProps
+  } = props;
+  const [imagePreview, setImagePreview] = useState<string>('');
 
   const { classProps } = useFileUploaderStyleProps();
   const { styleProps, props: transferProps } = useStyleProps(restProps);
+
+  const isFileImage = file.type.includes('image');
 
   const attachmentRef = useRef() as RefObject<HTMLLIElement>;
 
@@ -20,6 +40,12 @@ const FileUploaderAttachment = (props: SpiritFileUploaderAttachmentProps) => {
       onDismiss(id);
     }
   };
+
+  const onEditHandler = (event: MouseEvent) => onEdit && onEdit(event, file);
+
+  if (isFileImage) {
+    image2Base64Preview(file, 100, (compressedDataURL) => setImagePreview(compressedDataURL));
+  }
 
   useFileUploaderAttachment({ attachmentRef, file, name, onError });
 
@@ -31,10 +57,19 @@ const FileUploaderAttachment = (props: SpiritFileUploaderAttachmentProps) => {
       {...styleProps}
       className={classNames(classProps.attachment.root, styleProps.className)}
     >
-      <Icon name={iconName} aria-hidden="true" />
+      {hasImagePreview && imagePreview ? (
+        <AttachmentImagePreview label={label} imagePreview={imagePreview} />
+      ) : (
+        <Icon name={iconName} aria-hidden="true" />
+      )}
       <span className={classProps.attachment.name}>
         <span className="text-truncate">{label}</span>
       </span>
+      {onEdit && (
+        <span className={classProps.attachment.slot}>
+          <AttachmentActionButton onClick={onEditHandler}>{editButtonLabel}</AttachmentActionButton>
+        </span>
+      )}
       <AttachmentDismissButton onClick={dismissHandler}>{buttonLabel}</AttachmentDismissButton>
     </li>
   );

--- a/packages/web-react/src/components/FileUploader/FileUploaderContext.ts
+++ b/packages/web-react/src/components/FileUploader/FileUploaderContext.ts
@@ -8,6 +8,8 @@ const defaultContext: FileUploaderContextProps = {
   clearQueue: () => null,
   fileQueue: new Map(),
   onDismiss: () => new Map(),
+  findInQueue: () => null,
+  updateQueue: () => new Map(),
   errorMessages: {
     errorFileDuplicity: '',
     errorFileNotSupported: '',

--- a/packages/web-react/src/components/FileUploader/FileUploaderList.tsx
+++ b/packages/web-react/src/components/FileUploader/FileUploaderList.tsx
@@ -6,7 +6,7 @@ import { useFileUploaderStyleProps } from './useFileUploaderStyleProps';
 import { useFileUploaderContext } from './FileUploaderContext';
 
 const FileUploaderList = (props: SpiritFileUploaderListProps) => {
-  const { label, id, attachmentComponent, inputName, ...restProps } = props;
+  const { label, id, attachmentComponent, inputName, hasImagePreview, ...restProps } = props;
 
   const { classProps } = useFileUploaderStyleProps();
   const { styleProps, props: transferProps } = useStyleProps(restProps);
@@ -26,9 +26,10 @@ const FileUploaderList = (props: SpiritFileUploaderListProps) => {
           name: inputName,
           file,
           onDismiss,
+          hasImagePreview,
         }),
     );
-  }, [attachmentComponent, fileQueue, inputName, onDismiss]);
+  }, [attachmentComponent, fileQueue, inputName, onDismiss, hasImagePreview]);
 
   return (
     <>

--- a/packages/web-react/src/components/FileUploader/README.md
+++ b/packages/web-react/src/components/FileUploader/README.md
@@ -66,6 +66,24 @@ const { fileQueue, addToQueue, clearQueue, onDismiss } = useFileQueue();
 </FileUploader>;
 ```
 
+### List with image previews
+
+```javascript
+<FileUploaderList
+  id="fileUploaderExampleList"
+  label="Attachments"
+  inputName="attachments"
+  attachmentComponent={attachmentComponent}
+  hasImagePreview
+/>
+```
+
+### Editable Attachment
+
+```javascript
+<FileUploaderAttachment key={id} id={id} onEdit={(event, file) => console.log(event, file)} {...props} />
+```
+
 ### Validation State
 
 ```javascript
@@ -289,6 +307,8 @@ const resetStateHandler = () => {
 | `clearQueue`                          | `() => void`                                    | -       | ✔        | Callback to clear the queue                                         |
 | `fileQueue`                           | `FileQueueMapType`                              | -       | ✔        | Queue of items to upload                                            |
 | `onDismiss`                           | `(key: string) => FileQueueMapType`             | -       | ✔        | A callback to delete a particular item from the queue               |
+| `findInQueue`                         | `(key: string) => FileQueueMapType`             | -       | ✔        | A callback to find a particular item in the queue                   |
+| `updateQueue`                         | `(key: string, file: File) => FileQueueMapType` | -       | ✔        | A callback to update a particular item in the queue                 |
 | `isFluid`                             | `boolean`                                       | -       | ✕        | When the field is supposed to be fluid                              |
 | `errorMessages.errorMaxFileSize`      | `string`                                        | -       | ✕        | Translation for the error message: Maximum file size                |
 | `errorMessages.errorMaxUploadedFiles` | `string`                                        | -       | ✕        | Translation for the error message: Maximum number of uploaded files |
@@ -331,8 +351,9 @@ The rest of the properties are created from the default `<input>` element. [More
 
 | Prop name             | Type            | Default | Required | Description                                   |
 | --------------------- | --------------- | ------- | -------- | --------------------------------------------- |
-| `id`                  | `string`        | -       | ✔        | FileUploaderList id                           |
 | `attachmentComponent` | `string`        | -       | ✔        | A component for rendering a single attachment |
+| `hasImagePreview`     | `boolean`       | false   | ✕        | Show image preview in the list                |
+| `id`                  | `string`        | -       | ✔        | FileUploaderList id                           |
 | `inputName`           | `string`        | -       | ✔        | The name of the input field                   |
 | `label`               | `string`        | -       | ✕        | Label for the list                            |
 | `UNSAFE_className`    | `string`        | -       | ✕        | FileUploaderList custom class name            |
@@ -342,20 +363,32 @@ The rest of the properties are created from the default `<ul>` element. [More ab
 
 ## FileUploaderAttachment Props
 
-| Prop name          | Type                                | Default  | Required | Description                               |
-| ------------------ | ----------------------------------- | -------- | -------- | ----------------------------------------- |
-| `buttonLabel`      | `string`                            | `Remove` | ✕        | Dismiss button label                      |
-| `file`             | `File`                              | -        | ✔        | Attachment file object                    |
-| `iconName`         | `string`                            | `file`   | ✔        | Icon shown along the file                 |
-| `id`               | `string`                            | -        | ✔        | FileUploaderAttachment id                 |
-| `label`            | `string`                            | -        | ✔        | File name                                 |
-| `name`             | `string`                            | -        | ✔        | Input field name                          |
-| `onDismiss`        | `(key: string) => FileQueueMapType` | -        | ✔        | Callback to delete an item from the queue |
-| `onError`          | `FileUploaderErrorCallbackType`     | -        | ✕        | Callback on error condition               |
-| `UNSAFE_className` | `string`                            | -        | ✕        | FileUploaderAttachment custom class name  |
-| `UNSAFE_style`     | `CSSProperties`                     | -        | ✕        | FileUploaderAttachment custom style       |
+| Prop name          | Type                                 | Default  | Required | Description                               |
+| ------------------ | ------------------------------------ | -------- | -------- | ----------------------------------------- |
+| `buttonLabel`      | `string`                             | `Remove` | ✕        | Dismiss button label                      |
+| `editButtonLabel`  | `string`                             | `Edit`   | ✕        | Edit button label                         |
+| `file`             | `File`                               | -        | ✔        | Attachment file object                    |
+| `iconName`         | `string`                             | `file`   | ✕        | Icon shown along the file                 |
+| `id`               | `string`                             | -        | ✔        | FileUploaderAttachment id                 |
+| `label`            | `string`                             | -        | ✔        | File name                                 |
+| `name`             | `string`                             | -        | ✔        | Input field name                          |
+| `onDismiss`        | `(key: string) => FileQueueMapType`  | -        | ✔        | Callback to delete an item from the queue |
+| `onEdit`           | `(event: Event, file: File) => void` | -        | ✕        | Show and add function to edit button      |
+| `onError`          | `FileUploaderErrorCallbackType`      | -        | ✕        | Callback on error condition               |
+| `UNSAFE_className` | `string`                             | -        | ✕        | FileUploaderAttachment custom class name  |
+| `UNSAFE_style`     | `CSSProperties`                      | -        | ✕        | FileUploaderAttachment custom style       |
 
 The rest of the properties are created from the default `<li>` element. [More about the element][ListItemElementDocs]
+
+## AttachmentActionButton Props
+
+| Prop name          | Type                                   | Default | Required | Description                               |
+| ------------------ | -------------------------------------- | ------- | -------- | ----------------------------------------- |
+| `onClick`          | `MouseEventHandler<HTMLButtonElement>` | -       | ✕        | Button click handler                      |
+| `UNSAFE_className` | `string`                               | -       | ✕        | AttachmentDismissButton custom class name |
+| `UNSAFE_style`     | `CSSProperties`                        | -       | ✕        | AttachmentDismissButton custom style      |
+
+The rest of the properties are created from the default `<button>` element. [More about the element][ButtonElementDocs]
 
 ## AttachmentDismissButton Props
 

--- a/packages/web-react/src/components/FileUploader/UncontrolledFileUploader.tsx
+++ b/packages/web-react/src/components/FileUploader/UncontrolledFileUploader.tsx
@@ -34,7 +34,7 @@ const UncontrolledFileUploader = (props: SpiritUncontrolledFileUploaderProps) =>
     ...restProps
   } = props;
 
-  const { fileQueue, addToQueue, clearQueue, onDismiss } = useFileQueue();
+  const { fileQueue, addToQueue, clearQueue, onDismiss, findInQueue, updateQueue } = useFileQueue();
 
   useEffect(() => {
     if (onChange) {
@@ -50,6 +50,8 @@ const UncontrolledFileUploader = (props: SpiritUncontrolledFileUploaderProps) =>
       onDismiss={onDismiss}
       addToQueue={addToQueue}
       clearQueue={clearQueue}
+      findInQueue={findInQueue}
+      updateQueue={updateQueue}
       errorMessages={errorMessages}
       isFluid={isFluid}
       {...restProps}

--- a/packages/web-react/src/components/FileUploader/__tests__/FileUploaderList.test.tsx
+++ b/packages/web-react/src/components/FileUploader/__tests__/FileUploaderList.test.tsx
@@ -33,6 +33,8 @@ describe('FileUploaderList', () => {
         clearQueue={() => new Map()}
         addToQueue={() => new Map()}
         onDismiss={() => new Map()}
+        findInQueue={() => null}
+        updateQueue={() => new Map()}
       >
         <FileUploaderList {...props} attachmentComponent={attachmentComponent} />
       </FileUploader>,

--- a/packages/web-react/src/components/FileUploader/__tests__/useFileQueue.test.ts
+++ b/packages/web-react/src/components/FileUploader/__tests__/useFileQueue.test.ts
@@ -12,6 +12,8 @@ describe('useFileQueue', () => {
     expect(result.current.onDismiss).toBeDefined();
     expect(result.current.addToQueue).toBeDefined();
     expect(result.current.clearQueue).toBeDefined();
+    expect(result.current.findInQueue).toBeDefined();
+    expect(result.current.updateQueue).toBeDefined();
   });
 
   it('should add files to queue', () => {
@@ -58,5 +60,43 @@ describe('useFileQueue', () => {
     });
 
     expect(result.current.fileQueue.size).toBe(0);
+  });
+
+  it('should find in queue', () => {
+    const { result } = renderHook(() => useFileQueue());
+
+    act(() => {
+      result.current.addToQueue('test1_txt', file1);
+      result.current.addToQueue('test2_txt', file2);
+    });
+
+    expect(result.current.fileQueue.size).toBe(2);
+
+    act(() => {
+      result.current.findInQueue('test1_txt');
+      result.current.findInQueue('test2_txt');
+    });
+
+    expect(result.current.fileQueue.size).toBe(2);
+  });
+
+  it('should update queue', () => {
+    const { result } = renderHook(() => useFileQueue());
+
+    act(() => {
+      result.current.addToQueue('test1_txt', file1);
+      result.current.addToQueue('test2_txt', file2);
+    });
+
+    expect(result.current.fileQueue.size).toBe(2);
+
+    act(() => {
+      result.current.updateQueue('test1_txt', file2);
+      result.current.updateQueue('test2_txt', file1);
+    });
+
+    expect(result.current.fileQueue.size).toBe(2);
+    expect(result.current.fileQueue.get('test1_txt')).toBe(file2);
+    expect(result.current.fileQueue.get('test2_txt')).toBe(file1);
   });
 });

--- a/packages/web-react/src/components/FileUploader/__tests__/useFileUploaderStyleProps.test.ts
+++ b/packages/web-react/src/components/FileUploader/__tests__/useFileUploaderStyleProps.test.ts
@@ -29,6 +29,7 @@ describe('useFileUploaderStyleProps', () => {
     expect(result.current.classProps.attachment).toBeDefined();
     expect(result.current.classProps.attachment.root).toBe('FileUploaderAttachment');
     expect(result.current.classProps.attachment.button).toBe('FileUploaderAttachment__action');
+    expect(result.current.classProps.attachment.image).toBe('FileUploaderAttachment__image');
   });
 
   it('should return disabled', () => {

--- a/packages/web-react/src/components/FileUploader/constants.ts
+++ b/packages/web-react/src/components/FileUploader/constants.ts
@@ -1,7 +1,11 @@
 export const DEFAULT_FILE_SIZE_LIMIT = 10000000; // = 10 MB
 export const DEFAULT_FILE_QUEUE_LIMIT = 10;
+export const IMAGE_DIMENSION = 54; // px
 
 export const DEFAULT_ERROR_MESSAGE_MAX_FILE_SIZE = 'The file size limit has been exceeded';
 export const DEFAULT_ERROR_MESSAGE_QUEUE_DUPLICITY = 'This file already exists in the queue';
 export const DEFAULT_ERROR_MESSAGE_QUEUE_LIMIT = 'You have exceeded the number of files allowed in the queue';
 export const DEFAULT_ERROR_MESSAGE_UNSUPPORTED_FILE = 'This file type is not supported';
+export const DEFAULT_ICON_NAME = 'file';
+export const DEFAULT_BUTTON_LABEL = 'Remove';
+export const DEFAULT_EDIT_BUTTON_LABEL = 'Edit';

--- a/packages/web-react/src/components/FileUploader/index.ts
+++ b/packages/web-react/src/components/FileUploader/index.ts
@@ -2,6 +2,7 @@ export { default as FileUploader } from './FileUploader';
 export { default as FileUploaderInput } from './FileUploaderInput';
 export { default as FileUploaderList } from './FileUploaderList';
 export { default as FileUploaderAttachment } from './FileUploaderAttachment';
+export { default as AttachmentActionButton } from './AttachmentActionButton';
 export { default as AttachmentDismissButton } from './AttachmentDismissButton';
 export { default as UncontrolledFileUploader } from './UncontrolledFileUploader';
 export * from './useFileUploaderStyleProps';

--- a/packages/web-react/src/components/FileUploader/stories/FileUploaderWithImagePreview.tsx
+++ b/packages/web-react/src/components/FileUploader/stories/FileUploaderWithImagePreview.tsx
@@ -11,16 +11,23 @@ const Story: ComponentStory<typeof FileUploader> = () => {
   const { fileQueue, addToQueue, clearQueue, onDismiss, findInQueue, updateQueue } = useFileQueue();
 
   const attachmentComponent = ({ id, ...props }: SpiritFileUploaderAttachmentProps) => (
-    <FileUploaderAttachment key={id} id={id} {...props} />
+    <FileUploaderAttachment
+      key={id}
+      id={id}
+      onEdit={() => {
+        alert('Edit action');
+      }}
+      {...props}
+    />
   );
 
   return (
     <>
       <p>
-        <small>Here is an example with `accept` attribute and only images are allowed</small>
+        <small>Here is an example with `hasImagePreview` and `onEdit` attributes and only images are allowed</small>
       </p>
       <FileUploader
-        id="fileUploaderAcceptExample"
+        id="fileUploaderImagePreviewExample"
         onDismiss={onDismiss}
         fileQueue={fileQueue}
         addToQueue={addToQueue}
@@ -37,7 +44,7 @@ const Story: ComponentStory<typeof FileUploader> = () => {
           helperText="Max file size is 10 MB"
           validationText="Validation message"
           accept=".png,image/jpeg"
-          maxUploadedFiles={5}
+          maxUploadedFiles={1}
           /* eslint-disable-next-line no-console */
           onError={(error) => console.error(error)}
           isMultiple
@@ -47,6 +54,7 @@ const Story: ComponentStory<typeof FileUploader> = () => {
           label="Attachments"
           inputName="attachments"
           attachmentComponent={attachmentComponent}
+          hasImagePreview
         />
       </FileUploader>
     </>

--- a/packages/web-react/src/components/FileUploader/stories/FormWithFileUploader.tsx
+++ b/packages/web-react/src/components/FileUploader/stories/FormWithFileUploader.tsx
@@ -14,7 +14,7 @@ const Story = () => {
   const [validationText, setValidationText] = useState<string | undefined>(undefined);
   const [validationState, setValidationState] = useState<ValidationState | undefined>(undefined);
 
-  const { fileQueue, addToQueue, clearQueue, onDismiss } = useFileQueue();
+  const { fileQueue, addToQueue, clearQueue, onDismiss, findInQueue, updateQueue } = useFileQueue();
 
   const inputReference = createRef() as MutableRefObject<HTMLInputElement>;
   const dropZoneReference = createRef() as MutableRefObject<HTMLDivElement>;
@@ -70,6 +70,8 @@ const Story = () => {
         fileQueue={fileQueue}
         addToQueue={addToQueue}
         clearQueue={clearQueue}
+        findInQueue={findInQueue}
+        updateQueue={updateQueue}
       >
         <FileUploaderInput
           id="fileUploaderFormExampleInput"

--- a/packages/web-react/src/components/FileUploader/useFileQueue.ts
+++ b/packages/web-react/src/components/FileUploader/useFileQueue.ts
@@ -23,6 +23,19 @@ export const useFileQueue = (): FileQueueReturn => {
     return queue;
   };
 
+  const findInQueueHandler = (key: string) => queue.get(key) || null;
+
+  const updateQueueHandler = (key: string, file: File) => {
+    setQueue((prev) => {
+      const newState = new Map(prev);
+      newState.set(key, file);
+
+      return newState;
+    });
+
+    return queue;
+  };
+
   const clearQueueHandler = () => {
     setQueue((prev) => {
       prev.clear();
@@ -32,9 +45,11 @@ export const useFileQueue = (): FileQueueReturn => {
   };
 
   return {
-    fileQueue: queue,
-    onDismiss: onDismissHandler,
     addToQueue: addToQueueHandler,
     clearQueue: clearQueueHandler,
+    fileQueue: queue,
+    findInQueue: findInQueueHandler,
+    onDismiss: onDismissHandler,
+    updateQueue: updateQueueHandler,
   };
 };

--- a/packages/web-react/src/components/FileUploader/useFileUploaderInput.ts
+++ b/packages/web-react/src/components/FileUploader/useFileUploaderInput.ts
@@ -177,6 +177,7 @@ export const useFileUploaderInput = (props: UseFileUploaderInputProps): UseFileU
     }
 
     event.target.blur();
+    event.target.value = '';
   };
 
   useEffect(() => {

--- a/packages/web-react/src/components/FileUploader/useFileUploaderStyleProps.ts
+++ b/packages/web-react/src/components/FileUploader/useFileUploaderStyleProps.ts
@@ -35,6 +35,8 @@ export interface FileUploaderStyleReturn {
       root: string;
       button: string;
       name: string;
+      image: string;
+      slot: string;
     };
   };
 }
@@ -63,6 +65,8 @@ export const useFileUploaderStyleProps = (props?: FileUploaderStyleProps): FileU
   const fileUploaderAttachmentClass = `${fileUploaderClass}Attachment`;
   const fileUploaderAttachmentNameClass = `${fileUploaderAttachmentClass}__name`;
   const fileUploaderAttachmentButtonClass = `${fileUploaderAttachmentClass}__action`;
+  const fileUploaderAttachmentImageClass = `${fileUploaderAttachmentClass}__image`;
+  const fileUploaderAttachmentSlotClass = `${fileUploaderAttachmentClass}__slot`;
 
   return {
     classProps: {
@@ -95,6 +99,8 @@ export const useFileUploaderStyleProps = (props?: FileUploaderStyleProps): FileU
         root: fileUploaderAttachmentClass,
         button: fileUploaderAttachmentButtonClass,
         name: fileUploaderAttachmentNameClass,
+        image: fileUploaderAttachmentImageClass,
+        slot: fileUploaderAttachmentSlotClass,
       },
     },
   };

--- a/packages/web-react/src/components/FileUploader/utils.ts
+++ b/packages/web-react/src/components/FileUploader/utils.ts
@@ -25,4 +25,27 @@ const getAttachmentInput = (file: File, name: string, onError?: (error: string) 
   return attachmentInputElement;
 };
 
-export { getAttachmentInput };
+const image2Base64Preview = (file: File, maxWidth: number, callback: (base64Preview: string) => void) => {
+  const reader = new FileReader();
+
+  reader.onload = (event) => {
+    const image = new Image();
+    image.onload = () => {
+      const canvas = document.createElement('canvas');
+      const context = canvas.getContext('2d');
+      canvas.width = maxWidth;
+      canvas.height = (image.height / image.width) * maxWidth;
+      context?.drawImage(image, 0, 0, canvas.width, canvas.height);
+      const compressedDataURL = canvas.toDataURL('image/jpeg', 0.8);
+      callback(compressedDataURL);
+    };
+
+    if (event.target && event.target.result) {
+      image.src = event.target.result.toString();
+    }
+  };
+
+  reader.readAsDataURL(file);
+};
+
+export { getAttachmentInput, image2Base64Preview };

--- a/packages/web-react/src/types/fileUploader.ts
+++ b/packages/web-react/src/types/fileUploader.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, ReactNode } from 'react';
+import { MutableRefObject, ReactNode, MouseEvent } from 'react';
 import {
   SpiritButtonElementProps,
   SpiritDivElementProps,
@@ -24,7 +24,9 @@ export interface FileUploaderHandlingProps {
   addToQueue: (key: string, file: File) => FileQueueMapType;
   clearQueue: () => void;
   fileQueue: FileQueueMapType;
+  findInQueue: (key: string) => File | null;
   onDismiss: (key: string) => FileQueueMapType;
+  updateQueue: (key: string, file: File) => FileQueueMapType;
 }
 
 export interface FileUploaderErrorMessagesProps {
@@ -46,6 +48,8 @@ export interface FileUploaderIntermediateProps {
   validationText?: ValidationTextType;
 }
 
+export interface AttachmentActionButtonBaseProps extends SpiritButtonElementProps {}
+
 export interface AttachmentDismissButtonBaseProps extends SpiritButtonElementProps {}
 
 export interface FileUploaderInputBaseProps
@@ -64,6 +68,7 @@ export interface FileUploaderInputBaseProps
 
 export interface FileUploaderListBaseProps extends SpiritUListElementProps {
   attachmentComponent: FileUploaderAttachmentComponentType;
+  hasImagePreview?: boolean;
   id: string;
   inputName: string;
   label?: string;
@@ -71,6 +76,7 @@ export interface FileUploaderListBaseProps extends SpiritUListElementProps {
 
 export interface FileUploaderAttachmentBaseProps extends Omit<SpiritLItemElementProps, 'onError'> {
   buttonLabel?: string;
+  editButtonLabel?: string;
   file: File;
   iconName?: string;
   id: string;
@@ -78,6 +84,8 @@ export interface FileUploaderAttachmentBaseProps extends Omit<SpiritLItemElement
   name: string;
   onDismiss: (key: string) => FileQueueMapType;
   onError?: FileUploaderErrorCallbackType;
+  hasImagePreview?: boolean;
+  onEdit?: (event: MouseEvent, file: File) => void;
 }
 
 export interface FileUploaderBaseProps extends SpiritDivElementProps, Partial<FileUploaderErrorMessagesProps> {
@@ -99,6 +107,8 @@ export interface UncontrolledFileUploaderBaseProps
   onChange?: (fileQueue: FileQueueMapType) => void;
   onInputError?: FileUploaderErrorCallbackType;
 }
+
+export interface SpiritAttachmentActionButtonProps extends AttachmentActionButtonBaseProps {}
 
 export interface SpiritAttachmentDismissButtonProps extends AttachmentDismissButtonBaseProps {}
 


### PR DESCRIPTION
## Description
Add image preview for images in FileUploader and new param for turning this functionality on and off.
Add example for FileUploader with modal for crop image.

### Issue reference
[DS-852](https://jira.lmc.cz/browse/DS-852)

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
