### PR TITLE
Feat(web): FileUploader Image attachment preview #DS-850

### DIFF
--- a/packages/web/src/js/__tests__/FileUploader.test.ts
+++ b/packages/web/src/js/__tests__/FileUploader.test.ts
@@ -323,4 +323,19 @@ describe('FileUploader', () => {
       expect(FileUploader.isValidationTextInElement(validationText, emptyElement)).toBe(false);
     });
   });
+
+  describe('getFileFromQueue', () => {
+    it('should return the file from the file queue', () => {
+      const file = { name: 'test.txt' } as File;
+      instance.fileQueue = new Map().set('test', file);
+
+      expect(instance.getFileFromQueue('test')).toBe(file);
+    });
+
+    it('should return undefined if the file does not exist in the file queue', () => {
+      instance.fileQueue = new Map();
+
+      expect(instance.getFileFromQueue('test')).toBeUndefined();
+    });
+  });
 });

--- a/packages/web/src/js/utils/Image2Base64Preview.ts
+++ b/packages/web/src/js/utils/Image2Base64Preview.ts
@@ -1,0 +1,24 @@
+const image2Base64Preview = (file: File, maxWidth: number, callback: (base64Preview: string) => void) => {
+  const reader = new FileReader();
+
+  reader.onload = (event) => {
+    const image = new Image();
+    image.onload = () => {
+      const canvas = document.createElement('canvas');
+      const context = canvas.getContext('2d');
+      canvas.width = maxWidth;
+      canvas.height = (image.height / image.width) * maxWidth;
+      context?.drawImage(image, 0, 0, canvas.width, canvas.height);
+      const compressedDataURL = canvas.toDataURL('image/jpeg', 0.8);
+      callback(compressedDataURL);
+    };
+
+    if (event.target && event.target.result) {
+      image.src = event.target.result.toString();
+    }
+  };
+
+  reader.readAsDataURL(file);
+};
+
+export { image2Base64Preview };

--- a/packages/web/src/js/utils/index.ts
+++ b/packages/web/src/js/utils/index.ts
@@ -16,3 +16,4 @@ export * from './Deprecations';
 export * from './Elements';
 export { default as ScrollControl } from './ScrollControl';
 export * from './Transitions';
+export * from './Image2Base64Preview';

