### PR TITLE
Fix(web-react): Recalculate FileUploader image preview by crop values

### DIFF
--- a/apps/web-twig-demo/assets/scripts/file-uploader-meta-data.ts
+++ b/apps/web-twig-demo/assets/scripts/file-uploader-meta-data.ts
@@ -69,8 +69,8 @@ window.addEventListener('DOMContentLoaded', () => {
   const customEdit = (event) => {
     const key = event.target.closest('li').id;
     const newMeta = toggleMetaData
-      ? { x: 30, y: 30, width: 150, height: 150 }
-      : { x: 22, y: 0, width: 110, height: 100 };
+      ? { x: 30, y: 30, cropWidth: 150, cropHeight: 150, originalWidth: 560, originalHeight: 330 }
+      : { x: 22, y: 0, cropWidth: 110, cropHeight: 100, originalWidth: 560, originalHeight: 330 };
     toggleMetaData = !toggleMetaData;
     const file = FileUploaderInstance.getFileFromQueue(key).file;
     FileUploaderInstance.updateQueue(key, file, newMeta, updateQueueCallback);

--- a/packages/web-react/src/components/FileUploader/FileUploaderAttachment.tsx
+++ b/packages/web-react/src/components/FileUploader/FileUploaderAttachment.tsx
@@ -6,7 +6,12 @@ import { Icon } from '../Icon';
 import AttachmentActionButton from './AttachmentActionButton';
 import AttachmentDismissButton from './AttachmentDismissButton';
 import AttachmentImagePreview from './AttachmentImagePreview';
-import { DEFAULT_BUTTON_LABEL, DEFAULT_EDIT_BUTTON_LABEL, DEFAULT_ICON_NAME } from './constants';
+import {
+  DEFAULT_BUTTON_LABEL,
+  DEFAULT_EDIT_BUTTON_LABEL,
+  DEFAULT_ICON_NAME,
+  IMAGE_PREVIEW_BASE64_MAX_WIDTH,
+} from './constants';
 import { useFileUploaderAttachment } from './useFileUploaderAttachment';
 import { useFileUploaderStyleProps } from './useFileUploaderStyleProps';
 import { image2Base64Preview } from './utils';
@@ -50,7 +55,9 @@ const FileUploaderAttachment = (props: SpiritFileUploaderAttachmentProps) => {
   const onEditHandler = (event: MouseEvent) => onEdit && onEdit(event, file);
 
   if (isFileImage) {
-    image2Base64Preview(file, 100, (compressedDataURL) => setImagePreview(compressedDataURL));
+    image2Base64Preview(file, IMAGE_PREVIEW_BASE64_MAX_WIDTH, (compressedDataURL) =>
+      setImagePreview(compressedDataURL),
+    );
   }
 
   useFileUploaderAttachment({ attachmentRef, file, name, meta, onError });

--- a/packages/web-react/src/components/FileUploader/README.md
+++ b/packages/web-react/src/components/FileUploader/README.md
@@ -329,13 +329,13 @@ const customUpdate = (_event: MouseEvent, file: File) => {
 #### Updating Image Preview with cropped image
 
 When you are using FileUploader with some kind of image cropper you want to also update the image preview on FileUploaderAttachment when image changes.
-You can do this by passing a specific object in shape of coordinates (`{ x: number, y: number, width: number, height: number }`) to the `meta` argument.
+You can do this by passing a specific object in shape of coordinates (`{ x: number, y: number, cropWidth: number, cropHeight: number, originalWidth: number, originalHeight: number }`) to the `meta` argument.
 Then the coordinates will be applied to the preview image in the attachment.
 
 ```javascript
 // …
 const customUpdate = (_event: MouseEvent, file: File) => {
-  const meta = { x: 30, y: 30, width: 150, height: 150 };
+  const meta = { x: 30, y: 30, cropWidth: 150, cropHeight: 150, originalWidth: 560, originalHeight: 330 };
 
   return updateQueue(file.name, file, meta);
 };

--- a/packages/web-react/src/components/FileUploader/__tests__/useFileUploaderStyleProps.test.ts
+++ b/packages/web-react/src/components/FileUploader/__tests__/useFileUploaderStyleProps.test.ts
@@ -56,16 +56,16 @@ describe('useFileUploaderStyleProps', () => {
   it('should have CSS for crop image', () => {
     const { result } = renderHook(() =>
       useFileUploaderStyleProps({
-        meta: { x: 1, y: 2, width: 3, height: 4 },
+        meta: { x: 0, y: 0, cropWidth: 100, cropHeight: 100, originalWidth: 350, originalHeight: 200 },
       }),
     );
 
     expect(result.current.classProps.imageCropStyles).toBeDefined();
     expect(result.current.classProps.imageCropStyles).toStrictEqual({
-      '--file-uploader-attachment-image-height': '4px',
-      '--file-uploader-attachment-image-left': '-1px',
-      '--file-uploader-attachment-image-top': '-2px',
-      '--file-uploader-attachment-image-width': '3px',
+      '--file-uploader-attachment-image-height': '108px',
+      '--file-uploader-attachment-image-left': '-0px',
+      '--file-uploader-attachment-image-top': '-0px',
+      '--file-uploader-attachment-image-width': '189px',
     });
   });
 });

--- a/packages/web-react/src/components/FileUploader/constants.ts
+++ b/packages/web-react/src/components/FileUploader/constants.ts
@@ -1,6 +1,7 @@
 export const DEFAULT_FILE_SIZE_LIMIT = 10000000; // = 10 MB
 export const DEFAULT_FILE_QUEUE_LIMIT = 10;
-export const IMAGE_DIMENSION = 54; // px
+export const IMAGE_DIMENSION = 54; // px; @see: CSS class `.FileUploaderAttachment__image` in _FileUploaderAttachment.scss
+export const IMAGE_PREVIEW_BASE64_MAX_WIDTH = 500; // px
 
 export const DEFAULT_ERROR_MESSAGE_MAX_FILE_SIZE = 'The file size limit has been exceeded';
 export const DEFAULT_ERROR_MESSAGE_QUEUE_DUPLICITY = 'This file already exists in the queue';

--- a/packages/web-react/src/components/FileUploader/demo/FileUploaderMetaData.tsx
+++ b/packages/web-react/src/components/FileUploader/demo/FileUploaderMetaData.tsx
@@ -1,8 +1,8 @@
-import React, { useState, MouseEvent } from 'react';
+import React, { MouseEvent, useState } from 'react';
+import { FileUploader, FileUploaderAttachment, FileUploaderInput, FileUploaderList, useFileQueue } from '..';
 import { SpiritFileUploaderAttachmentProps } from '../../../types';
 import { Button } from '../../Button';
-import { Modal, ModalDialog, ModalBody, ModalFooter } from '../../Modal';
-import { FileUploader, FileUploaderAttachment, FileUploaderInput, FileUploaderList, useFileQueue } from '..';
+import { Modal, ModalBody, ModalDialog, ModalFooter } from '../../Modal';
 
 const FileUploaderMetaData = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -34,7 +34,9 @@ const FileUploaderMetaData = () => {
   };
 
   const customUpdate = (_event: MouseEvent, file: File) => {
-    const newMeta = toggleMeta ? { x: 30, y: 30, width: 150, height: 150 } : { x: 22, y: 0, width: 110, height: 100 };
+    const newMeta = toggleMeta
+      ? { x: 30, y: 30, cropWidth: 150, cropHeight: 150, originalWidth: 560, originalHeight: 330 }
+      : { x: 22, y: 0, cropWidth: 110, cropHeight: 100, originalWidth: 560, originalHeight: 330 };
 
     setIsModalOpen(false);
     setToggleMeta(!toggleMeta);

--- a/packages/web/src/js/FileUploader.ts
+++ b/packages/web/src/js/FileUploader.ts
@@ -273,7 +273,7 @@ class FileUploader extends BaseComponent {
     if (hasImagePreview && isFileImg) {
       AttachmentSvgIcon?.remove();
       AttachmentPreviewImage?.querySelector('img')?.setAttribute('alt', file.name);
-      image2Base64Preview(file, 100, (compressedDataURL) =>
+      image2Base64Preview(file, IMAGE_PREVIEW_BASE64_MAX_WIDTH, (compressedDataURL) =>
         AttachmentPreviewImage?.querySelector('img')?.setAttribute('src', compressedDataURL),
       );
     } else {

--- a/packages/web/src/scss/components/FileUploader/README.md
+++ b/packages/web/src/scss/components/FileUploader/README.md
@@ -485,12 +485,12 @@ const customUpdate = (_event: MouseEvent, file: File) => {
 #### Updating Image Preview with cropped image
 
 When you are using FileUploader with some kind of image cropper you want to also update the image preview on FileUploader attachment when image changes.
-You can do this by passing a specific object in shape of coordinates (`{ x: number, y: number, width: number, height: number }`) to the `meta` argument.
+You can do this by passing a specific object in shape of coordinates (`{ x: number, y: number, cropWidth: number, cropHeight: number, originalWidth: number, originalHeight: number }`) to the `meta` argument.
 Then the coordinates will be applied to the preview image in the attachment.
 
 ```javascript
 const customUpdate = (event: MouseEvent, file: File) => {
-  const meta = { x: 30, y: 30, width: 150, height: 150 };
+  const meta = { x: 30, y: 30, cropWidth: 150, cropHeight: 150, originalWidth: 560, originalHeight: 330 };
 
   return FileUploader.updateQueue(file.name, file, meta);
 };

--- a/packages/web/src/scss/components/FileUploader/index.html
+++ b/packages/web/src/scss/components/FileUploader/index.html
@@ -933,7 +933,7 @@
 
         const customEdit = (event) => {
           const key = event.target.closest('li').id
-          const newMeta = toggleMetaData ? { x: 30, y: 30, width: 150, height: 150 } : { x: 22, y: 0, width: 110, height: 100 };
+          const newMeta = toggleMetaData ? { x: 30, y: 30, cropWidth: 150, cropHeight: 150, originalWidth: 560, originalHeight: 330 } : { x: 22, y: 0, cropWidth: 110, cropHeight: 100, originalWidth: 560, originalHeight: 330 };
           toggleMetaData = !toggleMetaData;
           const file = FileUploaderInstance.getFileFromQueue(key).file;
           FileUploaderInstance.updateQueue(key, file, newMeta, updateQueueCallback);
@@ -954,7 +954,7 @@
         }
 
         CancelButton.addEventListener('click', removeFromQueue);
-        
+
         FileUploaderElement.addEventListener('queuedFile.fileUploader', event => {
           file = event.currentFile;
 
@@ -964,7 +964,7 @@
         FileUploaderElement.addEventListener('unqueuedFile.fileUploader', (event) => {
           callbackOnDismiss(event.currentFile);
         });
-        
+
         FileUploaderElement.addEventListener('editFile.fileUploader', (event) => {
           customEdit(event.currentFile);
         });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

* need to use additional dimensions - natural width and height to
        calculate dimensions of previewed image
* also need to better calculate the scale of the entire image and also
        position when we need to display the possible crop

### Additional context

https://almamedia.slack.com/archives/C050YPZ3YRW/p1698830929192449

### Issue reference

https://jira.lmc.cz/browse/DS-1038

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
