### PR TITLE
Twig: Introduce optional uniform appearance of `Modal`

### DIFF
--- a/packages/web-twig/src/Resources/components/Modal/Modal.stories.twig
+++ b/packages/web-twig/src/Resources/components/Modal/Modal.stories.twig
@@ -18,4 +18,8 @@
         {% include '@components/Modal/stories/ModalDisabledBackdropClick.twig' %}
     </DocsSection>
 
+    <DocsSection title="Feature Flag: Uniform Modal on Mobile">
+        {% include '@components/Modal/stories/ModalUniformModalOnMobile.twig' %}
+    </DocsSection>
+
 {% endblock %}

--- a/packages/web-twig/src/Resources/components/Modal/ModalDialog.twig
+++ b/packages/web-twig/src/Resources/components/Modal/ModalDialog.twig
@@ -1,6 +1,7 @@
 {# API #}
 {%- set props = props | default([]) -%}
 {%- set _elementType = props.elementType | default('article') -%}
+{%- set _isDockedOnMobile = props.isDockedOnMobile | default(false) -%}
 {%- set _isExpandedOnMobile = props.isExpandedOnMobile ?? true -%}
 {%- set _maxHeightFromTabletUp = props.maxHeightFromTabletUp | default(null) -%}
 {%- set _preferredHeightOnMobile = props.preferredHeightOnMobile | default(null) -%}
@@ -8,11 +9,12 @@
 
 {# Class names #}
 {%- set _rootClassName = _spiritClassPrefix ~ 'ModalDialog' -%}
+{%- set _rootDockOnMobileClassName = _isDockedOnMobile ? _spiritClassPrefix ~ 'ModalDialog--dockOnMobile' : null -%}
 {%- set _rootExpandOnMobileClassName = _isExpandedOnMobile ? _spiritClassPrefix ~ 'ModalDialog--expandOnMobile' : null -%}
 
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
-{%- set _classNames = [ _rootClassName, _rootExpandOnMobileClassName, _styleProps.className ] -%}
+{%- set _classNames = [ _rootClassName, _rootDockOnMobileClassName, _rootExpandOnMobileClassName, _styleProps.className ] -%}
 {%- set _allowedAttributes = _elementType == 'form' ? [
     'accept-charset',
     'action',

--- a/packages/web-twig/src/Resources/components/Modal/README.md
+++ b/packages/web-twig/src/Resources/components/Modal/README.md
@@ -108,22 +108,23 @@ You can use the `maxHeightFromTabletUp` option to override the max height on tab
 
 ### API
 
-| Name                          | Type                          | Default   | Required | Description                                                                                             |
-| ----------------------------- | ----------------------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------- |
-| `accept-charset`              | `string`                      | `null`    | ✕        | `elementType="form"` only: Character encodings to use for form submission (intentionally in kebab-case) |
-| `action`                      | `string`                      | `null`    | ✕        | `elementType="form"` only: URL to use for form submission                                               |
-| `autocomplete`                | `string`                      | `null`    | ✕        | `elementType="form"` only: [Automated assistance in filling][autocomplete-attr]                         |
-| `elementType`                 | `string`                      | `article` | ✕        | HTML tag to render                                                                                      |
-| `enctype`                     | `string`                      | `null`    | ✕        | `elementType="form"` only: Encoding to use for form submission                                          |
-| `isExpandedOnMobile`          | `bool`                        | `true`    | ✕        | If the ModalDialog should expand on mobile. Overrides any height defined by `preferredHeightOnMobile`.  |
-| `maxHeightFromTabletUp`       | `string`                      | `null`    | ✕        | Max height of the modal. Accepts any valid CSS value.                                                   |
-| `method`                      | [`get` \| `post` \| `dialog`] | `null`    | ✕        | `elementType="form"` only: HTTP method to use for form submission                                       |
-| `name`                        | `string`                      | `null`    | ✕        | `elementType="form"` only: Name of the form                                                             |
-| `novalidate`                  | `void`                        | `null`    | ✕        | `elementType="form"` only: [If the dialog should have validation disabled][novalidate-attr]             |
-| `preferredHeightFromTabletUp` | `string`                      | `null`    | ✕        | Preferred height of the modal on tablet and larger. Accepts any valid CSS value.                        |
-| `preferredHeightOnMobile`     | `string`                      | `null`    | ✕        | Preferred height of the modal on mobile. Accepts any valid CSS value.                                   |
-| `rel`                         | `string`                      | `null`    | ✕        | `elementType="form"` only: Relationship between the current document and the linked resource            |
-| `target`                      | `string`                      | `null`    | ✕        | `elementType="form"` only: Browsing context for form submission                                         |
+| Name                          | Type                          | Default   | Required | Description                                                                                                                              |
+| ----------------------------- | ----------------------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `accept-charset`              | `string`                      | `null`    | ✕        | `elementType="form"` only: Character encodings to use for form submission (intentionally in kebab-case)                                  |
+| `action`                      | `string`                      | `null`    | ✕        | `elementType="form"` only: URL to use for form submission                                                                                |
+| `autocomplete`                | `string`                      | `null`    | ✕        | `elementType="form"` only: [Automated assistance in filling][autocomplete-attr]                                                          |
+| `elementType`                 | `string`                      | `article` | ✕        | HTML tag to render                                                                                                                       |
+| `enctype`                     | `string`                      | `null`    | ✕        | `elementType="form"` only: Encoding to use for form submission                                                                           |
+| `isDockedOnMobile`            | `bool`                        | `false`   | ✕        | [REQUIRES FEATURE FLAG](#feature-flag-uniform-appearance-on-all-breakpoints): Dock the ModalDialog to the bottom of the screen on mobile |
+| `isExpandedOnMobile`          | `bool`                        | `true`    | ✕        | If the ModalDialog should expand on mobile. Overrides any height defined by `preferredHeightOnMobile`.                                   |
+| `maxHeightFromTabletUp`       | `string`                      | `null`    | ✕        | Max height of the modal. Accepts any valid CSS value.                                                                                    |
+| `method`                      | [`get` \| `post` \| `dialog`] | `null`    | ✕        | `elementType="form"` only: HTTP method to use for form submission                                                                        |
+| `name`                        | `string`                      | `null`    | ✕        | `elementType="form"` only: Name of the form                                                                                              |
+| `novalidate`                  | `void`                        | `null`    | ✕        | `elementType="form"` only: [If the dialog should have validation disabled][novalidate-attr]                                              |
+| `preferredHeightFromTabletUp` | `string`                      | `null`    | ✕        | Preferred height of the modal on tablet and larger. Accepts any valid CSS value.                                                         |
+| `preferredHeightOnMobile`     | `string`                      | `null`    | ✕        | Preferred height of the modal on mobile. Accepts any valid CSS value.                                                                    |
+| `rel`                         | `string`                      | `null`    | ✕        | `elementType="form"` only: Relationship between the current document and the linked resource                                             |
+| `target`                      | `string`                      | `null`    | ✕        | `elementType="form"` only: Browsing context for form submission                                                                          |
 
 On top of the API options, you can add `data-*` or `aria-*` attributes to
 further extend the component's descriptiveness and accessibility. Also, UNSAFE styling props are available,
@@ -321,6 +322,21 @@ When you put it all together:
 </Modal>
 ```
 
+## Feature Flag: Uniform Appearance on All Breakpoints
+
+The uniform appearance of modal dialog on all breakpoints is disabled by default. To enable it, either set the
+`$modal-enable-uniform-dialog` feature flag to `true` or use the `spirit-modal-enable-uniform-dialog` CSS class on any
+parent of the modal.
+
+For more info, see main [README][readme-feature-flags].
+
+### ⚠️ DEPRECATION NOTICE
+
+The uniform dialog appearance will replace current behavior in the next major release. Current mobile appearance will
+remain accessible via the `isDockedOnMobile` property.
+
+[What are deprecations?][readme-deprecations]
+
 ## JavaScript Plugin
 
 For full functionality, you need to provide Spirit JavaScript:
@@ -345,3 +361,5 @@ Or, feel free to write the controlling script yourself.
 [dictionary-alignment]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#alignment
 [escape-hatches]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web-twig/README.md#escape-hatches
 [scroll-view]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/src/Resources/components/ScrollView/README.md
+[readme-deprecations]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/README.md#deprecations
+[readme-feature-flags]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/README.md#feature-flags

--- a/packages/web-twig/src/Resources/components/Modal/__tests__/__fixtures__/modalDefault.twig
+++ b/packages/web-twig/src/Resources/components/Modal/__tests__/__fixtures__/modalDefault.twig
@@ -41,6 +41,7 @@
     <ModalDialog
         autocomplete="on"
         elementType="form"
+        isDockedOnMobile
         isExpandedOnMobile={ false }
         maxHeightFromTabletUp="700px"
         method="dialog"

--- a/packages/web-twig/src/Resources/components/Modal/__tests__/__snapshots__/modalDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Modal/__tests__/__snapshots__/modalDefault.twig.snap.html
@@ -59,7 +59,7 @@
     <!-- Render with all props -->
 
     <dialog class="Modal" id="modal-example-2" aria-labelledby="modal-example-2-title">
-      <form autocomplete="on" method="dialog" class="ModalDialog custom-class" style="--modal-max-height-tablet: 700px;--modal-preferred-height-mobile: 400px;--modal-preferred-height-tablet: 500px;outline: 5px solid blue; outline-offset: -5px;">
+      <form autocomplete="on" method="dialog" class="ModalDialog ModalDialog--dockOnMobile custom-class" style="--modal-max-height-tablet: 700px;--modal-preferred-height-mobile: 400px;--modal-preferred-height-tablet: 500px;outline: 5px solid blue; outline-offset: -5px;">
         <header class="ModalHeader">
           <h2 class="ModalHeader__title" id="modal-example-2-title">
             Title of the Modal

--- a/packages/web-twig/src/Resources/components/Modal/stories/ModalDefault.twig
+++ b/packages/web-twig/src/Resources/components/Modal/stories/ModalDefault.twig
@@ -1,10 +1,10 @@
-<Button data-spirit-toggle="modal" data-spirit-target="#example_basic">
+<Button data-spirit-toggle="modal" data-spirit-target="#example-basic">
     Open Modal
 </Button>
 
-<Modal id="example_basic" titleId="example_basic_title">
+<Modal id="example-basic" titleId="example-basic-title">
     <ModalDialog>
-        <ModalHeader modalId="example_basic" titleId="example_basic_title">
+        <ModalHeader modalId="example-basic" titleId="example-basic-title">
             Modal Title
         </ModalHeader>
         <ModalBody>
@@ -19,24 +19,24 @@
             <!-- Footer alignment demo: start -->
             <script>
                 const setFooterAlignment = (event) => {
-                    const footerElement = document.querySelector('#example_basic .ModalFooter');
+                    const footerElement = document.querySelector('#example-basic .ModalFooter');
 
                     footerElement.classList.remove('ModalFooter--left', 'ModalFooter--center', 'ModalFooter--right');
                     footerElement.classList.add(`ModalFooter--${event.target.value}`);
                 };
 
                 const toggleExpandOnMobile = () => {
-                    document.querySelector('#example_basic .ModalDialog').classList.toggle('ModalDialog--expandOnMobile');
+                    document.querySelector('#example-basic .ModalDialog').classList.toggle('ModalDialog--expandOnMobile');
                 };
             </script>
             <form onchange="setFooterAlignment(event)" class="d-none d-tablet-block">
                 <div>Footer alignment (from tablet up):</div>
-                <Radio id="footer_alignment_left" UNSAFE_className="mr-600" label="Left" value="left" name="footer_alignment" autocomplete="off" />
-                <Radio id="footer_alignment_center" UNSAFE_className="mr-600" label="Center" value="center" name="footer_alignment" autocomplete="off" />
-                <Radio id="footer_alignment_right" UNSAFE_className="mr-600" label="Right" value="right" name="footer_alignment" autocomplete="off" isChecked />
+                <Radio id="footer-alignment-left" UNSAFE_className="mr-600" label="Left" value="left" name="footer-alignment" autocomplete="off" />
+                <Radio id="footer-alignment-center" UNSAFE_className="mr-600" label="Center" value="center" name="footer-alignment" autocomplete="off" />
+                <Radio id="footer-alignment-right" UNSAFE_className="mr-600" label="Right" value="right" name="footer-alignment" autocomplete="off" isChecked />
             </form>
             <form class="d-tablet-none">
-                <Checkbox id="expand_on_mobile" label="Expand on mobile" value="right" onchange="toggleExpandOnMobile()" autocomplete="off" isChecked />
+                <Checkbox id="expand-on-mobile" label="Expand on mobile" value="right" onchange="toggleExpandOnMobile()" autocomplete="off" isChecked />
             </form>
             <!-- Footer alignment demo: end -->
             <!-- Content: end -->
@@ -45,14 +45,14 @@
         <ModalFooter description="Optional description">
             <Button
                 data-spirit-dismiss="modal"
-                data-spirit-target="#example_basic"
+                data-spirit-target="#example-basic"
             >
                 Primary action
             </Button>
             <Button
                 color="secondary"
                 data-spirit-dismiss="modal"
-                data-spirit-target="#example_basic"
+                data-spirit-target="#example-basic"
             >
                 Secondary action
             </Button>
@@ -60,13 +60,13 @@
     </ModalDialog>
 </Modal>
 
-<Button data-spirit-toggle="modal" data-spirit-target="#example_form">
+<Button data-spirit-toggle="modal" data-spirit-target="#example-form">
     Open Modal with a Form
 </Button>
 
-<Modal id="example_form" titleId="example_form_title">
+<Modal id="example-form" titleId="example-form-title">
     <ModalDialog elementType="form" method="dialog">
-        <ModalHeader modalId="example_form" titleId="example_form_title">
+        <ModalHeader modalId="example-form" titleId="example-form-title">
             Modal with a Form
         </ModalHeader>
         <ModalBody>
@@ -86,7 +86,7 @@
             <Button
                 color="secondary"
                 data-spirit-dismiss="modal"
-                data-spirit-target="#example_form"
+                data-spirit-target="#example-form"
             >
                 Secondary action
             </Button>
@@ -94,11 +94,11 @@
     </ModalDialog>
 </Modal>
 
-<Button data-spirit-toggle="modal" data-spirit-target="#example_custom_height">
+<Button data-spirit-toggle="modal" data-spirit-target="#example-custom-height">
     Open Modal with Custom Height
 </Button>
 
-<Modal id="example_custom_height" titleId="example_custom_height_title">
+<Modal id="example-custom-height" titleId="example-custom-height-title">
     <ModalDialog
         elementType="form"
         isExpandedOnMobile={ false }
@@ -107,7 +107,7 @@
         preferredHeightOnMobile="400px"
         preferredHeightFromTabletUp="500px"
     >
-        <ModalHeader modalId="example_custom_height" titleId="example_custom_height_title">
+        <ModalHeader modalId="example-custom-height" titleId="example-custom-height-title">
             Modal with Custom Height
         </ModalHeader>
         <ModalBody>
@@ -133,7 +133,7 @@
             <Button
                 color="secondary"
                 data-spirit-dismiss="modal"
-                data-spirit-target="#example_custom_height"
+                data-spirit-target="#example-custom-height"
             >
                 Secondary action
             </Button>

--- a/packages/web-twig/src/Resources/components/Modal/stories/ModalDisabledBackdropClick.twig
+++ b/packages/web-twig/src/Resources/components/Modal/stories/ModalDisabledBackdropClick.twig
@@ -1,10 +1,10 @@
-<Button data-spirit-toggle="modal" data-spirit-target="#example_disabled_backdrop_click">
+<Button data-spirit-toggle="modal" data-spirit-target="#example-disabled-backdrop-click">
     Open Modal
 </Button>
 
-<Modal id="example_disabled_backdrop_click" titleId="example_disabled_backdrop_click_title" closeOnBackdropClick={ false }>
+<Modal id="example-disabled-backdrop-click" titleId="example-disabled-backdrop-click-title" closeOnBackdropClick={ false }>
     <ModalDialog>
-        <ModalHeader modalId="example_disabled_backdrop_click" titleId="example_disabled_backdrop_click_title">
+        <ModalHeader modalId="example-disabled-backdrop-click" titleId="example-disabled-backdrop-click-title">
             Modal Title
         </ModalHeader>
         <ModalBody>
@@ -17,14 +17,14 @@
         <ModalFooter>
             <Button
                 data-spirit-dismiss="modal"
-                data-spirit-target="#example_disabled_backdrop_click"
+                data-spirit-target="#example-disabled-backdrop-click"
             >
                 Primary action
             </Button>
             <Button
                 color="secondary"
                 data-spirit-dismiss="modal"
-                data-spirit-target="#example_disabled_backdrop_click"
+                data-spirit-target="#example-disabled-backdrop-click"
             >
                 Secondary action
             </Button>

--- a/packages/web-twig/src/Resources/components/Modal/stories/ModalScrollingLongContent.twig
+++ b/packages/web-twig/src/Resources/components/Modal/stories/ModalScrollingLongContent.twig
@@ -1,10 +1,10 @@
-<Button data-spirit-toggle="modal" data-spirit-target="#example_long_content">
+<Button data-spirit-toggle="modal" data-spirit-target="#example-long-content">
     Open Modal with Long Content
 </Button>
 
-<Modal id="example_long_content" titleId="example_long_content_title">
+<Modal id="example-long-content" titleId="example-long-content-title">
     <ModalDialog>
-        <ModalHeader modalId="example_long_content" titleId="example_long_content_title">
+        <ModalHeader modalId="example-long-content" titleId="example-long-content-title">
             Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia perferendis reprehenderit, voluptate. Cum delectus dicta
         </ModalHeader>
         <ModalBody>
@@ -56,14 +56,14 @@
         <ModalFooter>
             <Button
                 data-spirit-dismiss="modal"
-                data-spirit-target="#example_long_content"
+                data-spirit-target="#example-long-content"
             >
                 Primary action
             </Button>
             <Button
                 color="secondary"
                 data-spirit-dismiss="modal"
-                data-spirit-target="#example_long_content"
+                data-spirit-target="#example-long-content"
             >
                 Secondary action
             </Button>
@@ -71,13 +71,13 @@
     </ModalDialog>
 </Modal>
 
-<Button data-spirit-toggle="modal" data-spirit-target="#example_scroll_view">
+<Button data-spirit-toggle="modal" data-spirit-target="#example-scroll-view">
     Open Modal with ScrollView
 </Button>
 
-<Modal id="example_scroll_view" titleId="example_scroll_view_title">
+<Modal id="example-scroll-view" titleId="example-scroll-view-title">
     <ModalDialog>
-        <ModalHeader modalId="example_scroll_view" titleId="example_scroll_view_title">
+        <ModalHeader modalId="example-scroll-view" titleId="example-scroll-view-title">
             Modal with ScrollView
         </ModalHeader>
         <ScrollView data-spirit-toggle="scrollView" overflowDecorators="both">
@@ -131,14 +131,14 @@
         <ModalFooter>
             <Button
                 data-spirit-dismiss="modal"
-                data-spirit-target="#example_scroll_view"
+                data-spirit-target="#example-scroll-view"
             >
                 Primary action
             </Button>
             <Button
                 color="secondary"
                 data-spirit-dismiss="modal"
-                data-spirit-target="#example_scroll_view"
+                data-spirit-target="#example-scroll-view"
             >
                 Secondary action
             </Button>

--- a/packages/web-twig/src/Resources/components/Modal/stories/ModalStacking.twig
+++ b/packages/web-twig/src/Resources/components/Modal/stories/ModalStacking.twig
@@ -1,10 +1,10 @@
-<Button data-spirit-toggle="modal" data-spirit-target="#example_stacking_parent">
+<Button data-spirit-toggle="modal" data-spirit-target="#example-stacking-parent">
     Open Modal
 </Button>
 
-<Modal id="example_stacking_parent" titleId="example_stacking_parent_title">
+<Modal id="example-stacking-parent" titleId="example-stacking-parent-title">
     <ModalDialog>
-        <ModalHeader modalId="example_stacking_parent" titleId="example_stacking_parent_title">
+        <ModalHeader modalId="example-stacking-parent" titleId="example-stacking-parent-title">
             Modal Title
         </ModalHeader>
         <ModalBody>
@@ -19,16 +19,16 @@
 
         </ModalBody>
         <ModalFooter>
-            <Button data-spirit-toggle="modal" data-spirit-target="#example_stacking_nested">
+            <Button data-spirit-toggle="modal" data-spirit-target="#example-stacking-nested">
                 Open stacked dialog
             </Button>
         </ModalFooter>
     </ModalDialog>
 </Modal>
 
-<Modal id="example_stacking_nested" titleId="example_stacking_nested_title">
+<Modal id="example-stacking-nested" titleId="example-stacking-nested-title">
     <ModalDialog>
-        <ModalHeader modalId="example_stacking_nested" titleId="example_stacking_nested_title">
+        <ModalHeader modalId="example-stacking-nested" titleId="example-stacking-nested-title">
             Stacked Modal Title
         </ModalHeader>
         <ModalBody>
@@ -58,7 +58,7 @@
             <Button
                 color="secondary"
                 data-spirit-dismiss="modal"
-                data-spirit-target="#example_stacking_nested"
+                data-spirit-target="#example-stacking-nested"
             >
                 Secondary action
             </Button>

--- a/packages/web-twig/src/Resources/components/Modal/stories/ModalUniformModalOnMobile.twig
+++ b/packages/web-twig/src/Resources/components/Modal/stories/ModalUniformModalOnMobile.twig
@@ -1,0 +1,77 @@
+<div class="spirit-feature-modal-enable-uniform-dialog" style="display: contents"><!-- Set `display: contents` to enable parent stack layout. -->
+    <Button data-spirit-toggle="modal" data-spirit-target="#example-uniform">
+        Open Modal
+    </Button>
+
+    <Button data-spirit-toggle="modal" data-spirit-target="#example-docked">
+        Open Docked Modal (mobile only)
+    </Button>
+
+    <Modal id="example-uniform" titleId="example-uniform-title">
+        <ModalDialog>
+            <ModalHeader modalId="example-uniform" titleId="example-uniform-title">
+                Modal Title
+            </ModalHeader>
+            <ModalBody>
+
+                <!-- Content: start -->
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+                    perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+                    provident unde. Eveniet, iste, molestiae?
+                </p>
+                <!-- Content: end -->
+
+            </ModalBody>
+            <ModalFooter description="Optional description">
+                <Button
+                    data-spirit-dismiss="modal"
+                    data-spirit-target="#example-uniform"
+                >
+                    Primary action
+                </Button>
+                <Button
+                    color="secondary"
+                    data-spirit-dismiss="modal"
+                    data-spirit-target="#example-uniform"
+                >
+                    Secondary action
+                </Button>
+            </ModalFooter>
+        </ModalDialog>
+    </Modal>
+
+    <Modal id="example-docked" titleId="example-docked-title">
+        <ModalDialog isDockedOnMobile>
+            <ModalHeader modalId="example-docked" titleId="example-docked-title">
+                Modal Title
+            </ModalHeader>
+            <ModalBody>
+
+                <!-- Content: start -->
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+                    perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+                    provident unde. Eveniet, iste, molestiae?
+                </p>
+                <!-- Content: end -->
+
+            </ModalBody>
+            <ModalFooter description="Optional description">
+                <Button
+                    data-spirit-dismiss="modal"
+                    data-spirit-target="#example-docked"
+                >
+                    Primary action
+                </Button>
+                <Button
+                    color="secondary"
+                    data-spirit-dismiss="modal"
+                    data-spirit-target="#example-docked"
+                >
+                    Secondary action
+                </Button>
+            </ModalFooter>
+        </ModalDialog>
+    </Modal>
+</div>


### PR DESCRIPTION
## Description

![image](https://github.com/lmc-eu/spirit-design-system/assets/5614085/5c856130-f515-4c25-893b-87f0a6381f46)

Add `spirit-feature-modal-enable-uniform-dialog` feature class to enable uniform appearance of `Modal` across all breakpoints.

Current mobile design is then accessible using the `isDockedOnMobile` property.

### Additional context

We need to make sure it works in all scenarios:

1. Current behavior must remain intact.
2. New appearance can be turned on via CSS class,
3. … or via Sass feature flag.

### Issue reference

https://jira.lmc.cz/browse/DS-1091