### PR TITLE
Feat(web-twig): Introduce option to disable scrolling inside Modal #D…

### DIFF
--- a/packages/web-twig/src/Resources/components/Modal/Modal.stories.twig
+++ b/packages/web-twig/src/Resources/components/Modal/Modal.stories.twig
@@ -17,8 +17,22 @@
             footerElement.classList.add(`ModalFooter--${event.target.value}`);
         };
 
+        const toggleDockOnMobile = (selector, dependingInputSelector) => {
+            const dependingInputElement = document.querySelector(dependingInputSelector);
+            const dependingLabelElement = dependingInputElement.closest('label');
+            const modalDialogElement = document.querySelector(selector);
+
+            modalDialogElement.classList.toggle('ModalDialog--dockOnMobile');
+            dependingInputElement.disabled = !dependingInputElement.disabled;
+            dependingLabelElement.classList.toggle('Checkbox--disabled');
+        }
+
         const toggleExpandOnMobile = (selector) => {
             document.querySelector(selector).classList.toggle('ModalDialog--expandOnMobile');
+        }
+
+        const toggleScrolling = (selector) => {
+            document.querySelector(selector).classList.toggle('ModalDialog--nonScrollable');
         }
     </script>
 

--- a/packages/web-twig/src/Resources/components/Modal/ModalDialog.twig
+++ b/packages/web-twig/src/Resources/components/Modal/ModalDialog.twig
@@ -3,6 +3,7 @@
 {%- set _elementType = props.elementType | default('article') -%}
 {%- set _isDockedOnMobile = props.isDockedOnMobile | default(false) -%}
 {%- set _isExpandedOnMobile = props.isExpandedOnMobile ?? true -%}
+{%- set _isScrollable = props.isScrollable ?? true -%}
 {%- set _maxHeightFromTabletUp = props.maxHeightFromTabletUp | default(null) -%}
 {%- set _preferredHeightOnMobile = props.preferredHeightOnMobile | default(null) -%}
 {%- set _preferredHeightFromTabletUp = props.preferredHeightFromTabletUp | default(null) -%}
@@ -11,10 +12,11 @@
 {%- set _rootClassName = _spiritClassPrefix ~ 'ModalDialog' -%}
 {%- set _rootDockOnMobileClassName = _isDockedOnMobile ? _spiritClassPrefix ~ 'ModalDialog--dockOnMobile' : null -%}
 {%- set _rootExpandOnMobileClassName = _isExpandedOnMobile ? _spiritClassPrefix ~ 'ModalDialog--expandOnMobile' : null -%}
