### PR TITLE
Revert(web-react): Move `common` dependency back to package

### DIFF
--- a/packages/form-validations/src/FormValidations.ts
+++ b/packages/form-validations/src/FormValidations.ts
@@ -1,7 +1,7 @@
 // Allow use of bitwise not in this case only, other solutions do not work
 /* eslint no-bitwise: ["error", { "allow": ["~"] }] */
 /* eslint-disable no-prototype-builtins */
-import { warning } from '@lmc-eu/spirit-common/utilities';
+import { warning } from './common/utilities';
 import { lang } from './lang';
 import {
   Field,

--- a/packages/form-validations/src/common/constants/__tests__/environments.test.ts
+++ b/packages/form-validations/src/common/constants/__tests__/environments.test.ts
@@ -1,0 +1,59 @@
+import { isDevelopment, isProduction, isTesting } from '../environments';
+
+describe('environments', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    // Most important - it clears the cache
+    jest.resetModules();
+    // Make a copy
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    // Restore old environment
+    process.env = OLD_ENV;
+  });
+
+  describe('isDevelopment', () => {
+    it('should return true when NODE_ENV is set to `development`', () => {
+      process.env.NODE_ENV = 'development';
+
+      expect(isDevelopment()).toBeTruthy();
+    });
+
+    it('should return false when NODE_ENV is not set to `development`', () => {
+      process.env.NODE_ENV = 'production';
+
+      expect(isDevelopment()).toBeFalsy();
+    });
+  });
+
+  describe('isTesting', () => {
+    it('should return true when NODE_ENV is set to `testing`', () => {
+      process.env.NODE_ENV = 'testing';
+
+      expect(isTesting()).toBeTruthy();
+    });
+
+    it('should return false when NODE_ENV is not set to `testing`', () => {
+      process.env.NODE_ENV = 'production';
+
+      expect(isTesting()).toBeFalsy();
+    });
+  });
+
+  describe('isProduction', () => {
+    it('should return true when NODE_ENV is set to `production`', () => {
+      process.env.NODE_ENV = 'production';
+
+      expect(isProduction()).toBeTruthy();
+    });
+
+    it('should return false when NODE_ENV is not set to `production`', () => {
+      process.env.NODE_ENV = 'development';
+
+      expect(isProduction()).toBeFalsy();
+    });
+  });
+});

--- a/packages/form-validations/src/common/constants/environments.ts
+++ b/packages/form-validations/src/common/constants/environments.ts
@@ -1,0 +1,9 @@
+export const ENVIRONMENTS = {
+  DEVELOPMENT: 'development',
+  TESTING: 'testing',
+  PRODUCTION: 'production',
+};
+
+export const isDevelopment = () => process.env.NODE_ENV === ENVIRONMENTS.DEVELOPMENT;
+export const isTesting = () => process.env.NODE_ENV === ENVIRONMENTS.TESTING;
+export const isProduction = () => process.env.NODE_ENV === ENVIRONMENTS.PRODUCTION;

--- a/packages/form-validations/src/common/constants/index.ts
+++ b/packages/form-validations/src/common/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './environments';

--- a/packages/form-validations/src/common/index.ts
+++ b/packages/form-validations/src/common/index.ts
@@ -1,0 +1,2 @@
+export * from './constants';
+export * from './utilities';

--- a/packages/form-validations/src/common/utilities/__tests__/warning.test.ts
+++ b/packages/form-validations/src/common/utilities/__tests__/warning.test.ts
@@ -1,0 +1,38 @@
+/* eslint-disable no-console --
+ * we are testing Console function
+ */
+import warning from '../warning';
+
+describe('warning', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - mocked
+    console.warn.mockRestore();
+  });
+
+  // testing truthy values
+  // eslint-disable-next-line symbol-description
+  it.each([1, -1, true, {}, [], Symbol(), 'hi'])(
+    'should not log a warning if the condition is truthy',
+    (truthyValue) => {
+      warning(truthyValue, 'message');
+
+      expect(console.warn).not.toHaveBeenCalled();
+    },
+  );
+
+  // https://github.com/getify/You-Dont-Know-JS/blob/master/types%20%26%20grammar/ch4.md#falsy-values
+  // testing falsy values
+  // eslint-disable-next-line no-undefined
+  it.each([undefined, null, false, +0, -0, NaN, ''])('should log a warning if the condition is falsy', (falsyValue) => {
+    const message: string = `hey ${String(falsyValue)}`;
+    warning(falsyValue, message);
+
+    expect(console.warn).toHaveBeenCalledWith(`Warning: ${message}`);
+    // @ts-expect-error - mocking console.warn
+    console.warn.mockClear();
+  });
+});

