### PR TITLE
Fix(web-twig): Do not render class in the `style` attribute of the `GridItem`

### DIFF
--- a/packages/web-twig/src/Resources/components/Grid/GridItem.twig
+++ b/packages/web-twig/src/Resources/components/Grid/GridItem.twig
@@ -31,7 +31,7 @@
 {%- endfor -%}
 
 {# Attributes #}
-{%- set _styleAttr = _style or (_styleProps.style is not same as(null)) ? 'style="' ~ _style ~ _styleProps | join() ~ '"' -%}
+{%- set _styleAttr = _style or (_styleProps.style is not same as(null)) ? 'style="' ~ _style ~ _styleProps.style | join() ~ '"' -%}
 
 <{{ _elementType }}
     {{ mainProps(props) }}

--- a/packages/web-twig/src/Resources/components/Grid/__tests__/__fixtures__/gridItemDefault.twig
+++ b/packages/web-twig/src/Resources/components/Grid/__tests__/__fixtures__/gridItemDefault.twig
@@ -1,5 +1,5 @@
 <Grid>
-    <GridItem columnStart="1" columnEnd="10">
+    <GridItem columnStart="1" columnEnd="10" UNSAFE_className="d-tablet-none">
         1–10
     </GridItem>
     <GridItem columnStart="1" columnEnd="span 2">

--- a/packages/web-twig/src/Resources/components/Grid/__tests__/__snapshots__/gridItemDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Grid/__tests__/__snapshots__/gridItemDefault.twig.snap.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <div class="Grid">
-      <div class="GridItem" style="--grid-item-column-start: 1;--grid-item-column-end: 10;">
+      <div class="GridItem d-tablet-none" style="--grid-item-column-start: 1;--grid-item-column-end: 10;">
         1&acirc;&#128;&#147;10
       </div>
 

--- a/packages/web-twig/src/Resources/components/Modal/ModalDialog.twig
+++ b/packages/web-twig/src/Resources/components/Modal/ModalDialog.twig
@@ -37,7 +37,7 @@
 {%- endif -%}
 
 {# Attributes #}
-{%- set _styleAttr = _style or (_styleProps.style is not same as(null)) ? 'style="' ~ _style ~ _styleProps | join() ~ '"' -%}
+{%- set _styleAttr = _style or (_styleProps.style is not same as(null)) ? 'style="' ~ _style ~ _styleProps.style | join() ~ '"' -%}
 
 <{{ _elementType }}
     {{ mainProps(props, _allowedAttributes) }}

--- a/packages/web-twig/src/Resources/components/Modal/__tests__/__fixtures__/modalDefault.twig
+++ b/packages/web-twig/src/Resources/components/Modal/__tests__/__fixtures__/modalDefault.twig
@@ -46,6 +46,7 @@
         method="dialog"
         preferredHeightOnMobile="400px"
         preferredHeightFromTabletUp="500px"
+        UNSAFE_className="custom-class"
         UNSAFE_style="outline: 5px solid blue; outline-offset: -5px;"
     >
         <ModalHeader

--- a/packages/web-twig/src/Resources/components/Modal/__tests__/__snapshots__/modalDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Modal/__tests__/__snapshots__/modalDefault.twig.snap.html
@@ -59,7 +59,7 @@
     <!-- Render with all props -->
 
     <dialog class="Modal" id="modal-example-2" aria-labelledby="modal-example-2-title">
-      <form autocomplete="on" method="dialog" class="ModalDialog" style="--modal-max-height-tablet: 700px;--modal-preferred-height-mobile: 400px;--modal-preferred-height-tablet: 500px;outline: 5px solid blue; outline-offset: -5px;">
+      <form autocomplete="on" method="dialog" class="ModalDialog custom-class" style="--modal-max-height-tablet: 700px;--modal-preferred-height-mobile: 400px;--modal-preferred-height-tablet: 500px;outline: 5px solid blue; outline-offset: -5px;">
         <header class="ModalHeader">
           <h2 class="ModalHeader__title" id="modal-example-2-title">
             Title of the Modal


### PR DESCRIPTION
Small bug fix. Currently it is `class` even passed to the `style` attribute.

❌ Current HTML output:
```
<div class="GridItem d-tablet-none" style="--grid-item-column-start: 1;display-tablet-none">
```

✅ Fixed HTML output:
```
<div class="GridItem d-tablet-none" style="--grid-item-column-start: 1;">
```