### PR TITLE
Docs: Twig allowed attributes

### DIFF
--- a/packages/web-twig/src/Resources/components/Accordion/README.md
+++ b/packages/web-twig/src/Resources/components/Accordion/README.md
@@ -207,12 +207,12 @@ The Accordion itself consists of several components which cannot be used indepen
 
 ### AccordionContent
 
-| Prop name      | Type      | Default | Required | Description                                                                 |
-| -------------- | --------- | ------- | -------- | --------------------------------------------------------------------------- |
-| `id`           | `string`  | `null`  | yes      | AccordionContent ID                                                         |
-| `isOpen`       | `boolean` | `false` | no       | If true, make the item open on page load                                    |
-| `labelledById` | `string`  | `null`  | yes      | AccordionHeader ID                                                          |
-| `parent`       | `string`  | `null`  | no       | A parent element selector that ensures that only one item is open at a time |
+| Prop name      | Type     | Default | Required | Description                                                                 |
+| -------------- | -------- | ------- | -------- | --------------------------------------------------------------------------- |
+| `id`           | `string` | `null`  | yes      | AccordionContent ID                                                         |
+| `isOpen`       | `bool`   | `false` | no       | If true, make the item open on page load                                    |
+| `labelledById` | `string` | `null`  | yes      | AccordionHeader ID                                                          |
+| `parent`       | `string` | `null`  | no       | A parent element selector that ensures that only one item is open at a time |
 
 On top of the API options, you can add `data-*` or `aria-*` attributes to
 further extend component's descriptiveness and accessibility. Also, UNSAFE styling props are available,

--- a/packages/web-twig/src/Resources/components/Button/README.md
+++ b/packages/web-twig/src/Resources/components/Button/README.md
@@ -37,11 +37,12 @@ Without lexer:
 | Prop name    | Type                                                                                      | Default   | Required | Description                                                                |
 | ------------ | ----------------------------------------------------------------------------------------- | --------- | -------- | -------------------------------------------------------------------------- |
 | `color`      | [Action Color dictionary][dictionary-color], [Emotion Color dictionary][dictionary-color] | `primary` | no       | Color variant                                                              |
+| `formtarget` | `string`                                                                                  | `null`    | no       | Submit button target                                                       |
 | `isBlock`    | `bool`                                                                                    | `false`   | no       | Span the element to the full width of its parent                           |
 | `isDisabled` | `bool`                                                                                    | `false`   | no       | If true, Button is disabled                                                |
 | `isLoading`  | `bool`                                                                                    | `false`   | no       | If true, Button is in a loading state, disabled and the Spinner is visible |
 | `isSquare`   | `bool`                                                                                    | `false`   | no       | If true, Button is square, usually only with an Icon                       |
-| `name`       | `string`                                                                                  | `null`    | no       | For use a button as a form data reference                                  |
+| `name`       | `string`                                                                                  | `null`    | no       | Submit button name                                                         |
 | `size`       | [Size dictionary][dictionary-size]                                                        | `medium`  | no       | Size variant                                                               |
 | `type`       | `string`                                                                                  | `button`  | no       | Type of the Button                                                         |
 

--- a/packages/web-twig/src/Resources/components/ButtonLink/ButtonLink.twig
+++ b/packages/web-twig/src/Resources/components/ButtonLink/ButtonLink.twig
@@ -20,10 +20,7 @@
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _rootColorClassName, _rootBlockClassName, _rootDisabledClassName, _rootLoadingClassName, _rootSizeClassName, _rootSquareClassName, _styleProps.className ] -%}
-{%- set _allowedAttributes = [
-    'title',
-    'target',
-] -%}
+{%- set _allowedAttributes = [ 'target', 'title' ] -%}
 
 <a
     {{ mainProps(props, _allowedAttributes) }}

--- a/packages/web-twig/src/Resources/components/ButtonLink/README.md
+++ b/packages/web-twig/src/Resources/components/ButtonLink/README.md
@@ -38,7 +38,7 @@ Without lexer:
 | `isDisabled` | `bool`                                                                                    | `false`   | no       | If true, ButtonLink is disabled                                                |
 | `isLoading`  | `bool`                                                                                    | `false`   | no       | If true, ButtonLink is in a loading state, disabled and the Spinner is visible |
 | `isSquare`   | `bool`                                                                                    | `false`   | no       | If true, ButtonLink is square, usually only with an Icon                       |
-| `target`     | `string`                                                                                  | `null`    | no       | Link target                                                                    |
+| `target`     | `string`                                                                                  | `null`    | no       | Browsing context for the link                                                  |
 | `title`      | `string`                                                                                  | `null`    | no       | Optional title to display on hover                                             |
 
 You can add `id`, `data-*` or `aria-*` attributes to further extend component's

