### PR TITLE
Fix(web): Prevent from removing spacing from Stack first child element

### DIFF
--- a/packages/web/src/scss/components/Stack/_Stack.scss
+++ b/packages/web/src/scss/components/Stack/_Stack.scss
@@ -50,12 +50,7 @@
 }
 
 .Stack--hasIntermediateDividers > :first-child {
-    padding-block-start: 0;
     border-block-start: none;
-}
-
-.Stack--hasIntermediateDividers > :last-child {
-    padding-block-end: 0;
 }
 
 .Stack--hasStartDivider > :first-child {


### PR DESCRIPTION

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