--- a/packages/web/src/scss/components/FileUploader/README.md
+++ b/packages/web/src/scss/components/FileUploader/README.md
@@ -273,6 +273,10 @@ list semantics for the selected files.
 </ul>
 ```
 
+| Name          | Usage                             | Description                         |
+| ------------- | --------------------------------- | ----------------------------------- |
+| Image preview | `data-spirit-imagePreview="true"` | Add preview for images in file list |
+
 ## FileUploaderAttachment
 
 FileUploaderAttachment represents the files to be uploaded. It is expected to be

--- a/packages/web/src/scss/components/FileUploader/index.html
+++ b/packages/web/src/scss/components/FileUploader/index.html
@@ -522,6 +522,165 @@
   <!-- FileUploader: end -->
 
 </section>
+
+<section class="docs-Section">
+  <h2 class="docs-Heading">Attachment with Image Preview</h2>
+
+  <!-- Modal: start -->
+  <dialog id="example_image_preview" class="Modal" aria-labelledby="example_image_preview">
+
+    <!-- ModalDialog: start -->
+    <div class="ModalDialog ModalDialog--expandOnMobile">
+
+      <!-- ModalBody: start -->
+      <div class="ModalBody">
+        <!-- here will be image -->
+      </div>
+      <!-- ModalBody: end -->
+
+      <!-- ModalFooter: start -->
+      <footer class="ModalFooter ModalFooter--right">
+        <div class="ModalFooter__actions">
+          <button
+            type="button"
+            class="Button Button--primary Button--medium"
+            data-spirit-target="#example_image_preview"
+            data-spirit-dismiss="modal"
+          >
+            Confirm
+          </button>
+          <button
+            type="button"
+            class="Button Button--secondary Button--medium"
+            data-spirit-target="#example_image_preview"
+            data-element="cancel"
+          >
+            Cancel
+          </button>
+        </div>
+      </footer>
+      <!-- ModalFooter: end -->
+
+    </div>
+    <!-- ModalDialog: end -->
+
+  </dialog>
+  <!-- Modal: end -->
+
+  <!-- FileUploader: start -->
+  <div id="example_customImagePreview" class="FileUploader" data-spirit-toggle="fileUploader">
+
+    <!-- FileUploaderAttachment template: start -->
+    <template data-spirit-snippet="item">
+      <li class="FileUploaderAttachment" data-spirit-populate-field="item">
+        <span class="FileUploaderAttachment__image">
+          <img src="" width="54" height="54" alt="" />
+        </span>
+        <svg width="24" height="24" aria-hidden="true">
+          <use xlink:href="/icons/svg/sprite.svg#file" />
+        </svg>
+        <span class="FileUploaderAttachment__name">
+          <span class="text-truncate" data-spirit-populate-field="name"></span>
+        </span>
+        <span class="FileUploaderAttachment__slot">
+
+          <!-- Slot content: start -->
+          <button type="button" class="FileUploaderAttachment__action" data-element="example-action">
+            <span class="accessibility-hidden">Edit</span>
+            <svg width="24" height="24" aria-hidden="true">
+              <use xlink:href="/icons/svg/sprite.svg#edit" />
+            </svg>
+          </button>
+          <!-- Slot content: end -->
+
+        </span>
+        <button type="button" class="FileUploaderAttachment__action" data-spirit-populate-field="button">
+          <span class="accessibility-hidden">Remove</span>
+          <svg width="24" height="24" aria-hidden="true">
+            <use xlink:href="/icons/svg/sprite.svg#close" />
+          </svg>
+        </button>
+      </li>
+    </template>
+    <!-- FileUploaderAttachment template: end -->
+
+    <!-- FileUploaderInput: start -->
+    <div class="FileUploaderInput" data-spirit-element="wrapper">
+      <label for="fileUploaderWithImagePreview" class="FileUploaderInput__label">Label</label>
+      <input type="file" id="fileUploaderWithImagePreview" name="attachment12" class="FileUploaderInput__input" multiple data-spirit-element="input" />
+      <div class="FileUploaderInput__dropZone" data-spirit-element="dropZone">
+        <svg width="24" height="24" aria-hidden="true">
+          <use xlink:href="/icons/svg/sprite.svg#upload" />
+        </svg>
+        <label for="fileUploaderWithImagePreview" class="FileUploaderInput__dropZoneLabel">
+          <span class="FileUploaderInput__link link-primary link-underlined">Upload your file(s)</span>
+          <span class="FileUploaderInput__dragAndDropLabel">or drag and drop here</span>
+        </label>
+        <div class="FileUploaderInput__helperText">Max size of each file is 10 MB</div>
+      </div>
+    </div>
+    <!-- FileUploaderInput: end -->
+
+    <!-- FileUploaderList: start -->
+    <h3 id="attachments-customImagePreview" hidden>Attachments</h3>
+    <ul class="FileUploaderList" aria-labelledby="attachments-customImagePreview" data-spirit-element="list" data-spirit-imagePreview="true"></ul>
+    <!-- FileUploaderList: end -->
+
+  </div>
+  <!-- FileUploader: end -->
+
+  <script type="module">
+    import Modal from '../../../js/Modal'
+    import FileUploader from '../../../js/FileUploader'
+
+    window.addEventListener('DOMContentLoaded', () => {
+      let file;
+      const ModalElement = document.getElementById('example_image_preview');
+      const ModalInstance = new Modal(ModalElement);
+      const ModalBody = ModalElement.querySelector('.ModalBody');
+      const cancelButton = ModalElement.querySelector('[data-element="cancel"]');
+      const FileUploaderElement = document.getElementById('example_customImagePreview');
+      const FileUploaderInstance = FileUploader.getInstance(FileUploaderElement);
+
+      const isFileImage = (file) => file.type.split('/')[0] === 'image';
+
+      const showModalPreview = (file) => {
+        if(isFileImage(file)) {
+          const reader = new FileReader();
+          
+          reader.readAsDataURL(file);
+          reader.onloadend = () => {
+            const base64data = reader.result;
+            localStorage.setItem('image', base64data);
+            ModalBody.innerHTML = `<img src="${base64data}" style="width: 100%; height: auto" alt="${file.name}" />`;
+            ModalInstance.show();
+          }
+        }
+      }
+
+      const removeFromQueue = () => {
+        FileUploaderInstance.removeFromQueue(FileUploaderInstance.getUpdatedFileName(file.name));
+        cleanup();
+      }
+
+      const cleanup = () => {
+        ModalInstance.hide();
+        ModalBody.innerHTML = '';
+        file = undefined;
+      }
+
+      cancelButton.addEventListener('click', removeFromQueue);
+
+      FileUploaderElement.addEventListener('queuedFile.fileUploader', event => {
+        file = event.currentFile;
+        showModalPreview(file);
+      });
+    });
+
+  </script>
+
+</section>
+
 <section class="docs-Section">
   <h2 class="docs-Heading">Attachment with Custom Actions</h2>
 


### PR DESCRIPTION
## Description

Add an example for FileUploader with a modal for cropping images. 
Add the imagePreview option to FileUploaderList for displaying image previews in the file list.

### Additional context

Add `data-spirit-imagePreview="true"` for image previews in file list
```
<ul class="FileUploaderList" aria-labelledby="attachments-customImagePreview" data-spirit-element="list" data-spirit-imagePreview="true"></ul>
```

New demo **Attachment with Image Preview**

### Issue reference

[web: JS FileUploader s fotkou](https://jira.lmc.cz/browse/DS-850)

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
