### PR TITLE
Chore(web-twig): Ignore tests and stories from exported package

### DIFF
--- a/packages/web-twig/.gitattributes
+++ b/packages/web-twig/.gitattributes
@@ -16,11 +16,11 @@
 /phpunit.xml.dist   export-ignore
 
 # Exclude story files from archive
-*.stories.twig
-**/stories/*
+*.stories.twig      export-ignore
+**/stories          export-ignore
 
 # Exclude test files from archive
-**/__tests__/*
+**/__tests__        export-ignore
 
 # Configure diff output for .php and .phar files.
 *.php diff=php


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Fixing configuration of the web-twig-bundle package which includes tests and stories and this should not happen.

### Additional context

Thanks @janicekt for this notice.

You can reproduce the package archive by running `git archive --format=tar.gz -o web-twig-test.tar.gz HEAD` in `packages/web-twig`.

### Issue reference

https://jira.lmc.cz/browse/DS-969

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