--- a/packages/form-validations/src/common/utilities/index.ts
+++ b/packages/form-validations/src/common/utilities/index.ts
@@ -1,0 +1,1 @@
+export { default as warning } from './warning';

--- a/packages/form-validations/src/common/utilities/warning.ts
+++ b/packages/form-validations/src/common/utilities/warning.ts
@@ -1,0 +1,32 @@
+import { isProduction } from '../constants/environments';
+
+const warning = (condition: unknown, message: string): void => {
+  // don't do anything in production
+  // wrapping in production check for better dead code elimination
+  if (!isProduction()) {
+    // condition passed: do not log
+    if (condition) {
+      return;
+    }
+
+    // Condition not passed
+    const text = `Warning: ${message}`;
+
+    if (typeof console !== 'undefined') {
+      // eslint-disable-next-line no-console -- we want to log a warning; so usage of Console is required
+      console.warn(text);
+    }
+
+    // Throwing an error and catching it immediately
+    // to improve debugging
+    // A consumer can use 'pause on caught exceptions'
+    // https://github.com/facebook/react/issues/4216
+    try {
+      throw Error(text);
+    } catch (x) {
+      // empty
+    }
+  }
+};
+
+export default warning;

--- a/packages/web-react/src/common/constants/__tests__/environments.test.ts
+++ b/packages/web-react/src/common/constants/__tests__/environments.test.ts
@@ -1,0 +1,59 @@
+import { isDevelopment, isProduction, isTesting } from '../environments';
+
+describe('environments', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    // Most important - it clears the cache
+    jest.resetModules();
+    // Make a copy
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    // Restore old environment
+    process.env = OLD_ENV;
+  });
+
+  describe('isDevelopment', () => {
+    it('should return true when NODE_ENV is set to `development`', () => {
+      process.env.NODE_ENV = 'development';
+
+      expect(isDevelopment()).toBeTruthy();
+    });
+
+    it('should return false when NODE_ENV is not set to `development`', () => {
+      process.env.NODE_ENV = 'production';
+
+      expect(isDevelopment()).toBeFalsy();
+    });
+  });
+
+  describe('isTesting', () => {
+    it('should return true when NODE_ENV is set to `testing`', () => {
+      process.env.NODE_ENV = 'testing';
+
+      expect(isTesting()).toBeTruthy();
+    });
+
+    it('should return false when NODE_ENV is not set to `testing`', () => {
+      process.env.NODE_ENV = 'production';
+
+      expect(isTesting()).toBeFalsy();
+    });
+  });
+
+  describe('isProduction', () => {
+    it('should return true when NODE_ENV is set to `production`', () => {
+      process.env.NODE_ENV = 'production';
+
+      expect(isProduction()).toBeTruthy();
+    });
+
+    it('should return false when NODE_ENV is not set to `production`', () => {
+      process.env.NODE_ENV = 'development';
+
+      expect(isProduction()).toBeFalsy();
+    });
+  });
+});

--- a/packages/web-react/src/common/constants/environments.ts
+++ b/packages/web-react/src/common/constants/environments.ts
@@ -1,0 +1,9 @@
+export const ENVIRONMENTS = {
+  DEVELOPMENT: 'development',
+  TESTING: 'testing',
+  PRODUCTION: 'production',
+};
+
+export const isDevelopment = () => process.env.NODE_ENV === ENVIRONMENTS.DEVELOPMENT;
+export const isTesting = () => process.env.NODE_ENV === ENVIRONMENTS.TESTING;
+export const isProduction = () => process.env.NODE_ENV === ENVIRONMENTS.PRODUCTION;

--- a/packages/web-react/src/common/constants/index.ts
+++ b/packages/web-react/src/common/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './environments';

--- a/packages/web-react/src/common/index.ts
+++ b/packages/web-react/src/common/index.ts
@@ -1,0 +1,2 @@
+export * from './constants';
+export * from './utilities';

