### PR TITLE
Fix(design-tokens): Exports field blocks build on product applications

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -21,13 +21,6 @@
   "module": "esm/index.js",
   "main": "cjs/index.js",
   "types": "types/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "sass": "./scss/index.scss"
-    }
-  },
   "scripts": {
     "prebuild": "yarn clean",
     "build:js": "vite build",


### PR DESCRIPTION
 <!-- Thank you for contributing! -->

## Description

 * missing scss/borders specifier or cannot find stylesheet to import

### Additional context

![Snímek obrazovky 2023-11-16 v 15 06 18](https://github.com/lmc-eu/spirit-design-system/assets/2481010/9a771bc7-b898-4ddd-9167-904e1b917b08)
![Snímek obrazovky 2023-11-20 v 11 18 21](https://github.com/lmc-eu/spirit-design-system/assets/2481010/53ea7a84-dbc1-43d6-8001-a246e2bd3dd3)


### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