+{%- set _rootScrollableClassName = _isScrollable ? null : _spiritClassPrefix ~ 'ModalDialog--nonScrollable' -%}
 
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
-{%- set _classNames = [ _rootClassName, _rootDockOnMobileClassName, _rootExpandOnMobileClassName, _styleProps.className ] -%}
+{%- set _classNames = [ _rootClassName, _rootDockOnMobileClassName, _rootExpandOnMobileClassName, _rootScrollableClassName, _styleProps.className ] -%}
 {%- set _allowedAttributes = _elementType == 'form' ? [
     'accept-charset',
     'action',

--- a/packages/web-twig/src/Resources/components/Modal/README.md
+++ b/packages/web-twig/src/Resources/components/Modal/README.md
@@ -105,6 +105,9 @@ This is useful for Modals with dynamic content, e.g. a list of items that can be
 </ModalDialog>
 ```
 
+👉 Please note the preferred height options are ignored when scrolling inside ModalDialog is
+[turned off](#disable-scrolling-inside-modaldialog).
+
 👉 Please note the custom height values are considered **preferred:** Modal will not expand beyond the viewport height.
 
 ### Custom Max Height
@@ -122,6 +125,8 @@ You can use the `maxHeightFromTabletUp` option to override the max height on tab
 </ModalDialog>
 ```
 
+👉 Please note the max height is ignored when scrolling inside ModalDialog is [turned off](#disable-scrolling-inside-modaldialog).
+
 👉 Please note the max height on mobile screens is currently not customizable. Let us know if you need this feature! 🙏
 
 ### API
@@ -135,6 +140,7 @@ You can use the `maxHeightFromTabletUp` option to override the max height on tab
 | `enctype`                     | `string`                      | `null`    | ✕        | `elementType="form"` only: Encoding to use for form submission                                                                           |
 | `isDockedOnMobile`            | `bool`                        | `false`   | ✕        | [REQUIRES FEATURE FLAG](#feature-flag-uniform-appearance-on-all-breakpoints): Dock the ModalDialog to the bottom of the screen on mobile |
 | `isExpandedOnMobile`          | `bool`                        | `true`    | ✕        | If the ModalDialog should expand on mobile. Overrides any height defined by `preferredHeightOnMobile`.                                   |
+| `isScrollable`                | `bool`                        | `true`    | ✕        | If the ModalDialog should be scrollable. If set to `false`, the dialog will not scroll and will expand to fit the content.               |
 | `maxHeightFromTabletUp`       | `string`                      | `null`    | ✕        | Max height of the modal. Accepts any valid CSS value.                                                                                    |
 | `method`                      | [`get` \| `post` \| `dialog`] | `null`    | ✕        | `elementType="form"` only: HTTP method to use for form submission                                                                        |
 | `name`                        | `string`                      | `null`    | ✕        | `elementType="form"` only: Name of the form                                                                                              |
@@ -304,6 +310,27 @@ takes over the responsibility for scrolling and provides visual overflow decorat
   </ModalBody>
 </ScrollView>
 ```
+
+### Disable Scrolling Inside ModalDialog
+
+Scrolling inside ModalDialog can be turned off by setting the `ModalDialog` prop `isScrollable` to `false`:
+
+```twig
+<ModalDialog isScrollable={ false }>
+  <!-- … -->
+</ModalDialog>
+```
+
+This way, the ModalBody will expand to fit the height of its content and the whole ModalDialog will scroll in case the
+content is longer than user's viewport.
+
+👉 Please note that this modifier class can produce unexpected results when used in combination with ScrollView.
+
+#### ⚠️ DEPRECATION NOTICE
+
+The `isScrollable` prop will be set to `false` by default in the next major release and the ModalDialog will be made
+non-scrollable by default. It will be possible to re-enable the inside scrolling by setting the
+`isScrollable` prop to `true` explicitly.
 
 ## Stacking Modals
 

--- a/packages/web-twig/src/Resources/components/Modal/__tests__/__fixtures__/modalDefault.twig
+++ b/packages/web-twig/src/Resources/components/Modal/__tests__/__fixtures__/modalDefault.twig
@@ -43,6 +43,7 @@
         elementType="form"
         isDockedOnMobile
         isExpandedOnMobile={ false }
+        isScrollable={ false }
         maxHeightFromTabletUp="700px"
         method="dialog"
         preferredHeightOnMobile="400px"

--- a/packages/web-twig/src/Resources/components/Modal/__tests__/__snapshots__/modalDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Modal/__tests__/__snapshots__/modalDefault.twig.snap.html
@@ -59,7 +59,7 @@
     <!-- Render with all props -->
 
     <dialog class="Modal Modal--top" id="modal-example-2" aria-labelledby="modal-example-2-title">
-      <form autocomplete="on" method="dialog" class="ModalDialog ModalDialog--dockOnMobile custom-class" style="--modal-max-height-tablet: 700px;--modal-preferred-height-mobile: 400px;--modal-preferred-height-tablet: 500px;outline: 5px solid blue; outline-offset: -5px;">
+      <form autocomplete="on" method="dialog" class="ModalDialog ModalDialog--dockOnMobile ModalDialog--nonScrollable custom-class" style="--modal-max-height-tablet: 700px;--modal-preferred-height-mobile: 400px;--modal-preferred-height-tablet: 500px;outline: 5px solid blue; outline-offset: -5px;">
         <header class="ModalHeader">
           <h2 class="ModalHeader__title" id="modal-example-2-title">
             Title of the Modal

--- a/packages/web-twig/src/Resources/components/Modal/stories/ModalScrollingLongContent.twig
+++ b/packages/web-twig/src/Resources/components/Modal/stories/ModalScrollingLongContent.twig
@@ -145,3 +145,57 @@
         </ModalFooter>
     </ModalDialog>
 </Modal>
+
+<Button data-spirit-toggle="modal" data-spirit-target="#example-non-scrolling-modal">
+    Open Modal with Disabled Scrolling Inside
+</Button>
+
+<Modal id="example-non-scrolling-modal" titleId="example-non-scrolling-modal-title">
+    <ModalDialog isScrollable={ false }>
+        <ModalHeader modalId="example-non-scrolling-modal" titleId="example-non-scrolling-modal-title">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+            perferendis reprehenderit, voluptate. Cum delectus dicta
+        </ModalHeader>
+        <ModalBody>
+
+            <!-- Content: start -->
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+                perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+                provident unde. Eveniet, iste, molestiae?
+            </p>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+                perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+                provident unde. Eveniet, iste, molestiae?
+            </p>
+            <p style="margin-bottom: 100vh">
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+                perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+                provident unde. Eveniet, iste, molestiae?
+            </p>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+                perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+                provident unde. Eveniet, iste, molestiae?
+            </p>
+            <!-- Content: end -->
+
+        </ModalBody>
+        <ModalFooter>
+            <Button
+                data-spirit-dismiss="modal"
+                data-spirit-target="#example-non-scrolling-modal"
+            >
+                Primary action
+            </Button>
+            <Button
+                color="secondary"
+                data-spirit-dismiss="modal"
+                data-spirit-target="#example-non-scrolling-modal"
+            >
+                Secondary action
+            </Button>
+        </ModalFooter>
+    </ModalDialog>
+</Modal>

--- a/packages/web-twig/src/Resources/components/Modal/stories/ModalUniformModalOnMobile.twig
+++ b/packages/web-twig/src/Resources/components/Modal/stories/ModalUniformModalOnMobile.twig
@@ -3,12 +3,8 @@
         Open Modal
     </Button>
 
-    <Button data-spirit-toggle="modal" data-spirit-target="#example-docked">
-        Open Docked Modal (mobile only)
-    </Button>
-
     <Modal id="example-uniform" titleId="example-uniform-title">
-        <ModalDialog>
+        <ModalDialog id="example-uniform-dialog">
             <ModalHeader modalId="example-uniform" titleId="example-uniform-title">
                 Modal Title
             </ModalHeader>
@@ -16,13 +12,13 @@
 
                 <!-- Content: start -->
                 <p>
-                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-                    perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-                    provident unde. Eveniet, iste, molestiae?
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam
+                    mollitia mollitia perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi
+                    natus provident unde. Eveniet, iste, molestiae?
                 </p>
 
                 <!-- Modal alignment demo: start -->
-                <form onchange="setModalAlignment(event, '#example-uniform')" class="mb-tablet-600">
+                <form onchange="setModalAlignment(event, '#example-uniform')" class="mb-600">
                     <div>Modal alignment:</div>
                     <Radio id="modal-uniform-alignment-top" UNSAFE_className="mr-600" label="Top" value="top" name="modal-alignment" autocomplete="off" />
                     <Radio id="modal-uniform-alignment-center" UNSAFE_className="mr-600" label="Center" value="center" name="modal-alignment" autocomplete="off" isChecked />
@@ -31,7 +27,7 @@
                 <!-- Modal alignment demo: end -->
 
                 <!-- Footer alignment demo: start -->
-                <form onchange="setFooterAlignment(event, '#example-uniform .ModalFooter')" class="d-none d-tablet-block">
+                <form onchange="setFooterAlignment(event, '#example-uniform .ModalFooter')" class="d-none d-tablet-block mb-600">
                     <div>Footer alignment (from tablet up):</div>
                     <Radio id="footer-uniform-alignment-left" UNSAFE_className="mr-600" label="Left" value="left" name="footer-alignment" autocomplete="off" />
                     <Radio id="footer-uniform-alignment-center" UNSAFE_className="mr-600" label="Center" value="center" name="footer-alignment" autocomplete="off" />
@@ -39,6 +35,14 @@
                 </form>
                 <!-- Footer alignment demo: end -->
 
+                <!-- Modal features demo: start -->
+                <Stack hasSpacing elementType="form">
+                    <Checkbox id="modal-uniform-docked" label="Dock on mobile" onChange="toggleDockOnMobile('#example-uniform-dialog', '#modal-uniform-expanded')" />
+                    <Checkbox id="modal-uniform-expanded" label="Expand on mobile (docked only)" onChange="toggleExpandOnMobile('#example-uniform-dialog')" isDisabled />
+                    <Checkbox id="modal-uniform-non-scrolling" label="Scrolling inside" onChange="toggleScrolling('#example-uniform-dialog')" isChecked />
+                </Stack>
+                <!-- Modal features demo: end -->
+
                 <!-- Content: end -->
 
             </ModalBody>
@@ -53,40 +57,6 @@
                     color="secondary"
                     data-spirit-dismiss="modal"
                     data-spirit-target="#example-uniform"
-                >
-                    Secondary action
-                </Button>
-            </ModalFooter>
-        </ModalDialog>
-    </Modal>
-
-    <Modal id="example-docked" titleId="example-docked-title">
-        <ModalDialog isDockedOnMobile>
-            <ModalHeader modalId="example-docked" titleId="example-docked-title">
-                Modal Title
-            </ModalHeader>
-            <ModalBody>
-
-                <!-- Content: start -->
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-                    perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-                    provident unde. Eveniet, iste, molestiae?
-                </p>
-                <!-- Content: end -->
-
-            </ModalBody>
-            <ModalFooter description="Optional description">
-                <Button
-                    data-spirit-dismiss="modal"
-                    data-spirit-target="#example-docked"
-                >
-                    Primary action
-                </Button>
-                <Button
-                    color="secondary"
-                    data-spirit-dismiss="modal"
-                    data-spirit-target="#example-docked"
                 >
                     Secondary action
                 </Button>


### PR DESCRIPTION
…S-732

Scrolling inside `ModalDialog` can now be turned off by setting the `isScrollable` prop to false.

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
