### PR TITLE
Test(web-react): Unnecessary use of `Date.now` refs #DS-766

### DIFF
--- a/packages/web-react/src/components/FileUploader/__tests__/useFileQueue.test.ts
+++ b/packages/web-react/src/components/FileUploader/__tests__/useFileQueue.test.ts
@@ -2,8 +2,8 @@ import { act, renderHook } from '@testing-library/react-hooks';
 import { useFileQueue } from '../useFileQueue';
 
 describe('useFileQueue', () => {
-  const file1 = new File([''], 'test1.txt', { type: 'text/plain', lastModified: Date.now() });
-  const file2 = new File([''], 'test1.txt', { type: 'text/plain', lastModified: Date.now() });
+  const file1 = new File([''], 'test1.txt', { type: 'text/plain', lastModified: 123456789 });
+  const file2 = new File([''], 'test1.txt', { type: 'text/plain', lastModified: 123456789 });
 
   it('should return defaults', () => {
     const { result } = renderHook(() => useFileQueue());


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Replacing Date.now with static value.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

https://jira.lmc.cz/browse/DS-766

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
