### PR TITLE
Fix(web): Use gap in Stack with spacing and without dividers #DS-880

### DIFF
--- a/packages/web/src/scss/components/Stack/README.md
+++ b/packages/web/src/scss/components/Stack/README.md
@@ -39,14 +39,17 @@ Usage with a list:
 
 ## Variants
 
-⚠ `Stack--hasSpacing` uses the CSS `padding` property to be able to create dividers using the `border` property.
+⚠ `Stack--hasSpacing` with dividers uses the CSS `padding` property to be able to create dividers using the `border` property.
 It is recommended to wrap the direct descendants of the `Stack` component to the proper HTML element.
 Otherwise, the applied spacing via vertical padding could break the visual view of the children's items.
+
+`Stack--hasSpacing` without dividers uses the CSS `gap` property.
 
 ### Spacing between items
 
 👉 The vertical spacing between items is applied via `Stack--hasSpacing`. The size corresponds with the value of the design token `$space-600`.
 In case you need another spacing, please use utility classes or add custom-defined styles to the direct descendants.
+Keep in mind, that spacing is applied by the `gap` property or by `padding` property in case of dividers.
 
 Usage with spacing:
 

--- a/packages/web/src/scss/components/Stack/_Stack.scss
+++ b/packages/web/src/scss/components/Stack/_Stack.scss
@@ -8,6 +8,16 @@
     list-style: none;
 }
 
+.Stack--hasSpacing {
+    gap: theme.$gap;
+}
+
+.Stack--hasSpacing.Stack--hasStartDivider,
+.Stack--hasSpacing.Stack--hasEndDivider,
+.Stack--hasSpacing.Stack--hasIntermediateDividers {
+    gap: 0;
+}
+
 // stylelint-disable selector-max-universal -- Let's be bold and tweak all direct descendants regardless of their type.
 .Stack > * {
     margin-block: 0;
@@ -17,20 +27,25 @@
     border-block-start: theme.$border;
 }
 
-.Stack--hasSpacing > * {
-    padding-block: math.div(theme.$padding-block, 2);
+.Stack--hasSpacing.Stack--hasStartDivider > *,
+.Stack--hasSpacing.Stack--hasEndDivider > * {
+    padding-block: math.div(theme.$gap, 2);
 }
 
 .Stack--hasSpacing.Stack--hasIntermediateDividers > * {
-    padding-block: theme.$padding-block;
+    padding-block: theme.$gap;
 }
 // stylelint-enable
 
-.Stack--hasSpacing > :first-child {
+.Stack--hasSpacing.Stack--hasStartDivider > :first-child,
+.Stack--hasSpacing.Stack--hasEndDivider > :first-child,
+.Stack--hasSpacing.Stack--hasIntermediateDividers > :first-child {
     padding-block-start: 0;
 }
 
-.Stack--hasSpacing > :last-child {
+.Stack--hasSpacing.Stack--hasStartDivider > :last-child,
+.Stack--hasSpacing.Stack--hasEndDivider > :last-child,
+.Stack--hasSpacing.Stack--hasIntermediateDividers > :last-child {
     padding-block-end: 0;
 }
 
@@ -52,9 +67,9 @@
 }
 
 .Stack--hasSpacing.Stack--hasStartDivider > :first-child {
-    padding-block-start: theme.$padding-block;
+    padding-block-start: theme.$gap;
 }
 
 .Stack--hasSpacing.Stack--hasEndDivider > :last-child {
-    padding-block-end: theme.$padding-block;
+    padding-block-end: theme.$gap;
 }

--- a/packages/web/src/scss/components/Stack/_theme.scss
+++ b/packages/web/src/scss/components/Stack/_theme.scss
@@ -1,4 +1,4 @@
 @use '@tokens' as tokens;
 
 $border: tokens.$border-width-100 tokens.$border-style-100 tokens.$border-secondary-default;
-$padding-block: tokens.$space-600;
+$gap: tokens.$space-600;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

We don't need to use padding if there are no dividers. Revert to use the gap in default hasSpacing Stack.

### Issue reference

https://jira.lmc.cz/browse/DS-880

Fixes #963 

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [x] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
