### PR TITLE
Feat(web): Enable `<button>` elements to be styled as links

### DIFF
--- a/packages/web/src/scss/components/Button/_Button.scss
+++ b/packages/web/src/scss/components/Button/_Button.scss
@@ -20,7 +20,7 @@
     border-style: theme.$border-style;
     border-radius: theme.$border-radius;
     user-select: none;
-    cursor: cursors.$button-links;
+    cursor: cursors.$buttons;
 
     &:hover,
     &:active,

--- a/packages/web/src/scss/components/FileUploader/_FileUploaderInput.scss
+++ b/packages/web/src/scss/components/FileUploader/_FileUploaderInput.scss
@@ -1,4 +1,4 @@
-// 1. Make whole drop zone clickable.
+// 1. Make whole drop zone clickable. Cursor is hard-coded because links always use pointer.
 // 2. Increase specificity (also in the mixin) by including `.FileUploaderInput__input` to override the `active` state.
 // 3. Increase specificity to make the disabled state override any other
 
@@ -6,6 +6,7 @@
 @use '../../theme/form-fields' as form-fields-theme;
 @use '../../tools/accessibility';
 @use '../../tools/form-fields' as form-fields-tools;
+@use '../../tools/links';
 @use '../../tools/typography';
 @use 'theme';
 
