### PR TITLE
Fix(web-react): HeaderDialog demo missed closeOnBackdropClick prop #DS-1075

### DIFF
--- a/packages/web-react/src/components/Dialog/Dialog.tsx
+++ b/packages/web-react/src/components/Dialog/Dialog.tsx
@@ -7,7 +7,7 @@ import { useCancelEvent, useClickOutside } from '../../hooks';
 // Solved using `as MutableRefObject<HTMLDialogElement | null>` but I do not like it
 
 const Dialog = (props: DialogProps, ref: ForwardedRef<HTMLDialogElement | null>): JSX.Element => {
-  const { children, isOpen, onClose, closeOnBackdropClick, ...restProps } = props;
+  const { children, isOpen, onClose, closeOnBackdropClick = true, ...restProps } = props;
   const dialogElementRef: MutableRefObject<ForwardedRef<HTMLDialogElement | null>> = useRef(ref);
   const contentElementRef: MutableRefObject<HTMLElement | null> = useRef(null);
 

--- a/packages/web-react/src/components/Modal/Modal.tsx
+++ b/packages/web-react/src/components/Modal/Modal.tsx
@@ -7,7 +7,7 @@ import { ModalProvider } from './ModalContext';
 import Dialog from '../Dialog/Dialog';
 
 const Modal = (props: SpiritModalProps) => {
-  const { children, isOpen, onClose, closeOnBackdropClick = true, id, ...restProps } = props;
+  const { children, isOpen, onClose, id, ...restProps } = props;
   const { classProps } = useModalStyleProps();
   const { styleProps, props: otherProps } = useStyleProps(restProps);
 
@@ -27,7 +27,6 @@ const Modal = (props: SpiritModalProps) => {
         id={id}
         isOpen={isOpen}
         onClose={onClose}
-        closeOnBackdropClick={closeOnBackdropClick}
         className={classNames(classProps.root, styleProps.className)}
         aria-labelledby={`${id}__title`}
       >


### PR DESCRIPTION
## Description

- Changed default value of `closeOnBackdropClick` to true on `<Dialog />` component.
- Removed default value of `closeOnBackdropClick` from `<Modal />` (will be default from Dialog)

### Additional context

### Issue reference

[HeaderDialog v React se nezavírá při backdrop click](https://jira.lmc.cz/browse/DS-1075)
