### PR TITLE
Fix(design-tokens): Use `sass` condition in `exports` field

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -24,7 +24,8 @@
   "exports": {
     ".": {
       "import": "./esm/index.js",
-      "require": "./cjs/index.js"
+      "require": "./cjs/index.js",
+      "sass": "./scss/index.scss"
     }
   },
   "scripts": {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

  * affects only Webpack
  * when the `exports` field is specified, only these module requests are available
  * any other requests will lead to a ModuleNotFound Error

### Additional context

https://webpack.js.org/guides/package-exports/#conditions

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
