### PR TITLE
Fix(web-react): Closing Modal by Escape key

### DIFF
--- a/packages/web-react/src/hooks/useCancelEvent.ts
+++ b/packages/web-react/src/hooks/useCancelEvent.ts
@@ -1,6 +1,12 @@
-import { useCallback, useEffect, MutableRefObject } from 'react';
+import { MutableRefObject, useCallback, useEffect } from 'react';
 
-const EVENT_CANCEL = 'cancel';
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/cancel_event
+ * @see https://jira.lmc.cz/browse/DS-1108
+ * Here should be used `cancel` event instead of `close` event.
+ * But when dialog is closed using `escape` key, `cancel` event is not fired.
+ */
+const EVENT_CANCEL = 'close';
 
 export const useCancelEvent = (ref: MutableRefObject<HTMLElement | null>, callback: (event: Event) => void) => {
   const handleCancel = useCallback(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

  * `cancel` event was not fired while closing dialog using escape key

### Additional context

- https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/open
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/cancel_event

### Issue reference

https://jira.lmc.cz/browse/DS-1108

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
