### PR TITLE
Chore(web): Require `sass` from v1.57.0 above due to `string.split`

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -86,6 +86,9 @@
     "vite": "4.5.1",
     "vite-plugin-handlebars": "1.6.0"
   },
+  "peerDependencies": {
+    "sass": ">=1.57.0"
+  },
   "nx": {
     "targets": {
       "build": {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

`string.split` is in Sass since 1.57.0

### Additional context

https://sass-lang.com/documentation/modules/string/#split

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
