### PR TITLE
Test(web-react): Ignore module pattern for `dist` directory

### DIFF
--- a/packages/web-react/config/jest/config.js
+++ b/packages/web-react/config/jest/config.js
@@ -53,6 +53,10 @@ const config = {
   // A list of reporter names that Jest uses when writing coverage reports. Any istanbul reporter can be used.
   // https://jestjs.io/docs/configuration#coveragereporters-arraystring--string-options
   coverageReporters: ['text', 'text-summary', ['lcov', { projectRoot: '../../' }]],
+
+  // An array of regexp pattern strings that are matched against all module paths before those paths are 'visible' to the loader.
+  // https://jestjs.io/docs/configuration#modulepathignorepatterns-arraystring
+  modulePathIgnorePatterns: ['<rootDir>/dist'],
 };
 
 module.exports = config;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

  * fixing:
```
jest-haste-map: Haste module naming collision: @lmc-eu/spirit-web-react The following files share their name; please adjust your hasteImpl:
  * <rootDir>/dist/package.json
  * <rootDir>/package.json
 ```

### Additional context

This message was displayed in the console when running tests and when there were build files in the `dist` directory.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