--- a/packages/web-react/src/common/utilities/__tests__/info.test.ts
+++ b/packages/web-react/src/common/utilities/__tests__/info.test.ts
@@ -1,0 +1,35 @@
+/* eslint-disable no-console --
+ * we are testing Console function
+ */
+import info from '../info';
+
+describe('info', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - mocked
+    console.info.mockRestore();
+  });
+
+  // testing truthy values
+  // eslint-disable-next-line symbol-description
+  it.each([1, -1, true, {}, [], Symbol(), 'hi'])('should not log a info if the condition is truthy', (truthyValue) => {
+    info(truthyValue, 'message');
+
+    expect(console.info).not.toHaveBeenCalled();
+  });
+
+  // https://github.com/getify/You-Dont-Know-JS/blob/master/types%20%26%20grammar/ch4.md#falsy-values
+  // testing falsy values
+  // eslint-disable-next-line no-undefined
+  it.each([undefined, null, false, +0, -0, NaN, ''])('should log a info if the condition is falsy', (falsyValue) => {
+    const message: string = `hey ${String(falsyValue)}`;
+    info(falsyValue, message);
+
+    expect(console.info).toHaveBeenCalledWith(`Info: ${message}`);
+    // @ts-expect-error - mocking console.info
+    console.info.mockClear();
+  });
+});

--- a/packages/web-react/src/common/utilities/__tests__/warning.test.ts
+++ b/packages/web-react/src/common/utilities/__tests__/warning.test.ts
@@ -1,0 +1,38 @@
+/* eslint-disable no-console --
+ * we are testing Console function
+ */
+import warning from '../warning';
+
+describe('warning', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - mocked
+    console.warn.mockRestore();
+  });
+
+  // testing truthy values
+  // eslint-disable-next-line symbol-description
+  it.each([1, -1, true, {}, [], Symbol(), 'hi'])(
+    'should not log a warning if the condition is truthy',
+    (truthyValue) => {
+      warning(truthyValue, 'message');
+
+      expect(console.warn).not.toHaveBeenCalled();
+    },
+  );
+
+  // https://github.com/getify/You-Dont-Know-JS/blob/master/types%20%26%20grammar/ch4.md#falsy-values
+  // testing falsy values
+  // eslint-disable-next-line no-undefined
+  it.each([undefined, null, false, +0, -0, NaN, ''])('should log a warning if the condition is falsy', (falsyValue) => {
+    const message: string = `hey ${String(falsyValue)}`;
+    warning(falsyValue, message);
+
+    expect(console.warn).toHaveBeenCalledWith(`Warning: ${message}`);
+    // @ts-expect-error - mocking console.warn
+    console.warn.mockClear();
+  });
+});

--- a/packages/web-react/src/common/utilities/index.ts
+++ b/packages/web-react/src/common/utilities/index.ts
@@ -1,0 +1,2 @@
+export { default as info } from './info';
+export { default as warning } from './warning';

--- a/packages/web-react/src/common/utilities/info.ts
+++ b/packages/web-react/src/common/utilities/info.ts
@@ -1,0 +1,22 @@
+import { isProduction } from '../constants/environments';
+
+const info = (condition: unknown, message: string): void => {
+  // don't do anything in production
+  // wrapping in production check for better dead code elimination
+  if (!isProduction()) {
+    // condition passed: do not log
+    if (condition) {
+      return;
+    }
+
+    // Condition not passed
+    const text = `Info: ${message}`;
+
+    if (typeof console !== 'undefined') {
+      // eslint-disable-next-line no-console -- we want to log a warning; so usage of Console is required
+      console.info(text);
+    }
+  }
+};
+
+export default info;

--- a/packages/web-react/src/common/utilities/warning.ts
+++ b/packages/web-react/src/common/utilities/warning.ts
@@ -1,0 +1,32 @@
+import { isProduction } from '../constants/environments';
+
+const warning = (condition: unknown, message: string): void => {
+  // don't do anything in production
+  // wrapping in production check for better dead code elimination
+  if (!isProduction()) {
+    // condition passed: do not log
+    if (condition) {
+      return;
+    }
+
+    // Condition not passed
+    const text = `Warning: ${message}`;
+
+    if (typeof console !== 'undefined') {
+      // eslint-disable-next-line no-console -- we want to log a warning; so usage of Console is required
+      console.warn(text);
+    }
+
+    // Throwing an error and catching it immediately
+    // to improve debugging
+    // A consumer can use 'pause on caught exceptions'
+    // https://github.com/facebook/react/issues/4216
+    try {
+      throw Error(text);
+    } catch (x) {
+      // empty
+    }
+  }
+};
+
+export default warning;

