### PR TITLE
Fix(web-react): Tabs styleProps #DS-977

### DIFF
--- a/packages/web-react/src/components/Tabs/README.md
+++ b/packages/web-react/src/components/Tabs/README.md
@@ -89,9 +89,11 @@ Tab list
 
 #### API
 
-| Name       | Type  | Default | Required | Description     |
-| ---------- | ----- | ------- | -------- | --------------- |
-| `children` | `any` | —       | ✕        | Child component |
+| Name               | Type            | Default | Required | Description               |
+| ------------------ | --------------- | ------- | -------- | ------------------------- |
+| `children`         | `any`           | —       | ✕        | Child component           |
+| `UNSAFE_className` | `string`        | —       | ✕        | Wrapper custom class name |
+| `UNSAFE_style`     | `CSSProperties` | —       | ✕        | Wrapper custom style      |
 
 ### TabItem
 
@@ -99,10 +101,12 @@ Tab list item
 
 #### API
 
-| Name       | Type                   | Default | Required | Description           |
-| ---------- | ---------------------- | ------- | -------- | --------------------- |
-| `forTab`   | [`string` \| `number`] | —       | ✔        | Identification of tab |
-| `children` | `any`                  | —       | ✕        | Child component       |
+| Name               | Type                   | Default | Required | Description               |
+| ------------------ | ---------------------- | ------- | -------- | ------------------------- |
+| `forTab`           | [`string` \| `number`] | —       | ✔        | Identification of tab     |
+| `children`         | `any`                  | —       | ✕        | Child component           |
+| `UNSAFE_className` | `string`               | —       | ✕        | Wrapper custom class name |
+| `UNSAFE_style`     | `CSSProperties`        | —       | ✕        | Wrapper custom style      |
 
 ### TabLink
 
@@ -122,9 +126,11 @@ Tab content wrapper
 
 #### API
 
-| Name       | Type  | Default | Required | Description     |
-| ---------- | ----- | ------- | -------- | --------------- |
-| `children` | `any` | —       | ✕        | Child component |
+| Name               | Type            | Default | Required | Description               |
+| ------------------ | --------------- | ------- | -------- | ------------------------- |
+| `children`         | `any`           | —       | ✕        | Child component           |
+| `UNSAFE_className` | `string`        | —       | ✕        | Wrapper custom class name |
+| `UNSAFE_style`     | `CSSProperties` | —       | ✕        | Wrapper custom style      |
 
 ### TabPane
 
@@ -132,9 +138,11 @@ Tab content item
 
 #### API
 
-| Name       | Type                   | Default | Required | Description           |
-| ---------- | ---------------------- | ------- | -------- | --------------------- |
-| `tabId`    | [`string` \| `number`] | —       | ✔        | Identification of tab |
-| `children` | `any`                  | —       | ✕        | Child component       |
+| Name               | Type                   | Default | Required | Description               |
+| ------------------ | ---------------------- | ------- | -------- | ------------------------- |
+| `tabId`            | [`string` \| `number`] | —       | ✔        | Identification of tab     |
+| `children`         | `any`                  | —       | ✕        | Child component           |
+| `UNSAFE_className` | `string`               | —       | ✕        | Wrapper custom class name |
+| `UNSAFE_style`     | `CSSProperties`        | —       | ✕        | Wrapper custom style      |
 
 For detailed information see [Tabs](https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/scss/components/Tabs/README.md) component.

--- a/packages/web-react/src/components/Tabs/TabContent.tsx
+++ b/packages/web-react/src/components/Tabs/TabContent.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
+import { useStyleProps } from '../../hooks';
 import { ChildrenProps, TransferProps } from '../../types';
 
 export type TabContentProps = ChildrenProps & TransferProps;
 
-const TabContent = ({ children, ...restProps }: TabContentProps): JSX.Element => <div {...restProps}>{children}</div>;
+const TabContent = ({ children, ...restProps }: TabContentProps): JSX.Element => {
+  const { styleProps, props: transferProps } = useStyleProps(restProps);
+
+  return (
+    <div {...transferProps} {...styleProps}>
+      {children}
+    </div>
+  );
+};
 
 export default TabContent;

--- a/packages/web-react/src/components/Tabs/TabItem.tsx
+++ b/packages/web-react/src/components/Tabs/TabItem.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import classNames from 'classnames';
+import { useStyleProps } from '../../hooks';
 import { ChildrenProps, TabId, TransferProps, ClickEvents, ClickEvent } from '../../types';
 import { useTabContext } from './TabContext';
 import { useTabsStyleProps } from './useTabsStyleProps';
