### PR TITLE
Fix(web-twig): Fix condition to render `aria-labelledby` attribute in the Modal component

### DIFF
--- a/packages/web-twig/src/Resources/components/Modal/Modal.twig
+++ b/packages/web-twig/src/Resources/components/Modal/Modal.twig
@@ -8,7 +8,7 @@
 
 {# Attributes #}
 {%- set _idAttr = _id ? 'id="' ~ _id | escape('html_attr') ~ '"' : null -%}
-{%- set _ariaLabelledbyAttr = _id ? 'aria-labelledby="' ~ _titleId | escape('html_attr') ~ '"' : null -%}
+{%- set _ariaLabelledbyAttr = _titleId ? 'aria-labelledby="' ~ _titleId | escape('html_attr') ~ '"' : null -%}
 
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}

--- a/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set modalDefault.twig__1.html
+++ b/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set modalDefault.twig__1.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <dialog aria-label="Modal Title" class="Modal" id="modal-example-mini" aria-labelledby="">
+    <dialog aria-label="Modal Title" class="Modal" id="modal-example-mini">
       <article class="ModalDialog ModalDialog--expandOnMobile">
         <header class="ModalHeader">
           <button aria-controls="modal-example-mini" aria-expanded="false" data-spirit-dismiss="modal" data-spirit-target="#modal-example-mini" class="Button Button--tertiary Button--medium Button--square" type="button"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" id="a79dff7a255f69bbe6e39d594aa2275b" aria-hidden="true">


### PR DESCRIPTION
## Description

Currently the `aria-labelledby` attribute is rendered based on `id` not `titleId`. The render condition had to be changed.

### Additional context

There is a slight difference between React and Twig implementation. Twig implementation allowed the developer to set the `titleId` while in the [React implementation](https://github.com/lmc-eu/spirit-design-system/blob/59c4fbf8d7ce658bcab7dae7d5f5d9f55f498956/packages/web-react/src/components/Modal/Modal.tsx#L31) the suffix `__title` is appended to the `id`.