--- a/packages/web-react/src/components/Button/useButtonStyleProps.ts
+++ b/packages/web-react/src/components/Button/useButtonStyleProps.ts
@@ -1,6 +1,6 @@
-import { warning } from '@lmc-eu/spirit-common/utilities';
 import classNames from 'classnames';
 import { ElementType } from 'react';
+import { warning } from '../../common/utilities';
 import { useClassNamePrefix } from '../../hooks';
 import { ButtonColor, ButtonSize, SpiritButtonProps } from '../../types';
 import { applyColor, applySize } from '../../utils/classname';

--- a/packages/web-react/src/components/ButtonLink/useButtonLinkStyleProps.ts
+++ b/packages/web-react/src/components/ButtonLink/useButtonLinkStyleProps.ts
@@ -1,6 +1,6 @@
-import { warning } from '@lmc-eu/spirit-common/utilities';
 import classNames from 'classnames';
 import { ElementType } from 'react';
+import { warning } from '../../common/utilities';
 import { useClassNamePrefix } from '../../hooks';
 import { ButtonColor, ButtonSize, SpiritButtonProps } from '../../types';
 import { applyColor, applySize } from '../../utils/classname';

--- a/packages/web-react/src/components/FileUploader/useFileUploaderInput.ts
+++ b/packages/web-react/src/components/FileUploader/useFileUploaderInput.ts
@@ -1,5 +1,5 @@
-import { warning } from '@lmc-eu/spirit-common/utilities';
 import { ChangeEvent, DragEvent, useEffect, useState } from 'react';
+import { warning } from '../../common/utilities';
 import { useDragAndDrop } from '../../hooks';
 import { DragAndDropHandlingProps, FileQueueMapType, FileUploaderQueueLimitBehaviorType } from '../../types';
 import { useFileUploaderContext } from './FileUploaderContext';

