### PR TITLE
Fix(web-twig): Do not render `id` twice in the `HeaderDialog`

### DIFF
--- a/packages/web-twig/src/Resources/components/Header/HeaderDialog.twig
+++ b/packages/web-twig/src/Resources/components/Header/HeaderDialog.twig
@@ -10,9 +10,10 @@
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
 {%- set _classNames = [ _rootClassName, _styleProps.className ] -%}
+{%- set _mainPropsWithoutId = props | filter((value, prop) => prop is not same as('id')) -%}
 
 <dialog
-    {{ mainProps(props) }}
+    {{ mainProps(_mainPropsWithoutId) }}
     {{ styleProp(_styleProps) }}
     {{ classProp(_classNames) }}
     id="{{ _id }}"


### PR DESCRIPTION
## Description

![image](https://github.com/lmc-eu/spirit-design-system/assets/33354913/e60fb687-9dfb-44ec-b69b-e0980bd5dbaa)
