### PR TITLE
Run visual tests also againts local servers

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -12,6 +12,7 @@ module.exports = {
       [
         // Use when committing changes/additions/removals to exact package
         'analytics',
+        'common',
         'design-tokens',
         'form-validations',
         'icons',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     'node_modules',
     '!.*.js',
     'packages/analytics',
+    'packages/common',
     'packages/web-react',
     'packages/web',
     'packages/form-validations',

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [labeled]
 
+env:
+  NODE_ENV: testing
+
 jobs:
   test:
     if: ${{ (github.event.label.name == 'e2e') || (github.ref == 'refs/heads/main') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,10 +3,11 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    types: [labeled]
 
 jobs:
   test:
+    if: ${{ (github.event.label.name == 'e2e') || (github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-22.04
     container:
       image: mcr.microsoft.com/playwright:v1.40.1-jammy

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ See individual [packages](#packages) to learn how to get started.
 | Package name                                                     | Description                                               | Version                                                  |
 | ---------------------------------------------------------------- | --------------------------------------------------------- | -------------------------------------------------------- |
 | [`@lmc-eu/spirit-analytics`](./packages/analytics)               | Analytic tools for Spirit Design System                   | [![@lmc-eu/spirit-analytics][sa-badge]][sa-npm]          |
+| [`@lmc-eu/spirit-common`](./packages/common)                     | Common scripts for Spirit Design System                   | Private                                                  |
 | [`@lmc-eu/spirit-design-tokens`](./packages/design-tokens)       | Design tokens for Spirit Design System                    | [![@lmc-eu/spirit-design-tokens][sdt-badge]][sdt-npm]    |
 | [`@lmc-eu/spirit-form-validations`](./packages/form-validations) | Form Validations for Spirit Design System                 | [![@lmc-eu/spirit-form-validations][sfv-badge]][sfv-npm] |
 | [`@lmc-eu/spirit-icons`](./packages/icons)                       | Icons for Spirit Design System                            | [![@lmc-eu/spirit-icons][si-badge]][si-npm]              |

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ See individual [packages](#packages) to learn how to get started.
 
 ### Prerequisites
 
-- [Node >= 14](https://nodejs.org)
-- [Yarn 1.22](https://yarnpkg.com)
-- [Lerna 4.x](https://lerna.js.org)
+- [NodeJS](https://nodejs.org)
+- [Yarn](https://yarnpkg.com)
+- [Lerna](https://lerna.js.org)
 
 ### Start Development
 

--- a/bin/make/e2e.sh
+++ b/bin/make/e2e.sh
@@ -5,4 +5,4 @@ set -o errexit
 PLAYWRIGHT_VERSION=1.40.1
 UBUNTU_VERSION=jammy
 
-docker run --rm --network host -v $(pwd):/work/ -w /work/ -it mcr.microsoft.com/playwright:v$PLAYWRIGHT_VERSION-$UBUNTU_VERSION yarn test:e2e
+docker run --rm --network=host --ipc=host -v $(pwd):/work/ -w /work/ -it mcr.microsoft.com/playwright:v$PLAYWRIGHT_VERSION-$UBUNTU_VERSION yarn test:e2e

--- a/packages/common/.eslintignore
+++ b/packages/common/.eslintignore
@@ -1,0 +1,18 @@
+# .eslintignore
+
+node_modules
+
+# NOTE:
+# The following directives are only relevant when linting the whole
+# project directory, ie. running `eslint .` ⚠️
+
+# If you compile JavaScript into some output folder, exclude it here
+dist
+build
+
+# Highly recommended to re-include JavaScript dotfiles to lint them
+# (This will cause .eslintrc.js to be linted by ESLint 🤘)
+!.*.js
+
+# Some tools use this pattern for their configuration files. Lint them!
+!*.config.js

--- a/packages/common/.eslintrc.js
+++ b/packages/common/.eslintrc.js
@@ -1,0 +1,46 @@
+module.exports = {
+  extends: [
+    '../../.eslintrc',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+    'plugin:prettier/recommended',
+    '@lmc-eu/eslint-config-jest',
+  ],
+
+  parser: '@typescript-eslint/parser', // the TypeScript parser we installed earlier
+
+  parserOptions: {
+    ecmaVersion: 'latest',
+    project: './tsconfig.json',
+  },
+
+  settings: {
+    'import/resolver': {
+      node: {
+        extensions: ['.js', '.ts'],
+      },
+    },
+  },
+
+  plugins: ['promise', '@typescript-eslint', 'prettier'],
+  rules: {
+    // disable for `scripts` and `config`
+    '@typescript-eslint/no-var-requires': 'off',
+    // allow ++ in for loops
+    'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
+    // disabled due to typescript
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': ['error', { allow: ['resolve', 'reject', 'done', 'next', 'error'] }],
+    // disabled due to typescript
+    'no-use-before-define': 'off',
+    '@typescript-eslint/no-use-before-define': 'warn',
+    // We are using typescript, disable jsdoc rules
+    'jsdoc/require-jsdoc': 'off',
+    'jsdoc/require-returns': 'off',
+    'jsdoc/require-param-type': 'off',
+    // allow reassign in properties
+    'no-param-reassign': ['warn', { props: false }],
+    // support monorepos
+    'import/no-extraneous-dependencies': ['error', { packageDir: ['./', '../../'] }],
+  },
+};

--- a/packages/common/.gitignore
+++ b/packages/common/.gitignore
@@ -1,0 +1,11 @@
+# Dependency directory
+node_modules
+
+# Caches
+.cache
+
+# Log files
+*.log
+
+# Code coverage
+.coverage

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/common/LICENSE.md
+++ b/packages/common/LICENSE.md
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 Alma Career
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+w

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,0 +1,19 @@
+# @lmc-eu/spirit-common
+
+> Common code, scripts, constants and settings of the Spirit Design System.
+
+## Install
+
+⚠️ This package is not published to npm.
+
+## Usage
+
+⚠️ This package is only used as a development dependency of other packages in the Spirit Design System.
+
+```js
+import { environments } from '@lmc-eu/spirit-common/constants/environments';
+```
+
+## License
+
+See the [LICENSE](LICENSE.md) file for information.

--- a/packages/common/config/jest/config.ts
+++ b/packages/common/config/jest/config.ts
@@ -1,0 +1,49 @@
+const config = {
+  // The root directory that Jest should scan for tests and modules within.
+  // https://jestjs.io/docs/configuration#rootdir-string
+  rootDir: '../../',
+
+  // This option tells Jest that all imported modules in your tests should be mocked automatically.
+  // https://jestjs.io/docs/configuration#automock-boolean
+  automock: false,
+
+  // Indicates whether each individual test should be reported during the run.
+  // https://jestjs.io/docs/configuration#verbose-boolean
+  verbose: false,
+
+  // A map from regular expressions to paths to transformers
+  // https://jestjs.io/docs/configuration#transform-objectstring-pathtotransformer--pathtotransformer-object
+  transform: {
+    '^.+\\.(t|j)sx?$': ['<rootDir>/../../node_modules/@swc/jest'],
+  },
+
+  // The test environment that will be used for testing.
+  // https://jestjs.io/docs/configuration#testenvironment-string
+  testEnvironment: 'jsdom',
+
+  // An array of regexp pattern strings that are matched against all test paths before executing the test
+  // https://jestjs.io/docs/configuration#testpathignorepatterns-arraystring
+  testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/', '.*__tests__/.*DataProvider.ts'],
+
+  // The directory where Jest should output its coverage files.
+  // https://jestjs.io/docs/configuration#coveragedirectory-string
+  coverageDirectory: './.coverage',
+
+  // An array of glob patterns indicating a set of files for which coverage information should be collected.
+  // https://jestjs.io/docs/configuration#collectcoveragefrom-array
+  collectCoverageFrom: ['<rootDir>/src/**/*.{js,jsx,ts,tsx}', '!<rootDir>/src/**/*.d.ts'],
+
+  // An array of regexp pattern strings that are matched against all file paths before executing the test.
+  // https://jestjs.io/docs/configuration#coveragepathignorepatterns-arraystring
+  coveragePathIgnorePatterns: ['__fixtures__', '.*.stories.*', '/stories/.*', '/demo/.*'],
+
+  // A list of reporter names that Jest uses when writing coverage reports. Any istanbul reporter can be used.
+  // https://jestjs.io/docs/configuration#coveragereporters-arraystring--string-options
+  coverageReporters: ['text', 'text-summary', ['lcov', { projectRoot: '../../' }]],
+
+  // An array of regexp pattern strings that are matched against all module paths before those paths are 'visible' to the loader.
+  // https://jestjs.io/docs/configuration#modulepathignorepatterns-arraystring
+  modulePathIgnorePatterns: ['<rootDir>/dist'],
+};
+
+module.exports = config;

--- a/packages/common/constants/__tests__/environments.test.ts
+++ b/packages/common/constants/__tests__/environments.test.ts
@@ -1,0 +1,31 @@
+import { isTesting } from '../environments';
+
+describe('environments', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    // Most important - it clears the cache
+    jest.resetModules();
+    // Make a copy
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    // Restore old environment
+    process.env = OLD_ENV;
+  });
+
+  describe('isTesting', () => {
+    it('should return true when NODE_ENV is set to `testing`', () => {
+      process.env.NODE_ENV = 'testing';
+
+      expect(isTesting()).toBeTruthy();
+    });
+
+    it('should return false when NODE_ENV is not set to `testing`', () => {
+      process.env.NODE_ENV = 'production';
+
+      expect(isTesting()).toBeFalsy();
+    });
+  });
+});

--- a/packages/common/constants/__tests__/servers.test.ts
+++ b/packages/common/constants/__tests__/servers.test.ts
@@ -1,0 +1,16 @@
+// @ts-expect-error TS2306: File is not a module.
+import { getDevelopmentEndpointUri } from '../servers';
+
+describe('servers', () => {
+  describe('getDevelopmentEndpointUri', () => {
+    it.each([
+      // [packageName, expectedUri]
+      ['web', 'http://localhost:5172'],
+      ['web-react', 'http://localhost:5173'],
+    ])('should return the correct development endpoint URI for a given package name', (packageName, expectedUri) => {
+      const result = getDevelopmentEndpointUri(packageName);
+
+      expect(result).toBe(expectedUri);
+    });
+  });
+});

--- a/packages/common/constants/environments.ts
+++ b/packages/common/constants/environments.ts
@@ -1,0 +1,7 @@
+export const ENVIRONMENTS = {
+  DEVELOPMENT: 'development',
+  TESTING: 'testing',
+  PRODUCTION: 'production',
+};
+
+export const isTesting = () => process.env.NODE_ENV === ENVIRONMENTS.TESTING;

--- a/packages/common/constants/servers.ts
+++ b/packages/common/constants/servers.ts
@@ -26,7 +26,7 @@ const SERVERS = {
       port: 4443,
     },
   },
-  PRODUCTION: {
+  TESTING: {
     web: 'https://spirit-design-system-demo.netlify.app/',
     'web-react': 'https://spirit-design-system-react.netlify.app/',
     'web-twig': '',

--- a/packages/common/constants/servers.ts
+++ b/packages/common/constants/servers.ts
@@ -39,7 +39,9 @@ const SERVERS = {
   },
 };
 
-const getDevelopmentEndpointUri = (packageName) =>
-  `http://${SERVERS.DEVELOPMENT[packageName].host}:${SERVERS.DEVELOPMENT[packageName].port}`;
+const getDevelopmentEndpointUri = (packageName, { isDocker } = { isDocker: false }) =>
+  `http://${isDocker ? 'host.docker.internal' : SERVERS.DEVELOPMENT[packageName].host}:${
+    SERVERS.DEVELOPMENT[packageName].port
+  }`;
 
 module.exports = { SERVERS, getDevelopmentEndpointUri };

--- a/packages/common/constants/servers.ts
+++ b/packages/common/constants/servers.ts
@@ -25,6 +25,12 @@ const SERVERS = {
       host: 'localhost',
       port: 4443,
     },
+    // @see: https://vitejs.dev/config/server-options.html
+    'form-validations': {
+      host: 'localhost',
+      port: 5174,
+      strictPort: true,
+    },
   },
   TESTING: {
     web: 'https://spirit-design-system-demo.netlify.app/',

--- a/packages/common/constants/servers.ts
+++ b/packages/common/constants/servers.ts
@@ -1,0 +1,39 @@
+/**
+ * ⚠️ This file is in CommonJS format only.
+ * It is mainly used in Vite configuration (`vite.config.ts`).
+ * Due to use of ESbuild, Vite configuration only supports importing CommonJS modules.
+ *
+ * @see https://github.com/vitejs/vite/issues/7981
+ */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+const SERVERS = {
+  DEVELOPMENT: {
+    // @see: https://vitejs.dev/config/server-options.html
+    web: {
+      host: 'localhost',
+      port: 5172,
+      strictPort: true,
+    },
+    // @see: https://vitejs.dev/config/server-options.html
+    'web-react': {
+      host: 'localhost',
+      port: 5173,
+      strictPort: true,
+    },
+    'web-twig': {
+      host: 'localhost',
+      port: 4443,
+    },
+  },
+  PRODUCTION: {
+    web: 'https://spirit-design-system-demo.netlify.app/',
+    'web-react': 'https://spirit-design-system-react.netlify.app/',
+    'web-twig': '',
+  },
+};
+
+const getDevelopmentEndpointUri = (packageName) =>
+  `http://${SERVERS.DEVELOPMENT[packageName].host}:${SERVERS.DEVELOPMENT[packageName].port}`;
+
+module.exports = { SERVERS, getDevelopmentEndpointUri };

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,5 +14,19 @@
     "type": "git",
     "url": "https://github.com/lmc-eu/spirit-design-system.git",
     "directory": "packages/common"
+  },
+  "scripts": {
+    "lint": "eslint ./",
+    "lint:fix": "yarn lint --fix",
+    "test": "npm-run-all --serial lint types test:unit:coverage",
+    "test:unit": "jest --config ./config/jest/config.ts",
+    "test:unit:watch": "yarn test:unit --watchAll",
+    "test:unit:coverage": "yarn test:unit --coverage",
+    "types": "tsc"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.8",
+    "@types/node": "20.9.0",
+    "jest": "29.7.0"
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@lmc-eu/spirit-common",
+  "version": "0.0.0",
+  "description": "Common code and scripts for Spirit Design System",
+  "license": "MIT",
+  "private": true,
+  "keywords": [
+    "spirit",
+    "common",
+    "design-system",
+    "shared"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lmc-eu/spirit-design-system.git",
+    "directory": "packages/common"
+  }
+}

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compileOnSave": true,
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "sourceMap": true,
+    "declaration": true,
+    "noEmit": true,
+    "removeComments": true,
+    "noEmitOnError": true,
+    "forceConsistentCasingInFileNames": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "strictFunctionTypes": true,
+    "resolveJsonModule": true,
+    "allowUnreachableCode": false,
+    "allowSyntheticDefaultImports": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noImplicitReturns": true,
+    "noUnusedParameters": false,
+    "noUnusedLocals": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "typeRoots": ["../../node_modules/@types"],
+    "types": ["node", "jest"],
+    "module": "es2020"
+  },
+  "include": ["./", "./.eslintrc.js"],
+  "exclude": ["./node_modules"]
+}

--- a/packages/form-validations/config/vite/app.ts
+++ b/packages/form-validations/config/vite/app.ts
@@ -1,8 +1,10 @@
+import { SERVERS } from '@lmc-eu/spirit-common/constants/servers';
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import handlebars from 'vite-plugin-handlebars';
 
 export default defineConfig({
+  server: SERVERS.DEVELOPMENT['form-validations'],
   plugins: [
     handlebars({
       partialDirectory: resolve(__dirname, '../../partials'),

--- a/packages/form-validations/package.json
+++ b/packages/form-validations/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@lmc-eu/browserslist-config": "2.0.0",
+    "@lmc-eu/spirit-common": "^0.0.0",
     "@lmc-eu/spirit-demo": "^0.1.0",
     "@lmc-eu/spirit-design-tokens": "^0.25.5",
     "@lmc-eu/spirit-web": "^1.6.0",

--- a/packages/web-react/config/vite/app.ts
+++ b/packages/web-react/config/vite/app.ts
@@ -1,13 +1,15 @@
-import { resolve } from 'path';
+import { SERVERS } from '@lmc-eu/spirit-common/constants/servers';
+import react from '@vitejs/plugin-react';
 import { readdirSync } from 'fs';
+import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import handlebars from 'vite-plugin-handlebars';
-import react from '@vitejs/plugin-react';
 import { getNestedDirs } from '../../scripts/build';
 
 const hiddenDemoComponents = ['Field', 'Dialog', 'Icon', 'TextFieldBase', 'VisuallyHidden'];
 
 export default defineConfig({
+  server: SERVERS.DEVELOPMENT['web-react'],
   plugins: [
     react(),
     handlebars({

--- a/packages/web-react/package.json
+++ b/packages/web-react/package.json
@@ -29,6 +29,7 @@
     "@lmc-eu/eslint-config-base": "3.0.2",
     "@lmc-eu/eslint-config-jest": "3.0.2",
     "@lmc-eu/eslint-config-react": "2.0.2",
+    "@lmc-eu/spirit-common": "^0.0.0",
     "@lmc-eu/spirit-demo": "^0.1.0",
     "@lmc-eu/spirit-design-tokens": "^0.25.5",
     "@lmc-eu/spirit-web": "^1.6.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -59,6 +59,7 @@
   },
   "devDependencies": {
     "@lmc-eu/browserslist-config": "2.0.0",
+    "@lmc-eu/spirit-common": "^0.0.0",
     "@lmc-eu/spirit-demo": "^0.1.0",
     "@lmc-eu/stylelint-config": "7.0.1",
     "@rollup/plugin-typescript": "11.1.5",

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,7 +1,7 @@
+import { SERVERS } from '@lmc-eu/spirit-common/constants/servers';
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import handlebars from 'vite-plugin-handlebars';
-import { SERVERS } from '../common/constants/servers';
 import { getNestedDirs } from './scripts/prepareDist';
 import { getListOfIcons, getListOfNestedDirectories } from './scripts/utils';
 

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,10 +1,12 @@
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import handlebars from 'vite-plugin-handlebars';
+import { SERVERS } from '../common/constants/servers';
 import { getNestedDirs } from './scripts/prepareDist';
 import { getListOfIcons, getListOfNestedDirectories } from './scripts/utils';
 
 export default defineConfig({
+  server: SERVERS.DEVELOPMENT.web,
   plugins: [
     handlebars({
       helpers: {

--- a/tests/e2e/demo-homepages.spec.ts
+++ b/tests/e2e/demo-homepages.spec.ts
@@ -1,13 +1,14 @@
 import { expect, test } from '@playwright/test';
+import { SERVERS } from '../../common/constants/servers';
 
 test.describe('Demo Homepages', () => {
   const demos = [
     {
-      url: 'https://spirit-design-system-demo.netlify.app/',
+      url: process.env.CI ? SERVERS.PRODUCTION.web : SERVERS.DEVELOPMENT.web,
       package: 'web',
     },
     {
-      url: 'https://spirit-design-system-react.netlify.app/',
+      url: process.env.CI ? SERVERS.PRODUCTION['web-react'] : SERVERS.DEVELOPMENT['web-react'],
       package: 'web-react',
     },
   ];

--- a/tests/e2e/demo-homepages.spec.ts
+++ b/tests/e2e/demo-homepages.spec.ts
@@ -1,14 +1,14 @@
+import { SERVERS, getDevelopmentEndpointUri } from '@lmc-eu/spirit-common/constants/servers';
 import { expect, test } from '@playwright/test';
-import { SERVERS } from '../../common/constants/servers';
 
 test.describe('Demo Homepages', () => {
   const demos = [
     {
-      url: process.env.CI ? SERVERS.PRODUCTION.web : SERVERS.DEVELOPMENT.web,
+      url: process.env.CI ? SERVERS.PRODUCTION.web : getDevelopmentEndpointUri('web'),
       package: 'web',
     },
     {
-      url: process.env.CI ? SERVERS.PRODUCTION['web-react'] : SERVERS.DEVELOPMENT['web-react'],
+      url: process.env.CI ? SERVERS.PRODUCTION['web-react'] : getDevelopmentEndpointUri('web-react'),
       package: 'web-react',
     },
   ];

--- a/tests/e2e/demo-homepages.spec.ts
+++ b/tests/e2e/demo-homepages.spec.ts
@@ -5,11 +5,11 @@ import { expect, test } from '@playwright/test';
 test.describe('Demo Homepages', () => {
   const demos = [
     {
-      url: isTesting() ? SERVERS.TESTING.web : getDevelopmentEndpointUri('web'),
+      url: isTesting() ? SERVERS.TESTING.web : getDevelopmentEndpointUri('web', { isDocker: true }),
       package: 'web',
     },
     {
-      url: isTesting() ? SERVERS.TESTING['web-react'] : getDevelopmentEndpointUri('web-react'),
+      url: isTesting() ? SERVERS.TESTING['web-react'] : getDevelopmentEndpointUri('web-react', { isDocker: true }),
       package: 'web-react',
     },
   ];

--- a/tests/e2e/demo-homepages.spec.ts
+++ b/tests/e2e/demo-homepages.spec.ts
@@ -1,14 +1,15 @@
+import { isTesting } from '@lmc-eu/spirit-common/constants/environments';
 import { SERVERS, getDevelopmentEndpointUri } from '@lmc-eu/spirit-common/constants/servers';
 import { expect, test } from '@playwright/test';
 
 test.describe('Demo Homepages', () => {
   const demos = [
     {
-      url: process.env.CI ? SERVERS.PRODUCTION.web : getDevelopmentEndpointUri('web'),
+      url: isTesting() ? SERVERS.TESTING.web : getDevelopmentEndpointUri('web'),
       package: 'web',
     },
     {
-      url: process.env.CI ? SERVERS.PRODUCTION['web-react'] : getDevelopmentEndpointUri('web-react'),
+      url: isTesting() ? SERVERS.TESTING['web-react'] : getDevelopmentEndpointUri('web-react'),
       package: 'web-react',
     },
   ];


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description
Introducing a new package `spirit-common` where are stored shared features, scripts and code.

E2E test can be now run against production URLs of development ones. Just set env variable `CI` to `true` for production urls.

### Additional context

The visual regression testing will be only run when the `e2e` label is used in PR.

### Issue reference

https://jira.lmc.cz/browse/DS-1093

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
