### PR TITLE
Feat(web): Introduce option to disable scrolling inside `Modal` #DS-732

### DIFF
--- a/packages/web-react/src/components/Modal/ModalDialog.tsx
+++ b/packages/web-react/src/components/Modal/ModalDialog.tsx
@@ -19,13 +19,14 @@ const ModalDialog = <E extends ElementType = ModalDialogElementType>(
     children,
     isDockedOnMobile,
     isExpandedOnMobile,
+    isScrollable,
     maxHeightFromTabletUp,
     preferredHeightOnMobile,
     preferredHeightFromTabletUp,
     ...restProps
   } = props;
 
-  const { classProps } = useModalStyleProps({ isDockedOnMobile, isExpandedOnMobile });
+  const { classProps } = useModalStyleProps({ isDockedOnMobile, isExpandedOnMobile, isScrollable });
   const { styleProps, props: otherProps } = useStyleProps(restProps);
 
   const customizedHeightStyle: CustomizedHeightCSSProperties = {

--- a/packages/web-react/src/components/Modal/README.md
+++ b/packages/web-react/src/components/Modal/README.md
@@ -114,6 +114,9 @@ This is useful for Modals with dynamic content, e.g. a list of items that can be
 </ModalDialog>
 ```
 
+👉 Please note the preferred height options are ignored when scrolling inside ModalDialog is
+[turned off](#disable-scrolling-inside-modaldialog).
+
 👉 Please note the custom height values are considered **preferred:** Modal will not expand beyond the viewport height.
 
 ### Custom Max Height
@@ -129,6 +132,8 @@ You can use the `maxHeightFromTabletUp` option to override the max height on tab
 <ModalDialog maxHeightFromTabletUp="700px">…</ModalDialog>
 ```
 
+👉 Please note the max height is ignored when scrolling inside ModalDialog is [turned off](#disable-scrolling-inside-modaldialog).
+
 👉 Please note the max height on mobile screens is currently not customizable. Let us know if you need this feature! 🙏
 
 ### API
@@ -139,6 +144,7 @@ You can use the `maxHeightFromTabletUp` option to override the max height on tab
 | `elementType`                 | [`article` \| `form`] | `article` | ✕        | ModalDialog element type                                                                                                                 |
 | `isDockedOnMobile`            | `bool`                | `false`   | ✕        | [REQUIRES FEATURE FLAG](#feature-flag-uniform-appearance-on-all-breakpoints): Dock the ModalDialog to the bottom of the screen on mobile |
 | `isExpandedOnMobile`          | `bool`                | `false`   | ✕        | ModalDialog shrinks to fit the height of its content                                                                                     |
+| `isScrollable`                | `bool`                | `true`    | ✕        | If the ModalDialog should be scrollable. If set to `false`, the dialog will not scroll and will expand to fit the content.               |
 | `maxHeightFromTabletUp`       | `string`              | `null`    | ✕        | Max height of the modal. Accepts any valid CSS value.                                                                                    |
 | `preferredHeightFromTabletUp` | `string`              | `null`    | ✕        | Preferred height of the modal on tablet and larger. Accepts any valid CSS value.                                                         |
 | `preferredHeightOnMobile`     | `string`              | `null`    | ✕        | Preferred height of the modal on mobile. Accepts any valid CSS value.                                                                    |
@@ -283,6 +289,27 @@ takes over the responsibility for scrolling and provides visual overflow decorat
   <ModalBody>…Long content…</ModalBody>
 </ScrollView>
 ```
+
+### Disable Scrolling Inside ModalDialog
+
+Scrolling inside ModalDialog can be turned off by setting the `ModalDialog` prop `isScrollable` to `false`:
+
+```jsx
+<ModalDialog isScrollable="false">
+  <!-- … -->
+</ModalDialog>
+```
+
+This way, the ModalBody will expand to fit the height of its content and the whole ModalDialog will scroll in case the
+content is longer than user's viewport.
+
+👉 Please note that this modifier class can produce unexpected results when used in combination with ScrollView.
+
+#### ⚠️ DEPRECATION NOTICE
+
+The `isScrollable` prop will be set to `false` by default in the next major release and the ModalDialog will be made
+non-scrollable by default. It will be possible to re-enable the inside scrolling by setting the
+`isScrollable` boolean prop.
 
 ## Stacking Modals
 

--- a/packages/web-react/src/components/Modal/__tests__/ModalDialog.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/ModalDialog.test.tsx
@@ -1,4 +1,6 @@
 import '@testing-library/jest-dom';
+import React from 'react';
+import { render } from '@testing-library/react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
@@ -10,4 +12,54 @@ describe('ModalDialog', () => {
   stylePropsTest(ModalDialog);
 
   restPropsTest(ModalDialog, 'article');
+
+  it('should render children', () => {
+    const dom = render(
+      <ModalDialog>
+        <div>Test</div>
+      </ModalDialog>,
+    );
+
+    expect(dom.container).toHaveTextContent('Test');
+  });
+
+  it('should render with custom element type', () => {
+    const dom = render(
+      <ModalDialog elementType="section">
+        <div>Test</div>
+      </ModalDialog>,
+    );
+
+    expect(dom.container.querySelector('section')).toBeInTheDocument();
+  });
+
+  it('should render docked on mobile', () => {
+    const dom = render(
+      <ModalDialog isDockedOnMobile>
+        <div>Test</div>
+      </ModalDialog>,
+    );
+
+    expect(dom.container.querySelector('.ModalDialog')).toHaveClass('ModalDialog--dockOnMobile');
+  });
+
+  it('should render expanded on mobile', () => {
+    const dom = render(
+      <ModalDialog isExpandedOnMobile>
+        <div>Test</div>
+      </ModalDialog>,
+    );
+
+    expect(dom.container.querySelector('.ModalDialog')).toHaveClass('ModalDialog--expandOnMobile');
+  });
+
+  it('should render non scrollable', () => {
+    const dom = render(
+      <ModalDialog isScrollable={false}>
+        <div>Test</div>
+      </ModalDialog>,
+    );
+
+    expect(dom.container.querySelector('.ModalDialog')).toHaveClass('ModalDialog--nonScrollable');
+  });
 });

--- a/packages/web-react/src/components/Modal/demo/ModalScrollingLongContent.tsx
+++ b/packages/web-react/src/components/Modal/demo/ModalScrollingLongContent.tsx
@@ -4,12 +4,15 @@ import { Button, Modal, ModalBody, ModalDialog, ModalFooter, ModalHeader, Scroll
 const ModalScrollingLongContent = () => {
   const [isFirstOpen, setFirstOpen] = useState(false);
   const [isSecondOpen, setSecondOpen] = useState(false);
+  const [isThirdOpen, setThirdOpen] = useState(false);
 
   const toggleFirstModal = () => setFirstOpen(!isFirstOpen);
   const toggleSecondModal = () => setSecondOpen(!isSecondOpen);
+  const toggleThirdModal = () => setThirdOpen(!isThirdOpen);
 
   const handleFirstClose = () => setFirstOpen(false);
   const handleSecondClose = () => setSecondOpen(false);
+  const handleThirdClose = () => setThirdOpen(false);
 
   return (
     <>
@@ -126,6 +129,45 @@ const ModalScrollingLongContent = () => {
           <ModalFooter>
             <Button onClick={handleSecondClose}>Primary action</Button>
             <Button color="secondary" onClick={handleSecondClose}>
+              Secondary action
+            </Button>
+          </ModalFooter>
+        </ModalDialog>
+      </Modal>
+
+      <Button onClick={toggleThirdModal}>Open Modal with Disabled Scrolling Inside</Button>
+
+      <Modal id="example-non-scrolling-modal" isOpen={isThirdOpen} onClose={handleThirdClose}>
+        <ModalDialog isScrollable={false}>
+          <ModalHeader>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+            perferendis reprehenderit, voluptate. Cum delectus dicta
+          </ModalHeader>
+          <ModalBody>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+              perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+              provident unde. Eveniet, iste, molestiae?
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+              perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+              provident unde. Eveniet, iste, molestiae?
+            </p>
+            <p style={{ marginBottom: '100vh' }}>
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+              perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+              provident unde. Eveniet, iste, molestiae?
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+              perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+              provident unde. Eveniet, iste, molestiae?
+            </p>
+          </ModalBody>
+          <ModalFooter>
+            <Button onClick={handleThirdClose}>Primary action</Button>
+            <Button color="secondary" onClick={handleThirdClose}>
               Secondary action
             </Button>
           </ModalFooter>

--- a/packages/web-react/src/components/Modal/demo/ModalUniformModalOnMobile.tsx
+++ b/packages/web-react/src/components/Modal/demo/ModalUniformModalOnMobile.tsx
@@ -1,33 +1,46 @@
 import React, { ChangeEvent, useState } from 'react';
 import { AlignmentX, AlignmentXDictionaryType, AlignmentY, AlignmentYDictionaryType } from '../../..';
-import { Button, Modal, ModalBody, ModalDialog, ModalFooter, ModalHeader, Radio } from '../..';
+import { Button, Checkbox, Modal, ModalBody, ModalDialog, ModalFooter, ModalHeader, Radio, Stack } from '../..';
 
 const ModalDefault = () => {
-  const [isFirstOpen, setFirstOpen] = useState(false);
-  const [isSecondOpen, setSecondOpen] = useState(false);
+  const [isOpen, setOpen] = useState(false);
   const [modalAlign, setModalAlign] = useState<AlignmentYDictionaryType>(AlignmentY.CENTER);
   const [footerAlign, setFooterAlign] = useState<AlignmentXDictionaryType>(AlignmentX.RIGHT);
+  const [isDockedOnMobile, setIsDockedOnMobile] = useState(false);
+  const [isExpandedOnMobile, setIsExpandedOnMobile] = useState(false);
+  const [isScrollable, setIsScrollable] = useState(true);
 
-  const toggleFirstModal = () => setFirstOpen(!isFirstOpen);
-  const toggleSecondModal = () => setSecondOpen(!isSecondOpen);
+  const toggleModal = () => setOpen(!isOpen);
 
-  const handleFirstClose = () => setFirstOpen(false);
-  const handleSecondClose = () => setSecondOpen(false);
+  const handleClose = () => setOpen(false);
   const handleModalAlignChange = (event: ChangeEvent<HTMLInputElement>) => {
     setModalAlign(event.target.value as AlignmentYDictionaryType);
   };
   const handleFooterAlignChange = (event: ChangeEvent<HTMLInputElement>) => {
     setFooterAlign(event.target.value as AlignmentXDictionaryType);
   };
+  const handleDockedOnMobileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setIsDockedOnMobile(event.target.checked);
+  };
+  const handleExpandedOnMobileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setIsExpandedOnMobile(event.target.checked);
+  };
+  const handleScrollableChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setIsScrollable(event.target.checked);
+  };
 
   return (
     <>
       {/* Set `display: contents` to enable parent stack layout. */}
       <div className="spirit-feature-modal-enable-uniform-dialog" style={{ display: 'contents' }}>
-        <Button onClick={toggleFirstModal}>Open Modal</Button>
+        <Button onClick={toggleModal}>Open Modal</Button>
 
-        <Modal alignmentY={modalAlign} id="example-uniform" isOpen={isFirstOpen} onClose={handleFirstClose}>
-          <ModalDialog>
+        <Modal alignmentY={modalAlign} id="example-uniform" isOpen={isOpen} onClose={handleClose}>
+          <ModalDialog
+            isExpandedOnMobile={isExpandedOnMobile}
+            isDockedOnMobile={isDockedOnMobile}
+            isScrollable={isScrollable}
+          >
             <ModalHeader>Modal Title</ModalHeader>
             <ModalBody>
               <p>
@@ -35,7 +48,7 @@ const ModalDefault = () => {
                 mollitia mollitia perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi
                 natus provident unde. Eveniet, iste, molestiae?
               </p>
-              <form className="mb-tablet-600">
+              <form className="mb-600">
                 <div>Modal alignment:</div>
                 <Radio
                   id="modal-uniform-alignment-top"
@@ -68,7 +81,7 @@ const ModalDefault = () => {
                   onChange={handleModalAlignChange}
                 />
               </form>
-              <form className="d-none d-tablet-block">
+              <form className="d-none d-tablet-block mb-600">
                 <div>Footer alignment (from tablet up):</div>
                 <Radio
                   id="footer-uniform-alignment-left"
@@ -101,31 +114,37 @@ const ModalDefault = () => {
                   onChange={handleFooterAlignChange}
                 />
               </form>
+              <Stack hasSpacing elementType="form">
+                <Checkbox
+                  autoComplete="off"
+                  id="modal-uniform-docked"
+                  label="Dock on mobile"
+                  name="modal-uniform-docked"
+                  isChecked={isDockedOnMobile}
+                  onChange={handleDockedOnMobileChange}
+                />
+                <Checkbox
+                  autoComplete="off"
+                  id="modal-uniform-expanded"
+                  isDisabled={!isDockedOnMobile}
+                  label="Expand on mobile (docked only)"
+                  name="modal-uniform-expanded"
+                  isChecked={isExpandedOnMobile}
+                  onChange={handleExpandedOnMobileChange}
+                />
+                <Checkbox
+                  autoComplete="off"
+                  id="modal-uniform-non-scrolling"
+                  label="Scrolling inside"
+                  name="modal-uniform-non-scrolling"
+                  isChecked={isScrollable}
+                  onChange={handleScrollableChange}
+                />
+              </Stack>
             </ModalBody>
             <ModalFooter alignmentX={footerAlign} description="Optional description">
-              <Button onClick={handleFirstClose}>Primary action</Button>
-              <Button color="secondary" onClick={handleFirstClose}>
-                Secondary action
-              </Button>
-            </ModalFooter>
-          </ModalDialog>
-        </Modal>
-
-        <Button onClick={toggleSecondModal}>Open Docked Modal (mobile only)</Button>
-
-        <Modal id="example-docked" isOpen={isSecondOpen} onClose={handleSecondClose}>
-          <ModalDialog isDockedOnMobile isExpandedOnMobile>
-            <ModalHeader>Modal Title</ModalHeader>
-            <ModalBody>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam
-                mollitia perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus
-                perferendis provident unde. Eveniet, iste, molestiae?
-              </p>
-            </ModalBody>
-            <ModalFooter description="Optional description">
-              <Button onClick={handleSecondClose}>Primary action</Button>
-              <Button color="secondary" onClick={handleSecondClose}>
+              <Button onClick={handleClose}>Primary action</Button>
+              <Button color="secondary" onClick={handleClose}>
                 Secondary action
               </Button>
             </ModalFooter>

--- a/packages/web-react/src/components/Modal/stories/ModalDialog.stories.tsx
+++ b/packages/web-react/src/components/Modal/stories/ModalDialog.stories.tsx
@@ -17,6 +17,9 @@ const meta: Meta<typeof ModalDialog> = {
     isExpandedOnMobile: {
       control: 'boolean',
     },
+    isScrollable: {
+      control: 'boolean',
+    },
     maxHeightFromTabletUp: {
       control: 'text',
     },
@@ -30,6 +33,7 @@ const meta: Meta<typeof ModalDialog> = {
   args: {
     isDockedOnMobile: false,
     isExpandedOnMobile: false,
+    isScrollable: true,
     maxHeightFromTabletUp: '',
     preferredHeightOnMobile: '',
     preferredHeightFromTabletUp: '',

--- a/packages/web-react/src/components/Modal/useModalStyleProps.ts
+++ b/packages/web-react/src/components/Modal/useModalStyleProps.ts
@@ -7,6 +7,7 @@ export interface ModalStylesProps {
   footerAlignment?: AlignmentXDictionaryType;
   isDockedOnMobile?: boolean;
   isExpandedOnMobile?: boolean;
+  isScrollable?: boolean;
   modalAlignment?: AlignmentYDictionaryType;
 }
 
@@ -26,19 +27,13 @@ export interface ModalStylesReturn {
   };
 }
 
-export function useModalStyleProps(
-  {
-    footerAlignment = AlignmentX.RIGHT,
-    isDockedOnMobile,
-    isExpandedOnMobile,
-    modalAlignment = AlignmentY.CENTER,
-  }: ModalStylesProps = {
-    footerAlignment: AlignmentX.RIGHT,
-    isDockedOnMobile: false,
-    isExpandedOnMobile: false,
-    modalAlignment: AlignmentX.CENTER,
-  },
-): ModalStylesReturn {
+export function useModalStyleProps({
+  footerAlignment = AlignmentX.RIGHT,
+  isDockedOnMobile = false,
+  isExpandedOnMobile = false,
+  isScrollable = true,
+  modalAlignment = AlignmentY.CENTER,
+}: ModalStylesProps = {}): ModalStylesReturn {
   const modalClass = useClassNamePrefix('Modal');
   const modalAlignClasses = {
     top: `${modalClass}--top`,
@@ -48,6 +43,7 @@ export function useModalStyleProps(
   const modalDialogClass = `${modalClass}Dialog`;
   const modalDialogDockedOnMobileClass = `${modalDialogClass}--dockOnMobile`;
   const modalDialogExpandedOnMobileClass = `${modalDialogClass}--expandOnMobile`;
+  const modalDialogNonScrollableClass = `${modalDialogClass}--nonScrollable`;
   const modalHeaderClass = `${modalClass}Header`;
   const modalTitleClass = `${modalHeaderClass}__title`;
   const modalBodyClass = `${modalClass}Body`;
@@ -64,6 +60,7 @@ export function useModalStyleProps(
     dialog: classNames(modalDialogClass, {
       [modalDialogDockedOnMobileClass]: isDockedOnMobile,
       [modalDialogExpandedOnMobileClass]: isExpandedOnMobile,
+      [modalDialogNonScrollableClass]: !isScrollable,
     }),
     title: modalTitleClass,
     header: modalHeaderClass,

--- a/packages/web-react/src/types/modal.ts
+++ b/packages/web-react/src/types/modal.ts
@@ -28,6 +28,7 @@ export type ModalDialogBaseProps<E extends ElementType = ModalDialogElementType>
   elementType?: E;
   isDockedOnMobile?: boolean;
   isExpandedOnMobile?: boolean;
+  isScrollable?: boolean;
 } & ChildrenProps &
   StyleProps;
 

--- a/packages/web-twig/src/Resources/components/Modal/Modal.stories.twig
+++ b/packages/web-twig/src/Resources/components/Modal/Modal.stories.twig
@@ -17,8 +17,22 @@
             footerElement.classList.add(`ModalFooter--${event.target.value}`);
         };
 
+        const toggleDockOnMobile = (selector, dependingInputSelector) => {
+            const dependingInputElement = document.querySelector(dependingInputSelector);
+            const dependingLabelElement = dependingInputElement.closest('label');
+            const modalDialogElement = document.querySelector(selector);
+
+            modalDialogElement.classList.toggle('ModalDialog--dockOnMobile');
+            dependingInputElement.disabled = !dependingInputElement.disabled;
+            dependingLabelElement.classList.toggle('Checkbox--disabled');
+        }
+
         const toggleExpandOnMobile = (selector) => {
             document.querySelector(selector).classList.toggle('ModalDialog--expandOnMobile');
+        }
+
+        const toggleScrolling = (selector) => {
+            document.querySelector(selector).classList.toggle('ModalDialog--nonScrollable');
         }
     </script>
 

--- a/packages/web-twig/src/Resources/components/Modal/ModalDialog.twig
+++ b/packages/web-twig/src/Resources/components/Modal/ModalDialog.twig
@@ -3,6 +3,7 @@
 {%- set _elementType = props.elementType | default('article') -%}
 {%- set _isDockedOnMobile = props.isDockedOnMobile | default(false) -%}
 {%- set _isExpandedOnMobile = props.isExpandedOnMobile ?? true -%}
+{%- set _isScrollable = props.isScrollable ?? true -%}
 {%- set _maxHeightFromTabletUp = props.maxHeightFromTabletUp | default(null) -%}
 {%- set _preferredHeightOnMobile = props.preferredHeightOnMobile | default(null) -%}
 {%- set _preferredHeightFromTabletUp = props.preferredHeightFromTabletUp | default(null) -%}
@@ -11,10 +12,11 @@
 {%- set _rootClassName = _spiritClassPrefix ~ 'ModalDialog' -%}
 {%- set _rootDockOnMobileClassName = _isDockedOnMobile ? _spiritClassPrefix ~ 'ModalDialog--dockOnMobile' : null -%}
 {%- set _rootExpandOnMobileClassName = _isExpandedOnMobile ? _spiritClassPrefix ~ 'ModalDialog--expandOnMobile' : null -%}
+{%- set _rootScrollableClassName = _isScrollable ? null : _spiritClassPrefix ~ 'ModalDialog--nonScrollable' -%}
 
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
-{%- set _classNames = [ _rootClassName, _rootDockOnMobileClassName, _rootExpandOnMobileClassName, _styleProps.className ] -%}
+{%- set _classNames = [ _rootClassName, _rootDockOnMobileClassName, _rootExpandOnMobileClassName, _rootScrollableClassName, _styleProps.className ] -%}
 {%- set _allowedAttributes = _elementType == 'form' ? [
     'accept-charset',
     'action',

--- a/packages/web-twig/src/Resources/components/Modal/README.md
+++ b/packages/web-twig/src/Resources/components/Modal/README.md
@@ -105,6 +105,9 @@ This is useful for Modals with dynamic content, e.g. a list of items that can be
 </ModalDialog>
 ```
 
+👉 Please note the preferred height options are ignored when scrolling inside ModalDialog is
+[turned off](#disable-scrolling-inside-modaldialog).
+
 👉 Please note the custom height values are considered **preferred:** Modal will not expand beyond the viewport height.
 
 ### Custom Max Height
@@ -122,6 +125,8 @@ You can use the `maxHeightFromTabletUp` option to override the max height on tab
 </ModalDialog>
 ```
 
+👉 Please note the max height is ignored when scrolling inside ModalDialog is [turned off](#disable-scrolling-inside-modaldialog).
+
 👉 Please note the max height on mobile screens is currently not customizable. Let us know if you need this feature! 🙏
 
 ### API
@@ -135,6 +140,7 @@ You can use the `maxHeightFromTabletUp` option to override the max height on tab
 | `enctype`                     | `string`                      | `null`    | ✕        | `elementType="form"` only: Encoding to use for form submission                                                                           |
 | `isDockedOnMobile`            | `bool`                        | `false`   | ✕        | [REQUIRES FEATURE FLAG](#feature-flag-uniform-appearance-on-all-breakpoints): Dock the ModalDialog to the bottom of the screen on mobile |
 | `isExpandedOnMobile`          | `bool`                        | `true`    | ✕        | If the ModalDialog should expand on mobile. Overrides any height defined by `preferredHeightOnMobile`.                                   |
+| `isScrollable`                | `bool`                        | `true`    | ✕        | If the ModalDialog should be scrollable. If set to `false`, the dialog will not scroll and will expand to fit the content.               |
 | `maxHeightFromTabletUp`       | `string`                      | `null`    | ✕        | Max height of the modal. Accepts any valid CSS value.                                                                                    |
 | `method`                      | [`get` \| `post` \| `dialog`] | `null`    | ✕        | `elementType="form"` only: HTTP method to use for form submission                                                                        |
 | `name`                        | `string`                      | `null`    | ✕        | `elementType="form"` only: Name of the form                                                                                              |
@@ -304,6 +310,27 @@ takes over the responsibility for scrolling and provides visual overflow decorat
   </ModalBody>
 </ScrollView>
 ```
+
+### Disable Scrolling Inside ModalDialog
+
+Scrolling inside ModalDialog can be turned off by setting the `ModalDialog` prop `isScrollable` to `false`:
+
+```twig
+<ModalDialog isScrollable={ false }>
+  <!-- … -->
+</ModalDialog>
+```
+
+This way, the ModalBody will expand to fit the height of its content and the whole ModalDialog will scroll in case the
+content is longer than user's viewport.
+
+👉 Please note that this modifier class can produce unexpected results when used in combination with ScrollView.
+
+#### ⚠️ DEPRECATION NOTICE
+
+The `isScrollable` prop will be set to `false` by default in the next major release and the ModalDialog will be made
+non-scrollable by default. It will be possible to re-enable the inside scrolling by setting the
+`isScrollable` prop to `true` explicitly.
 
 ## Stacking Modals
 

--- a/packages/web-twig/src/Resources/components/Modal/__tests__/__fixtures__/modalDefault.twig
+++ b/packages/web-twig/src/Resources/components/Modal/__tests__/__fixtures__/modalDefault.twig
@@ -43,6 +43,7 @@
         elementType="form"
         isDockedOnMobile
         isExpandedOnMobile={ false }
+        isScrollable={ false }
         maxHeightFromTabletUp="700px"
         method="dialog"
         preferredHeightOnMobile="400px"

--- a/packages/web-twig/src/Resources/components/Modal/__tests__/__snapshots__/modalDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Modal/__tests__/__snapshots__/modalDefault.twig.snap.html
@@ -59,7 +59,7 @@
     <!-- Render with all props -->
 
     <dialog class="Modal Modal--top" id="modal-example-2" aria-labelledby="modal-example-2-title">
-      <form autocomplete="on" method="dialog" class="ModalDialog ModalDialog--dockOnMobile custom-class" style="--modal-max-height-tablet: 700px;--modal-preferred-height-mobile: 400px;--modal-preferred-height-tablet: 500px;outline: 5px solid blue; outline-offset: -5px;">
+      <form autocomplete="on" method="dialog" class="ModalDialog ModalDialog--dockOnMobile ModalDialog--nonScrollable custom-class" style="--modal-max-height-tablet: 700px;--modal-preferred-height-mobile: 400px;--modal-preferred-height-tablet: 500px;outline: 5px solid blue; outline-offset: -5px;">
         <header class="ModalHeader">
           <h2 class="ModalHeader__title" id="modal-example-2-title">
             Title of the Modal

--- a/packages/web-twig/src/Resources/components/Modal/stories/ModalScrollingLongContent.twig
+++ b/packages/web-twig/src/Resources/components/Modal/stories/ModalScrollingLongContent.twig
@@ -145,3 +145,57 @@
         </ModalFooter>
     </ModalDialog>
 </Modal>
+
+<Button data-spirit-toggle="modal" data-spirit-target="#example-non-scrolling-modal">
+    Open Modal with Disabled Scrolling Inside
+</Button>
+
+<Modal id="example-non-scrolling-modal" titleId="example-non-scrolling-modal-title">
+    <ModalDialog isScrollable={ false }>
+        <ModalHeader modalId="example-non-scrolling-modal" titleId="example-non-scrolling-modal-title">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+            perferendis reprehenderit, voluptate. Cum delectus dicta
+        </ModalHeader>
+        <ModalBody>
+
+            <!-- Content: start -->
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+                perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+                provident unde. Eveniet, iste, molestiae?
+            </p>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+                perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+                provident unde. Eveniet, iste, molestiae?
+            </p>
+            <p style="margin-bottom: 100vh">
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+                perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+                provident unde. Eveniet, iste, molestiae?
+            </p>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+                perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+                provident unde. Eveniet, iste, molestiae?
+            </p>
+            <!-- Content: end -->
+
+        </ModalBody>
+        <ModalFooter>
+            <Button
+                data-spirit-dismiss="modal"
+                data-spirit-target="#example-non-scrolling-modal"
+            >
+                Primary action
+            </Button>
+            <Button
+                color="secondary"
+                data-spirit-dismiss="modal"
+                data-spirit-target="#example-non-scrolling-modal"
+            >
+                Secondary action
+            </Button>
+        </ModalFooter>
+    </ModalDialog>
+</Modal>

--- a/packages/web-twig/src/Resources/components/Modal/stories/ModalUniformModalOnMobile.twig
+++ b/packages/web-twig/src/Resources/components/Modal/stories/ModalUniformModalOnMobile.twig
@@ -3,12 +3,8 @@
         Open Modal
     </Button>
 
-    <Button data-spirit-toggle="modal" data-spirit-target="#example-docked">
-        Open Docked Modal (mobile only)
-    </Button>
-
     <Modal id="example-uniform" titleId="example-uniform-title">
-        <ModalDialog>
+        <ModalDialog id="example-uniform-dialog">
             <ModalHeader modalId="example-uniform" titleId="example-uniform-title">
                 Modal Title
             </ModalHeader>
@@ -16,13 +12,13 @@
 
                 <!-- Content: start -->
                 <p>
-                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-                    perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-                    provident unde. Eveniet, iste, molestiae?
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam
+                    mollitia mollitia perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi
+                    natus provident unde. Eveniet, iste, molestiae?
                 </p>
 
                 <!-- Modal alignment demo: start -->
-                <form onchange="setModalAlignment(event, '#example-uniform')" class="mb-tablet-600">
+                <form onchange="setModalAlignment(event, '#example-uniform')" class="mb-600">
                     <div>Modal alignment:</div>
                     <Radio id="modal-uniform-alignment-top" UNSAFE_className="mr-600" label="Top" value="top" name="modal-alignment" autocomplete="off" />
                     <Radio id="modal-uniform-alignment-center" UNSAFE_className="mr-600" label="Center" value="center" name="modal-alignment" autocomplete="off" isChecked />
@@ -31,7 +27,7 @@
                 <!-- Modal alignment demo: end -->
 
                 <!-- Footer alignment demo: start -->
-                <form onchange="setFooterAlignment(event, '#example-uniform .ModalFooter')" class="d-none d-tablet-block">
+                <form onchange="setFooterAlignment(event, '#example-uniform .ModalFooter')" class="d-none d-tablet-block mb-600">
                     <div>Footer alignment (from tablet up):</div>
                     <Radio id="footer-uniform-alignment-left" UNSAFE_className="mr-600" label="Left" value="left" name="footer-alignment" autocomplete="off" />
                     <Radio id="footer-uniform-alignment-center" UNSAFE_className="mr-600" label="Center" value="center" name="footer-alignment" autocomplete="off" />
@@ -39,6 +35,14 @@
                 </form>
                 <!-- Footer alignment demo: end -->
 
+                <!-- Modal features demo: start -->
+                <Stack hasSpacing elementType="form">
+                    <Checkbox id="modal-uniform-docked" label="Dock on mobile" onChange="toggleDockOnMobile('#example-uniform-dialog', '#modal-uniform-expanded')" />
+                    <Checkbox id="modal-uniform-expanded" label="Expand on mobile (docked only)" onChange="toggleExpandOnMobile('#example-uniform-dialog')" isDisabled />
+                    <Checkbox id="modal-uniform-non-scrolling" label="Scrolling inside" onChange="toggleScrolling('#example-uniform-dialog')" isChecked />
+                </Stack>
+                <!-- Modal features demo: end -->
+
                 <!-- Content: end -->
 
             </ModalBody>
@@ -53,40 +57,6 @@
                     color="secondary"
                     data-spirit-dismiss="modal"
                     data-spirit-target="#example-uniform"
-                >
-                    Secondary action
-                </Button>
-            </ModalFooter>
-        </ModalDialog>
-    </Modal>
-
-    <Modal id="example-docked" titleId="example-docked-title">
-        <ModalDialog isDockedOnMobile>
-            <ModalHeader modalId="example-docked" titleId="example-docked-title">
-                Modal Title
-            </ModalHeader>
-            <ModalBody>
-
-                <!-- Content: start -->
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-                    perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-                    provident unde. Eveniet, iste, molestiae?
-                </p>
-                <!-- Content: end -->
-
-            </ModalBody>
-            <ModalFooter description="Optional description">
-                <Button
-                    data-spirit-dismiss="modal"
-                    data-spirit-target="#example-docked"
-                >
-                    Primary action
-                </Button>
-                <Button
-                    color="secondary"
-                    data-spirit-dismiss="modal"
-                    data-spirit-target="#example-docked"
                 >
                     Secondary action
                 </Button>

--- a/packages/web/src/scss/components/Modal/README.md
+++ b/packages/web/src/scss/components/Modal/README.md
@@ -60,6 +60,9 @@ This is useful for Modals with dynamic content, e.g. a list of items that can be
 </dialog>
 ```
 
+👉 Please note the preferred height options are ignored when scrolling inside ModalDialog is
+[turned off](#disable-scrolling-inside-modaldialog).
+
 👉 Please note the custom height values are considered **preferred:** Modal will not expand beyond the viewport height.
 
 ### Custom Max Height
@@ -81,6 +84,8 @@ You can use the custom property `--modal-max-height-tablet` to override the max 
   <!-- ModalDialog -->
 </dialog>
 ```
+
+👉 Please note the max height is ignored when scrolling inside ModalDialog is [turned off](#disable-scrolling-inside-modaldialog).
 
 👉 Please note the max height on mobile screens is currently not customizable. Let us know if you need this feature! 🙏
 
@@ -246,7 +251,7 @@ Use our JavaScript plugin to open your Modal, e.g.:
 </button>
 ```
 
-## Disable Modal closing on backdrop click
+## Disable Modal Closing on Backdrop Click
 
 Disable modal close when clicking on the backdrop.
 You can still close modal with close buttons or ESC key.
@@ -279,6 +284,27 @@ scrolling, e.g.:
   <div class="ScrollView__overflowDecorators ScrollView__overflowDecorators--borders" aria-hidden="true"></div>
 </div>
 ```
+
+### Disable Scrolling Inside ModalDialog
+
+Scrolling inside ModalDialog can be turned off by adding the `ModalDialog--nonScrollable` modifier class:
+
+```html
+<article class="ModalDialog ModalDialog--nonScrollable">
+  <!-- … -->
+</article>
+```
+
+This way, the ModalBody will expand to fit the height of its content and the whole ModalDialog will scroll in case the
+content is longer than user's viewport.
+
+👉 Please note that this modifier class can produce unexpected results when used in combination with ScrollView.
+
+#### ⚠️ DEPRECATION NOTICE
+
+The `.ModalDialog--nonScrollable` modifier will be removed in the next major release and the ModalDialog will be made
+non-scrollable by default. It will be possible to re-enable the inside scrolling by adding the
+`.ModalDialog--scrollable` modifier class (which will remain the recommended default usage).
 
 ## Stacking Modals
 

--- a/packages/web/src/scss/components/Modal/_Modal.scss
+++ b/packages/web/src/scss/components/Modal/_Modal.scss
@@ -1,7 +1,7 @@
 // 1. In order to be transitioned, the visibility of the dialog is controlled through `opacity` and `visibility`
 //    properties instead of the default `display`.
 // 2. Use a `::before` pseudo-element instead of `::backdrop` to make fading possible.
-// 3. Clip overflow during transition on mobile screens.
+// 3. Allow scrolling through the backdrop.
 // 4. Restore text selection after `all: unset`.
 // 5. For alignments other than `top`, prefer the `bottom` CSS property to enable smooth transitions between the uniform
 //    and docked variants (see `_ModalDialog.scss`).
@@ -12,14 +12,13 @@
 
 .Modal {
     --modal-scale: #{theme.$transition-scale-ratio};
-    --modal-translate-x: -50%;
 
     all: unset;
     position: fixed;
     inset: 0;
     z-index: 1;
     display: flex; // 1.
-    overflow: hidden; // 3.
+    padding-block: theme.$padding-y;
     visibility: hidden; // 1.
     opacity: 0; // 1.
     pointer-events: none; // 1.
@@ -56,13 +55,13 @@
 .Modal--center,
 .Modal:not(.Modal--top, .Modal--bottom) {
     --modal-top: auto;
-    --modal-bottom: 50%;
-    --modal-translate-y: 50%;
+    --modal-bottom: auto;
+    --modal-translate-y: 0;
     --modal-transform-origin: center center;
 }
 
 .Modal--top {
-    --modal-top: #{theme.$padding-y};
+    --modal-top: 0;
     --modal-bottom: auto;
     --modal-translate-y: #{-1 * theme.$transition-shift-distance};
     --modal-transform-origin: top center;
@@ -70,7 +69,7 @@
 
 .Modal--bottom {
     --modal-top: auto;
-    --modal-bottom: #{theme.$padding-y};
+    --modal-bottom: 0;
     --modal-translate-y: #{theme.$transition-shift-distance};
     --modal-transform-origin: bottom center;
 }
@@ -88,10 +87,6 @@
     &::before {
         visibility: visible;
         opacity: 1;
+        pointer-events: none; // 3.
     }
-}
-
-.Modal--center[open],
-.Modal[open]:not(.Modal--top, .Modal--bottom) {
-    --modal-translate-y: 50%;
 }

--- a/packages/web/src/scss/components/Modal/_Modal.scss
+++ b/packages/web/src/scss/components/Modal/_Modal.scss
@@ -1,10 +1,11 @@
 // 1. In order to be transitioned, the visibility of the dialog is controlled through `opacity` and `visibility`
 //    properties instead of the default `display`.
-// 2. Use a `::before` pseudo-element instead of `::backdrop` to make fading possible.
-// 3. Allow scrolling through the backdrop.
-// 4. Restore text selection after `all: unset`.
-// 5. For alignments other than `top`, prefer the `bottom` CSS property to enable smooth transitions between the uniform
-//    and docked variants (see `_ModalDialog.scss`).
+// 2. Simply use Modal background color instead of `::backdrop` to make fading possible. (A pseudo-element cannot be
+//    used because it covers the scrollbar of the ModalDialog with the inside scrolling turned off.)
+// 3. Use background gradient to prevent background from flickering in Safari.
+// 4. Clip overflow during transition of the docked variant on mobile screens.
+// 5. Allow scrolling through the modal. Has no effect unless the modal is taller than the viewport.
+// 6. Restore text selection after `all: unset`.
 
 @use 'sass:map';
 @use '../../tools/breakpoint';
@@ -19,6 +20,8 @@
     z-index: 1;
     display: flex; // 1.
     padding-block: theme.$padding-y;
+    overflow: hidden; // 4.
+    background: linear-gradient(#{theme.$backdrop-background-color}, #{theme.$backdrop-background-color}); // 8.
     visibility: hidden; // 1.
     opacity: 0; // 1.
     pointer-events: none; // 1.
@@ -29,29 +32,16 @@
         background-color: transparent;
     }
 
-    // 2.
-    &::before {
-        content: '';
-        position: fixed;
-        inset: 0;
-        z-index: -2;
-        background-color: theme.$backdrop-background-color;
-        visibility: hidden;
-        opacity: 0;
-    }
-
     @media (prefers-reduced-motion: no-preference) {
         transition-property: visibility, opacity;
         transition-duration: theme.$transition-duration;
-
-        // 2.
-        &::before {
-            transition: inherit;
-        }
     }
 }
 
-// 5.
+.Modal:has(.ModalDialog--nonScrollable) {
+    overflow-y: auto; // 5.
+}
+
 .Modal--center,
 .Modal:not(.Modal--top, .Modal--bottom) {
     --modal-top: auto;
@@ -80,13 +70,6 @@
 
     visibility: visible;
     opacity: 1;
-    user-select: text; // 4.
+    user-select: text; // 6.
     pointer-events: auto;
-
-    // 2.
-    &::before {
-        visibility: visible;
-        opacity: 1;
-        pointer-events: none; // 3.
-    }
 }

--- a/packages/web/src/scss/components/Modal/_ModalDialog.scss
+++ b/packages/web/src/scss/components/Modal/_ModalDialog.scss
@@ -5,6 +5,7 @@
 // 4. Suppress bottom alignment of the docked variant and use the alignment variants of `.Modal` instead.
 // 5. Unfortunately, the open state cannot be part of the parent `-docked-modal-dialog()` mixin because it's not
 //    possible to generate selector for the feature class scenario.
+// 6. Override bottom padding of parent `.Modal` in the docked variant.
 
 @use 'sass:map';
 @use '../../settings/feature-flags';
@@ -17,25 +18,24 @@
 
     --scroll-view-vertical-height: auto; // 2.
 
-    position: fixed;
-    top: var(--modal-top);
-    bottom: var(--modal-bottom);
-    left: 50%;
     display: flex;
     flex-direction: column;
     box-sizing: border-box; // 3.
     width: theme.$dialog-width;
+    margin-inline: auto;
+    margin-top: var(--modal-top);
+    margin-bottom: var(--modal-bottom);
     overflow-x: hidden;
     overflow-y: auto;
     color: theme.$dialog-text-color;
     background-color: theme.$dialog-background-color;
     box-shadow: theme.$dialog-shadow;
-    transform: translate(var(--modal-translate-x), var(--modal-translate-y)) scale(var(--modal-scale));
+    transform: translateY(var(--modal-translate-y)) scale(var(--modal-scale));
     overscroll-behavior: contain;
     transform-origin: var(--modal-transform-origin);
 
     @media (prefers-reduced-motion: no-preference) {
-        transition-property: bottom, width, height, max-height, border-radius, transform; // 1.
+        transition-property: width, height, max-height, border-radius, transform; // 1.
         transition-duration: inherit;
     }
 }
@@ -70,7 +70,7 @@
 @mixin -docked-modal-dialog() {
     @include breakpoint.down(map.get(theme.$breakpoints, tablet)) {
         --modal-top: auto;
-        --modal-bottom: 0;
+        --modal-bottom: #{-1 * theme.$padding-y}; // 6.
         --modal-translate-y: #{theme.$transition-shift-distance};
         --modal-transform-origin: bottom center;
 

--- a/packages/web/src/scss/components/Modal/_ModalDialog.scss
+++ b/packages/web/src/scss/components/Modal/_ModalDialog.scss
@@ -6,6 +6,7 @@
 // 5. Unfortunately, the open state cannot be part of the parent `-docked-modal-dialog()` mixin because it's not
 //    possible to generate selector for the feature class scenario.
 // 6. Override bottom padding of parent `.Modal` in the docked variant.
+// 7. Override the min-height of the expanded docked variant.
 
 @use 'sass:map';
 @use '../../settings/feature-flags';
@@ -53,17 +54,26 @@
         width: theme.$dialog-uniform-width;
         max-width: calc(100% - #{theme.$padding-x});
         height: theme.$dialog-uniform-height;
-        max-height: theme.$dialog-uniform-max-height;
+        min-height: unset; // 7. @deprecated Can be removed once the uniform modal dialog has been made default.
         border-radius: theme.$dialog-border-radius;
     }
 
     @include breakpoint.up(map.get(theme.$breakpoints, tablet)) {
-        height: theme.$dialog-height-tablet;
-        max-height: theme.$dialog-uniform-max-height-tablet;
+        height: theme.$dialog-uniform-height-tablet;
     }
 
     @include breakpoint.up(map.get(theme.$breakpoints, desktop)) {
         width: theme.$dialog-width-desktop;
+    }
+}
+
+@mixin -scrollable-uniform-modal-dialog($from-breakpoint) {
+    @if $from-breakpoint == 0 {
+        max-height: theme.$dialog-uniform-max-height;
+    }
+
+    @include breakpoint.up(map.get(theme.$breakpoints, tablet)) {
+        max-height: theme.$dialog-uniform-max-height-tablet;
     }
 }
 
@@ -76,8 +86,7 @@
 
         width: theme.$dialog-width;
         max-width: none;
-        height: theme.$dialog-height;
-        max-height: theme.$dialog-max-height;
+        height: theme.$dialog-docked-height;
         border-radius: theme.$dialog-border-radius theme.$dialog-border-radius 0 0;
     }
 }
@@ -91,8 +100,21 @@
 
 @mixin -expand-docked-modal-dialog() {
     @include breakpoint.down(map.get(theme.$breakpoints, tablet)) {
-        height: theme.$dialog-max-height;
+        min-height: theme.$dialog-docked-expanded-height;
     }
+}
+
+@mixin -scrollable-docked-modal-dialog() {
+    @include breakpoint.down(map.get(theme.$breakpoints, tablet)) {
+        max-height: theme.$dialog-docked-expanded-height;
+    }
+}
+
+// @deprecated The non-scrollable modal dialog is deprecated and will be removed in the next major release.
+// Migration: In CSS, make the modal dialog non-scrollable by default so scrolling inside is turned on by a modifier class.
+@mixin -non-scrollable-modal-dialog() {
+    height: auto;
+    max-height: none;
 }
 
 .ModalDialog {
@@ -102,9 +124,12 @@
     // Migration: Remove the feature flag and make the uniform dialog the default.
     @if feature-flags.$modal-enable-uniform-dialog {
         @include -uniform-modal-dialog($from-breakpoint: map.get(theme.$breakpoints, mobile));
+        @include -scrollable-uniform-modal-dialog($from-breakpoint: map.get(theme.$breakpoints, mobile));
     } @else {
         @include -docked-modal-dialog();
+        @include -scrollable-docked-modal-dialog();
         @include -uniform-modal-dialog($from-breakpoint: map.get(theme.$breakpoints, tablet));
+        @include -scrollable-uniform-modal-dialog($from-breakpoint: map.get(theme.$breakpoints, tablet));
 
         [open] > & {
             @include -open-docked-modal-dialog();
@@ -126,22 +151,36 @@
     .ModalDialog--dockOnMobile.ModalDialog--expandOnMobile {
         @include -expand-docked-modal-dialog();
     }
+
+    .ModalDialog--nonScrollable {
+        @include -non-scrollable-modal-dialog();
+    }
 } @else {
     .spirit-feature-modal-enable-uniform-dialog .ModalDialog {
         @include -uniform-modal-dialog($from-breakpoint: map.get(theme.$breakpoints, mobile));
+        @include -scrollable-uniform-modal-dialog($from-breakpoint: map.get(theme.$breakpoints, mobile));
     }
 
     .spirit-feature-modal-enable-uniform-dialog .ModalDialog--dockOnMobile {
         @include -docked-modal-dialog();
+        @include -scrollable-docked-modal-dialog();
     }
 
     .spirit-feature-modal-enable-uniform-dialog [open] > .ModalDialog--dockOnMobile {
         @include -open-docked-modal-dialog();
     }
 
-    // stylelint-disable-next-line selector-max-class -- Only target the docked variant.
+    // stylelint-disable selector-max-class, no-descending-specificity -- Only target the docked variant.
     .ModalDialog--expandOnMobile,
     .spirit-feature-modal-enable-uniform-dialog .ModalDialog--dockOnMobile.ModalDialog--expandOnMobile {
         @include -expand-docked-modal-dialog();
+    }
+    // stylelint-enable selector-max-class
+
+    // @deprecated The non-scrollable modal dialog is deprecated and will be removed in the next major release.
+    // Migration: In CSS, make the modal dialog non-scrollable by default so scrolling inside is turned on by a modifier class.
+    .ModalDialog--nonScrollable,
+    .spirit-feature-modal-enable-uniform-dialog .ModalDialog--nonScrollable {
+        @include -non-scrollable-modal-dialog();
     }
 }

--- a/packages/web/src/scss/components/Modal/_theme.scss
+++ b/packages/web/src/scss/components/Modal/_theme.scss
@@ -19,21 +19,22 @@ $common-padding-x-tablet: tokens.$space-800;
 $dialog-width: 100%;
 $dialog-width-tablet: 640px;
 $dialog-width-desktop: 680px;
-$dialog-height: var(--modal-preferred-height-mobile, min-content);
-$dialog-height-tablet: var(--modal-preferred-height-tablet, min-content);
-$dialog-max-height: calc(100dvh - #{tokens.$space-1100});
-$dialog-max-height-tablet: min(var(--modal-max-height-tablet, 600px), calc(100dvh - #{2 * tokens.$space-600}));
 $dialog-text-color: tokens.$text-primary-default;
 $dialog-border-radius: tokens.$radius-200;
 $dialog-background-color: tokens.$background-basic;
 $dialog-shadow: tokens.$shadow-300;
 
-// @deprecated The "uniform" Header padding is deprecated and will be removed in the next major release.
+// @deprecated The "uniform" dialog dimensions are deprecated and will be removed in the next major release.
 // Migration: Rename the variables containing the `uniform` keyword to remove it.
 $dialog-uniform-width: 640px;
 $dialog-uniform-height: var(--modal-preferred-height-mobile, min-content);
-$dialog-uniform-max-height: min(var(--modal-max-height-mobile, 600px), calc(100dvh - #{2 * tokens.$space-600}));
-$dialog-uniform-max-height-tablet: min(var(--modal-max-height-tablet, 600px), calc(100dvh - #{2 * tokens.$space-600}));
+$dialog-uniform-height-tablet: var(--modal-preferred-height-tablet, min-content);
+$dialog-uniform-max-height: min(var(--modal-max-height-mobile, 600px), calc(100dvh - #{2 * $padding-y}));
+$dialog-uniform-max-height-tablet: min(var(--modal-max-height-tablet, 600px), calc(100dvh - #{2 * $padding-y}));
+
+$dialog-docked-height: var(--modal-preferred-height-mobile, min-content);
+$dialog-docked-margin-top: tokens.$space-1100;
+$dialog-docked-expanded-height: calc(100dvh - #{$dialog-docked-margin-top});
 
 // ModalHeader
 $header-gap: tokens.$space-400;

--- a/packages/web/src/scss/components/Modal/index.html
+++ b/packages/web/src/scss/components/Modal/index.html
@@ -15,8 +15,21 @@
     footerElement.classList.add(`ModalFooter--${event.target.value}`);
   };
 
+  const toggleDockOnMobile = (selector, dependingInputSelector) => {
+    const dependingInputElement = document.querySelector(dependingInputSelector);
+    const dependingLabelElement = dependingInputElement.closest('label');
+
+    document.querySelector(selector).classList.toggle('ModalDialog--dockOnMobile');
+    dependingInputElement.disabled = !dependingInputElement.disabled;
+    dependingLabelElement.classList.toggle('Checkbox--disabled');
+  }
+
   const toggleExpandOnMobile = (selector) => {
     document.querySelector(selector).classList.toggle('ModalDialog--expandOnMobile');
+  }
+
+  const toggleScrolling = (selector) => {
+    document.querySelector(selector).classList.toggle('ModalDialog--nonScrollable');
   }
 </script>
 
@@ -559,6 +572,100 @@
     </dialog>
     <!-- Modal: end -->
 
+    <button
+      type="button"
+      class="Button Button--primary Button--medium"
+      data-spirit-toggle="modal"
+      data-spirit-target="#example-non-scrolling-modal"
+      aria-controls="example-non-scrolling-modal"
+      aria-expanded="false"
+    >
+      Open Modal with Disabled Scrolling Inside
+    </button>
+
+    <!-- Modal: start -->
+    <dialog id="example-non-scrolling-modal" class="Modal Modal--center" aria-labelledby="example-non-scrolling-modal-title">
+
+      <!-- ModalDialog: start -->
+      <article class="ModalDialog ModalDialog--nonScrollable">
+
+        <!-- ModalHeader: start -->
+        <header class="ModalHeader">
+          <h2 id="example-non-scrolling-modal-title" class="ModalHeader__title">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia perferendis reprehenderit, voluptate. Cum delectus dicta
+          </h2>
+          <button
+            type="button"
+            class="Button Button--tertiary Button--square Button--medium"
+            data-spirit-dismiss="modal"
+            data-spirit-target="#example-non-scrolling-modal"
+            aria-controls="example-non-scrolling-modal"
+            aria-expanded="false"
+          >
+            <svg width="24" height="24" aria-hidden="true">
+              <use xlink:href="/icons/svg/sprite.svg#close" />
+            </svg>
+            <span class="accessibility-hidden">Close</span>
+          </button>
+        </header>
+        <!-- ModalHeader: end -->
+
+        <!-- ModalBody: start -->
+        <div class="ModalBody">
+          <!-- Content: start -->
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+            provident unde. Eveniet, iste, molestiae?
+          </p>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+            provident unde. Eveniet, iste, molestiae?
+          </p>
+          <p style="margin-bottom: 100vh">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+            provident unde. Eveniet, iste, molestiae?
+          </p>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+            provident unde. Eveniet, iste, molestiae?
+          </p>
+          <!-- Content: end -->
+        </div>
+        <!-- ModalBody: end -->
+
+        <!-- ModalFooter: start -->
+        <footer class="ModalFooter ModalFooter--right">
+          <div class="ModalFooter__actions">
+            <button
+              type="button"
+              class="Button Button--primary Button--medium"
+              data-spirit-dismiss="modal"
+              data-spirit-target="#example-non-scrolling-modal"
+            >
+              Primary action
+            </button>
+            <button
+              type="button"
+              class="Button Button--secondary Button--medium"
+              data-spirit-dismiss="modal"
+              data-spirit-target="#example-non-scrolling-modal"
+            >
+              Secondary action
+            </button>
+          </div>
+        </footer>
+        <!-- ModalFooter: end -->
+
+      </article>
+      <!-- ModalDialog: end -->
+
+    </dialog>
+    <!-- Modal: end -->
+
   </div>
 
 </section>
@@ -802,17 +909,6 @@
       Open Modal
     </button>
 
-    <button
-      type="button"
-      class="Button Button--primary Button--medium"
-      data-spirit-toggle="modal"
-      data-spirit-target="#example-docked"
-      aria-controls="example-docked"
-      aria-expanded="false"
-    >
-      Open Docked Modal (mobile only)
-    </button>
-
     <!-- Modal: start -->
     <dialog id="example-uniform" class="Modal Modal--center" aria-labelledby="example-uniform-title">
 
@@ -847,7 +943,7 @@
             provident unde. Eveniet, iste, molestiae?
           </p>
           <!-- Modal alignment demo: start -->
-          <form onchange="setModalAlignment(event, '#example-uniform')" class="mb-tablet-600">
+          <form onchange="setModalAlignment(event, '#example-uniform')" class="mb-600">
             <div>Modal alignment:</div>
             <label for="modal-uniform-alignment-top" class="Radio mr-600">
               <input type="radio" id="modal-uniform-alignment-top" name="modal-alignment" value="top" class="Radio__input" autocomplete="off" />
@@ -864,7 +960,7 @@
           </form>
           <!-- Modal alignment demo: end -->
           <!-- Footer alignment demo: start -->
-          <form onchange="setFooterAlignment(event, '#example-uniform .ModalFooter')" class="d-none d-tablet-block">
+          <form onchange="setFooterAlignment(event, '#example-uniform .ModalFooter')" class="d-none d-tablet-block mb-600">
             <div>Footer alignment (from tablet up):</div>
             <label for="footer-uniform-alignment-left" class="Radio mr-600">
               <input type="radio" id="footer-uniform-alignment-left" name="footer-alignment" value="left" class="Radio__input" autocomplete="off" />
@@ -880,6 +976,29 @@
             </label>
           </form>
           <!-- Footer alignment demo: end -->
+          <!-- Modal features demo: start -->
+          <form class="Stack Stack--hasSpacing">
+            <label for="modal-uniform-docked" class="Checkbox">
+              <input type="checkbox" id="modal-uniform-docked" class="Checkbox__input" onchange="toggleDockOnMobile('#example-uniform-dialog', '#modal-uniform-expanded')" autocomplete="off" />
+              <span class="Checkbox__text">
+                  <span class="Checkbox__label">Dock on mobile</span>
+                </span>
+            </label>
+            <label for="modal-uniform-expanded" class="Checkbox Checkbox--disabled" id="modal-uniform-expanded-label">
+              <input type="checkbox" id="modal-uniform-expanded" class="Checkbox__input" onchange="toggleExpandOnMobile('#example-uniform-dialog')" autocomplete="off" disabled />
+              <span class="Checkbox__text">
+                  <span class="Checkbox__label">Expand on mobile (docked only)</span>
+                </span>
+            </label>
+            <label for="modal-uniform-non-scrolling" class="Checkbox">
+              <input type="checkbox" id="modal-uniform-non-scrolling" class="Checkbox__input" onchange="toggleScrolling('#example-uniform-dialog')" autocomplete="off" checked />
+              <span class="Checkbox__text">
+                  <span class="Checkbox__label">Scrolling inside</span>
+                </span>
+            </label>
+          </form>
+          <!-- Modal features demo: end -->
+
           <!-- Content: end -->
         </div>
         <!-- ModalBody: end -->
@@ -903,75 +1022,6 @@
               class="Button Button--secondary Button--medium"
               data-spirit-dismiss="modal"
               data-spirit-target="#example-uniform"
-            >
-              Secondary action
-            </button>
-          </div>
-        </footer>
-        <!-- ModalFooter: end -->
-
-      </article>
-      <!-- ModalDialog: end -->
-
-    </dialog>
-    <!-- Modal: end -->
-
-    <!-- Modal: start -->
-    <dialog id="example-docked" class="Modal Modal--center" aria-labelledby="example-docked-title">
-
-      <!-- ModalDialog: start -->
-      <article id="example-docked-dialog" class="ModalDialog ModalDialog--dockOnMobile ModalDialog--expandOnMobile">
-
-        <!-- ModalHeader: start -->
-        <header class="ModalHeader">
-          <h2 id="example-docked-title" class="ModalHeader__title">Modal Title</h2>
-          <button
-            type="button"
-            class="Button Button--tertiary Button--square Button--medium"
-            data-spirit-dismiss="modal"
-            data-spirit-target="#example-docked"
-            aria-controls="example-docked"
-            aria-expanded="false"
-          >
-            <svg width="24" height="24" aria-hidden="true">
-              <use xlink:href="/icons/svg/sprite.svg#close" />
-            </svg>
-            <span class="accessibility-hidden">Close</span>
-          </button>
-        </header>
-        <!-- ModalHeader: end -->
-
-        <!-- ModalBody: start -->
-        <div class="ModalBody">
-          <!-- Content: start -->
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-            provident unde. Eveniet, iste, molestiae?
-          </p>
-          <!-- Content: end -->
-        </div>
-        <!-- ModalBody: end -->
-
-        <!-- ModalFooter: start -->
-        <footer class="ModalFooter ModalFooter--right">
-          <div class="ModalFooter__description">
-            Optional description
-          </div>
-          <div class="ModalFooter__actions">
-            <button
-              type="button"
-              class="Button Button--primary Button--medium"
-              data-spirit-dismiss="modal"
-              data-spirit-target="#example-docked"
-            >
-              Primary action
-            </button>
-            <button
-              type="button"
-              class="Button Button--secondary Button--medium"
-              data-spirit-dismiss="modal"
-              data-spirit-target="#example-docked"
             >
               Secondary action
             </button>


### PR DESCRIPTION
## Description

Scrolling inside `ModalDialog` can now be turned off by adding the `ModalDialog--nonScrolling` modifier class.

### Additional context

![image](https://github.com/lmc-eu/spirit-design-system/assets/5614085/3b62749f-f674-4341-80a2-ff0a5be0f407)

![image](https://github.com/lmc-eu/spirit-design-system/assets/5614085/1798f493-9369-4a8e-b22e-3752e7d00149)

### Issue reference

https://jira.almacareer.tech/browse/DS-732