--- a/packages/web-twig/src/Resources/components/Collapse/README.md
+++ b/packages/web-twig/src/Resources/components/Collapse/README.md
@@ -53,13 +53,13 @@ attributes to register trigger events.
 
 ## API
 
-| Prop name     | Type      | Default | Required | Description                                                            |
-| ------------- | --------- | ------- | -------- | ---------------------------------------------------------------------- |
-| `breakpoint`  | `string`  | `null`  | no       | Breakpoint level [mobile,tablet,desktop]                               |
-| `elementType` | `string`  | `'div'` | no       | Custom element type for wrapper and content                            |
-| `id`          | `string`  | -       | yes      | Collapse ID                                                            |
-| `isOpen`      | `boolean` | `false` | no       | If true, make the item open on page load                               |
-| `parent`      | `string`  | `null`  | no       | A parent element selector that ensures that only one item is opened \* |
+| Prop name     | Type     | Default | Required | Description                                                            |
+| ------------- | -------- | ------- | -------- | ---------------------------------------------------------------------- |
+| `breakpoint`  | `string` | `null`  | no       | Breakpoint level [mobile,tablet,desktop]                               |
+| `elementType` | `string` | `'div'` | no       | Custom element type for wrapper and content                            |
+| `id`          | `string` | -       | yes      | Collapse ID                                                            |
+| `isOpen`      | `bool`   | `false` | no       | If true, make the item open on page load                               |
+| `parent`      | `string` | `null`  | no       | A parent element selector that ensures that only one item is opened \* |
 
 (\*) Attribute for Accordion implementation
 
@@ -69,13 +69,13 @@ see the [Escape hatches][escape-hatches] section in README to learn how and when
 
 ## Trigger attributes
 
-| Prop name            | Type      | Default    | Required | Description                         |
-| -------------------- | --------- | ---------- | -------- | ----------------------------------- |
-| `aria-controls`      | `string`  | -          | no       | Aria controls state (auto)          |
-| `aria-expanded`      | `string`  | -          | no       | Aria expanded state (auto)          |
-| `data-spirit-more`   | `boolean` | -          | no       | For hide on collapse as more button |
-| `data-spirit-target` | `string`  | -          | yes      | Target selector                     |
-| `data-spirit-toggle` | `string`  | `collapse` | yes      | Iterable selector                   |
+| Prop name            | Type     | Default    | Required | Description                         |
+| -------------------- | -------- | ---------- | -------- | ----------------------------------- |
+| `aria-controls`      | `string` | -          | no       | Aria controls state (auto)          |
+| `aria-expanded`      | `string` | -          | no       | Aria expanded state (auto)          |
+| `data-spirit-more`   | `bool`   | -          | no       | For hide on collapse as more button |
+| `data-spirit-target` | `string` | -          | yes      | Target selector                     |
+| `data-spirit-toggle` | `string` | `collapse` | yes      | Iterable selector                   |
 
 Other necessary attributes are toggled automatically, like `aria-controls` and `aria-expanded` when component is loaded
 or width of window is changed. There can be several triggers, the same rules apply to each.

--- a/packages/web-twig/src/Resources/components/FieldGroup/README.md
+++ b/packages/web-twig/src/Resources/components/FieldGroup/README.md
@@ -99,8 +99,8 @@ When validated on server:
 
 | Prop name               | Type                                           | Default | Required | Description                                |
 | ----------------------- | ---------------------------------------------- | ------- | -------- | ------------------------------------------ |
-| `helperText`            | `string`                                       | `null`  | no\*\*   | Custom helper text                         |
 | `form`                  | `string`                                       | `null`  | no       | Parent form ID                             |
+| `helperText`            | `string`                                       | `null`  | no\*\*   | Custom helper text                         |
 | `id`                    | `string`                                       | —       | yes      | Group and label identification             |
 | `isDisabled`            | `bool`                                         | `false` | no       | If true, the group is disabled             |
 | `isLabelHidden`         | `bool`                                         | `false` | no       | If true, label is hidden                   |

--- a/packages/web-twig/src/Resources/components/FileUploader/README.md
+++ b/packages/web-twig/src/Resources/components/FileUploader/README.md
@@ -50,9 +50,9 @@ By adding the `isFluid` attribute, FileUploader can take up all the available ho
 
 ### API
 
-| Prop name | Type      | Default | Required | Description                                                |
-| --------- | --------- | ------- | -------- | ---------------------------------------------------------- |
-| `isFluid` | `boolean` | `false` | no       | If true, the element spans to the full width of its parent |
+| Prop name | Type   | Default | Required | Description                                                |
+| --------- | ------ | ------- | -------- | ---------------------------------------------------------- |
+| `isFluid` | `bool` | `false` | no       | If true, the element spans to the full width of its parent |
 
 On top of the API options, you can add `data-*` or `aria-*` attributes to
 further extend component's descriptiveness and accessibility. Also, UNSAFE styling props are available,

