### PR TITLE
Fix(web-twig): Do not render CSS property in the `GridItem` style attribute if the value is empty

### DIFF
--- a/packages/web-twig/src/Resources/components/Grid/GridItem.twig
+++ b/packages/web-twig/src/Resources/components/Grid/GridItem.twig
@@ -21,8 +21,10 @@
     {%- if value is iterable -%}
         {%- set itemType = 'grid-item-' ~ type ~ '-' ~ item | lower -%}
         {%- for breakpoint, bpValue in value -%}
-            {%- set suffix = (breakpoint == 'mobile') ? '' : '-' ~ breakpoint -%}
-            {%- set _style = _style ~ '--' ~ itemType ~ suffix ~ ': ' ~ bpValue ~ ';' -%}
+            {%- if bpValue -%}
+                {%- set suffix = (breakpoint == 'mobile') ? '' : '-' ~ breakpoint -%}
+                {%- set _style = _style ~ '--' ~ itemType ~ suffix ~ ': ' ~ bpValue ~ ';' -%}
+            {%- endif -%}
         {%- endfor -%}
     {%- else -%}
         {%- set itemType = 'grid-item-' ~ type ~ '-' ~ item | lower -%}

--- a/packages/web-twig/src/Resources/components/Grid/__tests__/__fixtures__/gridItemDefault.twig
+++ b/packages/web-twig/src/Resources/components/Grid/__tests__/__fixtures__/gridItemDefault.twig
@@ -8,4 +8,7 @@
     <GridItem columnStart="1" columnEnd="{{ { mobile: 5, tablet: 9 } }}" rowStart="{{ { desktop: 2 } }}">
         1–5 (mobile) 1–9 (tablet) and on desktop second row
     </GridItem>
+    <GridItem columnStart="1" columnEnd="{{ { mobile: '', tablet: 9 } }}" rowStart="{{ { desktop: 2 } }}">
+        1–5 (mobile) 1–9 (tablet) and on desktop second row
+    </GridItem>
 </Grid>

--- a/packages/web-twig/src/Resources/components/Grid/__tests__/__snapshots__/gridItemDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Grid/__tests__/__snapshots__/gridItemDefault.twig.snap.html
@@ -17,6 +17,10 @@
       <div class="GridItem" style="--grid-item-column-start: 1;--grid-item-column-end: 5;--grid-item-column-end-tablet: 9;--grid-item-row-start-desktop: 2;">
         1&acirc;&#128;&#147;5 (mobile) 1&acirc;&#128;&#147;9 (tablet) and on desktop second row
       </div>
+
+      <div class="GridItem" style="--grid-item-column-start: 1;--grid-item-column-end-tablet: 9;--grid-item-row-start-desktop: 2;">
+        1&acirc;&#128;&#147;5 (mobile) 1&acirc;&#128;&#147;9 (tablet) and on desktop second row
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
I was going around… Small nitpicking. ✨ ⛏️ 

When we needed to send a `null` value to a prop, the CSS property was generated without an assigned value.

**Source code from Jobs.cz**
```
<GridItem
      columnStart="{{ gridItemColumnStart ? gridItemColumnStart[loop.index] : null }}"
      columnEnd="{{ gridItemColumnEnd ? gridItemColumnEnd[loop.index] : null }}"
      rowStart="{{ gridItemRowStart ? gridItemRowStart[loop.index] : null }}"
      rowEnd="{{ gridItemRowEnd ? gridItemRowEnd[loop.index] : null }}"
  >
      <MedallionGalleryImage image="{{ image }}" />
  </GridItem>
```

→ 

😞 **Current output**
```
<div
    class="GridItem"
    style="--grid-item-column-start: ;--grid-item-column-end: ;--grid-item-row-start: ;--grid-item-row-end: ;"
>...</div>
```

✨ **Upcoming output**
```
<div class="GridItem">...</div>
```

