### PR TITLE
Fix(web): Drop support of Windows high contrast mode in `Radio` to fix antialiasing issues

### DIFF
--- a/packages/web/src/scss/components/Radio/_Radio.scss
+++ b/packages/web/src/scss/components/Radio/_Radio.scss
@@ -1,8 +1,4 @@
 // 1. Use `box-shadow` to ensure the state of the radio is visible when printed.
-// 2. Make sure the state of the radio is accessible in forced-colors mode (e.g. Windows High Contrast Mode) where
-//    our `box-shadow` indicator is removed.
-//
-// See: https://moderncss.dev/pure-css-custom-styled-radio-buttons/
 
 @use 'sass:map';
 @use '../../theme/form-fields' as form-fields-theme;
@@ -36,7 +32,6 @@ $_field-name: 'Radio';
         width: theme.$input-inner-dot-size;
         height: theme.$input-inner-dot-size;
         border-radius: theme.$input-border-radius;
-        background-color: canvastext; // 2.
         box-shadow: theme.$input-box-shadow-before; // 1.
         transform: scale(0);
         transition-property: transform;


### PR DESCRIPTION
The edges of selected `Radio` input should now be smooth and not pixelated.

It seems we can have either printer-friendly, or Windows-HCM-friendly inputs, not both.

🙏🏻 Test on a non-high-dpi display is necessary (I don't have one).