### PR TITLE
Fix(web): Set correct order of hover, focus and active states in CSS

### DIFF
--- a/packages/web/src/scss/components/Button/_Button.scss
+++ b/packages/web/src/scss/components/Button/_Button.scss
@@ -84,8 +84,8 @@
     color: transparent;
 
     &:hover,
-    &:active,
-    &:focus {
+    &:focus,
+    &:active {
         color: transparent;
     }
 }

--- a/packages/web/src/scss/components/Pagination/_Pagination.scss
+++ b/packages/web/src/scss/components/Pagination/_Pagination.scss
@@ -26,8 +26,8 @@
     border-radius: theme.$item-radius;
     background-color: theme.$item-default-background;
 
-    &:focus,
-    &:hover {
+    &:hover,
+    &:focus {
         text-decoration: none;
         color: theme.$item-hover-color;
         background-color: theme.$item-hover-background;
@@ -41,9 +41,9 @@
 }
 
 .Pagination__link--current,
-.Pagination__link--current:active,
+.Pagination__link--current:hover,
 .Pagination__link--current:focus,
-.Pagination__link--current:hover {
+.Pagination__link--current:active {
     color: theme.$item-selected-color;
     background-color: theme.$item-selected-background;
     cursor: cursors.$disabled;

--- a/packages/web/src/scss/foundation/_links.scss
+++ b/packages/web/src/scss/foundation/_links.scss
@@ -10,15 +10,15 @@ a {
     text-underline-offset: links.$text-underline-offset;
     color: tokens.$action-link-primary-default;
 
-    &:active {
-        text-decoration: underline;
-        color: tokens.$action-link-primary-active;
-    }
-
     @media (hover: hover) {
         &:hover {
             text-decoration: underline;
             color: tokens.$action-link-primary-hover;
         }
+    }
+
+    &:active {
+        text-decoration: underline;
+        color: tokens.$action-link-primary-active;
     }
 }

--- a/packages/web/src/scss/helpers/links/_links.scss
+++ b/packages/web/src/scss/helpers/links/_links.scss
@@ -24,8 +24,8 @@
 
 // Allows link underline everywhere, except for headings default state
 .link-underlined,
-[class*='typography-heading'] a:active,
-[class*='typography-heading'] a:hover {
+[class*='typography-heading'] a:hover,
+[class*='typography-heading'] a:active {
     text-decoration: underline;
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Currently, hover state overrode active on click, because you were still hovering. So active has to be set after hover as mentioned in [w3schools](https://www.w3schools.com/cssref/sel_active.php#:~:text=Note%3A%20%3Aactive%20MUST%20come%20after%20%3Ahover%20(if%20present)%20in%20the%20CSS%20definition%20in%20order%20to%20be%20effective). We also decided to keep the order hover, focus and active. So I fixed this everywhere. 

---

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [x] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