--- a/packages/web-twig/src/Resources/components/FileUploader/README.md
+++ b/packages/web-twig/src/Resources/components/FileUploader/README.md
@@ -183,6 +183,7 @@ To mark the input as disabled, simply add the `isDisabled` attribute:
 
 | Prop name               | Type                                           | Default                 | Required | Description                                                           |
 | ----------------------- | ---------------------------------------------- | ----------------------- | -------- | --------------------------------------------------------------------- |
+| `accept`                | `string`                                       | `null`                  | no       | Allowed file types                                                    |
 | `dragAndDropText`       | `string`                                       | `or drag and drop here` | no       | Text shown in the drop zone if drag-and-drop is enabled on the device |
 | `helperText`            | `string`                                       | `null`                  | no\*\*   | Custom helper text                                                    |
 | `iconName`              | `string`                                       | `upload`                | no       | Icon used in the drop zone                                            |
@@ -193,6 +194,7 @@ To mark the input as disabled, simply add the `isDisabled` attribute:
 | `label`                 | `string`                                       | `null`                  | no\*     | Label text                                                            |
 | `maxFileSize`           | `number`                                       | `1000000`               | no       | The maximum size of the uploaded file in bytes                        |
 | `maxUploadedFiles`      | `number`                                       | `10`                    | no       | Maximum file upload queue size                                        |
+| `multiple`              | `bool`                                         | `false`                 | no       | If true, multiple files can be selected                               |
 | `name`                  | `string`                                       | `null`                  | no       | Input name                                                            |
 | `pickAFileText`         | `string`                                       | `Upload your file`      | no       | Text shown in the drop zone                                           |
 | `queueLimitBehavior`    | `'hide', 'disable', 'none'`                    | `none`                  | no       | Input behavior when the file queue is filled                          |

--- a/packages/web-twig/src/Resources/components/Header/README.md
+++ b/packages/web-twig/src/Resources/components/Header/README.md
@@ -245,11 +245,11 @@ There is no API for HeaderNavItem.
 
 ##### HeaderLink API
 
-| Prop name   | Type      | Default | Required | Description             |
-| ----------- | --------- | ------- | -------- | ----------------------- |
-| `href`      | `string`  | —       | yes      | Link URL                |
-| `isCurrent` | `boolean` | `false` | no       | Mark link as current    |
-| `target`    | `string`  | `null`  | no       | HTML `target` attribute |
+| Prop name   | Type      | Default | Required | Description                   |
+| ----------- | --------- | ------- | -------- | ----------------------------- |
+| `href`      | `string`  | —       | yes      | Link URL                      |
+| `isCurrent` | `boolean` | `false` | no       | Mark link as current          |
+| `target`    | `string`  | `null`  | no       | Browsing context for the link |
 
 ##### HeaderButton API
 
@@ -385,11 +385,11 @@ There is no API for HeaderDialogNavItem.
 
 ##### HeaderDialogLink API
 
-| Prop name   | Type      | Default | Required | Description             |
-| ----------- | --------- | ------- | -------- | ----------------------- |
-| `href`      | `string`  | —       | yes      | Link URL                |
-| `isCurrent` | `boolean` | `false` | no       | Mark link as current    |
-| `target`    | `string`  | `null`  | no       | HTML `target` attribute |
+| Prop name   | Type      | Default | Required | Description                   |
+| ----------- | --------- | ------- | -------- | ----------------------------- |
+| `href`      | `string`  | —       | yes      | Link URL                      |
+| `isCurrent` | `boolean` | `false` | no       | Mark link as current          |
+| `target`    | `string`  | `null`  | no       | Browsing context for the link |
 
 ##### HeaderDialogButton API
 

--- a/packages/web-twig/src/Resources/components/Header/README.md
+++ b/packages/web-twig/src/Resources/components/Header/README.md
@@ -108,7 +108,7 @@ just branding.
 | Prop name  | Type                      | Default       | Required | Description                         |
 | ---------- | ------------------------- | ------------- | -------- | ----------------------------------- |
 | `color`    | `transparent`, `inverted` | `transparent` | no       | Color variant                       |
-| `isSimple` | `boolean`                 | `false`       | no       | Shorter, centered version of Header |
+| `isSimple` | `bool`                    | `false`       | no       | Shorter, centered version of Header |
 
 On top of the API options, you can add `data-*` or `aria-*` attributes to
 further extend component's descriptiveness and accessibility. Also, UNSAFE styling props are available,
@@ -245,11 +245,11 @@ There is no API for HeaderNavItem.
 
 ##### HeaderLink API
 
