### PR TITLE
Feat(web-react): Introduce BreadcrumbsItem component

### DIFF
--- a/packages/web-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,10 +1,8 @@
 import classNames from 'classnames';
-import React, { ElementType } from 'react';
-import { useClassNamePrefix } from '../../hooks';
+import React, { ElementType, Fragment } from 'react';
 import { useStyleProps } from '../../hooks/styleProps';
 import { SpiritBreadcrumbsProps } from '../../types';
-import { Icon } from '../Icon';
-import { Link } from '../Link';
+import BreadcrumbsItem from './BreadcrumbsItem';
 import { useBreadcrumbsStyleProps } from './useBreadcrumbsStyleProps';
 
 const defaultProps = {
@@ -15,10 +13,6 @@ export const Breadcrumbs = <T extends ElementType = 'nav'>(props: SpiritBreadcru
   const { children, elementType: ElementTag = 'nav', goBackTitle, items, ...restProps } = props;
   const { classProps, props: modifiedProps } = useBreadcrumbsStyleProps({ ...restProps });
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
-
-  const displayTabletNoneClassName = useClassNamePrefix('d-tablet-none');
-  const displayNoneClassName = useClassNamePrefix('d-none');
-  const displayTabletFlexClassName = useClassNamePrefix('d-tablet-flex');
 
   const isLast = (index: number, itemsCount: number) => {
     return index === itemsCount - 1;
@@ -34,27 +28,16 @@ export const Breadcrumbs = <T extends ElementType = 'nav'>(props: SpiritBreadcru
       <ol>
         {children ||
           items?.map((item, index) => (
-            <React.Fragment key={`BreadcrumbsItem_${item.title}`}>
+            <Fragment key={`BreadcrumbsItem_${item.title}`}>
               {index === items.length - 2 && goBackTitle && (
-                <li className={displayTabletNoneClassName}>
-                  <Icon name="chevron-left" />
-                  <Link href={item.url} color="primary" isUnderlined>
-                    {goBackTitle}
-                  </Link>
-                </li>
+                <BreadcrumbsItem href={item.url} isGoBackOnly>
+                  {goBackTitle}
+                </BreadcrumbsItem>
               )}
-              <li className={classNames(displayNoneClassName, displayTabletFlexClassName)}>
-                {index !== 0 && <Icon name="chevron-right" />}
-                <Link
-                  href={item.url}
-                  color={isLast(index, items?.length) ? 'secondary' : 'primary'}
-                  isUnderlined={!isLast(index, items?.length)}
-                  aria-current={isLast(index, items?.length) ? 'page' : undefined}
-                >
-                  {item.title}
-                </Link>
-              </li>
-            </React.Fragment>
+              <BreadcrumbsItem href={item.url} isCurrent={isLast(index, items?.length)}>
+                {item.title}
+              </BreadcrumbsItem>
+            </Fragment>
           ))}
       </ol>
     </ElementTag>

--- a/packages/web-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -22,7 +22,7 @@ export const Breadcrumbs = <T extends ElementType = 'nav'>(props: SpiritBreadcru
     <ElementTag
       {...otherProps}
       {...styleProps}
-      className={classNames(classProps, styleProps.className)}
+      className={classNames(classProps.root, styleProps.className)}
       aria-label="Breadcrumb"
     >
       <ol>

--- a/packages/web-react/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -1,0 +1,39 @@
+import classNames from 'classnames';
+import React from 'react';
+import { useStyleProps } from '../../hooks';
+import { SpiritBreadcrumbsItemProps } from '../../types';
+import { Icon } from '../Icon';
+import { Link } from '../Link';
+import { useBreadcrumbsStyleProps } from './useBreadcrumbsStyleProps';
+
+const defaultProps = {
+  iconNameEnd: 'chevron-right',
+  iconNameStart: 'chevron-left',
+  isCurrent: false,
+  isGoBackOnly: false,
+};
+
+export const BreadcrumbsItem = (props: SpiritBreadcrumbsItemProps) => {
+  const { children, href, isCurrent, iconNameStart, iconNameEnd, ...restProps } = props;
+  const { classProps, props: otherProps } = useBreadcrumbsStyleProps({ ...restProps });
+  const { styleProps, props: transferProps } = useStyleProps(otherProps);
+
+  return (
+    <li {...transferProps} {...styleProps} className={classNames(classProps.item, styleProps.className)}>
+      {restProps.isGoBackOnly && iconNameStart && <Icon name={iconNameStart} />}
+      <Link
+        href={href}
+        color={isCurrent ? 'secondary' : 'primary'}
+        isUnderlined={!isCurrent}
+        aria-current={isCurrent ? 'page' : undefined}
+      >
+        {children}
+      </Link>
+      {!isCurrent && !restProps.isGoBackOnly && iconNameEnd && <Icon name={iconNameEnd} />}
+    </li>
+  );
+};
+
+BreadcrumbsItem.defaultProps = defaultProps;
+
+export default BreadcrumbsItem;

--- a/packages/web-react/src/components/Breadcrumbs/README.md
+++ b/packages/web-react/src/components/Breadcrumbs/README.md
@@ -1,10 +1,14 @@
 # Breadcrumbs
 
+## Usage
+
+### Basic
+
 ```jsx
 import { Breadcrumbs } from '@lmc-eu/spirit-web-react/components';
 ```
 
-Define breadcrumb items as array type of `BreadcrumbsItem[]`.
+Define breadcrumb items as an array type of `BreadcrumbsItem[]`.
 
 ```jsx
 const items = [
@@ -27,17 +31,15 @@ const items = [
 ];
 ```
 
-## Basic example usage
-
 Simply pass the breadcrumbs array as a prop:
 
 ```jsx
 <Breadcrumbs items={items} goBackTitle="Custom back link translation" />
 ```
 
-## Example of custom usage
+### Custom usage
 
-Use custom content for ordered list as component's children instead of passing breadcrumb items array via props:
+Use custom content for the ordered list as component's children instead of passing breadcrumb items array via props:
 
 ```jsx
 <Breadcrumbs>
@@ -51,15 +53,42 @@ Use custom content for ordered list as component's children instead of passing b
 </Breadcrumbs>
 ```
 
-## API
+### API
 
-| Name               | Type                | Default | Required | Description                                                                                                                                                                                 |
-| ------------------ | ------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `children`         | `ReactNode`         | —       | ✕        | Custom content to override items rendering from array                                                                                                                                       |
-| `elementType`      | `ElementType`       | `nav`   | ✕        | Type of element used as wrapper                                                                                                                                                             |
-| `goBackTitle`      | `string`            | —       | ✔        | Title/translation for back link to previous page on mobile. It's essential to be set along with items. If items property is not passed, backlink is to be created within children property. |
-| `items`            | `BreadcrumbsItem[]` | —       | ✕        | Navigation menu items                                                                                                                                                                       |
-| `UNSAFE_className` | `string`            | —       | ✕        | Wrapper custom class name                                                                                                                                                                   |
-| `UNSAFE_style`     | `CSSProperties`     | —       | ✕        | Wrapper custom style                                                                                                                                                                        |
+| Name               | Type                | Default | Required | Description                                                                                                                                                                                      |
+| ------------------ | ------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `children`         | `ReactNode`         | —       | ✕        | Custom content to override items rendering from array                                                                                                                                            |
+| `elementType`      | `ElementType`       | `nav`   | ✕        | Type of element used as wrapper                                                                                                                                                                  |
+| `goBackTitle`      | `string`            | —       | ✕        | Title/translation for back link to previous page on mobile. It's essential to be set along with items. If items property is not passed, the back link is to be created within children property. |
+| `items`            | `BreadcrumbsItem[]` | —       | ✕        | Navigation menu items                                                                                                                                                                            |
+| `UNSAFE_className` | `string`            | —       | ✕        | Wrapper custom class name                                                                                                                                                                        |
+| `UNSAFE_style`     | `CSSProperties`     | —       | ✕        | Wrapper custom style                                                                                                                                                                             |
+
+## BreadcrumbsItem
+
+Use the `BreadcrumbsItem` component for the ordered list as the component's children instead of passing the breadcrumb items array via props:
+
+```jsx
+<Breadcrumbs>
+  {items.map((item, index) => (
+    <BreadcrumbsItem key={`BreadcrumbsItem_${item.title}`} isCurrent={items.length === index - 1} href={item.url}>
+      {item.title}
+    </BreadcrumbsItem>
+  ))}
+</Breadcrumbs>
+```
+
+### API
+
+| Name               | Type            | Default         | Required | Description                                 |
+| ------------------ | --------------- | --------------- | -------- | ------------------------------------------- |
+| `children`         | `ReactNode`     | —               | ✕        | Children node                               |
+| `href`             | `string`        | —               | ✔        | URL                                         |
+| `iconNameEnd`      | `string`        | `chevron-right` | ✕        | Icon name at the end of the item            |
+| `iconNameStart`    | `string`        | `chevron-left`  | ✕        | Icon name at the start of the item          |
+| `isCurrent`        | `boolean`       | `false`         | ✕        | Whether is the item the current page        |
+| `isGoBackOnly`     | `boolean`       | `false`         | ✕        | Whether should be displayed in go back mode |
+| `UNSAFE_className` | `string`        | —               | ✕        | Wrapper custom class name                   |
+| `UNSAFE_style`     | `CSSProperties` | —               | ✕        | Wrapper custom style                        |
 
 For detailed information see [Breadcrumbs](https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/scss/components/Breadcrumbs/README.md) component

--- a/packages/web-react/src/components/Breadcrumbs/__tests__/BreadcrumbsItem.test.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/__tests__/BreadcrumbsItem.test.tsx
@@ -1,0 +1,73 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
+import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
+import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
+import BreadcrumbsItem from '../BreadcrumbsItem';
+
+describe('BreadcrumbsItem', () => {
+  classNamePrefixProviderTest(BreadcrumbsItem, 'd-none');
+  classNamePrefixProviderTest(BreadcrumbsItem, 'd-tablet-flex');
+
+  stylePropsTest(BreadcrumbsItem);
+
+  restPropsTest(BreadcrumbsItem, 'li');
+
+  describe('BreadcrumbsItem with go back title', () => {
+    const BreadcrumbsItemGoBack = () => (
+      <BreadcrumbsItem href="/test" isGoBackOnly>
+        test_title
+      </BreadcrumbsItem>
+    );
+
+    const dom = render(<BreadcrumbsItemGoBack />);
+    const listElement = dom.container.querySelector('li') as HTMLLIElement;
+    const linkElement = listElement.querySelector('a') as HTMLAnchorElement;
+
+    it('should render BreadcrumbsItem with go back title', () => {
+      expect(linkElement).toHaveTextContent('test_title');
+    });
+
+    it('should have primary underlined link', () => {
+      expect(linkElement).toHaveClass('link-primary link-underlined');
+    });
+
+    it('should have icon on start', () => {
+      const firstElement = listElement.firstChild as SVGElement;
+
+      expect(firstElement.tagName).toBe('svg');
+    });
+
+    classNamePrefixProviderTest(BreadcrumbsItemGoBack, 'd-tablet-none');
+  });
+
+  describe('BreadcrumbsItem is current', () => {
+    const BreadcrumbsItemCurrent = () => (
+      <BreadcrumbsItem href="/test" isCurrent>
+        test_title
+      </BreadcrumbsItem>
+    );
+    const dom = render(<BreadcrumbsItemCurrent />);
+    const listElement = dom.container.querySelector('li') as HTMLLIElement;
+    const linkElement = listElement.querySelector('a') as HTMLAnchorElement;
+
+    it('should have secondary color', () => {
+      expect(linkElement).toHaveClass('link-secondary');
+    });
+
+    it('should not be underlined', () => {
+      expect(linkElement).not.toHaveClass('text-underlined');
+    });
+
+    it('should have aria-current set to page', () => {
+      expect(linkElement).toHaveAttribute('aria-current', 'page');
+    });
+
+    it('should not have icon on end', () => {
+      const lastElement = listElement.lastChild as SVGElement;
+
+      expect(lastElement.tagName).not.toBe('svg');
+    });
+  });
+});

--- a/packages/web-react/src/components/Breadcrumbs/__tests__/useBreadcrumbsStyleProps.test.ts
+++ b/packages/web-react/src/components/Breadcrumbs/__tests__/useBreadcrumbsStyleProps.test.ts
@@ -6,6 +6,15 @@ describe('useBreadcrumbsStyleProps', () => {
     const props = {};
     const { result } = renderHook(() => useBreadcrumbsStyleProps(props));
 
-    expect(result.current.classProps).toBe('Breadcrumbs');
+    expect(result.current.classProps.root).toBe('Breadcrumbs');
+    expect(result.current.classProps.item).toBe('d-none d-tablet-flex');
+  });
+
+  it('should return style props for go back only', () => {
+    const props = { isGoBackOnly: true };
+    const { result } = renderHook(() => useBreadcrumbsStyleProps(props));
+
+    expect(result.current.classProps.root).toBe('Breadcrumbs');
+    expect(result.current.classProps.item).toBe('d-tablet-none');
   });
 });

--- a/packages/web-react/src/components/Breadcrumbs/demo/BreadcrumbsCustom.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/demo/BreadcrumbsCustom.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { Icon } from '../../Icon';
 import { Link } from '../../Link';
 import { Breadcrumbs } from '../Breadcrumbs';
@@ -24,7 +24,7 @@ const BreadcrumbsCustom = () => {
   ];
 
   return (
-    <Breadcrumbs goBackTitle="Back">
+    <Breadcrumbs>
       {items.map((item, index) => {
         const isLastItem = index === items.length - 1;
 
@@ -35,14 +35,22 @@ const BreadcrumbsCustom = () => {
         };
 
         return (
-          <>
-            {index !== 0 && <Icon name="chevron-right" />}
-            <li key={`BreadcrumbsItem_${item.title}`}>
+          <Fragment key={`BreadcrumbsItem_${item.title}`}>
+            {index === items.length - 2 && (
+              <li className="d-tablet-none">
+                <Icon name="chevron-left" />
+                <Link href={item.url} color="primary" isUnderlined>
+                  Back
+                </Link>
+              </li>
+            )}
+            <li className="d-none d-tablet-flex">
+              {index !== 0 && <Icon name="chevron-right" />}
               <Link href={item.url} {...linkParams}>
                 {item.title}
               </Link>
             </li>
-          </>
+          </Fragment>
         );
       })}
     </Breadcrumbs>

--- a/packages/web-react/src/components/Breadcrumbs/demo/BreadcrumbsDefault.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/demo/BreadcrumbsDefault.tsx
@@ -21,7 +21,7 @@ const BreadcrumbsDefault = () => {
     },
   ];
 
-  return <Breadcrumbs items={items} goBackTitle="Custom back link translation" />;
+  return <Breadcrumbs items={items} goBackTitle="Back" />;
 };
 
 export default BreadcrumbsDefault;

--- a/packages/web-react/src/components/Breadcrumbs/index.ts
+++ b/packages/web-react/src/components/Breadcrumbs/index.ts
@@ -1,3 +1,5 @@
 export * from './Breadcrumbs';
-export * from './useBreadcrumbsStyleProps';
 export { default as Breadcrumbs } from './Breadcrumbs';
+export * from './BreadcrumbsItem';
+export { default as BreadcrumbsItem } from './BreadcrumbsItem';
+export * from './useBreadcrumbsStyleProps';

--- a/packages/web-react/src/components/Breadcrumbs/stories/BreadcrumbsItem.stories.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/stories/BreadcrumbsItem.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { Breadcrumbs, BreadcrumbsItem } from '..';
+
+const meta: Meta<typeof BreadcrumbsItem> = {
+  title: 'Components/Breadcrumbs',
+  component: BreadcrumbsItem,
+  argTypes: {
+    iconNameEnd: {
+      control: 'text',
+      table: {
+        defaultValue: { summary: 'chevron-right' },
+      },
+    },
+    iconNameStart: {
+      control: 'text',
+      table: {
+        defaultValue: { summary: 'chevron-left' },
+      },
+    },
+    isCurrent: {
+      control: 'boolean',
+      table: {
+        defaultValue: { summary: true },
+      },
+    },
+    isGoBackOnly: {
+      control: 'boolean',
+      table: {
+        defaultValue: { summary: false },
+      },
+    },
+  },
+  args: {
+    href: '#currentUrl',
+    isCurrent: true,
+    children: 'Current page',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BreadcrumbsItem>;
+
+export const BreadcrumbsItemPlayground: Story = {
+  name: 'BreadcrumbsItem',
+  render: (args) => (
+    <Breadcrumbs>
+      <BreadcrumbsItem href="#rootUrl">Root</BreadcrumbsItem>
+      <BreadcrumbsItem href="#categoryUrl">Category</BreadcrumbsItem>
+      <BreadcrumbsItem href="#subcategoryUrl">Subcategory</BreadcrumbsItem>
+      <BreadcrumbsItem href="#subcategoryUrl" isGoBackOnly>
+        Back
+      </BreadcrumbsItem>
+      <BreadcrumbsItem {...args} />
+    </Breadcrumbs>
+  ),
+};

--- a/packages/web-react/src/components/Breadcrumbs/useBreadcrumbsStyleProps.ts
+++ b/packages/web-react/src/components/Breadcrumbs/useBreadcrumbsStyleProps.ts
@@ -1,14 +1,15 @@
 import { useClassNamePrefix } from '../../hooks/useClassNamePrefix';
-import { BreadcrumbsProps } from '../../types';
+import { BreadcrumbsStyleProps } from '../../types';
 
 export interface BreadcrumbsStyles {
   /** className props */
   classProps: string;
   /** props to be passed to the element */
-  props: BreadcrumbsProps;
+  props: BreadcrumbsStyleProps;
 }
 
-export function useBreadcrumbsStyleProps(props: BreadcrumbsProps): BreadcrumbsStyles {
+export function useBreadcrumbsStyleProps<P extends BreadcrumbsStyleProps>(props: P): BreadcrumbsStyles {
+  const { isGoBackOnly, ...restProps } = props;
   const breadcrumbsClass = useClassNamePrefix('Breadcrumbs');
 
   return {

--- a/packages/web-react/src/components/Breadcrumbs/useBreadcrumbsStyleProps.ts
+++ b/packages/web-react/src/components/Breadcrumbs/useBreadcrumbsStyleProps.ts
@@ -1,9 +1,13 @@
+import classNames from 'classnames';
 import { useClassNamePrefix } from '../../hooks/useClassNamePrefix';
 import { BreadcrumbsStyleProps } from '../../types';
 
 export interface BreadcrumbsStyles {
   /** className props */
-  classProps: string;
+  classProps: {
+    root: string;
+    item: string;
+  };
   /** props to be passed to the element */
   props: BreadcrumbsStyleProps;
 }
@@ -11,9 +15,19 @@ export interface BreadcrumbsStyles {
 export function useBreadcrumbsStyleProps<P extends BreadcrumbsStyleProps>(props: P): BreadcrumbsStyles {
   const { isGoBackOnly, ...restProps } = props;
   const breadcrumbsClass = useClassNamePrefix('Breadcrumbs');
+  const displayNoneClassName = useClassNamePrefix('d-none');
+  const displayTabletFlexClassName = useClassNamePrefix('d-tablet-flex');
+  const displayTabletNoneClassName = useClassNamePrefix('d-tablet-none');
 
   return {
-    classProps: breadcrumbsClass,
-    props,
+    classProps: {
+      root: breadcrumbsClass,
+      item: classNames({
+        [displayNoneClassName]: !isGoBackOnly,
+        [displayTabletFlexClassName]: !isGoBackOnly,
+        [displayTabletNoneClassName]: isGoBackOnly,
+      }),
+    },
+    props: restProps,
   };
 }

--- a/packages/web-react/src/types/breadcrumbs.ts
+++ b/packages/web-react/src/types/breadcrumbs.ts
@@ -1,10 +1,20 @@
 import { ElementType, JSXElementConstructor } from 'react';
 import { ChildrenProps, StyleProps, TransferProps } from './shared';
 
-export type BreadcrumbsItem = {
+type BreadcrumbsItem = {
   title: string;
   url: string;
 };
+
+export type BreadcrumbsItems = BreadcrumbsItem[];
+
+export interface SpiritBreadcrumbsItemProps extends ChildrenProps {
+  href: string;
+  iconNameEnd?: string;
+  iconNameStart?: string;
+  isCurrent?: boolean;
+  isGoBackOnly?: boolean;
+}
 
 export interface AriaBreadcrumbsElementTypeProps<T extends ElementType = 'nav'> {
   /**
@@ -15,12 +25,14 @@ export interface AriaBreadcrumbsElementTypeProps<T extends ElementType = 'nav'> 
   elementType?: T | JSXElementConstructor<unknown>;
 }
 
-export interface BreadcrumbsProps extends StyleProps, TransferProps {}
+export interface BreadcrumbsStyleProps extends StyleProps, TransferProps {
+  isGoBackOnly?: boolean;
+}
 
 export interface SpiritBreadcrumbsProps<T extends ElementType = 'nav'>
   extends AriaBreadcrumbsElementTypeProps<T>,
     StyleProps,
     ChildrenProps {
-  goBackTitle: string;
-  items?: BreadcrumbsItem[];
+  goBackTitle?: string;
+  items?: BreadcrumbsItems;
 }

--- a/packages/web-twig/src/Resources/components/Breadcrumbs/Breadcrumbs.twig
+++ b/packages/web-twig/src/Resources/components/Breadcrumbs/Breadcrumbs.twig
@@ -6,9 +6,6 @@
 
 {# Class names #}
 {%- set _rootClassName = _spiritClassPrefix ~ 'Breadcrumbs' -%}
-{%- set _displayNoneClassName = _spiritClassPrefix ~ 'd-none' -%}
-{%- set _displayTabletNoneClassName = _spiritClassPrefix ~ 'd-tablet-none' -%}
-{%- set _displayTabletFlexClassName = _spiritClassPrefix ~ 'd-tablet-flex' -%}
 
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
@@ -25,24 +22,9 @@
         <ol>
             {% for item in _items %}
                 {% if loop.index is same as(_items|length - 1) and _goBackTitle is not same as('') %}
-                    <li class="{{ _displayTabletNoneClassName }}">
-                        <Icon name="chevron-left" />
-                        <Link href="{{ item.url }}" color="primary" isUnderlined>{{ _goBackTitle }}</Link>
-                    </li>
+                    <BreadcrumbsItem href={ item.url } isGoBackOnly>{{ _goBackTitle }}</BreadcrumbsItem>
                 {% endif %}
-                <li {{ classProp([_displayNoneClassName, _displayTabletFlexClassName]) }}>
-                    {% if loop.index0 is not same as(0) %}
-                        <Icon name="chevron-right" />
-                    {% endif %}
-                    <Link
-                        href="{{ item.url }}"
-                        color="{{ loop.last ? 'secondary' : 'primary' }}"
-                        isUnderlined="{{ loop.last is not same as(true) }}"
-                        aria-current="{{ loop.last ? 'page' : 'false' }}"
-                    >
-                        {{ item.title }}
-                    </Link>
-                </li>
+                <BreadcrumbsItem isCurrent={ loop.last } href={ item.url }>{{ item.title }}</BreadcrumbsItem>
             {% endfor %}
         </ol>
     {%- else -%}

--- a/packages/web-twig/src/Resources/components/Breadcrumbs/BreadcrumbsItem.twig
+++ b/packages/web-twig/src/Resources/components/Breadcrumbs/BreadcrumbsItem.twig
@@ -1,0 +1,38 @@
+{# API #}
+{%- set props = props | default([]) -%}
+{%- set _children = block('content') -%}
+{%- set _href = props.href -%}
+{%- set _iconNameEnd = props.iconNameEnd | default('chevron-right') -%}
+{%- set _iconNameStart = props.iconNameStart | default('chevron-left') -%}
+{%- set _isCurrent = props.isCurrent | default(false) -%}
+{%- set _isGoBackOnly = props.isGoBackOnly | default(false) -%}
+
+{# Class names #}
+{%- set _displayNoneClassName = _spiritClassPrefix ~ 'd-none' -%}
+{%- set _displayTabletNoneClassName = _spiritClassPrefix ~ 'd-tablet-none' -%}
+{%- set _displayTabletFlexClassName = _spiritClassPrefix ~ 'd-tablet-flex' -%}
+
+{# Miscellaneous #}
+{%- set _styleProps = useStyleProps(props) -%}
+{% if _isGoBackOnly is not same as(true) %}
+    {%- set _classNames = [ _styleProps.className, _displayNoneClassName, _displayTabletFlexClassName ] -%}
+{% else %}
+    {%- set _classNames = [ _styleProps.className, _displayTabletNoneClassName ] -%}
+{% endif %}
+
+<li {{ mainProps(props) }} {{ styleProp(_styleProps) }} {{ classProp(_classNames) }}>
+    {% if _isGoBackOnly and _iconNameStart %}
+        <Icon name={ _iconNameStart } />
+    {% endif %}
+    <Link
+        href={ _href }
+        color="{{ _isCurrent ? 'secondary' : 'primary' }}"
+        isUnderlined="{{ _isCurrent is not same as(true) }}"
+        aria-current="{{ _isCurrent ? 'page' : 'false' }}"
+    >
+        {{ _children }}
+    </Link>
+    {% if _isCurrent is not same as(true) and _isGoBackOnly is not same as(true) and _iconNameEnd %}
+        <Icon name={ _iconNameEnd } />
+    {% endif %}
+</li>

--- a/packages/web-twig/src/Resources/components/Breadcrumbs/README.md
+++ b/packages/web-twig/src/Resources/components/Breadcrumbs/README.md
@@ -1,6 +1,6 @@
 # Breadcrumbs
 
-This is Twig implementation of the [Breadcrumbs] component.
+This is the Twig implementation of the [Breadcrumbs] component.
 
 Basic example usage:
 
@@ -25,8 +25,8 @@ Basic example usage:
 ] %}
 ```
 
-```html
-<Breadcrumbs items="{{ items }}" />
+```twig
+<Breadcrumbs items={ items } />
 ```
 
 Without lexer:
@@ -88,18 +88,48 @@ Without lexer:
 {% endembed %}
 ```
 
-## API
+## Breadcrumbs
 
 The Breadcrumbs component works with breadcrumb items passed from parent and renders the content by itself or its
 content can be overridden by any custom block content.
 
-## Breadcrumbs
+### API
 
 | Name          | Type     | Default | Required | Description                                                                                                                                                                                                                                                                       |
 | ------------- | -------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `elementType` | `string` | `nav`   | ✕        | HTML tag to render                                                                                                                                                                                                                                                                |
 | `goBackTitle` | `string` | —       | ✕        | Title/translation for back link to previous page on mobile. It's essential to be set along with items. If items property is not passed, backlink is to be created within children property. [**Optional DEPRECATED**][Deprecated] Will be **required** in the next major version. |
 | `items`       | `array`  | `[]`    | ✕        | Navigation menu items                                                                                                                                                                                                                                                             |
+
+You can add `id`, `data-*` or `aria-*` attributes to further extend the component's
+descriptiveness and accessibility. Also, UNSAFE styling props are available,
+see the [Escape hatches][escape-hatches] section in README to learn how and when to use them.
+
+## BreadcrumbsItem
+
+Use the `BreadcrumbsItem` component for the ordered list as the component's children instead of passing the breadcrumb items array via props:
+
+```twig
+<Breadcrumbs>
+  {% for item in items %}
+    <BreadcrumbsItem isCurrent={ loop.last } href={ item.url }>
+        {{ item.title }}
+    </BreadcrumbsItem>
+  {% endfor %}
+</Breadcrumbs>
+```
+
+### API
+
+| Name               | Type            | Default         | Required | Description                                 |
+| ------------------ | --------------- | --------------- | -------- | ------------------------------------------- |
+| `href`             | `string`        | —               | ✔        | URL                                         |
+| `iconNameEnd`      | `string`        | `chevron-right` | ✕        | Icon name at the end of the item            |
+| `iconNameStart`    | `string`        | `chevron-left`  | ✕        | Icon name at the start of the item          |
+| `isCurrent`        | `boolean`       | `false`         | ✕        | Whether is the item the current page        |
+| `isGoBackOnly`     | `boolean`       | `false`         | ✕        | Whether should be displayed in go back mode |
+| `UNSAFE_className` | `string`        | —               | ✕        | Wrapper custom class name                   |
+| `UNSAFE_style`     | `CSSProperties` | —               | ✕        | Wrapper custom style                        |
 
 You can add `id`, `data-*` or `aria-*` attributes to further extend the component's
 descriptiveness and accessibility. Also, UNSAFE styling props are available,

--- a/packages/web-twig/src/Resources/components/Breadcrumbs/__tests__/__fixtures__/breadcrumbsDefault.twig
+++ b/packages/web-twig/src/Resources/components/Breadcrumbs/__tests__/__fixtures__/breadcrumbsDefault.twig
@@ -17,4 +17,4 @@
     },
 ] %}
 
-<Breadcrumbs items="{{ items }}" goBackTitle="Back" />
+<Breadcrumbs items={ items } goBackTitle="Back" />

--- a/packages/web-twig/src/Resources/components/Breadcrumbs/__tests__/__snapshots__/breadcrumbsDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Breadcrumbs/__tests__/__snapshots__/breadcrumbsDefault.twig.snap.html
@@ -8,31 +8,32 @@
     <nav class="Breadcrumbs" aria-label="Breadcrumb">
       <ol>
         <li class="d-none d-tablet-flex">
-          <a aria-current="false" href="#rootUrl" class="link-primary link-underlined">Root</a>
+          <a aria-current="false" href="#rootUrl" class="link-primary link-underlined">Root</a> <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" id="fa2b65b7e049d1eae33532715c70980f" aria-hidden="true">
+          <path d="M9.29006 7.05475C8.90006 7.44475 8.90006 8.07475 9.29006 8.46475L13.1701 12.3447L9.29006 16.2247C8.90006 16.6147 8.90006 17.2447 9.29006 17.6347C9.68006 18.0247 10.3101 18.0247 10.7001 17.6347L15.2901 13.0447C15.6801 12.6547 15.6801 12.0247 15.2901 11.6347L10.7001 7.04475C10.3201 6.66475 9.68006 6.66475 9.29006 7.05475Z" fill="currentColor">
+          </path></svg>
         </li>
 
         <li class="d-none d-tablet-flex">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" id="fa2b65b7e049d1eae33532715c70980f" aria-hidden="true">
-          <path d="M9.29006 7.05475C8.90006 7.44475 8.90006 8.07475 9.29006 8.46475L13.1701 12.3447L9.29006 16.2247C8.90006 16.6147 8.90006 17.2447 9.29006 17.6347C9.68006 18.0247 10.3101 18.0247 10.7001 17.6347L15.2901 13.0447C15.6801 12.6547 15.6801 12.0247 15.2901 11.6347L10.7001 7.04475C10.3201 6.66475 9.68006 6.66475 9.29006 7.05475Z" fill="currentColor">
-          </path></svg> <a aria-current="false" href="#categoryUrl" class="link-primary link-underlined">Category</a>
+          <a aria-current="false" href="#categoryUrl" class="link-primary link-underlined">Category</a> <svg width="24" height="24" fill="none" viewbox="0 0 24 24" aria-hidden="true">
+          <use href="#fa2b65b7e049d1eae33532715c70980f">
+          </use></svg>
         </li>
 
         <li class="d-tablet-none">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" id="421fdea4d7e5f5b250c10b634f7b9366" aria-hidden="true">
           <path d="M14.71 7.05471C14.32 6.66471 13.69 6.66471 13.3 7.05471L8.70998 11.6447C8.31998 12.0347 8.31998 12.6647 8.70998 13.0547L13.3 17.6447C13.69 18.0347 14.32 18.0347 14.71 17.6447C15.1 17.2547 15.1 16.6247 14.71 16.2347L10.83 12.3447L14.71 8.46471C15.1 8.07471 15.09 7.43471 14.71 7.05471Z" fill="currentColor">
-          </path></svg><a href="#subcategoryUrl" class="link-primary link-underlined">Back</a>
+          </path></svg> <a aria-current="false" href="#subcategoryUrl" class="link-primary link-underlined">Back</a>
         </li>
 
         <li class="d-none d-tablet-flex">
+          <a aria-current="false" href="#subcategoryUrl" class="link-primary link-underlined">Subcategory</a>
           <svg width="24" height="24" fill="none" viewbox="0 0 24 24" aria-hidden="true">
           <use href="#fa2b65b7e049d1eae33532715c70980f">
-          </use></svg> <a aria-current="false" href="#subcategoryUrl" class="link-primary link-underlined">Subcategory</a>
+          </use></svg>
         </li>
 
         <li class="d-none d-tablet-flex">
-          <svg width="24" height="24" fill="none" viewbox="0 0 24 24" aria-hidden="true">
-          <use href="#fa2b65b7e049d1eae33532715c70980f">
-          </use></svg> <a aria-current="page" href="#currentUrl" class="link-secondary">Current page</a>
+          <a aria-current="page" href="#currentUrl" class="link-secondary">Current page</a>
         </li>
       </ol>
     </nav>

--- a/packages/web-twig/src/Resources/components/Breadcrumbs/stories/BreadcrumbsCustom.twig
+++ b/packages/web-twig/src/Resources/components/Breadcrumbs/stories/BreadcrumbsCustom.twig
@@ -8,8 +8,8 @@
             <Link href="#categoryUrl" color="primary" isUnderlined>Category</Link>
         </li>
         <li class="d-tablet-none">
-            <Icon name="chevron-right" />
-            <Link href="#subcategoryUrl" color="primary" isUnderlined>Custom go back link</Link>
+            <Icon name="chevron-left" />
+            <Link href="#subcategoryUrl" color="primary" isUnderlined>Back</Link>
         </li>
         <li class="d-none d-tablet-flex">
             <Icon name="chevron-right" />

--- a/packages/web-twig/src/Resources/components/Breadcrumbs/stories/BreadcrumbsDefault.twig
+++ b/packages/web-twig/src/Resources/components/Breadcrumbs/stories/BreadcrumbsDefault.twig
@@ -1,20 +1,20 @@
 {% set items = [
-  {
-    title: 'Root',
-    url: '#rootUrl',
-  },
-  {
-    title: 'Category',
-    url: '#categoryUrl',
-  },
-  {
-    title: 'Subcategory',
-    url: '#subcategoryUrl',
-  },
-  {
-    title: 'Current page',
-    url: '#currentUrl',
-  },
+    {
+        title: 'Root',
+        url: '#rootUrl',
+    },
+    {
+        title: 'Category',
+        url: '#categoryUrl',
+    },
+    {
+        title: 'Subcategory',
+        url: '#subcategoryUrl',
+    },
+    {
+        title: 'Current page',
+        url: '#currentUrl',
+    },
 ] %}
 
-<Breadcrumbs items={{ items }} />
+<Breadcrumbs goBackTitle="Back" items={{ items }} />

--- a/packages/web-twig/src/Resources/twig-components/breadcrumbsItem.twig
+++ b/packages/web-twig/src/Resources/twig-components/breadcrumbsItem.twig
@@ -1,0 +1,1 @@
+{% extends '@spirit/Breadcrumbs/BreadcrumbsItem.twig' %}

--- a/packages/web/src/scss/components/Breadcrumbs/index.html
+++ b/packages/web/src/scss/components/Breadcrumbs/index.html
@@ -6,12 +6,15 @@
     <ol>
       <li class="d-none d-tablet-flex">
         <a href="#rootUrl" class="link-primary link-underlined">Root</a>
-      </li>
-      <li class="d-none d-tablet-flex">
         <svg class="Icon" width="24" height="24">
           <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
         </svg>
+      </li>
+      <li class="d-none d-tablet-flex">
         <a href="#categoryUrl" class="link-primary link-underlined">Category</a>
+        <svg class="Icon" width="24" height="24">
+          <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
+        </svg>
       </li>
       <li class="d-tablet-none">
         <svg class="Icon" width="24" height="24">
@@ -20,23 +23,20 @@
         <a href="#subcategoryUrl" class="link-primary link-underlined">Back</a>
       </li>
       <li class="d-none d-tablet-flex">
+        <a href="#subcategoryUrl" class="link-primary link-underlined">Subcategory</a>
         <svg class="Icon" width="24" height="24">
           <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
         </svg>
-        <a href="#subcategoryUrl" class="link-primary link-underlined">Subcategory</a>
       </li>
       <li class="d-none d-tablet-flex">
-        <svg class="Icon" width="24" height="24">
-          <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
-        </svg>
         <a href="#currentUrl" aria-current="page" class="link-secondary">Current page</a>
       </li>
     </ol>
   </nav>
 </section>
 
-<!-- 
-  This code is a copy of the 'Default' section. 
+<!--
+  This code is a copy of the 'Default' section.
   We need a visually identical demo to the Twig & React, where we have both the 'Default' and 'Custom' implementations.
 -->
 <section class="docs-Section">
@@ -45,12 +45,15 @@
     <ol>
       <li class="d-none d-tablet-flex">
         <a href="#rootUrl" class="link-primary link-underlined">Root</a>
-      </li>
-      <li class="d-none d-tablet-flex">
         <svg class="Icon" width="24" height="24">
           <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
         </svg>
+      </li>
+      <li class="d-none d-tablet-flex">
         <a href="#categoryUrl" class="link-primary link-underlined">Category</a>
+        <svg class="Icon" width="24" height="24">
+          <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
+        </svg>
       </li>
       <li class="d-tablet-none">
         <svg class="Icon" width="24" height="24">
@@ -59,15 +62,12 @@
         <a href="#subcategoryUrl" class="link-primary link-underlined">Back</a>
       </li>
       <li class="d-none d-tablet-flex">
+        <a href="#subcategoryUrl" class="link-primary link-underlined">Subcategory</a>
         <svg class="Icon" width="24" height="24">
           <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
         </svg>
-        <a href="#subcategoryUrl" class="link-primary link-underlined">Subcategory</a>
       </li>
       <li class="d-none d-tablet-flex">
-        <svg class="Icon" width="24" height="24">
-          <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
-        </svg>
         <a href="#currentUrl" aria-current="page" class="link-secondary">Current page</a>
       </li>
     </ol>


### PR DESCRIPTION
  * and refactor Breadcrumbs to use it

refs #DS-835

<!-- Thank you for contributing! -->

## Description

Refactoring of Breadcrumbs to simplify the usage of the component by adding the new `BreadcrumbsItem` subcomponent to render items more easily.

### Additional context

There was a concept of the two slots for icons - `iconStart` and `iconEnd`. Now we agreed that props for icon names would be just enough - `iconNameStart` and `iconNameEnd`.

Also, the arrows were switched from the original implementation. Now the default arrow is on the end for better manipulation in coditions.

### Issue reference

https://jira.lmc.cz/browse/DS-835

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
