### PR TITLE
Docs(web-react): Corrected the example for Dropdown #DS-601

### DIFF
--- a/packages/web-react/src/components/Dropdown/README.md
+++ b/packages/web-react/src/components/Dropdown/README.md
@@ -6,11 +6,11 @@ This is the React implementation of the [Dropdown] component.
 ## Usage
 
 ```jsx
-import { Dropdown } from '@lmc-eu/spirit-web-react/components';
+import { Dropdown, Button } from '@lmc-eu/spirit-web-react/components';
 ```
 
 ```jsx
-<Dropdown id="DropdownExample" renderToggle={({ trigger }) => <button {...trigger}>…</button>}>
+<Dropdown id="DropdownExample" renderTrigger={({ trigger }) => <Button {...trigger}>Trigger</Button>}>
   …
 </Dropdown>
 ```


### PR DESCRIPTION
## Description

- Replaced `renderToggle` with `renderTrigger` as the correct prop

### Additional context

Reported bug was fixed by previous changes and bug reporter confirmed that it is working. 
I just found this typo in README file.

### Issue reference

[web-react: Dropdown nejde zavřít s a elementem jak trigger](https://jira.lmc.cz/browse/DS-601)