### PR TITLE
Fix(web): Fix ModalDialog unset box-sizing #DS-878

### DIFF
--- a/packages/web/src/scss/components/Modal/_ModalDialog.scss
+++ b/packages/web/src/scss/components/Modal/_ModalDialog.scss
@@ -1,6 +1,7 @@
 // 1. Intentionally transition also the worse performing properties to smooth out the changes of viewport size around
 //    the tablet breakpoint.
 // 2. Use ScrollView's backdoor to fix its height inside ModalDialog in Safari.
+// 3. We need to set the box-sizing again because the parent element unsets styles using `all: unset`.
 
 @use 'sass:map';
 @use '../../tools/breakpoint';
@@ -17,6 +18,7 @@
     left: 50%;
     display: flex;
     flex-direction: column;
+    box-sizing: border-box; // 3.
     width: theme.$dialog-width;
     height: theme.$dialog-height;
     max-height: theme.$dialog-max-height;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

All:unset did reset box-sizing too, but we didn't set it again, so the inherited value was wrong.

### Issue reference

https://jira.lmc.cz/browse/DS-878

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [x] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