--- a/packages/web-react/src/components/FileUploader/utils.ts
+++ b/packages/web-react/src/components/FileUploader/utils.ts
@@ -1,4 +1,4 @@
-import { warning } from '@lmc-eu/spirit-common/utilities';
+import { warning } from '../../common/utilities';
 import { FileMetadata } from '../../types/fileUploader';
 
 const getAttachmentInput = (

--- a/packages/web-react/src/components/Icon/Icon.tsx
+++ b/packages/web-react/src/components/Icon/Icon.tsx
@@ -1,5 +1,5 @@
-import { warning } from '@lmc-eu/spirit-common/utilities';
 import React from 'react';
+import { warning } from '../../common/utilities';
 import { useIcon, useStyleProps } from '../../hooks';
 import { IconProps } from '../../types';
 import { htmlParser } from '../../utils/htmlParser';

--- a/packages/web-react/src/hooks/styleProps.ts
+++ b/packages/web-react/src/hooks/styleProps.ts
@@ -1,5 +1,5 @@
-import { warning } from '@lmc-eu/spirit-common/utilities';
 import { CSSProperties, HTMLAttributes } from 'react';
+import { warning } from '../common/utilities';
 import { StyleProps } from '../types/shared/style';
 
 export type StylePropsResult = {

--- a/packages/web-react/src/hooks/useDeprecationMessage.ts
+++ b/packages/web-react/src/hooks/useDeprecationMessage.ts
@@ -1,5 +1,5 @@
-import { warning } from '@lmc-eu/spirit-common/utilities';
 import { useEffect } from 'react';
+import { warning } from '../common/utilities';
 
 export interface UseDeprecationMessageProps {
   method?: 'component' | 'property' | 'custom';

--- a/packages/web/src/js/FileUploader.ts
+++ b/packages/web/src/js/FileUploader.ts
@@ -1,5 +1,5 @@
-import { info, warning } from '@lmc-eu/spirit-common/utilities';
 import BaseComponent from './BaseComponent';
+import { info, warning } from './common/utilities';
 import { EventHandler, SelectorEngine } from './dom';
 import { SpiritConfig, enableToggleAutoloader, image2Base64Preview } from './utils';
 

--- a/packages/web/src/js/Modal.ts
+++ b/packages/web/src/js/Modal.ts
@@ -1,5 +1,5 @@
-import { warning } from '@lmc-eu/spirit-common/utilities';
 import BaseComponent from './BaseComponent';
+import { warning } from './common/utilities';
 import EventHandler from './dom/EventHandler';
 import SelectorEngine from './dom/SelectorEngine';
 import { enableToggleTrigger, ScrollControl, SpiritConfig } from './utils';

--- a/packages/web/src/js/Offcanvas.ts
+++ b/packages/web/src/js/Offcanvas.ts
@@ -1,6 +1,6 @@
-import { warning } from '@lmc-eu/spirit-common/utilities';
 import { breakpoints } from '@lmc-eu/spirit-design-tokens';
 import BaseComponent from './BaseComponent';
+import { warning } from './common/utilities';
 import EventHandler from './dom/EventHandler';
 import { ScrollControl, SpiritConfig, enableDismissTrigger, enableToggleTrigger } from './utils';
 

--- a/packages/web/src/js/common/constants/__tests__/environments.test.ts
+++ b/packages/web/src/js/common/constants/__tests__/environments.test.ts
@@ -1,0 +1,59 @@
+import { isDevelopment, isProduction, isTesting } from '../environments';
+
+describe('environments', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    // Most important - it clears the cache
+    jest.resetModules();
+    // Make a copy
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    // Restore old environment
+    process.env = OLD_ENV;
+  });
+
+  describe('isDevelopment', () => {
+    it('should return true when NODE_ENV is set to `development`', () => {
+      process.env.NODE_ENV = 'development';
+
+      expect(isDevelopment()).toBeTruthy();
+    });
+
+    it('should return false when NODE_ENV is not set to `development`', () => {
+      process.env.NODE_ENV = 'production';
+
+      expect(isDevelopment()).toBeFalsy();
+    });
+  });
+
+  describe('isTesting', () => {
+    it('should return true when NODE_ENV is set to `testing`', () => {
+      process.env.NODE_ENV = 'testing';
+
+      expect(isTesting()).toBeTruthy();
+    });
+
+    it('should return false when NODE_ENV is not set to `testing`', () => {
+      process.env.NODE_ENV = 'production';
+
+      expect(isTesting()).toBeFalsy();
+    });
+  });
+
+  describe('isProduction', () => {
+    it('should return true when NODE_ENV is set to `production`', () => {
+      process.env.NODE_ENV = 'production';
+
+      expect(isProduction()).toBeTruthy();
+    });
+
+    it('should return false when NODE_ENV is not set to `production`', () => {
+      process.env.NODE_ENV = 'development';
+
+      expect(isProduction()).toBeFalsy();
+    });
+  });
+});

--- a/packages/web/src/js/common/constants/environments.ts
+++ b/packages/web/src/js/common/constants/environments.ts
@@ -1,0 +1,9 @@
+export const ENVIRONMENTS = {
+  DEVELOPMENT: 'development',
+  TESTING: 'testing',
+  PRODUCTION: 'production',
+};
+
+export const isDevelopment = () => process.env.NODE_ENV === ENVIRONMENTS.DEVELOPMENT;
+export const isTesting = () => process.env.NODE_ENV === ENVIRONMENTS.TESTING;
+export const isProduction = () => process.env.NODE_ENV === ENVIRONMENTS.PRODUCTION;

--- a/packages/web/src/js/common/constants/index.ts
+++ b/packages/web/src/js/common/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './environments';

--- a/packages/web/src/js/common/index.ts
+++ b/packages/web/src/js/common/index.ts
@@ -1,0 +1,2 @@
+export * from './constants';
+export * from './utilities';

--- a/packages/web/src/js/common/utilities/__tests__/info.test.ts
+++ b/packages/web/src/js/common/utilities/__tests__/info.test.ts
@@ -1,0 +1,35 @@
+/* eslint-disable no-console --
+ * we are testing Console function
+ */
+import info from '../info';
+
+describe('info', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - mocked
+    console.info.mockRestore();
+  });
+
+  // testing truthy values
+  // eslint-disable-next-line symbol-description
+  it.each([1, -1, true, {}, [], Symbol(), 'hi'])('should not log a info if the condition is truthy', (truthyValue) => {
+    info(truthyValue, 'message');
+
+    expect(console.info).not.toHaveBeenCalled();
+  });
+
+  // https://github.com/getify/You-Dont-Know-JS/blob/master/types%20%26%20grammar/ch4.md#falsy-values
+  // testing falsy values
+  // eslint-disable-next-line no-undefined
+  it.each([undefined, null, false, +0, -0, NaN, ''])('should log a info if the condition is falsy', (falsyValue) => {
+    const message: string = `hey ${String(falsyValue)}`;
+    info(falsyValue, message);
+
+    expect(console.info).toHaveBeenCalledWith(`Info: ${message}`);
+    // @ts-expect-error - mocking console.info
+    console.info.mockClear();
+  });
+});

