### PR TITLE
Chore(repo): Remove lerna option for disabling verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ publish: ## Publish packages to repository, pass the parameter "pkg=" to publish
 else
 publish:
 	@$(eval pkg ?=)
-	$(PKG_EXECUTE) $(MONOREPO_TOOL) publish from-package --yes --no-verify-access $(MONOREPO_TOOL_FLAGS)
+	$(PKG_EXECUTE) $(MONOREPO_TOOL) publish from-package --yes $(MONOREPO_TOOL_FLAGS)
 endif
 
 ## —— Miscellaneous 🛠️ ——————————————————————————————————————————————————————————————


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

  * verify-access --verify-access=false and --no-verify-access are no longer needed
  * the legacy preemptive access verification is now disabled by default
  * requests will fail with appropriate errors when not authorized correctly

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

refs #32

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