@@ -10,6 +12,7 @@ export interface TabItemProps extends ChildrenProps, TransferProps, ClickEvents 
 const TabItem = ({ children, forTab, onClick, ...restProps }: TabItemProps): JSX.Element => {
   const { selectTab, selectedTabId, onSelectionChange } = useTabContext();
   const { classProps } = useTabsStyleProps({ forTab, selectedTabId });
+  const { styleProps, props: transferProps } = useStyleProps(restProps);
 
   const handleClick = (event: ClickEvent) => {
     selectTab(forTab);
@@ -26,9 +29,10 @@ const TabItem = ({ children, forTab, onClick, ...restProps }: TabItemProps): JSX
   return (
     <li className={classProps.item}>
       <button
-        {...restProps}
+        {...transferProps}
+        {...styleProps}
         type="button"
-        className={classProps.link}
+        className={classNames(classProps.link, styleProps.className)}
         role="tab"
         aria-selected={selectedTabId === forTab}
         id={`${forTab}-tab`}

--- a/packages/web-react/src/components/Tabs/TabList.tsx
+++ b/packages/web-react/src/components/Tabs/TabList.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import classNames from 'classnames';
+import { useStyleProps } from '../../hooks';
 import { ChildrenProps, TransferProps } from '../../types';
 import { useTabsStyleProps } from './useTabsStyleProps';
 
@@ -6,9 +8,10 @@ export type TabListProps = ChildrenProps & TransferProps;
 
 const TabList = ({ children, ...restProps }: TabListProps): JSX.Element => {
   const { classProps } = useTabsStyleProps();
+  const { styleProps, props: transferProps } = useStyleProps(restProps);
 
   return (
-    <ul {...restProps} className={classProps.root} role="tablist">
+    <ul {...transferProps} {...styleProps} className={classNames(classProps.root, styleProps.className)} role="tablist">
       {children}
     </ul>
   );

--- a/packages/web-react/src/components/Tabs/TabPane.tsx
+++ b/packages/web-react/src/components/Tabs/TabPane.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import classNames from 'classnames';
+import { useStyleProps } from '../../hooks';
 import { ChildrenProps, TabId, TransferProps } from '../../types';
 import { useTabContext } from './TabContext';
 import { useTabsStyleProps } from './useTabsStyleProps';
@@ -10,12 +12,14 @@ export interface TabPaneProps extends ChildrenProps, TransferProps {
 const TabPane = ({ children, tabId, ...restProps }: TabPaneProps): JSX.Element | null => {
   const { selectedTabId } = useTabContext();
   const { classProps } = useTabsStyleProps({ tabId, selectedTabId });
+  const { styleProps, props: transferProps } = useStyleProps(restProps);
 
   return selectedTabId === tabId ? (
     <div
-      {...restProps}
+      {...transferProps}
+      {...styleProps}
       id={tabId.toString()}
-      className={classProps.pane}
+      className={classNames(classProps.pane, styleProps.className)}
       role="tabpanel"
       aria-labelledby={`${tabId}-tab`}
     >

--- a/packages/web-react/src/components/Tabs/__tests__/TabItem.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabItem.test.tsx
@@ -2,11 +2,14 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
+import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { withTabsContext } from '../../../../tests/testUtils/withTabsContext';
 import TabItem from '../TabItem';
 
 describe('TabItem', () => {
+  stylePropsTest((props) => <TabItem forTab={1} data-testid="TabItemTestId" {...props} />, 'TabItemTestId');
+
   classNamePrefixProviderTest(() => <TabItem forTab={0} />, 'Tabs__item');
 
   restPropsTest((props) => <TabItem forTab={0} {...props} />, 'button');

--- a/packages/web-react/src/components/Tabs/__tests__/TabLink.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabLink.test.tsx
@@ -2,9 +2,12 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
+import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import TabLink from '../TabLink';
 
 describe('TabLink', () => {
+  stylePropsTest((props) => <TabLink href="#" itemProps={props} />);
+
   classNamePrefixProviderTest(TabLink, 'Tabs__item');
 
   it('should render anchor tag', () => {

--- a/packages/web-react/src/components/Tabs/__tests__/TabList.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabList.test.tsx
@@ -1,7 +1,11 @@
 import '@testing-library/jest-dom';
+import React from 'react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
+import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import TabList from '../TabList';
 
 describe('TabList', () => {
+  stylePropsTest((props) => <TabList data-testid="TabListTestId" {...props} />, 'TabListTestId');
+
   classNamePrefixProviderTest(TabList, 'Tabs');
 });

--- a/packages/web-react/src/components/Tabs/__tests__/TabPane.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabPane.test.tsx
@@ -2,12 +2,26 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
+import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { withTabsContext } from '../../../../tests/testUtils/withTabsContext';
 import { TabsContextType } from '../TabContext';
+import Tabs from '../Tabs';
+import TabContent from '../TabContent';
 import TabPane from '../TabPane';
 
 describe('TabPane', () => {
+  stylePropsTest(
+    (props) => (
+      <Tabs selectedTab={1} toggle={() => {}}>
+        <TabContent>
+          <TabPane tabId={1} data-testid="TabPaneTestId" {...props} />
+        </TabContent>
+      </Tabs>
+    ),
+    'TabPaneTestId',
+  );
+
   classNamePrefixProviderTest(
     withTabsContext((props) => <TabPane {...props} tabId="test" />, { selectedTabId: 'test' } as TabsContextType),
     'TabsPane',


### PR DESCRIPTION
## Description

- Added `styleProps` to **TabsContent**, **TabItem**, **TabList** and **TabPane**
- `UNSAFE_className` and `UNSAFE_style` added to API tables for **TabsContent**, **TabItem**, **TabList** and **TabPane**

### Additional context

### Issue reference

[React: Tabs nemají styleProps](https://jira.lmc.cz/browse/DS-977)
