### PR TITLE
Feat(web-react): Deprecate props in FileUploaderAttachment DS-881

### DIFF
--- a/packages/web-react/src/components/FileUploader/FileUploaderAttachment.tsx
+++ b/packages/web-react/src/components/FileUploader/FileUploaderAttachment.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, RefObject, MouseEvent, useState } from 'react';
 import classNames from 'classnames';
 import { SpiritFileUploaderAttachmentProps } from '../../types';
-import { useStyleProps } from '../../hooks';
+import { useDeprecationMessage, useStyleProps } from '../../hooks';
 import { useFileUploaderStyleProps } from './useFileUploaderStyleProps';
 import { useFileUploaderAttachment } from './useFileUploaderAttachment';
 import AttachmentImagePreview from './AttachmentImagePreview';
@@ -13,17 +13,21 @@ import AttachmentDismissButton from './AttachmentDismissButton';
 
 const FileUploaderAttachment = (props: SpiritFileUploaderAttachmentProps) => {
   const {
+    /** @deprecated Will be removed in the next major version. */
+    buttonLabel,
+    /** @deprecated Will be removed in the next major version. */
+    editButtonLabel,
+    editText,
     file,
     hasImagePreview,
+    iconName = DEFAULT_ICON_NAME,
     id,
     label,
     name,
     onDismiss,
-    onError,
     onEdit,
-    iconName = DEFAULT_ICON_NAME,
-    buttonLabel = DEFAULT_BUTTON_LABEL,
-    editButtonLabel = DEFAULT_EDIT_BUTTON_LABEL,
+    onError,
+    removeText,
     ...restProps
   } = props;
   const [imagePreview, setImagePreview] = useState<string>('');
@@ -49,6 +53,26 @@ const FileUploaderAttachment = (props: SpiritFileUploaderAttachmentProps) => {
 
   useFileUploaderAttachment({ attachmentRef, file, name, onError });
 
+  useDeprecationMessage({
+    method: 'property',
+    trigger: !!buttonLabel,
+    componentName: 'FileUploaderAttachment',
+    propertyProps: {
+      deprecatedName: 'buttonLabel',
+      newName: 'removeText',
+    },
+  });
+
+  useDeprecationMessage({
+    method: 'property',
+    trigger: !!editButtonLabel,
+    componentName: 'FileUploaderAttachment',
+    propertyProps: {
+      deprecatedName: 'editButtonLabel',
+      newName: 'editText',
+    },
+  });
+
   return (
     <li
       id={id}
@@ -67,10 +91,14 @@ const FileUploaderAttachment = (props: SpiritFileUploaderAttachmentProps) => {
       </span>
       {onEdit && (
         <span className={classProps.attachment.slot}>
-          <AttachmentActionButton onClick={onEditHandler}>{editButtonLabel}</AttachmentActionButton>
+          <AttachmentActionButton onClick={onEditHandler}>
+            {editText || editButtonLabel || DEFAULT_EDIT_BUTTON_LABEL}
+          </AttachmentActionButton>
         </span>
       )}
-      <AttachmentDismissButton onClick={dismissHandler}>{buttonLabel}</AttachmentDismissButton>
+      <AttachmentDismissButton onClick={dismissHandler}>
+        {removeText || buttonLabel || DEFAULT_BUTTON_LABEL}
+      </AttachmentDismissButton>
     </li>
   );
 };

--- a/packages/web-react/src/components/FileUploader/README.md
+++ b/packages/web-react/src/components/FileUploader/README.md
@@ -363,20 +363,22 @@ The rest of the properties are created from the default `<ul>` element. [More ab
 
 ## FileUploaderAttachment Props
 
-| Name               | Type                                 | Default  | Required | Description                               |
-| ------------------ | ------------------------------------ | -------- | -------- | ----------------------------------------- |
-| `buttonLabel`      | `string`                             | `Remove` | ✕        | Dismiss button label                      |
-| `editButtonLabel`  | `string`                             | `Edit`   | ✕        | Edit button label                         |
-| `file`             | `File`                               | -        | ✔        | Attachment file object                    |
-| `iconName`         | `string`                             | `file`   | ✕        | Icon shown along the file                 |
-| `id`               | `string`                             | -        | ✔        | FileUploaderAttachment id                 |
-| `label`            | `string`                             | -        | ✔        | File name                                 |
-| `name`             | `string`                             | -        | ✔        | Input field name                          |
-| `onDismiss`        | `(key: string) => FileQueueMapType`  | -        | ✔        | Callback to delete an item from the queue |
-| `onEdit`           | `(event: Event, file: File) => void` | -        | ✕        | Show and add function to edit button      |
-| `onError`          | `FileUploaderErrorCallbackType`      | -        | ✕        | Callback on error condition               |
-| `UNSAFE_className` | `string`                             | -        | ✕        | FileUploaderAttachment custom class name  |
-| `UNSAFE_style`     | `CSSProperties`                      | -        | ✕        | FileUploaderAttachment custom style       |
+| Name               | Type                                 | Default  | Required | Description                                                                 |
+| ------------------ | ------------------------------------ | -------- | -------- | --------------------------------------------------------------------------- |
+| `buttonLabel`      | `string`                             | `Remove` | ✕        | [**DEPRECATED**][Deprecated] in favor of `removeText`; Dismiss button label |
+| `editButtonLabel`  | `string`                             | `Edit`   | ✕        | [**DEPRECATED**][Deprecated] in favor of `editText`; Edit button label      |
+| `editText`         | `string`                             | `Edit`   | ✕        | Edit button label                                                           |
+| `file`             | `File`                               | -        | ✔        | Attachment file object                                                      |
+| `iconName`         | `string`                             | `file`   | ✕        | Icon shown along the file                                                   |
+| `id`               | `string`                             | -        | ✔        | FileUploaderAttachment id                                                   |
+| `label`            | `string`                             | -        | ✔        | File name                                                                   |
+| `name`             | `string`                             | -        | ✔        | Input field name                                                            |
+| `onDismiss`        | `(key: string) => FileQueueMapType`  | -        | ✔        | Callback to delete an item from the queue                                   |
+| `onEdit`           | `(event: Event, file: File) => void` | -        | ✕        | Show and add function to edit button                                        |
+| `onError`          | `FileUploaderErrorCallbackType`      | -        | ✕        | Callback on error condition                                                 |
+| `removeText`       | `string`                             | `Remove` | ✕        | Dismiss button label                                                        |
+| `UNSAFE_className` | `string`                             | -        | ✕        | FileUploaderAttachment custom class name                                    |
+| `UNSAFE_style`     | `CSSProperties`                      | -        | ✕        | FileUploaderAttachment custom style                                         |
 
 The rest of the properties are created from the default `<li>` element. [More about the element][ListItemElementDocs]
 
@@ -444,3 +446,4 @@ For detailed information see [FileUploader] component.
 [InputElementDocs]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
 [ListElementDocs]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul
 [ListItemElementDocs]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li
+[Deprecated]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web-react/README.md#deprecations

--- a/packages/web-react/src/types/fileUploader.ts
+++ b/packages/web-react/src/types/fileUploader.ts
@@ -75,17 +75,21 @@ export interface FileUploaderListBaseProps extends SpiritUListElementProps {
 }
 
 export interface FileUploaderAttachmentBaseProps extends Omit<SpiritLItemElementProps, 'onError'> {
+  /** @deprecated Will be removed in the next major version. */
   buttonLabel?: string;
+  /** @deprecated Will be removed in the next major version. */
   editButtonLabel?: string;
+  editText?: string;
   file: File;
+  hasImagePreview?: boolean;
   iconName?: string;
   id: string;
   label: string;
   name: string;
   onDismiss: (key: string) => FileQueueMapType;
-  onError?: FileUploaderErrorCallbackType;
-  hasImagePreview?: boolean;
   onEdit?: (event: MouseEvent, file: File) => void;
+  onError?: FileUploaderErrorCallbackType;
+  removeText?: string;
 }
 
 export interface FileUploaderBaseProps extends SpiritDivElementProps, Partial<FileUploaderErrorMessagesProps> {


### PR DESCRIPTION
## Description
Add deprecations to `FileUploaderAttachment` button label props.

Deprecate prop `buttonLabel`, use `removeText` instead. 
Deprecate prop `editButtonLabel`, use `editText` instead.

### Additional context

Changing props from `buttonLabel` -> `removeText` and `editButtonLabel` -> `editText` for better match with other text props across project.

### Issue reference

[DS-881 FileUploader má rozdílně pojmenované API](https://jira.lmc.cz/browse/DS-881)