@@ -50,13 +51,10 @@ $_field-name: 'FileUploaderInput';
 
 // 1.
 .FileUploaderInput__link {
-    cursor: pointer;
+    @include links.base();
+    @include links.stretch();
 
-    &::before {
-        content: '';
-        position: absolute;
-        inset: 0;
-    }
+    cursor: pointer;
 }
 
 .FileUploaderInput__dragAndDropLabel {

--- a/packages/web/src/scss/foundation/_links.scss
+++ b/packages/web/src/scss/foundation/_links.scss
@@ -1,24 +1,10 @@
-@use '@tokens' as tokens;
-@use '../settings/links';
+@use '../settings/links' as links-settings;
+@use '../tools/links' as links-tools;
 
 :any-link {
-    text-decoration: none;
+    text-decoration: links-settings.$text-decoration-default;
 }
 
 a {
-    text-decoration-skip-ink: links.$text-decoration-skip-ink;
-    text-underline-offset: links.$text-underline-offset;
-    color: tokens.$action-link-primary-default;
-
-    @media (hover: hover) {
-        &:hover {
-            text-decoration: underline;
-            color: tokens.$action-link-primary-hover;
-        }
-    }
-
-    &:active {
-        text-decoration: underline;
-        color: tokens.$action-link-primary-active;
-    }
+    @include links-tools.base($set-color: true);
 }

--- a/packages/web/src/scss/helpers/links/_links.scss
+++ b/packages/web/src/scss/helpers/links/_links.scss
@@ -1,3 +1,10 @@
+// 1. Reset button styles for individual link variants.
+// 2. Generate link colors for all link states.
+// 3. Links in headings always have the default decoration, even those with `.link-underlined`.
+// 4. Allow link underline everywhere, except for headings in default state.
+// 5. Allow link stretching over the closest element with `position: relative`.
+// 6. Only links in headings have visited state.
+
 @use 'sass:map';
 @use '@tokens' as tokens;
 @use '../../settings/cursors';
@@ -6,6 +13,10 @@
 @use '../../tools/dictionaries';
 @use '../../tools/links' as links-tools;
 
+// 1.
+@include dictionaries.prepare-button-links(dictionaries-settings.$action-link-colors);
+
+// 2.
 @include dictionaries.generate-link-colors(
     '.link',
     dictionaries-settings.$action-link-colors,
@@ -13,37 +24,35 @@
     (default, hover, active, disabled)
 );
 
-.link-disabled {
+// stylelint-disable-next-line selector-no-qualifying-type -- Increase specificity to override button variant styles.
+.link-disabled,
+button.link-disabled {
     cursor: cursors.$disabled;
 }
 
-// All links in headings behave the same
+// 3.
 [class*='typography-heading'] a {
-    text-decoration: none;
+    text-decoration: links-settings.$text-decoration-default;
 }
 
-// Allows link underline everywhere, except for headings default state
+// 4.
 .link-underlined,
 [class*='typography-heading'] a:hover,
 [class*='typography-heading'] a:active {
-    text-decoration: underline;
+    text-decoration: links-settings.$text-decoration-hover;
 }
 
+// 5.
 .link-stretched {
     @include links-tools.stretch();
 }
 
-// Make sure non-anchor elements get the same decoration style as real links
-.link-underlined:not(a) {
-    text-decoration-skip-ink: links-settings.$text-decoration-skip-ink;
-    text-underline-offset: links-settings.$text-underline-offset;
-}
-
-// Only links in headings have visited state
+// 6.
 [class*='typography-heading'] :visited {
     color: map.get(tokens.$action-colors, link-primary-visited);
 }
 
+// 6.
 @include dictionaries.generate-link-colors(
     '[class*="typography-heading"] .link',
     dictionaries-settings.$text-colors,

--- a/packages/web/src/scss/helpers/links/_links.scss
+++ b/packages/web/src/scss/helpers/links/_links.scss
@@ -2,8 +2,9 @@
 // 2. Generate link colors for all link states.
 // 3. Links in headings always have the default decoration, even those with `.link-underlined`.
 // 4. Allow link underline everywhere, except for headings in default state.
-// 5. Allow link stretching over the closest element with `position: relative`.
-// 6. Only links in headings have visited state.
+// 5. Disable pointer and text decoration changes for "disabled" links (intended for link-like `<button>` elements).
+// 6. Allow link stretching over the closest element with `position: relative`.
+// 7. Only links in headings can have visited state (that's our design decision).
 
 @use 'sass:map';
 @use '@tokens' as tokens;
@@ -24,12 +25,6 @@
     (default, hover, active, disabled)
 );
 
-// stylelint-disable-next-line selector-no-qualifying-type -- Increase specificity to override button variant styles.
-.link-disabled,
-button.link-disabled {
-    cursor: cursors.$disabled;
-}
-
 // 3.
 [class*='typography-heading'] a {
     text-decoration: links-settings.$text-decoration-default;
@@ -43,16 +38,30 @@ button.link-disabled {
 }
 
 // 5.
+// stylelint-disable selector-no-qualifying-type -- Increase specificity to override button variant styles.
+.link-disabled,
+button.link-disabled {
+    cursor: cursors.$disabled;
+}
+
+// 5.
+.link-disabled:not(.link-underlined),
+button.link-disabled:not(.link-underlined) {
+    text-decoration: links-settings.$text-decoration-default;
+}
+// stylelint-enable selector-no-qualifying-type
+
+// 6.
 .link-stretched {
     @include links-tools.stretch();
 }
 
-// 6.
+// 7.
 [class*='typography-heading'] :visited {
     color: map.get(tokens.$action-colors, link-primary-visited);
 }
 
-// 6.
+// 7.
 @include dictionaries.generate-link-colors(
     '[class*="typography-heading"] .link',
     dictionaries-settings.$text-colors,

--- a/packages/web/src/scss/helpers/links/index.html
+++ b/packages/web/src/scss/helpers/links/index.html
@@ -1,11 +1,10 @@
 {{#> layout/plain }}
 
 <section class="docs-Section">
-  
+
   <h2 class="docs-Heading">Default</h2>
 
   <div class="docs-Stack docs-Stack--start">
-
     <p>
       <a href="#" class="link-primary">Primary Link</a>
     </p>
@@ -15,13 +14,15 @@
     <p class="docs-Box">
       <a href="#" class="link-inverted">Inverted Link</a>
     </p>
-  
+    <p>
+      <button type="button" class="link-primary">Link as button</button>
+    </p>
   </div>
 
 </section>
 
 <section class="docs-Section">
-  
+
   <h2 class="docs-Heading">Disabled</h2>
 
   <div class="docs-Stack docs-Stack--start">
@@ -34,16 +35,18 @@
     <p class="docs-Box">
       <a href="#" class="link-inverted link-disabled">Inverted Disabled Link</a>
     </p>
+    <p>
+      <button type="button" class="link-primary link-disabled" disabled>Link as button</button>
+    </p>
   </div>
 
 </section>
 
 <section class="docs-Section">
-  
+
   <h2 class="docs-Heading">Underlined</h2>
 
   <div class="docs-Stack docs-Stack--start">
-
     <p>
       <a href="#" class="link-primary link-underlined">Primary Underlined Link</a>
     </p>
@@ -53,13 +56,15 @@
     <p class="docs-Box">
       <a href="#" class="link-inverted link-underlined">Inverted Underlined Link</a>
     </p>
-
+    <p>
+      <button type="button" class="link-primary link-underlined">Link as button</button>
+    </p>
   </div>
 
 </section>
 
 <section class="docs-Section">
-  
+
   <h2 class="docs-Heading">Underlined & Disabled</h2>
 
   <div class="docs-Stack docs-Stack--start">
@@ -69,19 +74,21 @@
     <p>
       <a href="#" class="link-secondary link-disabled link-underlined">Secondary Disabled Underlined Link</a>
     </p>
-    <p class="docs-Box mb-1000">
+    <p class="docs-Box">
       <a href="#" class="link-inverted link-disabled link-underlined">Inverted Disabled Underlined Link</a>
+    </p>
+    <p>
+      <button type="button" class="link-primary link-disabled link-underlined" disabled>Link as button</button>
     </p>
   </div>
 
 </section>
 
 <section class="docs-Section">
-  
+
   <h2 class="docs-Heading">Headings with links</h2>
 
   <div class="docs-Stack docs-Stack--start">
-
     <h3 class="typography-heading-xsmall-text">
       Heading XSmall Text with <a href="#">link (default style), obtains visited state</a>
     </h3>
@@ -91,7 +98,11 @@
     <h3 class="typography-heading-xsmall-text">
       Heading XSmall Text with <a href="#">link without underlined class, behaves the same as the one before</a>
     </h3>
+    <h3 class="typography-heading-xsmall-text">
+      Heading XSmall Text with <button type="button" class="link-primary">link as button</button>
+    </h3>
+  </div>
 
-  </section>
+</section>
 
 {{/layout/plain }}

--- a/packages/web/src/scss/settings/_cursors.scss
+++ b/packages/web/src/scss/settings/_cursors.scss
@@ -1,3 +1,3 @@
 $disabled: default;
 $form-fields: pointer;
-$button-links: pointer;
+$buttons: pointer;

--- a/packages/web/src/scss/settings/_links.scss
+++ b/packages/web/src/scss/settings/_links.scss
@@ -1,2 +1,4 @@
+$text-decoration-default: none;
+$text-decoration-hover: underline;
 $text-decoration-skip-ink: none;
 $text-underline-offset: 0.1875em;

--- a/packages/web/src/scss/tools/_dictionaries.scss
+++ b/packages/web/src/scss/tools/_dictionaries.scss
@@ -1,7 +1,11 @@
+@use 'sass:list';
 @use 'sass:map';
 @use 'sass:string';
 @use '@tokens' as tokens;
+@use './links';
+@use './list' as spirit-list;
 @use './placement';
+@use './reset';
 @use './string' as spirit-string;
 @use './typography';
 
@@ -120,6 +124,24 @@
     }
 }
 
+// Mixin to reset button styling for individual link variants.
+// Parameters are:
+// * $dictionary-values: list of the dictionary values to generate
+@mixin prepare-button-links($dictionary-values) {
+    $selectors: ();
+
+    @each $dictionary-value in $dictionary-values {
+        $selectors: list.append($selectors, 'button.link-#{$dictionary-value}');
+    }
+
+    #{spirit-list.to-string($selectors, ', ')} {
+        @include reset.button();
+        @include links.base();
+
+        user-select: text;
+    }
+}
+
 // Mixin to generate link color classes based on a dictionary
 // Parameters are:
 // * $selector: the selector to generate
@@ -136,7 +158,7 @@
         @each $print-value in $print-values {
             $variant-class: '#{$dictionary-value}';
             @if $print-value == 'disabled' {
-                $variant-class: '#{$dictionary-value}.link-#{$print-value}:any-link';
+                $variant-class: '#{$dictionary-value}.link-#{$print-value}';
             } @else if $print-value != 'default' {
                 $variant-class: '#{$dictionary-value}:#{$print-value}';
             }
@@ -181,7 +203,7 @@
         $placement-modifier: spirit-string.convert-kebab-case-to-camel-case($placement);
 
         .#{$class-name}[#{$data-attribute}='#{$placement-modifier}'] {
-            // stylelint-disable scss/at-extend-no-missing-placeholder -- We are extending classes created by generate-placements().
+            // stylelint-disable-next-line scss/at-extend-no-missing-placeholder -- We are extending classes created by generate-placements().
             @extend .#{$class-name}--#{$placement-modifier};
         }
     }

--- a/packages/web/src/scss/tools/_links.scss
+++ b/packages/web/src/scss/tools/_links.scss
@@ -1,9 +1,38 @@
+@use '@tokens' as tokens;
+@use '../settings/links';
+
+@mixin base($set-color: false) {
+    text-decoration-skip-ink: links.$text-decoration-skip-ink;
+    text-underline-offset: links.$text-underline-offset;
+
+    @if $set-color {
+        color: tokens.$action-link-primary-default;
+    }
+
+    @media (hover: hover) {
+        &:hover {
+            text-decoration: links.$text-decoration-hover;
+
+            @if $set-color {
+                color: tokens.$action-link-primary-hover;
+            }
+        }
+    }
+
+    &:active {
+        text-decoration: links.$text-decoration-hover;
+
+        @if $set-color {
+            color: tokens.$action-link-primary-active;
+        }
+    }
+}
+
 @mixin stretch($pseudo-element: before) {
     &::#{$pseudo-element} {
         content: '';
         position: absolute;
         z-index: 0;
-        display: block;
         inset: 0;
     }
 }

--- a/packages/web/src/scss/tools/_reset.scss
+++ b/packages/web/src/scss/tools/_reset.scss
@@ -12,5 +12,5 @@
     border-radius: 0;
     background: none;
     box-shadow: none;
-    cursor: cursors.$button-links;
+    cursor: cursors.$buttons;
 }


### PR DESCRIPTION
Using `<button>` element for links is now possible:

```html
<button class="link-primary">Link button</button>
```

![image](https://github.com/lmc-eu/spirit-design-system/assets/5614085/52567853-19d7-49b8-b51e-4f0f4451dbc6)

https://jira.lmc.cz/browse/DS-1060

Also, disabled buttons no longer obtain underline on hover:

https://jira.lmc.cz/browse/DS-1042