### PR TITLE
Fix(analytics): HTML element is not the PascalCase component

### DIFF
--- a/packages/analytics/src/scanners/__tests__/twigScanner.test.ts
+++ b/packages/analytics/src/scanners/__tests__/twigScanner.test.ts
@@ -55,6 +55,16 @@ describe('twigScanner', () => {
       expect(result).toBe('local_component');
     });
 
+    it('should return "local_component" if the nodeName is not in the localComponents array but it is a Component', () => {
+      const nodeName = 'ComponentTest';
+      const localComponents = ['Component1', 'Component2', 'Component3'];
+      const baseComponents = ['BaseComponent1', 'BaseComponent2'];
+
+      const result = twigScanner.determineModuleNameFromComponents(nodeName, localComponents, baseComponents);
+
+      expect(result).toBe('local_component');
+    });
+
     it('should return "@lmc-eu/spirit-web-twig" if the nodeName is in the baseComponents array', () => {
       const nodeName = 'BaseComponent2';
       const localComponents = ['Component1', 'Component2', 'Component3'];
@@ -66,7 +76,7 @@ describe('twigScanner', () => {
     });
 
     it('should return "html_element" if the nodeName is not in the localComponents or baseComponents array', () => {
-      const nodeName = 'UnknownComponent';
+      const nodeName = 'div';
       const localComponents = ['Component1', 'Component2', 'Component3'];
       const baseComponents = ['BaseComponent1', 'BaseComponent2'];
 

--- a/packages/analytics/src/scanners/twigScanner.ts
+++ b/packages/analytics/src/scanners/twigScanner.ts
@@ -52,12 +52,13 @@ export function determineModuleNameFromComponents(
   localComponents: Array<string>,
   baseComponents: Array<string>,
 ) {
-  if (localComponents.includes(nodeName)) {
-    return 'local_component';
-  }
-
   if (baseComponents.includes(nodeName)) {
     return '@lmc-eu/spirit-web-twig';
+  }
+
+  const pascalCaseRegex = /^([A-Z][a-z0-9]+)+$/;
+  if (localComponents.includes(nodeName) || nodeName.match(pascalCaseRegex)) {
+    return 'local_component';
   }
 
   return 'html_element';


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Double-check the component name and assert it for PascalCase, because HTML elements are not PascalCase written.

In our adoption data, we have some components marked as `html_element`.

```
  "html_element:ProgressBar": [
    {
      "path": "templates/front/macros/rating.html.twig:221",
      "props": {
        "size": "small",
        "value": "{{ percentage }}"
      }
    }
  ],
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
