### PR TITLE
Fix(web-react): Do not render empty `style` prop

### DIFF
--- a/packages/web-react/src/hooks/__tests__/styleProps.test.ts
+++ b/packages/web-react/src/hooks/__tests__/styleProps.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { useStyleProps } from '../styleProps';
 import { StyleProps } from '../../types';
+import { useStyleProps } from '../styleProps';
 
 describe('styleProps', () => {
   describe('#useStyleProps', () => {
@@ -9,11 +9,12 @@ describe('styleProps', () => {
         { UNSAFE_style: { 'vertical-align': 'center' }, UNSAFE_className: 'Button' },
         { className: 'Button', style: { 'vertical-align': 'center' } },
       ],
-      [{ role: 'button' }, { UNSAFE_className: undefined, style: {} }],
+      [{ role: 'button' }, { UNSAFE_className: undefined, style: undefined }],
       [
         { role: 'button', UNSAFE_style: { 'vertical-align': 'center' } },
         { className: undefined, style: { 'vertical-align': 'center' } },
       ],
+      [{ role: 'button' }, { className: undefined, style: undefined }],
     ])('should use UNSAFE_style and UNSAFE_className props', (input, expected) => {
       expect(useStyleProps(input as StyleProps).styleProps).toEqual(expected);
     });

--- a/packages/web-react/src/hooks/styleProps.ts
+++ b/packages/web-react/src/hooks/styleProps.ts
@@ -40,7 +40,7 @@ export function useStyleProps<T extends StyleProps>(props: T): StylePropsResult 
   }
 
   const styleProps = {
-    style,
+    style: Object.keys(style).length > 0 ? style : undefined,
     className: UNSAFE_className,
   };
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

When not using `UNSAFE_style` prop, the default `{}` is rendered into the DOM. Using `undefined` instead.

### Additional context

Every snapshot in product, like KukAD:
```js
<ul
        className="Tabs"
        role="tablist"
        style={{}} // <- here
>
```

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
