### PR TITLE
Feat(web-twig): Enable pass `formtarget` attribute to the `Button`

### DIFF
--- a/packages/web-twig/src/Resources/components/Button/Button.twig
+++ b/packages/web-twig/src/Resources/components/Button/Button.twig
@@ -22,7 +22,7 @@
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _rootColorClassName, _rootSizeClassName, _rootBlockClassName, _rootLoadingClassName, _rootSquareClassName, _styleProps.className ] -%}
-{%- set _allowedAttributes = [ 'name' ] -%}
+{%- set _allowedAttributes = [ 'formtarget', 'name' ] -%}
 
 <button
     {{ mainProps(props, _allowedAttributes) }}

--- a/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set buttonWithMainProps.twig__1.html
+++ b/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set buttonWithMainProps.twig__1.html
@@ -5,6 +5,6 @@
     </title>
   </head>
   <body>
-    <button id="testId" name="testName" data-main="main" aria-label="label" onclick="alert('&quot; test')" class="Button Button--primary Button--medium" type="button">button</button> <button id="testId" name="testName" data-main="main" aria-label="label" onclick="alert('&quot; test')" class="Button Button--primary Button--medium" type="button">button</button> <button id="testId" name="testName" data-main="main" aria-label="label" onclick="document.body.append('&lt;span&gt;hello there&lt;/span&gt;'); return false;" class="Button Button--primary Button--medium" type="button">button</button> <button id="testId" name="testName" data-main="main" aria-label="label" onclick="document.body.append('&lt;span&gt;hello there&lt;/span&gt;'); return false;" class="Button Button--primary Button--medium" type="button">button</button>
+    <button id="testId" name="testName" data-main="main" aria-label="label" onclick="alert('&quot; test')" formtarget="_blank" class="Button Button--primary Button--medium" type="button">button</button> <button id="testId" name="testName" data-main="main" aria-label="label" onclick="document.body.append('&lt;span&gt;hello there&lt;/span&gt;'); return false;" class="Button Button--primary Button--medium" type="button">button</button>
   </body>
 </html>

--- a/packages/web-twig/tests/components-fixtures/buttonWithMainProps.twig
+++ b/packages/web-twig/tests/components-fixtures/buttonWithMainProps.twig
@@ -1,9 +1,7 @@
 {% set onClickCallback = "alert('\" test')" %}
 
-<Button id="testId" name="testName" data-main="main" aria-label="label" not-valid-prop="unexist" color="primary" onclick={onClickCallback}>button</Button>
-<Button id="testId" name="testName" data-main="main" aria-label="label" not-valid-prop="unexist" color="primary" onclick={onClickCallback}>button</Button>
+<Button id="testId" name="testName" data-main="main" aria-label="label" not-valid-prop="unexist" color="primary" onclick={onClickCallback} formtarget="_blank">button</Button>
 
 {% set onClickAppend = "document.body.append('<span>hello there</span>'); return false;" %}
 
-<Button id="testId" name="testName" data-main="main" aria-label="label" not-valid-prop="unexist" color="primary" onclick={onClickAppend}>button</Button>
 <Button id="testId" name="testName" data-main="main" aria-label="label" not-valid-prop="unexist" color="primary" onclick={onClickAppend}>button</Button>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

For the purpose of the modernized CV, where we would like to display PDF preview in a new browser window after successful form submit, we need to extend Button's API to be able to pass [`formtarget` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-formtarget:~:text=type%3D%22submit%22%3E%20elements.-,formtarget,-If%20the%20button).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
- It's necessary to extend React implementation as well.
- I would like open the discussion about extending (and [mention](https://github.com/lmc-eu/spirit-design-system/pull/957#pullrequestreview-1566810299)) API with HTML global attributes. Currently the components have strict list of the allowed attributes so every unsupported attribute has to be allow on the demand. What if we defined an extended list of allowed HTML attributes for every component?
---
