### PR TITLE
Feat(web-twig): Introduce vertical alignment options for `Modal` #DS-940

### DIFF
--- a/packages/web-twig/src/Resources/components/Modal/Modal.stories.twig
+++ b/packages/web-twig/src/Resources/components/Modal/Modal.stories.twig
@@ -2,6 +2,26 @@
 
 {% block content %}
 
+    <script>
+        const setModalAlignment = (event, selector) => {
+            const modalElement = document.querySelector(selector);
+
+            modalElement.classList.remove('Modal--top', 'Modal--center', 'Modal--bottom');
+            modalElement.classList.add(`Modal--${event.target.value}`);
+        };
+
+        const setFooterAlignment = (event, selector) => {
+            const footerElement = document.querySelector(selector);
+
+            footerElement.classList.remove('ModalFooter--left', 'ModalFooter--center', 'ModalFooter--right');
+            footerElement.classList.add(`ModalFooter--${event.target.value}`);
+        };
+
+        const toggleExpandOnMobile = (selector) => {
+            document.querySelector(selector).classList.toggle('ModalDialog--expandOnMobile');
+        }
+    </script>
+
     <DocsSection title="Modal">
         {% include '@components/Modal/stories/ModalDefault.twig' %}
     </DocsSection>

--- a/packages/web-twig/src/Resources/components/Modal/Modal.twig
+++ b/packages/web-twig/src/Resources/components/Modal/Modal.twig
@@ -1,22 +1,24 @@
 {# API #}
 {%- set props = props | default([]) -%}
+{%- set _alignmentY = props.alignmentY | default('center') -%}
 {%- set _id = props.id -%}
 {%- set _titleId = props.titleId | default(null) -%}
 {%- set _closeOnBackdropClick = props.closeOnBackdropClick ?? true -%}
 
 {# Class names #}
 {%- set _rootClassName = _spiritClassPrefix ~ 'Modal' -%}
+{%- set _rootAlignmentYClassName = _spiritClassPrefix ~ 'Modal--' ~ _alignmentY -%}
 
 {# Attributes #}
 {%- set _idAttr = _id ? 'id="' ~ _id | escape('html_attr') ~ '"' : null -%}
 {%- set _ariaLabelledbyAttr = _titleId ? 'aria-labelledby="' ~ _titleId | escape('html_attr') ~ '"' : null -%}
 {%- set _closeOnBackdropClickString = _closeOnBackdropClick ? 'true' : 'false' -%}
-{%- set _dataBackdropCloseDisabledAttr = 
+{%- set _dataBackdropCloseDisabledAttr =
     _closeOnBackdropClick ? null : 'data-spirit-close-on-backdrop-click="' ~ _closeOnBackdropClickString | escape('html_attr') ~ '"' -%}
 
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
-{%- set _classNames = [ _rootClassName, _styleProps.className ] -%}
+{%- set _classNames = [ _rootClassName, _rootAlignmentYClassName, _styleProps.className ] -%}
 {%- set _mainPropsWithoutId = props | filter((value, prop) => prop is not same as('id')) -%}
 
 <dialog

--- a/packages/web-twig/src/Resources/components/Modal/README.md
+++ b/packages/web-twig/src/Resources/components/Modal/README.md
@@ -24,13 +24,31 @@ provides several accessibility advantages.
 👉 Please note the `titleId` attribute is linked to the title inside the [Modal Header](#modalheader) and provides an
 accessible name for the dialog.
 
+### Vertical Alignment
+
+Modal can be aligned to the center (default), top, or bottom. These values come from the
+[alignment dictionary][dictionary-alignment]. Using a corresponding alignment option will align the modal accordingly:
+
+- `top`
+- `center` (default)
+- `bottom`
+
+Example:
+
+```twig
+<Modal alignmentY="top" id="modal-example" titleId="modal-example-title">
+  …
+</Modal>
+```
+
 ### API
 
-| Name                   | Type     | Default | Required | Description                                           |
-| ---------------------- | -------- | ------- | -------- | ----------------------------------------------------- |
-| `closeOnBackdropClick` | `bool`   | `true`  | ✕        | Whether the modal will close when backdrop is clicked |
-| `id`                   | `string` | —       | ✔        | Modal ID                                              |
-| `titleId`              | `string` | `null`  | ✕        | ID of the title inside ModalHeader                    |
+| Name                   | Type                                          | Default  | Required | Description                                           |
+| ---------------------- | --------------------------------------------- | -------- | -------- | ----------------------------------------------------- |
+| `alignmentY`           | [AlignmentY dictionary][dictionary-alignment] | `center` | ✕        | Vertical alignment of modal                           |
+| `closeOnBackdropClick` | `bool`                                        | `true`   | ✕        | Whether the modal will close when backdrop is clicked |
+| `id`                   | `string`                                      | —        | ✔        | Modal ID                                              |
+| `titleId`              | `string`                                      | `null`   | ✕        | ID of the title inside ModalHeader                    |
 
 On top of the API options, you can add `data-*` or `aria-*` attributes to
 further extend the component's descriptiveness and accessibility. Also, UNSAFE styling props are available,
@@ -230,7 +248,8 @@ Optionally, you can add a description into the footer:
 ### Footer Alignment
 
 ModalFooter can be aligned to the right (default), center, or left. These values come from the
-[dictionary][dictionary-alignment]. Using a corresponding alignment option will align the footer actions accordingly:
+[alignment dictionary][dictionary-alignment]. Using a corresponding alignment option will align the footer actions
+accordingly:
 
 - `right` (default)
 - `center`

--- a/packages/web-twig/src/Resources/components/Modal/__tests__/__fixtures__/modalDefault.twig
+++ b/packages/web-twig/src/Resources/components/Modal/__tests__/__fixtures__/modalDefault.twig
@@ -37,7 +37,7 @@
 </Modal>
 
 <!-- Render with all props -->
-<Modal id="modal-example-2" titleId="modal-example-2-title">
+<Modal alignmentY="top" id="modal-example-2" titleId="modal-example-2-title">
     <ModalDialog
         autocomplete="on"
         elementType="form"

--- a/packages/web-twig/src/Resources/components/Modal/__tests__/__snapshots__/modalDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Modal/__tests__/__snapshots__/modalDefault.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <dialog aria-label="Modal Title" class="Modal" id="modal-example-mini">
+    <dialog aria-label="Modal Title" class="Modal Modal--center" id="modal-example-mini">
       <article class="ModalDialog ModalDialog--expandOnMobile">
         <header class="ModalHeader">
           <button aria-controls="modal-example-mini" aria-expanded="false" data-spirit-dismiss="modal" data-spirit-target="#modal-example-mini" class="Button Button--tertiary Button--medium Button--square" type="button"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" id="a79dff7a255f69bbe6e39d594aa2275b" aria-hidden="true">
@@ -28,7 +28,7 @@
     </dialog>
     <!-- Render with header title and rich footer -->
 
-    <dialog class="Modal" id="modal-example" aria-labelledby="modal-example-title">
+    <dialog class="Modal Modal--center" id="modal-example" aria-labelledby="modal-example-title">
       <article class="ModalDialog ModalDialog--expandOnMobile">
         <header class="ModalHeader">
           <h2 class="ModalHeader__title" id="modal-example-title">
@@ -58,7 +58,7 @@
     </dialog>
     <!-- Render with all props -->
 
-    <dialog class="Modal" id="modal-example-2" aria-labelledby="modal-example-2-title">
+    <dialog class="Modal Modal--top" id="modal-example-2" aria-labelledby="modal-example-2-title">
       <form autocomplete="on" method="dialog" class="ModalDialog ModalDialog--dockOnMobile custom-class" style="--modal-max-height-tablet: 700px;--modal-preferred-height-mobile: 400px;--modal-preferred-height-tablet: 500px;outline: 5px solid blue; outline-offset: -5px;">
         <header class="ModalHeader">
           <h2 class="ModalHeader__title" id="modal-example-2-title">

--- a/packages/web-twig/src/Resources/components/Modal/__tests__/__snapshots__/modalDisabledBackdropClick.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Modal/__tests__/__snapshots__/modalDisabledBackdropClick.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <dialog class="Modal" id="example_disabled_backdrop_click" aria-labelledby="example_disabled_backdrop_click_title" data-spirit-close-on-backdrop-click="false">
+    <dialog class="Modal Modal--center" id="example_disabled_backdrop_click" aria-labelledby="example_disabled_backdrop_click_title" data-spirit-close-on-backdrop-click="false">
       <article class="ModalDialog ModalDialog--expandOnMobile">
         <header class="ModalHeader">
           <h2 class="ModalHeader__title" id="example_disabled_backdrop_click_title">

--- a/packages/web-twig/src/Resources/components/Modal/stories/ModalDefault.twig
+++ b/packages/web-twig/src/Resources/components/Modal/stories/ModalDefault.twig
@@ -16,29 +16,27 @@
                 provident unde. Eveniet, iste, molestiae?
             </p>
 
+            <!-- Modal alignment demo: start -->
+            <form onchange="setModalAlignment(event, '#example-basic')" class="d-none d-tablet-block mb-600">
+                <div>Modal alignment (from tablet up):</div>
+                <Radio id="modal-alignment-top" UNSAFE_className="mr-600" label="Top" value="top" name="modal-alignment" autocomplete="off" />
+                <Radio id="modal-alignment-center" UNSAFE_className="mr-600" label="Center" value="center" name="modal-alignment" autocomplete="off" isChecked />
+                <Radio id="modal-alignment-bottom" UNSAFE_className="mr-600" label="Bottom" value="bottom" name="modal-alignment" autocomplete="off" />
+            </form>
+            <!-- Modal alignment demo: end -->
+
             <!-- Footer alignment demo: start -->
-            <script>
-                const setFooterAlignment = (event) => {
-                    const footerElement = document.querySelector('#example-basic .ModalFooter');
-
-                    footerElement.classList.remove('ModalFooter--left', 'ModalFooter--center', 'ModalFooter--right');
-                    footerElement.classList.add(`ModalFooter--${event.target.value}`);
-                };
-
-                const toggleExpandOnMobile = () => {
-                    document.querySelector('#example-basic .ModalDialog').classList.toggle('ModalDialog--expandOnMobile');
-                };
-            </script>
-            <form onchange="setFooterAlignment(event)" class="d-none d-tablet-block">
+            <form onchange="setFooterAlignment(event, '#example-basic .ModalFooter')" class="d-none d-tablet-block">
                 <div>Footer alignment (from tablet up):</div>
                 <Radio id="footer-alignment-left" UNSAFE_className="mr-600" label="Left" value="left" name="footer-alignment" autocomplete="off" />
                 <Radio id="footer-alignment-center" UNSAFE_className="mr-600" label="Center" value="center" name="footer-alignment" autocomplete="off" />
                 <Radio id="footer-alignment-right" UNSAFE_className="mr-600" label="Right" value="right" name="footer-alignment" autocomplete="off" isChecked />
             </form>
             <form class="d-tablet-none">
-                <Checkbox id="expand-on-mobile" label="Expand on mobile" value="right" onchange="toggleExpandOnMobile()" autocomplete="off" isChecked />
+                <Checkbox id="expand-on-mobile" label="Expand on mobile" value="right" onchange="toggleExpandOnMobile('#example-basic .ModalDialog')" autocomplete="off" isChecked />
             </form>
             <!-- Footer alignment demo: end -->
+
             <!-- Content: end -->
 
         </ModalBody>

--- a/packages/web-twig/src/Resources/components/Modal/stories/ModalUniformModalOnMobile.twig
+++ b/packages/web-twig/src/Resources/components/Modal/stories/ModalUniformModalOnMobile.twig
@@ -20,6 +20,25 @@
                     perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
                     provident unde. Eveniet, iste, molestiae?
                 </p>
+
+                <!-- Modal alignment demo: start -->
+                <form onchange="setModalAlignment(event, '#example-uniform')" class="mb-600">
+                    <div>Modal alignment:</div>
+                    <Radio id="modal-uniform-alignment-top" UNSAFE_className="mr-600" label="Top" value="top" name="modal-alignment" autocomplete="off" />
+                    <Radio id="modal-uniform-alignment-center" UNSAFE_className="mr-600" label="Center" value="center" name="modal-alignment" autocomplete="off" isChecked />
+                    <Radio id="modal-uniform-alignment-bottom" UNSAFE_className="mr-600" label="Bottom" value="bottom" name="modal-alignment" autocomplete="off" />
+                </form>
+                <!-- Modal alignment demo: end -->
+
+                <!-- Footer alignment demo: start -->
+                <form onchange="setFooterAlignment(event, '#example-uniform .ModalFooter')" class="d-none d-tablet-block">
+                    <div>Footer alignment (from tablet up):</div>
+                    <Radio id="footer-uniform-alignment-left" UNSAFE_className="mr-600" label="Left" value="left" name="footer-alignment" autocomplete="off" />
+                    <Radio id="footer-uniform-alignment-center" UNSAFE_className="mr-600" label="Center" value="center" name="footer-alignment" autocomplete="off" />
+                    <Radio id="footer-uniform-alignment-right" UNSAFE_className="mr-600" label="Right" value="right" name="footer-alignment" autocomplete="off" isChecked />
+                </form>
+                <!-- Footer alignment demo: end -->
+
                 <!-- Content: end -->
 
             </ModalBody>


### PR DESCRIPTION
## Description

New `alignmentY` option can be set to `top`, `center` (default), or `bottom`.

### Additional context

![obrazek](https://github.com/lmc-eu/spirit-design-system/assets/5614085/910e88f5-ff6f-40ec-a417-232f65d829a9)

### Issue reference

https://jira.lmc.cz/browse/DS-940