### PR TITLE
Chore(ci): Revert back npm-install action to v1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,9 +31,7 @@ jobs:
         run: git fetch --no-tags --depth=50 origin main
 
       - name: Install dependencies
-        # @TODO: uncomment after https://github.com/bahmutov/npm-install/issues/175 is resolved
-        # uses: bahmutov/npm-install@v1
-        uses: u0reo/npm-install@fix/restore-failure
+        uses: bahmutov/npm-install@v1.8.33
         with:
           useRollingCache: true
 

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -22,9 +22,7 @@ jobs:
         run: git fetch --no-tags --depth=50 origin main
 
       - name: Install dependencies
-        # @TODO: uncomment after https://github.com/bahmutov/npm-install/issues/175 is resolved
-        # uses: bahmutov/npm-install@v1
-        uses: u0reo/npm-install@fix/restore-failure
+        uses: bahmutov/npm-install@v1.8.33
         with:
           useRollingCache: true
 

--- a/.github/workflows/component-analysis.yaml
+++ b/.github/workflows/component-analysis.yaml
@@ -24,9 +24,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install dependencies
-        # @TODO: uncomment after https://github.com/bahmutov/npm-install/issues/175 is resolved
-        # uses: bahmutov/npm-install@v1
-        uses: u0reo/npm-install@fix/restore-failure
+        uses: bahmutov/npm-install@v1.8.33
         with:
           useRollingCache: true
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,9 +17,7 @@ jobs:
           persist-credentials: false
 
       - name: Install dependencies
-        # @TODO: uncomment after https://github.com/bahmutov/npm-install/issues/175 is resolved
-        # uses: bahmutov/npm-install@v1
-        uses: u0reo/npm-install@fix/restore-failure
+        uses: bahmutov/npm-install@v1.8.33
         with:
           useRollingCache: true
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,9 +22,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install dependencies
-        # @TODO: uncomment after https://github.com/bahmutov/npm-install/issues/175 is resolved
-        # uses: bahmutov/npm-install@v1
-        uses: u0reo/npm-install@fix/restore-failure
+        uses: bahmutov/npm-install@v1.8.33
         with:
           useRollingCache: true
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,9 +23,7 @@ jobs:
         run: git fetch --no-tags --depth=50 origin main
 
       - name: Install dependencies
-        # @TODO: uncomment after https://github.com/bahmutov/npm-install/issues/175 is resolved
-        # uses: bahmutov/npm-install@v1
-        uses: u0reo/npm-install@fix/restore-failure
+        uses: bahmutov/npm-install@v1.8.33
         with:
           useRollingCache: true
 


### PR DESCRIPTION
## Description

  * the issue with cache miss was resolved and workaround should not be used anymore

### Additional context

The version must be exactly picked because there is a disconnection between the repository of npm-install and GitHub Marketplace

  * @see https://github.com/bahmutov/npm-install/pull/188#issuecomment-1661750171

### Issue reference

  * @see https://github.com/bahmutov/npm-install/issues/175

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
