### PR TITLE
Fix(web, web-react): FileUploader error messages

### DIFF
--- a/packages/web-react/src/components/FileUploader/useFileUploaderInput.ts
+++ b/packages/web-react/src/components/FileUploader/useFileUploaderInput.ts
@@ -31,13 +31,13 @@ export const useFileUploaderInput = (props: UseFileUploaderInputProps): UseFileU
 
   const checkAllowedFileSize = (file: File) => {
     if (file.size > maxFileSize) {
-      throw new Error(`${errorMessages?.errorMaxFileSize} "${file.name}"`);
+      throw new Error(`${file.name}: ${errorMessages?.errorMaxFileSize}`);
     }
   };
 
   const checkFileDuplicity = (file: File) => {
     if (isMultiple && fileQueue.has(getUpdatedFileName(file.name))) {
-      throw new Error(`${errorMessages?.errorFileDuplicity} "${file.name}"`);
+      throw new Error(`${file.name}: ${errorMessages?.errorFileDuplicity}`);
     }
   };
 
@@ -78,7 +78,7 @@ export const useFileUploaderInput = (props: UseFileUploaderInputProps): UseFileU
     }
 
     if (!isTypeSupported) {
-      throw new Error(`${errorMessages?.errorFileNotSupported} "${file.name}"`);
+      throw new Error(`${file.name}: ${errorMessages?.errorFileNotSupported}`);
     }
   };
 

--- a/packages/web/src/js/FileUploader.ts
+++ b/packages/web/src/js/FileUploader.ts
@@ -179,7 +179,7 @@ class FileUploader extends BaseComponent {
     }
 
     if (!isTypeSupported) {
-      throw new Error(`"${file.name}": ${this.errors.errorFileNotSupported}`);
+      throw new Error(`${file.name}: ${this.errors.errorFileNotSupported}`);
     }
   }
 

--- a/packages/web/src/js/__tests__/FileUploader.test.ts
+++ b/packages/web/src/js/__tests__/FileUploader.test.ts
@@ -161,7 +161,7 @@ describe('FileUploader', () => {
       it('should throw an error for an unsupported file type', () => {
         const file = new File(['content'], 'example.txt', { type: 'text/plain' });
         expect(() => fileUploader.checkAllowedFileType(file)).toThrow(
-          `"example.txt": is not a supported file. Please ensure you are uploading a supported file format`,
+          `example.txt: is not a supported file. Please ensure you are uploading a supported file format`,
         );
       });
     });


### PR DESCRIPTION
## Description

- FileUploader error messages changed to match across all packages
- They are now formated like this: `<filename>: <error message>`

### Additional context

<img width="943" alt="image" src="https://github.com/lmc-eu/spirit-design-system/assets/26870554/03d5aa12-f5dd-43e6-b8ec-f1b4a94c3983">

### Issue reference

[FileUploader: nekonzistence v error hlášce](https://jira.lmc.cz/browse/DS-1051)
