### PR TITLE
Fix(web): Remove unused data attribute in Accordion #DS-883

### DIFF
--- a/packages/web-twig/src/Resources/components/Accordion/Accordion.twig
+++ b/packages/web-twig/src/Resources/components/Accordion/Accordion.twig
@@ -19,7 +19,6 @@
     {{ styleProp(_styleProps) }}
     {{ _idAttr | raw }}
     {{ classProp(_classNames) }}
-    data-spirit-toggle="accordion"
 >
     {% block content %}{% endblock %}
 </{{ _elementType }}>

--- a/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set accordionDefault.twig__1.html
+++ b/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set accordionDefault.twig__1.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <section id="AccordionExample" class="Accordion" data-spirit-toggle="accordion">
+    <section id="AccordionExample" class="Accordion">
       <article id="AccordionItemExample0" class="Accordion__item">
         <h3 id="AccordionItemExample0Header" class="Accordion__itemHeader">
           <button type="button" class="Accordion__itemToggle" data-spirit-toggle="collapse" data-spirit-target="AccordionItemExample0Content" aria-expanded="false" aria-controls="AccordionItemExample0Content">Accordion

--- a/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set accordionStayOpen.twig__1.html
+++ b/packages/web-twig/tests/__snapshots__/ComponentsSnapshotTest__test with data set accordionStayOpen.twig__1.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <section class="Accordion" data-spirit-toggle="accordion">
+    <section class="Accordion">
       <article id="AccordionItemExample0" class="Accordion__item">
         <h3 id="AccordionItemExample0Header" class="Accordion__itemHeader">
           <button type="button" class="Accordion__itemToggle" data-spirit-toggle="collapse" data-spirit-target="AccordionItemExample0Content" aria-expanded="false" aria-controls="AccordionItemExample0Content">Accordion

--- a/packages/web/src/js/__tests__/Collapse.test.ts
+++ b/packages/web/src/js/__tests__/Collapse.test.ts
@@ -108,7 +108,6 @@ describe('Collapse', () => {
         <section
           id="accordionExample1"
           class="Accordion"
-          data-spirit-toggle="accordion"
         >
           <article
             id="accordionExample1_article_0"

--- a/packages/web/src/scss/components/Accordion/README.md
+++ b/packages/web/src/scss/components/Accordion/README.md
@@ -19,7 +19,7 @@ Building blocks:
 Common wrapper for all items:
 
 ```html
-<section class="Accordion" data-spirit-toggle="accordion">
+<section class="Accordion">
   <!-- One or more items inside -->
 </section>
 ```
@@ -117,7 +117,7 @@ When you put it all together:
 
 ```html
 <!-- Accordion: start -->
-<section class="Accordion" data-spirit-toggle="accordion">
+<section class="Accordion">
   <!-- Accordion item: start -->
   <article id="example_1_item_1" class="Accordion__item">
     <!-- Accordion item header: start -->
@@ -180,7 +180,7 @@ Link individual **Collapse items** to their **Accordion parent** via
 First add an `id` to your Accordion wrapper:
 
 ```html
-<section id="accordion" class="Accordion" data-spirit-toggle="accordion">
+<section id="accordion" class="Accordion">
   <!-- Accordion items inside -->
 </section>
 ```

--- a/packages/web/src/scss/components/Accordion/index.html
+++ b/packages/web/src/scss/components/Accordion/index.html
@@ -7,7 +7,7 @@
   <div class="mb-400">
 
     <!-- Accordion: start -->
-    <section class="Accordion" data-spirit-toggle="accordion">
+    <section class="Accordion">
 
       <!-- Accordion item: start -->
       <article id="example_1_item_1" class="Accordion__item">
@@ -228,7 +228,6 @@
     <section
       id="example_2"
       class="Accordion"
-      data-spirit-toggle="accordion"
     >
 
       <!-- Accordion item: start -->


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

It is not used anywhere in the JS. It was probably replaced by data-spirit-parent and someone forgot to remove this.

### Issue reference

DS-883

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [x] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