--- a/packages/web/src/js/common/utilities/__tests__/warning.test.ts
+++ b/packages/web/src/js/common/utilities/__tests__/warning.test.ts
@@ -1,0 +1,38 @@
+/* eslint-disable no-console --
+ * we are testing Console function
+ */
+import warning from '../warning';
+
+describe('warning', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - mocked
+    console.warn.mockRestore();
+  });
+
+  // testing truthy values
+  // eslint-disable-next-line symbol-description
+  it.each([1, -1, true, {}, [], Symbol(), 'hi'])(
+    'should not log a warning if the condition is truthy',
+    (truthyValue) => {
+      warning(truthyValue, 'message');
+
+      expect(console.warn).not.toHaveBeenCalled();
+    },
+  );
+
+  // https://github.com/getify/You-Dont-Know-JS/blob/master/types%20%26%20grammar/ch4.md#falsy-values
+  // testing falsy values
+  // eslint-disable-next-line no-undefined
+  it.each([undefined, null, false, +0, -0, NaN, ''])('should log a warning if the condition is falsy', (falsyValue) => {
+    const message: string = `hey ${String(falsyValue)}`;
+    warning(falsyValue, message);
+
+    expect(console.warn).toHaveBeenCalledWith(`Warning: ${message}`);
+    // @ts-expect-error - mocking console.warn
+    console.warn.mockClear();
+  });
+});

--- a/packages/web/src/js/common/utilities/index.ts
+++ b/packages/web/src/js/common/utilities/index.ts
@@ -1,0 +1,2 @@
+export { default as info } from './info';
+export { default as warning } from './warning';

--- a/packages/web/src/js/common/utilities/info.ts
+++ b/packages/web/src/js/common/utilities/info.ts
@@ -1,0 +1,22 @@
+import { isProduction } from '../constants/environments';
+
+const info = (condition: unknown, message: string): void => {
+  // don't do anything in production
+  // wrapping in production check for better dead code elimination
+  if (!isProduction()) {
+    // condition passed: do not log
+    if (condition) {
+      return;
+    }
+
+    // Condition not passed
+    const text = `Info: ${message}`;
+
+    if (typeof console !== 'undefined') {
+      // eslint-disable-next-line no-console -- we want to log a warning; so usage of Console is required
+      console.info(text);
+    }
+  }
+};
+
+export default info;

--- a/packages/web/src/js/common/utilities/warning.ts
+++ b/packages/web/src/js/common/utilities/warning.ts
@@ -1,0 +1,32 @@
+import { isProduction } from '../constants/environments';
+
+const warning = (condition: unknown, message: string): void => {
+  // don't do anything in production
+  // wrapping in production check for better dead code elimination
+  if (!isProduction()) {
+    // condition passed: do not log
+    if (condition) {
+      return;
+    }
+
+    // Condition not passed
+    const text = `Warning: ${message}`;
+
+    if (typeof console !== 'undefined') {
+      // eslint-disable-next-line no-console -- we want to log a warning; so usage of Console is required
+      console.warn(text);
+    }
+
+    // Throwing an error and catching it immediately
+    // to improve debugging
+    // A consumer can use 'pause on caught exceptions'
+    // https://github.com/facebook/react/issues/4216
+    try {
+      throw Error(text);
+    } catch (x) {
+      // empty
+    }
+  }
+};
+
+export default warning;

--- a/packages/web/src/js/utils/Deprecations.ts
+++ b/packages/web/src/js/utils/Deprecations.ts
@@ -1,4 +1,4 @@
-import { warning } from '@lmc-eu/spirit-common/utilities';
+import { warning } from '../common/utilities';
 
 const deprecatedDataAttribute = (
   componentName: string,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

  * ESM and CJS were not correctly built when using `common` package code

### Additional context

This is a workaround to make our builds work and to allow us to publish all changes. For the second try, there should be a much deeper investigation of how to set up a shared directory for Typescript using references and aliases.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