-| Prop name   | Type      | Default | Required | Description                   |
-| ----------- | --------- | ------- | -------- | ----------------------------- |
-| `href`      | `string`  | —       | yes      | Link URL                      |
-| `isCurrent` | `boolean` | `false` | no       | Mark link as current          |
-| `target`    | `string`  | `null`  | no       | Browsing context for the link |
+| Prop name   | Type     | Default | Required | Description                   |
+| ----------- | -------- | ------- | -------- | ----------------------------- |
+| `href`      | `string` | —       | yes      | Link URL                      |
+| `isCurrent` | `bool`   | `false` | no       | Mark link as current          |
+| `target`    | `string` | `null`  | no       | Browsing context for the link |
 
 ##### HeaderButton API
 
@@ -291,11 +291,11 @@ Close button closes the Header Dialog using our Off-canvas JavaScript plugin.
 <HeaderDialogCloseButton dialogId="my-header-dialog" />
 ```
 
-| Prop name       | Type      | Default | Required | Description                     |
-| --------------- | --------- | ------- | -------- | ------------------------------- |
-| `dialogId`      | `string`  | —       | yes      | ID of the parent HeaderDialog   |
-| `enableDismiss` | `boolean` | `true`  | no       | Enable Off-canvas JS dismiss    |
-| `label`         | `string`  | `Close` | no       | Label of the menu toggle button |
+| Prop name       | Type     | Default | Required | Description                     |
+| --------------- | -------- | ------- | -------- | ------------------------------- |
+| `dialogId`      | `string` | —       | yes      | ID of the parent HeaderDialog   |
+| `enableDismiss` | `bool`   | `true`  | no       | Enable Off-canvas JS dismiss    |
+| `label`         | `string` | `Close` | no       | Label of the menu toggle button |
 
 On top of the API options, you can add `data-*` or `aria-*` attributes to
 further extend component's descriptiveness and accessibility. Also, UNSAFE styling props are available,
@@ -385,11 +385,11 @@ There is no API for HeaderDialogNavItem.
 
 ##### HeaderDialogLink API
 
-| Prop name   | Type      | Default | Required | Description                   |
-| ----------- | --------- | ------- | -------- | ----------------------------- |
-| `href`      | `string`  | —       | yes      | Link URL                      |
-| `isCurrent` | `boolean` | `false` | no       | Mark link as current          |
-| `target`    | `string`  | `null`  | no       | Browsing context for the link |
+| Prop name   | Type     | Default | Required | Description                   |
+| ----------- | -------- | ------- | -------- | ----------------------------- |
+| `href`      | `string` | —       | yes      | Link URL                      |
+| `isCurrent` | `bool`   | `false` | no       | Mark link as current          |
+| `target`    | `string` | `null`  | no       | Browsing context for the link |
 
 ##### HeaderDialogButton API
 

--- a/packages/web-twig/src/Resources/components/Header/_abstracts/Link.twig
+++ b/packages/web-twig/src/Resources/components/Header/_abstracts/Link.twig
@@ -14,9 +14,7 @@
 
 {# Miscellaneous #}
 {%- set _classNames = [ _rootClassName, _rootCurrentClassName, _class ] -%}
-{%- set _allowedAttributes = [
-    'target',
-] -%}
+{%- set _allowedAttributes = [ 'target' ] -%}
 
 <a
     {{ mainProps(props, _allowedAttributes) }}

--- a/packages/web-twig/src/Resources/components/Heading/README.md
+++ b/packages/web-twig/src/Resources/components/Heading/README.md
@@ -28,10 +28,11 @@ Without lexer:
 
 ## API
 
-| Prop name     | Type                                        | Default  | Required | Description        |
-| ------------- | ------------------------------------------- | -------- | -------- | ------------------ |
-| `size`        | [Size Extended dictionary][dictionary-size] | `medium` | no       | Size of the text   |
-| `elementType` | `string`                                    | `div`    | no       | HTML tag to render |
+| Prop name     | Type                                        | Default  | Required | Description                                                    |
+| ------------- | ------------------------------------------- | -------- | -------- | -------------------------------------------------------------- |
+| `size`        | [Size Extended dictionary][dictionary-size] | `medium` | no       | Size of the text                                               |
+| `elementType` | `string`                                    | `div`    | no       | HTML tag to render                                             |
+| `translate`   | [`yes`, `no`]                               | `null`   | no       | Set to `no` to disable machine translation of the text content |
 
 You can add `id`, `data-*` or `aria-*` attributes to further extend component's
 descriptiveness and accessibility. Also, UNSAFE styling props are available,

--- a/packages/web-twig/src/Resources/components/Link/Link.twig
+++ b/packages/web-twig/src/Resources/components/Link/Link.twig
@@ -13,10 +13,7 @@
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _colorClassName, _rootDisabledClassName, _rootUnderlinedClassName, _styleProps.className ] -%}
-{%- set _allowedAttributes = [
-    'title',
-    'target',
-] -%}
+{%- set _allowedAttributes = [ 'target', 'title' ] -%}
 
 <a
     {{ mainProps(props, _allowedAttributes) }}

--- a/packages/web-twig/src/Resources/components/Link/README.md
+++ b/packages/web-twig/src/Resources/components/Link/README.md
@@ -41,7 +41,7 @@ Without lexer:
 | `href`         | `string`                                         | —         | yes      | Link URL                           |
 | `isDisabled`   | `bool`                                           | `false`   | no       | If true, Link is disabled          |
 | `isUnderlined` | `bool`                                           | `false`   | no       | If true, Link is underlined        |
-| `target`       | `string`                                         | `null`    | no       | Link target                        |
+| `target`       | `string`                                         | `null`    | no       | Browsing context for the link      |
 | `title`        | `string`                                         | `null`    | no       | Optional title to display on hover |
 
 You can add `id`, `data-*` or `aria-*` attributes to further extend component's

--- a/packages/web-twig/src/Resources/components/Modal/README.md
+++ b/packages/web-twig/src/Resources/components/Modal/README.md
@@ -64,11 +64,11 @@ footer of the dialog.
 | `autocomplete`                | `string`                  | `null`    | no       | `elementType="form"` only: [Automated assistance in filling][autocomplete-attr]                         |
 | `elementType`                 | `string`                  | `article` | no       | HTML tag to render                                                                                      |
 | `enctype`                     | `string`                  | `null`    | no       | `elementType="form"` only: Encoding to use for form submission                                          |
-| `isExpandedOnMobile`          | `boolean`                 | `true`    | no       | If the ModalDialog should expand on mobile. Overrides any height defined by `preferredHeightOnMobile`.  |
+| `isExpandedOnMobile`          | `bool`                    | `true`    | no       | If the ModalDialog should expand on mobile. Overrides any height defined by `preferredHeightOnMobile`.  |
 | `maxHeightFromTabletUp`       | `string`                  | `null`    | no       | Max height of the modal. Accepts any valid CSS value.                                                   |
 | `method`                      | [`get`, `post`, `dialog`] | `null`    | no       | `elementType="form"` only: HTTP method to use for form submission                                       |
 | `name`                        | `string`                  | `null`    | no       | `elementType="form"` only: Name of the form                                                             |
-| `novalidate`                  | `boolean`                 | `false`   | no       | `elementType="form"` only: If the dialog should have validation disabled                                |
+| `novalidate`                  | `bool`                    | `false`   | no       | `elementType="form"` only: If the dialog should have validation disabled                                |
 | `preferredHeightOnMobile`     | `string`                  | `null`    | no       | Preferred height of the modal on mobile. Accepts any valid CSS value.                                   |
 | `preferredHeightFromTabletUp` | `string`                  | `null`    | no       | Preferred height of the modal on tablet and larger. Accepts any valid CSS value.                        |
 | `rel`                         | `string`                  | `null`    | no       | `elementType="form"` only: Relationship between the current document and the linked resource            |
@@ -130,12 +130,12 @@ accessible name for the dialog, e.g. using the `aria-label` attribute on
 
 ### API
 
-| Prop name       | Type      | Default | Required | Description             |
-| --------------- | --------- | ------- | -------- | ----------------------- |
-| `closeLabel`    | `string`  | `Close` | no       | Custom close label      |
-| `enableDismiss` | `boolean` | `true`  | no       | Enable JS Modal dismiss |
-| `modalId`       | `string`  | —       | yes      | Modal ID                |
-| `titleId`       | `string`  | `null`  | no       | ID of the title         |
+| Prop name       | Type     | Default | Required | Description             |
+| --------------- | -------- | ------- | -------- | ----------------------- |
+| `closeLabel`    | `string` | `Close` | no       | Custom close label      |
+| `enableDismiss` | `bool`   | `true`  | no       | Enable JS Modal dismiss |
+| `modalId`       | `string` | —       | yes      | Modal ID                |
+| `titleId`       | `string` | `null`  | no       | ID of the title         |
 
 On top of the API options, you can add `data-*` or `aria-*` attributes to
 further extend component's descriptiveness and accessibility. Also, UNSAFE styling props are available,

--- a/packages/web-twig/src/Resources/components/Modal/README.md
+++ b/packages/web-twig/src/Resources/components/Modal/README.md
@@ -57,18 +57,27 @@ footer of the dialog.
 
 ### API
 
-| Prop name                     | Type      | Default   | Required | Description                                                                                            |
-| ----------------------------- | --------- | --------- | -------- | ------------------------------------------------------------------------------------------------------ |
-| `elementType`                 | `string`  | `article` | no       | HTML tag to render                                                                                     |
-| `isExpandedOnMobile`          | `boolean` | `true`    | no       | If the ModalDialog should expand on mobile. Overrides any height defined by `preferredHeightOnMobile`. |
-| `maxHeightFromTabletUp`       | `string`  | `null`    | no       | Max height of the modal. Accepts any valid CSS value.                                                  |
-| `preferredHeightOnMobile`     | `string`  | `null`    | no       | Preferred height of the modal on mobile. Accepts any valid CSS value.                                  |
-| `preferredHeightFromTabletUp` | `string`  | `null`    | no       | Preferred height of the modal on tablet and larger. Accepts any valid CSS value.                       |
+| Prop name                     | Type                      | Default   | Required | Description                                                                                             |
+| ----------------------------- | ------------------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| `accept-charset`              | `string`                  | `null`    | no       | `elementType="form"` only: Character encodings to use for form submission (intentionally in kebab-case) |
+| `action`                      | `string`                  | `null`    | no       | `elementType="form"` only: URL to use for form submission                                               |
+| `autocomplete`                | `string`                  | `null`    | no       | `elementType="form"` only: [Automated assistance in filling][autocomplete-attr]                         |
+| `elementType`                 | `string`                  | `article` | no       | HTML tag to render                                                                                      |
+| `enctype`                     | `string`                  | `null`    | no       | `elementType="form"` only: Encoding to use for form submission                                          |
+| `isExpandedOnMobile`          | `boolean`                 | `true`    | no       | If the ModalDialog should expand on mobile. Overrides any height defined by `preferredHeightOnMobile`.  |
+| `maxHeightFromTabletUp`       | `string`                  | `null`    | no       | Max height of the modal. Accepts any valid CSS value.                                                   |
+| `method`                      | [`get`, `post`, `dialog`] | `null`    | no       | `elementType="form"` only: HTTP method to use for form submission                                       |
+| `name`                        | `string`                  | `null`    | no       | `elementType="form"` only: Name of the form                                                             |
+| `novalidate`                  | `boolean`                 | `false`   | no       | `elementType="form"` only: If the dialog should have validation disabled                                |
+| `preferredHeightOnMobile`     | `string`                  | `null`    | no       | Preferred height of the modal on mobile. Accepts any valid CSS value.                                   |
+| `preferredHeightFromTabletUp` | `string`                  | `null`    | no       | Preferred height of the modal on tablet and larger. Accepts any valid CSS value.                        |
+| `rel`                         | `string`                  | `null`    | no       | `elementType="form"` only: Relationship between the current document and the linked resource            |
+| `target`                      | `string`                  | `null`    | no       | `elementType="form"` only: Browsing context for form submission                                         |
 
 On top of the API options, you can add `data-*` or `aria-*` attributes to
 further extend component's descriptiveness and accessibility. Also, UNSAFE styling props are available,
 see the [Escape hatches][escape-hatches] section in README to learn how and when to use them.
-These attributes will be passed to the topmost HTML element of the component. Also all `form` attributes
+These attributes will be passed to the topmost HTML element of the component. Also, all `form` attributes
 are allowed when the `elementType` is set to `form`.
 
 ### Forms in Modal
@@ -221,5 +230,6 @@ When you put it all together:
 
 [modal]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web/src/scss/components/Modal
 [mdn-dialog-form]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#usage_notes
+[autocomplete-attr]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
 [dictionary-alignment]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#alignment
 [escape-hatches]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web-twig/README.md#escape-hatches

--- a/packages/web-twig/src/Resources/components/Pagination/README.md
+++ b/packages/web-twig/src/Resources/components/Pagination/README.md
@@ -96,13 +96,13 @@ These attributes will be passed to the topmost HTML element of the component.
 
 #### API
 
-| Prop name            | Type      | Default | Required | Description                            |
-| -------------------- | --------- | ------- | -------- | -------------------------------------- |
-| `accessibilityLabel` | `string`  | `null`  | yes      | Accessibility label of the link        |
-| `href`               | `string`  | `null`  | no       | URL target of a link                   |
-| `isCurrent`          | `boolean` | `false` | no       | Mark link as current                   |
-| `pageNumber`         | `string`  | `null`  | yes      | Page number, hidden for screen readers |
-| `target`             | `string`  | `null`  | no       | Browsing context for the link          |
+| Prop name            | Type     | Default | Required | Description                            |
+| -------------------- | -------- | ------- | -------- | -------------------------------------- |
+| `accessibilityLabel` | `string` | `null`  | yes      | Accessibility label of the link        |
+| `href`               | `string` | `null`  | no       | URL target of a link                   |
+| `isCurrent`          | `bool`   | `false` | no       | Mark link as current                   |
+| `pageNumber`         | `string` | `null`  | yes      | Page number, hidden for screen readers |
+| `target`             | `string` | `null`  | no       | Browsing context for the link          |
 
 You can add `data-*` or `aria-*` attributes to further extend component's
 descriptiveness and accessibility. Also, UNSAFE styling props are available,

--- a/packages/web-twig/src/Resources/components/Pagination/README.md
+++ b/packages/web-twig/src/Resources/components/Pagination/README.md
@@ -102,7 +102,7 @@ These attributes will be passed to the topmost HTML element of the component.
 | `href`               | `string`  | `null`  | no       | URL target of a link                   |
 | `isCurrent`          | `boolean` | `false` | no       | Mark link as current                   |
 | `pageNumber`         | `string`  | `null`  | yes      | Page number, hidden for screen readers |
-| `target`             | `string`  | `null`  | no       | HTML `target` attribute                |
+| `target`             | `string`  | `null`  | no       | Browsing context for the link          |
 
 You can add `data-*` or `aria-*` attributes to further extend component's
 descriptiveness and accessibility. Also, UNSAFE styling props are available,
@@ -142,7 +142,7 @@ These attributes will be passed to the topmost HTML element of the component.
 | -------------------- | -------- | -------------------- | -------- | --------------------------------- |
 | `accessibilityLabel` | `string` | `Next` or `Previous` | no       | Accessibility label of the button |
 | `href`               | `string` | —                    | no       | Link URL                          |
-| `target`             | `string` | `null`               | no       | HTML `target` attribute           |
+| `target`             | `string` | `null`               | no       | Browsing context for the link     |
 
 You can add `data-*` or `aria-*` attributes to further extend component's
 descriptiveness and accessibility. Also, UNSAFE styling props are available,

--- a/packages/web-twig/src/Resources/components/Tabs/README.md
+++ b/packages/web-twig/src/Resources/components/Tabs/README.md
@@ -56,18 +56,18 @@ There is no API for TabItem.
 
 ### TabLink
 
-| Prop name    | Type      | Default | Required | Description                  |
-| ------------ | --------- | ------- | -------- | ---------------------------- |
-| `href`       | `string`  | `null`  | no       | URL target of a link         |
-| `isSelected` | `boolean` | `false` | no       | Whether is tab item selected |
-| `target`     | `string`  | `null`  | no       | Target tab pane ID           |
+| Prop name    | Type     | Default | Required | Description                  |
+| ------------ | -------- | ------- | -------- | ---------------------------- |
+| `href`       | `string` | `null`  | no       | URL target of a link         |
+| `isSelected` | `bool`   | `false` | no       | Whether is tab item selected |
+| `target`     | `string` | `null`  | no       | Target tab pane ID           |
 
 ### TabPane
 
 | Prop name    | Type      | Default | Required | Description                    |
 | ------------ | --------- | ------- | -------- | ------------------------------ |
 | `id`         | `string ` | `null`  | yes      | Tab pane target identification |
-| `isSelected` | `boolean` | `false` | no       | Whether is tab pane selected   |
+| `isSelected` | `bool`    | `false` | no       | Whether is tab pane selected   |
 | `label`      | `string`  | `null`  | no       | Aria label of the tab pane     |
 
 You can add `id`, `data-*` or `aria-*` attributes to further extend component's

--- a/packages/web-twig/src/Resources/components/Tag/README.md
+++ b/packages/web-twig/src/Resources/components/Tag/README.md
@@ -35,7 +35,7 @@ Without lexer:
 | ------------- | ------------------------------------------------------- | --------- | -------- | ---------------------------------------------- |
 | `color`       | [Emotion Color dictionary][dictionary-color], `neutral` | `neutral` | no       | Color of the component                         |
 | `elementType` | `string`                                                | `span`    | no       | HTML tag to render                             |
-| `isSubtle`    | `boolean`                                               | `false`   | no       | Whether the Tag is displayed in subtle variant |
+| `isSubtle`    | `bool`                                                  | `false`   | no       | Whether the Tag is displayed in subtle variant |
 | `size`        | [Size Extended dictionary][dictionary-size]             | `medium`  | no       | Size of the Tag                                |
 
 You can add `id`, `data-*` or `aria-*` attributes to further extend component's

--- a/packages/web-twig/src/Resources/components/Text/README.md
+++ b/packages/web-twig/src/Resources/components/Text/README.md
@@ -29,11 +29,12 @@ Without lexer:
 
 ## API
 
-| Prop name     | Type                                        | Default   | Required | Description          |
-| ------------- | ------------------------------------------- | --------- | -------- | -------------------- |
-| `elementType` | `string`                                    | `p`       | no       | HTML tag to render   |
-| `emphasis`    | `regular`, `bold`, `italic`                 | `regular` | no       | Emphasis of the text |
-| `size`        | [Size Extended dictionary][dictionary-size] | `medium`  | no       | Size of the text     |
+| Prop name     | Type                                        | Default   | Required | Description                                                    |
+| ------------- | ------------------------------------------- | --------- | -------- | -------------------------------------------------------------- |
+| `elementType` | `string`                                    | `p`       | no       | HTML tag to render                                             |
+| `emphasis`    | `regular`, `bold`, `italic`                 | `regular` | no       | Emphasis of the text                                           |
+| `size`        | [Size Extended dictionary][dictionary-size] | `medium`  | no       | Size of the text                                               |
+| `translate`   | [`yes`, `no`]                               | `null`    | no       | Set to `no` to disable machine translation of the text content |
 
 You can add `id`, `data-*` or `aria-*` attributes to further extend component's
 descriptiveness and accessibility. Also, UNSAFE styling props are available,

--- a/packages/web-twig/src/Resources/components/Text/Text.twig
+++ b/packages/web-twig/src/Resources/components/Text/Text.twig
@@ -13,5 +13,5 @@
 {%- set _allowedAttributes = [ 'translate' ] -%}
 
 <{{ _elementType }} {{ mainProps(props, _allowedAttributes) }} {{ styleProp(_styleProps) }} {{ classProp(_classNames) }}>
-{%- block content %}{% endblock -%}
+    {%- block content %}{% endblock -%}
 </{{ _elementType }}>

--- a/packages/web-twig/src/Resources/components/TextArea/README.md
+++ b/packages/web-twig/src/Resources/components/TextArea/README.md
@@ -48,6 +48,7 @@ Without lexer:
 
 | Prop name               | Type                                           | Default | Required | Description                                                                                                 |
 | ----------------------- | ---------------------------------------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `autocomplete`          | `string`                                       | `null`  | no       | [Automated assistance in filling][autocomplete-attr]                                                        |
 | `helperText`            | `string`                                       | `null`  | no       | Custom helper text                                                                                          |
 | `id`                    | `string`                                       | —       | yes      | TextArea and label identification                                                                           |
 | `inputProps`            | `string[]`                                     | `[]`    | no       | Pass additional attributes to the textarea element                                                          |
@@ -99,5 +100,6 @@ Then you need to add attribute `isAutoResizing` to the component.
 
 [textarea]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web/src/scss/components/TextArea
 [web-readme]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/README.md
+[autocomplete-attr]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
 [dictionary-validation]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation
 [escape-hatches]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web-twig/README.md#escape-hatches

--- a/packages/web-twig/src/Resources/components/TextField/README.md
+++ b/packages/web-twig/src/Resources/components/TextField/README.md
@@ -60,7 +60,7 @@ Without lexer:
 
 | Prop name               | Type                                                          | Default | Required | Description                                                             |
 | ----------------------- | ------------------------------------------------------------- | ------- | -------- | ----------------------------------------------------------------------- |
-| `autocomplete`          | `bool`                                                        | `false` | no       | If the field should have autocomplete enabled                           |
+| `autocomplete`          | `string`                                                      | `null`  | no       | [Automated assistance in filling][autocomplete-attr]                    |
 | `hasPasswordToggle`     | `bool`                                                        | `false` | no       | If true, the `type` is set to `password` and a password toggle is shown |
 | `helperText`            | `string`                                                      | `null`  | no       | Custom helper text                                                      |
 | `id`                    | `string`                                                      | —       | yes      | Input and label identification                                          |
@@ -89,5 +89,6 @@ see the [Escape hatches][escape-hatches] section in README to learn how and when
 These attributes will be passed to the topmost HTML element of the component.
 
 [textfield]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web/src/scss/components/TextField
+[autocomplete-attr]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
 [dictionary-validation]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation
 [escape-hatches]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web-twig/README.md#escape-hatches

--- a/packages/web-twig/src/Resources/components/TextFieldBase/README.md
+++ b/packages/web-twig/src/Resources/components/TextFieldBase/README.md
@@ -60,7 +60,7 @@ Without lexer:
 
 | Prop name               | Type                                                          | Default | Required | Description                                                             |
 | ----------------------- | ------------------------------------------------------------- | ------- | -------- | ----------------------------------------------------------------------- |
-| `autocomplete`          | `bool`                                                        | `false` | no       | If the field should have autocomplete enabled                           |
+| `autocomplete`          | `string`                                                      | `null`  | no       | [Automated assistance in filling][autocomplete-attr]                    |
 | `hasPasswordToggle`     | `bool`                                                        | `false` | no       | If true, the `type` is set to `password` and a password toggle is shown |
 | `helperText`            | `string`                                                      | `null`  | no       | Custom helper text                                                      |
 | `id`                    | `string`                                                      | —       | yes      | Input and label identification                                          |
@@ -91,5 +91,6 @@ see the [Escape hatches][escape-hatches] section in README to learn how and when
 These attributes will be passed to the topmost HTML element of the component.
 
 [textfield]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web/src/scss/components/TextField
+[autocomplete-attr]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
 [dictionary-validation]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation
 [escape-hatches]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web-twig/README.md#escape-hatches


### PR DESCRIPTION
- Document all allowed HTML attributes in all components
- Unify the syntax of boolean props

Partially relates to #957.