### PR TITLE
Feat(web-twig): Move data-spirit-toggle attribute into TabLink component

### DIFF
--- a/packages/web-twig/src/Resources/components/Tabs/README.md
+++ b/packages/web-twig/src/Resources/components/Tabs/README.md
@@ -7,10 +7,10 @@ Basic example usage:
 ```html
 <TabList>
   <TabItem>
-    <TabLink isSelected id="pane1-tab" target="pane1" data-spirit-toggle="tabs">Item selected</TabLink>
+    <TabLink isSelected id="pane1-tab" target="pane1">Item selected</TabLink>
   </TabItem>
   <TabItem>
-    <TabLink id="pane2-tab" target="pane2" data-spirit-toggle="tabs">Item</TabLink>
+    <TabLink id="pane2-tab" target="pane2">Item</TabLink>
   </TabItem>
   <TabItem>
     <TabLink href="https://www.example.com">Item link</TabLink>

--- a/packages/web-twig/src/Resources/components/Tabs/TabLink.twig
+++ b/packages/web-twig/src/Resources/components/Tabs/TabLink.twig
@@ -12,6 +12,7 @@
 {# Attributes #}
 {%- set _ariaControlsAttr = _target ? 'aria-controls="' ~ _target | escape('html_attr') ~ '"' : null -%}
 {%- set _dataTargetAttr = _target ? 'data-spirit-target="#' ~ _target | escape('html_attr') ~ '"' : null -%}
+{%- set _dataToggleAttr = _target ? 'data-spirit-toggle="tabs"' : null -%}
 {%- set _roleAttr = _href ? 'role="tab"' : null -%}
 {%- set _typeAttr = _href ? null : 'type="button"' -%}
 
@@ -29,6 +30,7 @@
     aria-selected="{{ _ariaSelected }}"
     {{ _ariaControlsAttr | raw }}
     {{ _dataTargetAttr | raw }}
+    {{ _dataToggleAttr | raw }}
     {{ _roleAttr | raw }}
     {{ _typeAttr | raw }}
 >

--- a/packages/web-twig/src/Resources/components/Tabs/stories/TabsDefault.twig
+++ b/packages/web-twig/src/Resources/components/Tabs/stories/TabsDefault.twig
@@ -1,9 +1,9 @@
 <TabList>
     <TabItem>
-        <TabLink isSelected id="pane1-tab" data-spirit-toggle="tabs" target="pane1">Item 1</TabLink>
+        <TabLink isSelected id="pane1-tab" target="pane1">Item 1</TabLink>
     </TabItem>
     <TabItem>
-        <TabLink id="pane2-tab" data-spirit-toggle="tabs" target="pane2">Item 2</TabLink>
+        <TabLink id="pane2-tab" target="pane2">Item 2</TabLink>
     </TabItem>
     <TabItem>
         <TabLink href="https://www.example.com">Item link</TabLink>

--- a/packages/web-twig/tests/components-fixtures/tabsDefault.twig
+++ b/packages/web-twig/tests/components-fixtures/tabsDefault.twig
@@ -1,11 +1,11 @@
 <TabList>
     <TabItem>
-        <TabLink isSelected id="pane1-tab" data-spirit-toggle="tabs" target="pane1">
+        <TabLink isSelected id="pane1-tab" target="pane1">
             Item selected
         </TabLink>
     </TabItem>
     <TabItem>
-        <TabLink id="pane2-tab" data-spirit-toggle="tabs" target="pane2">
+        <TabLink id="pane2-tab" target="pane2">
             Item
         </TabLink>
     </TabItem>


### PR DESCRIPTION
Hi, 
I discovered a strange use of data attribute outside of a component, without which the component itself doesn't work. I think the implementation should be inside.

## Description

Move data-spirit-toggle attribute into TabLink component.
