### PR TITLE
Fix(web-react): Get initial scroll from offsetY

### DIFF
--- a/packages/web-react/config/jest/setupTestingLibrary.ts
+++ b/packages/web-react/config/jest/setupTestingLibrary.ts
@@ -2,6 +2,7 @@
 import '@testing-library/jest-dom';
 
 const originalError = console.error;
+let originalScrollTo: typeof window.scrollTo;
 
 beforeAll(() => {
   console.error = (...args) => {
@@ -10,10 +11,14 @@ beforeAll(() => {
     }
     originalError.call(console, ...args);
   };
+
+  originalScrollTo = window.scrollTo;
+  window.scrollTo = jest.fn();
 });
 
 afterAll(() => {
   console.error = originalError;
+  window.scrollTo = originalScrollTo;
 });
 
 // jsdom not support dialog events

--- a/packages/web-react/docs/DocsSections.tsx
+++ b/packages/web-react/docs/DocsSections.tsx
@@ -8,10 +8,18 @@ interface DocsSectionProps {
   stackAlignment?: 'start' | 'center' | 'end' | 'stretch';
   tag?: string;
   title: string;
+  [x: string]: unknown;
 }
 
-const DocsSection = ({ children, hasStack = true, stackAlignment = 'start', title, tag }: DocsSectionProps) => (
-  <section className="docs-Section">
+const DocsSection = ({
+  children,
+  hasStack = true,
+  stackAlignment = 'start',
+  title,
+  tag,
+  ...restProps
+}: DocsSectionProps) => (
+  <section className="docs-Section" {...restProps}>
     <h2 className="docs-Heading">
       {title}
       {tag && (

--- a/packages/web-react/src/components/Modal/demo/index.tsx
+++ b/packages/web-react/src/components/Modal/demo/index.tsx
@@ -8,9 +8,9 @@ import icons from '@lmc-eu/spirit-icons/dist/icons';
 import DocsSection from '../../../../docs/DocsSections';
 import { IconsProvider } from '../../../context';
 import ModalDefault from './ModalDefault';
+import ModalDisabledBackdropClick from './ModalDisabledBackdropClick';
 import ModalScrollingLongContent from './ModalScrollingLongContent';
 import ModalStacking from './ModalStacking';
-import ModalDisabledBackdropClick from './ModalDisabledBackdropClick';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
@@ -24,7 +24,10 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
       <DocsSection title="Stacking Modals">
         <ModalStacking />
       </DocsSection>
-      <DocsSection title="Disabled Backdrop Click">
+      <a href="#test" title="test">
+        test
+      </a>
+      <DocsSection title="Disabled Backdrop Click" id="test" style={{ marginBottom: '2000px' }}>
         <ModalDisabledBackdropClick />
       </DocsSection>
     </IconsProvider>

--- a/packages/web-react/src/hooks/__tests__/useScrollControl.test.ts
+++ b/packages/web-react/src/hooks/__tests__/useScrollControl.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import { MutableRefObject } from 'react';
 import { useScrollControl } from '../useScrollControl';
 
@@ -45,7 +45,7 @@ describe('useScrollControl', () => {
       renderHook(() => useScrollControl(mockRef, false));
     });
 
-    expect(scrollToSpy).toHaveBeenCalledWith(0, 0);
+    expect(scrollToSpy).toHaveBeenCalledWith(0, -0);
     expect(document.body.classList.contains('is-scrolling-disabled')).toBe(false);
     expect(document.body.style.top).toBe('');
   });

--- a/packages/web-react/src/hooks/useScrollControl.ts
+++ b/packages/web-react/src/hooks/useScrollControl.ts
@@ -17,7 +17,7 @@ const enableScroll = (offsetY: number) => {
   body.style.paddingRight = '';
   body.style.top = '';
   body.classList.remove(CLASSNAME_SCROLLING_DISABLED);
-  window.scrollTo(0, offsetY);
+  window.scrollTo(0, -offsetY);
 };
 
 export const useScrollControl = (ref: MutableRefObject<HTMLDialogElement | null>, isOpen: boolean) => {

--- a/packages/web-react/src/hooks/useScrollControl.ts
+++ b/packages/web-react/src/hooks/useScrollControl.ts
@@ -1,4 +1,4 @@
-import { useEffect, MutableRefObject } from 'react';
+import { MutableRefObject, useEffect } from 'react';
 
 const CLASSNAME_SCROLLING_DISABLED = 'is-scrolling-disabled';
 
@@ -17,7 +17,7 @@ const enableScroll = (offsetY: number) => {
   body.style.paddingRight = '';
   body.style.top = '';
   body.classList.remove(CLASSNAME_SCROLLING_DISABLED);
-  window.scrollTo(0, -offsetY);
+  window.scrollTo(0, offsetY);
 };
 
 export const useScrollControl = (ref: MutableRefObject<HTMLDialogElement | null>, isOpen: boolean) => {
@@ -25,7 +25,7 @@ export const useScrollControl = (ref: MutableRefObject<HTMLDialogElement | null>
     if (isOpen) {
       disableScroll();
     } else if (ref.current && !ref.current.open) {
-      const offsetY = parseFloat(document.body.style.top || '0');
+      const offsetY = parseFloat(document.body.style.top || '0') || window.scrollY;
       enableScroll(offsetY);
     }
   }, [isOpen, ref]);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

  * useEffect runs enableScroll function by default
  * at that time the document.body.style.top is not set
  * so the function falls back to 0 even if the window is scrolled
  * do not work particularly with #anchors

### Additional context

* https://github.com/lmc-eu/spirit-design-system/pull/1140

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
