### PR TITLE
Feat(analytics): Add a timestamp to the scanner result files

### DIFF
--- a/packages/analytics/src/constants.ts
+++ b/packages/analytics/src/constants.ts
@@ -1,7 +1,7 @@
 export const OUTPUT_FILENAME_PREFIX = 'spirit-analytics';
 export const OUTPUT_DIR = '.scanner';
 export const ROOT_PATH = '.';
-export const REACT_OUTPUT_FILE = 'adoption-data-react.json';
-export const TWIG_OUTPUT_FILE = './.scanner/adoption-data-twig.json';
+export const REACT_OUTPUT_FILE_NAME = 'adoption-data-react';
+export const TWIG_OUTPUT_FILE_NAME = './.scanner/adoption-data-twig';
 export const TWIG_CORE_COMPONENTS_PATH = './vendor/lmc/spirit-web-twig-bundle/src/Resources/twig-components';
 export const TWIG_CONFIG_FILE = './config/spirit-web-twig.yml';

--- a/packages/analytics/src/processors/spiritAdoptionProcessor.ts
+++ b/packages/analytics/src/processors/spiritAdoptionProcessor.ts
@@ -1,9 +1,9 @@
 import { path } from 'zx';
-import { OUTPUT_DIR, REACT_OUTPUT_FILE, ROOT_PATH } from '../constants';
-import { _dirname, getModuleName } from '../helpers';
+import { OUTPUT_DIR, REACT_OUTPUT_FILE_NAME, ROOT_PATH } from '../constants';
+import { _dirname, getModuleName, timestamp } from '../helpers';
 import { Component } from '../types';
 
-const OUTPUT_FILE = path.resolve(process.cwd(), `${OUTPUT_DIR}/${REACT_OUTPUT_FILE}`);
+const OUTPUT_FILE = path.resolve(process.cwd(), `${OUTPUT_DIR}/${REACT_OUTPUT_FILE_NAME}-${timestamp()}.json`);
 
 const getRelativePath = (absolutePath: string) => path.relative(path.resolve(_dirname, ROOT_PATH), absolutePath);
 

--- a/packages/analytics/src/scanners/twig-scanner.config.ts
+++ b/packages/analytics/src/scanners/twig-scanner.config.ts
@@ -1,9 +1,16 @@
-import { ROOT_PATH, TWIG_CONFIG_FILE, TWIG_CORE_COMPONENTS_PATH, TWIG_OUTPUT_FILE } from '../constants';
+import {
+  OUTPUT_DIR,
+  ROOT_PATH,
+  TWIG_CONFIG_FILE,
+  TWIG_CORE_COMPONENTS_PATH,
+  TWIG_OUTPUT_FILE_NAME,
+} from '../constants';
+import { timestamp } from '../helpers';
 
 export default {
   crawlFrom: ROOT_PATH,
   exclude: ['node_modules', 'dist', 'build', 'coverage', 'public', 'vendor', 'storybook-static'],
   configFile: TWIG_CONFIG_FILE,
-  outputFile: TWIG_OUTPUT_FILE,
+  outputFile: `${OUTPUT_DIR}/${TWIG_OUTPUT_FILE_NAME}-${timestamp()}.json`,
   coreComponentsPath: TWIG_CORE_COMPONENTS_PATH,
 };


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Adding a time mark to the files with scanner results; e. g. `adoption-data-<type>-YYYY-MM-DD.json`

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
