### PR TITLE
Fix(web-react): The rest props were transfered twice on FieldGroup

### DIFF
--- a/packages/web-react/src/components/FieldGroup/FieldGroup.tsx
+++ b/packages/web-react/src/components/FieldGroup/FieldGroup.tsx
@@ -34,7 +34,6 @@ const FieldGroup = (props: SpiritFieldGroupProps) => {
       {...styleProps}
       className={classNames(classProps.root, styleProps.className)}
       disabled={isDisabled}
-      {...rest}
     >
       <legend className="accessibility-hidden">{label}</legend>
       {!isLabelHidden && (


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

  * causing `UNSAFE_style` be placed on DOM element during test

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
