### PR TITLE
Chore(ci): Skip Nx cache on Netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,11 +12,19 @@
   publish = ".storybook/build"
 
   # Default build command.
-  command = "yarn lerna run --scope @lmc-eu/spirit-icons build --skip-nx-cache && yarn storybook:build"
+  command = """\
+    yarn lerna run --scope @lmc-eu/spirit-icons build --skip-nx-cache \
+    && yarn storybook:build \
+    """
 
   # Ignore builds on Netlify
   ignore = "node ./scripts/ignoreNetlifyBuilds.js"
 
 [context.deploy-preview]
   # Deploy preview only if there are changes in some directories
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./packages/web-react/src/ .storybook/ ./packages/web-react/docs/stories/"
+  ignore = """\
+    git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF \
+    ./packages/web-react/src/ \
+    .storybook/ \
+    ./packages/web-react/docs/stories/ \
+    """

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@
   publish = ".storybook/build"
 
   # Default build command.
-  command = "yarn lerna run --scope @lmc-eu/spirit-icons build && yarn storybook:build"
+  command = "yarn lerna run --scope @lmc-eu/spirit-icons build --skip-nx-cache && yarn storybook:build"
 
   # Ignore builds on Netlify
   ignore = "node ./scripts/ignoreNetlifyBuilds.js"

--- a/packages/web-react/netlify.toml
+++ b/packages/web-react/netlify.toml
@@ -16,7 +16,7 @@
   publish = "build"
 
   # Default build command.
-  command = "cd ../../ && yarn lerna run --scope @lmc-eu/spirit-icons build && yarn lerna run --scope @lmc-eu/spirit-web-react examples:build"
+  command = "cd ../../ && yarn lerna run --scope @lmc-eu/spirit-icons build --skip-nx-cache && yarn lerna run --scope @lmc-eu/spirit-web-react examples:build --skip-nx-cache"
 
   # Ignore builds on Netlify
   ignore = "node ../../scripts/ignoreNetlifyBuilds.js"

--- a/packages/web-react/netlify.toml
+++ b/packages/web-react/netlify.toml
@@ -16,7 +16,11 @@
   publish = "build"
 
   # Default build command.
-  command = "cd ../../ && yarn lerna run --scope @lmc-eu/spirit-icons build --skip-nx-cache && yarn lerna run --scope @lmc-eu/spirit-web-react examples:build --skip-nx-cache"
+  command = """\
+    cd ../../ \
+    && yarn lerna run --scope @lmc-eu/spirit-icons build --skip-nx-cache \
+    && yarn lerna run --scope @lmc-eu/spirit-web-react examples:build --skip-nx-cache \
+    """
 
   # Ignore builds on Netlify
   ignore = "node ../../scripts/ignoreNetlifyBuilds.js"


### PR DESCRIPTION
## Description

  * caused build fails by rejecting the local cache during Netlify builds
  * @see: https://answers.netlify.com/t/ support-guide-nx-monorepo-site-does-not-reflect-changes-after-build/73657
  * @see: https://nx.dev/recipes/troubleshooting/unknown-local-cache

### Additional context

@pavelklibani This is the root of the problem of why your Netlify builds failed. IMHO

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
