### PR TITLE
Chore(ci): Rename label that runs visual tests on PR

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   test:
-    if: ${{ (github.event.label.name == 'e2e') || (github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event.label.name == 'run visual tests') || (github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-22.04
     container:
       image: mcr.microsoft.com/playwright:v1.40.1-jammy


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

We have agreed that we will be using the label `run visual tests` for PRs where we want to run visual tests.

The label `e2e` is removed.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
