### PR TITLE
Fix(web-react): Handle event capturing correctly in Dialog

### DIFF
--- a/packages/web-react/src/components/Dialog/Dialog.tsx
+++ b/packages/web-react/src/components/Dialog/Dialog.tsx
@@ -13,14 +13,17 @@ const Dialog = (props: DialogProps, ref: ForwardedRef<HTMLDialogElement | null>)
 
   // handles toggling based on state
   const { closeDialog } = useDialog(dialogElementRef as MutableRefObject<HTMLDialogElement | null>, isOpen);
+  const handleClickOutside = (event: Event) => {
+    closeDialog();
+    onClose(event);
+  };
+
   // handles closing by clicking outside the dialog
   useClickOutside({
     ref: contentElementRef,
-    callback: (event: Event) => {
-      closeDialog();
-      onClose(event);
-    },
+    callback: isOpen ? handleClickOutside : undefined,
   });
+
   // handles closing using Escape key
   useCancelEvent(dialogElementRef as MutableRefObject<HTMLDialogElement | null>, onClose);
 

--- a/packages/web-react/src/components/Modal/ModalHeader.tsx
+++ b/packages/web-react/src/components/Modal/ModalHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { useStyleProps } from '../../hooks';
-import { ModalHeaderProps } from '../../types';
+import { ClickEvent, ModalHeaderProps } from '../../types';
 import { useModalStyleProps } from './useModalStyleProps';
 import { useModalContext } from './ModalContext';
 import { Button } from '../Button';
@@ -21,7 +21,15 @@ const ModalHeader = (props: ModalHeaderProps) => {
           {children}
         </h2>
       )}
-      <Button isSquare color="tertiary" onClick={onClose} aria-expanded={isOpen} aria-controls={id}>
+      <Button
+        isSquare
+        color="tertiary"
+        onClick={(event: ClickEvent) => {
+          onClose(event);
+        }}
+        aria-expanded={isOpen}
+        aria-controls={id}
+      >
         <Icon name="close" />
         <span className="accessibility-hidden">{closeLabel}</span>
       </Button>

--- a/packages/web-react/src/components/Modal/demo/ModalStacked.tsx
+++ b/packages/web-react/src/components/Modal/demo/ModalStacked.tsx
@@ -26,10 +26,10 @@ const Story = (props: unknown) => {
 
   return (
     <IconsProvider value={icons}>
-      <Button onClick={toggleFirstModal} aria-expanded={isFirstOpen} aria-controls="#ModalExample">
+      <Button onClick={toggleFirstModal} aria-expanded={isFirstOpen} aria-controls="#NestedModal">
         {isFirstOpen ? 'Close' : 'Open'} Modal
       </Button>
-      <Modal id="ModalExampleStacked" isOpen={isSecondOpen} onClose={handleSecondClose}>
+      <Modal id="ChildModal" isOpen={isSecondOpen} onClose={handleSecondClose}>
         <ModalDialog>
           <ModalHeader>Modal stacked</ModalHeader>
           <ModalBody>
@@ -49,7 +49,7 @@ const Story = (props: unknown) => {
           </ModalFooter>
         </ModalDialog>
       </Modal>
-      <Modal id="ModalExample" isOpen={isFirstOpen} onClose={handleFirstClose}>
+      <Modal id="NestedModal" isOpen={isFirstOpen} onClose={handleFirstClose}>
         <ModalDialog>
           <ModalHeader>Modal </ModalHeader>
           <ModalBody>

--- a/packages/web-react/src/hooks/__tests__/useClickOutside.test.ts
+++ b/packages/web-react/src/hooks/__tests__/useClickOutside.test.ts
@@ -1,0 +1,21 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { MutableRefObject } from 'react';
+import { useClickOutside } from '../useClickOutside';
+
+describe('useClickOutside', () => {
+  it('should not call the callback when a click event occurs inside the ref element', () => {
+    const callback = jest.fn();
+    const containerRef = { current: document.createElement('div') } as MutableRefObject<HTMLElement | null>;
+
+    renderHook(() => useClickOutside({ ref: containerRef, callback }));
+
+    const clickEvent = new MouseEvent('click', { bubbles: true });
+    const insideElement = document.createElement('div');
+    document.body.appendChild(insideElement);
+
+    containerRef.current!.appendChild(insideElement);
+    insideElement.dispatchEvent(clickEvent);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
refs #DS-937

<!-- Thank you for contributing! -->

## Description

When using a form inside the Modal the click and submit of the form should work.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

The click to form, checkbox, and submit was prevented from defaulting due to the cooperation of nesting modals.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

https://jira.lmc.cz/browse/DS-937
---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
