### PR TITLE
Fix(web-react): Click outside hook prevents click on input label

### DIFF
--- a/packages/web-react/src/components/Modal/demo/index.tsx
+++ b/packages/web-react/src/components/Modal/demo/index.tsx
@@ -4,6 +4,8 @@ import DocsSection from '../../../../docs/DocsSections';
 import Modal from '../stories/Modal';
 import ModalWithCustomHeight from '../stories/ModalWithCustomHeight';
 import ModalWithLongText from '../stories/ModalWithLongText';
+import ModalWithCheckbox from '../stories/ModalWithCheckbox';
+import ModalStacked from '../stories/ModalStacked';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
@@ -15,6 +17,12 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     </DocsSection>
     <DocsSection title="Modal with Long Text">
       <ModalWithLongText />
+    </DocsSection>
+    <DocsSection title="Modal with Checkbox">
+      <ModalWithCheckbox />
+    </DocsSection>
+    <DocsSection title="Modal Stacked">
+      <ModalStacked />
     </DocsSection>
   </React.StrictMode>,
 );

--- a/packages/web-react/src/components/Modal/stories/ModalStacked.tsx
+++ b/packages/web-react/src/components/Modal/stories/ModalStacked.tsx
@@ -1,0 +1,81 @@
+// Because there is no `dist` directory during the CI run
+/* eslint-disable import/no-extraneous-dependencies, import/extensions, import/no-unresolved */
+import React, { useState } from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore: No declaration file
+import icons from '@lmc-eu/spirit-icons/dist/icons';
+import { Modal, ModalDialog, ModalHeader, ModalBody, ModalFooter } from '..';
+import { Button } from '../../Button';
+import { IconsProvider } from '../../../context';
+
+// @see: https://github.com/storybookjs/storybook/issues/8104#issuecomment-932310244
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const Story = (props: unknown) => {
+  const [isFirstOpen, setFirstOpen] = useState(false);
+  const [isSecondOpen, setSecondOpen] = useState(false);
+
+  const toggleFirstModal = () => setFirstOpen(!isFirstOpen);
+  const toggleSecondModal = () => setSecondOpen(!isSecondOpen);
+
+  const handleFirstClose = () => {
+    setFirstOpen(false);
+  };
+  const handleSecondClose = () => {
+    setSecondOpen(false);
+  };
+
+  return (
+    <IconsProvider value={icons}>
+      <Button onClick={toggleFirstModal} aria-expanded={isFirstOpen} aria-controls="#ModalExample">
+        {isFirstOpen ? 'Close' : 'Open'} Modal
+      </Button>
+      <Modal id="ModalExampleStacked" isOpen={isSecondOpen} onClose={handleSecondClose}>
+        <ModalDialog>
+          <ModalHeader>Modal stacked</ModalHeader>
+          <ModalBody>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+              mollitia perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus
+              provident unde. Eveniet, iste, molestiae?
+            </p>
+          </ModalBody>
+          <ModalFooter>
+            <Button color="primary" onClick={handleSecondClose}>
+              Confirm
+            </Button>
+            <Button color="tertiary" onClick={handleSecondClose}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        </ModalDialog>
+      </Modal>
+      <Modal id="ModalExample" isOpen={isFirstOpen} onClose={handleFirstClose}>
+        <ModalDialog>
+          <ModalHeader>Modal </ModalHeader>
+          <ModalBody>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+              mollitia perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus
+              provident unde. Eveniet, iste, molestiae?
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+              mollitia perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus
+              provident unde. Eveniet, iste, molestiae?
+            </p>
+          </ModalBody>
+          <ModalFooter>
+            <Button color="primary" onClick={toggleSecondModal}>
+              Open stacked
+            </Button>
+            <Button color="tertiary" onClick={handleFirstClose}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        </ModalDialog>
+      </Modal>
+    </IconsProvider>
+  );
+};
+
+export default Story;

--- a/packages/web-react/src/components/Modal/stories/ModalWithCheckbox.tsx
+++ b/packages/web-react/src/components/Modal/stories/ModalWithCheckbox.tsx
@@ -1,0 +1,56 @@
+// Because there is no `dist` directory during the CI run
+/* eslint-disable import/no-extraneous-dependencies, import/extensions, import/no-unresolved */
+import React, { useState } from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore: No declaration file
+import icons from '@lmc-eu/spirit-icons/dist/icons';
+import { IconsProvider } from '../../../context';
+import Modal from '../Modal';
+import ModalDialog from '../ModalDialog';
+import ModalBody from '../ModalBody';
+import ModalHeader from '../ModalHeader';
+import ModalFooter from '../ModalFooter';
+import { Button } from '../../Button';
+import { Checkbox } from '../../Checkbox';
+
+// @see: https://github.com/storybookjs/storybook/issues/8104#issuecomment-932310244
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const Story = (props: unknown) => {
+  const [isOpen, setOpen] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
+  const toggleModal = () => setOpen(!isOpen);
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <IconsProvider value={icons}>
+      <Button onClick={toggleModal} aria-expanded={isOpen} aria-controls="#ModalExample">
+        {isOpen ? 'Close' : 'Open'} Modal
+      </Button>
+      <Modal id="ModalExample" isOpen={isOpen} onClose={handleClose}>
+        <ModalDialog>
+          <ModalHeader>Modal Title</ModalHeader>
+          <ModalBody>
+            <Checkbox
+              key={`checkbox-test-${Number(isChecked)}`}
+              id="checkbox-1"
+              label="element 1"
+              isChecked={isChecked}
+              onChange={() => setIsChecked((prev) => !prev)}
+            />
+            <Checkbox label="element-2" id="checkbox-2" />
+          </ModalBody>
+          <ModalFooter>
+            <Button color="tertiary" onClick={handleClose}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        </ModalDialog>
+      </Modal>
+    </IconsProvider>
+  );
+};
+
+export default Story;

--- a/packages/web-react/src/hooks/useClickOutside.ts
+++ b/packages/web-react/src/hooks/useClickOutside.ts
@@ -17,8 +17,13 @@ export const useClickOutside = ({ ref, callback }: UseClickOutsideProps): void =
         callback(event);
       }
 
-      // Cancel the default action to avoid it being handled twice.
-      if (ref?.current?.parentNode?.contains(event?.target as Node)) {
+      // Cancel the default action to avoid it being handled twice for button click.
+      // This whitelist do not seems right to me but it is quick workaround until we can better support
+      // Modal composition
+      if (
+        ref?.current?.parentNode?.contains(event?.target as Node) &&
+        ['DIALOG', 'BUTTON'].includes((event?.target as Node)?.nodeName)
+      ) {
         event.preventDefault();
       }
     },


### PR DESCRIPTION
refs #DS-879

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`event.preventDefault` in the `useClickOutside` hook prevents the default click on the label in the checkbox being applied and thus the input is checked.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

https://jira.lmc.cz/browse/DS-879
---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
