### PR TITLE
Docs(web, web-react, web-twig): Minor typo fix

### DIFF
--- a/packages/web-react/MIGRATION-v1.md
+++ b/packages/web-react/MIGRATION-v1.md
@@ -135,7 +135,7 @@ Instead of the `size` prop, use `boxSize` in `Icon` component.
 ## Remove `error` Validation State in favor of `danger` [#DS-677](https://jira.lmc.cz/browse/DS-677) ([ad2c2fb](https://github.com/lmc-eu/spirit-design-system/commit/ad2c2fb))
 
 Instead of the `error` value of the validationState prop, use `danger`.
-This applies to Checkbox, Radio, TextField, TextArea, and TextFieldBase.
+This applies to Checkbox, Radio, TextField, TextArea and TextFieldBase.
 
 - `<TextField validationState="error" …>` → `<TextField validationState="danger" …>`
 

--- a/packages/web-twig/MIGRATION-v2.md
+++ b/packages/web-twig/MIGRATION-v2.md
@@ -215,7 +215,7 @@ List of affected components:
 ## Remove `error` Validation State in favor of `danger` [#DS-677](https://jira.lmc.cz/browse/DS-677) ([7d4077f](https://github.com/lmc-eu/spirit-design-system/commit/7d4077f))
 
 Instead of the `error` value of the validationState prop, use `danger`.
-This applies to Checkbox, Radio, TextField, TextArea, and TextFieldBase.
+This applies to Checkbox, Radio, TextField, TextArea and TextFieldBase.
 
 - `<TextField validationState="error" …>` → `<TextField validationState="danger" …>`
 

--- a/packages/web/MIGRATION-v1.md
+++ b/packages/web/MIGRATION-v1.md
@@ -225,13 +225,13 @@ This applies to Checkbox, TextArea, and TextField components.
 - `<div class="TextField__message" …>` → `<div class="TextField__validationText" …>`
 - `<div class="TextArea__message" …>` → `<div class="TextArea__validationText" …>`
 
-Also, the demos of Checkbox, RadioField, Select, TextArea, and TextField components
+Also, the demos of Checkbox, Radio, Select, TextArea, and TextField components
 have been unified and improved.
 
 ## Remove `error` state from Checkbox, Radio, TextField, and TextArea [#DS-677](https://jira.lmc.cz/browse/DS-677) ([f93976c](https://github.com/lmc-eu/spirit-design-system/commit/f93976c))
 
 Instead of the `--error` modifier or `has-error` class, use `--danger` or `has-danger`
-respectively. This applies to Checkbox, Radio, TextField, and TextArea.
+respectively. This applies to Checkbox, Radio, TextField and TextArea.
 
 - `<div class="TextField--error" …>` → `<div class="TextField--danger" …>`
 - `<div class="TextField has-error" …>` → `<div class="TextField has-danger" …>`


### PR DESCRIPTION
## Description

Just a small typo fixes in the migration guides. 🧹