### PR TITLE
Refactor(web-react): Move away from the `defaultProps`

### DIFF
--- a/packages/web-react/src/components/Alert/Alert.tsx
+++ b/packages/web-react/src/components/Alert/Alert.tsx
@@ -7,13 +7,21 @@ import { Icon } from '../Icon';
 import { useAlertIcon } from './useAlertIcon';
 import { useAlertStyleProps } from './useAlertStyleProps';
 
-const defaultProps = {
+const defaultProps: Partial<SpiritAlertProps> = {
   color: 'success',
   isCentered: false,
+  elementType: 'div',
 };
 
 export const Alert = <T extends ElementType = 'div', E = void>(props: SpiritAlertProps<T, E>): JSX.Element => {
-  const { elementType: ElementTag = 'div', children, color, iconName, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const {
+    elementType: ElementTag = defaultProps.elementType as ElementType,
+    children,
+    color,
+    iconName,
+    ...restProps
+  } = propsWithDefaults;
   const { classProps, props: modifiedProps } = useAlertStyleProps({ color, ...restProps });
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
   const alertIconName = useAlertIcon({ color, iconName, ...otherProps });
@@ -35,7 +43,5 @@ export const Alert = <T extends ElementType = 'div', E = void>(props: SpiritAler
     </ElementTag>
   );
 };
-
-Alert.defaultProps = defaultProps;
 
 export default Alert;

--- a/packages/web-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -5,12 +5,20 @@ import { SpiritBreadcrumbsProps } from '../../types';
 import BreadcrumbsItem from './BreadcrumbsItem';
 import { useBreadcrumbsStyleProps } from './useBreadcrumbsStyleProps';
 
-const defaultProps = {
+const defaultProps: Partial<SpiritBreadcrumbsProps> = {
+  elementType: 'nav',
   items: [],
 };
 
 export const Breadcrumbs = <T extends ElementType = 'nav'>(props: SpiritBreadcrumbsProps<T>): JSX.Element => {
-  const { children, elementType: ElementTag = 'nav', goBackTitle, items, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const {
+    children,
+    elementType: ElementTag = defaultProps.elementType as ElementType,
+    goBackTitle,
+    items,
+    ...restProps
+  } = propsWithDefaults;
   const { classProps, props: modifiedProps } = useBreadcrumbsStyleProps({ ...restProps });
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
 
@@ -43,7 +51,5 @@ export const Breadcrumbs = <T extends ElementType = 'nav'>(props: SpiritBreadcru
     </ElementTag>
   );
 };
-
-Breadcrumbs.defaultProps = defaultProps;
 
 export default Breadcrumbs;

--- a/packages/web-react/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -14,7 +14,8 @@ const defaultProps = {
 };
 
 export const BreadcrumbsItem = (props: SpiritBreadcrumbsItemProps) => {
-  const { children, href, isCurrent, iconNameStart, iconNameEnd, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const { children, href, isCurrent, iconNameStart, iconNameEnd, ...restProps } = propsWithDefaults;
   const { classProps, props: otherProps } = useBreadcrumbsStyleProps({ ...restProps });
   const { styleProps, props: transferProps } = useStyleProps(otherProps);
 
@@ -37,7 +38,5 @@ export const BreadcrumbsItem = (props: SpiritBreadcrumbsItemProps) => {
     </li>
   );
 };
-
-BreadcrumbsItem.defaultProps = defaultProps;
 
 export default BreadcrumbsItem;

--- a/packages/web-react/src/components/Button/Button.tsx
+++ b/packages/web-react/src/components/Button/Button.tsx
@@ -6,7 +6,7 @@ import { Spinner } from '../Spinner';
 import { useButtonAriaProps } from './useButtonAriaProps';
 import { useButtonStyleProps } from './useButtonStyleProps';
 
-const defaultProps = {
+const defaultProps: Partial<SpiritButtonProps> = {
   color: 'primary',
   isBlock: false,
   isDisabled: false,
@@ -14,6 +14,7 @@ const defaultProps = {
   isSquare: false,
   size: 'medium',
   type: 'button',
+  elementType: 'button',
 };
 
 /* We need an exception for components exported with forwardRef */
@@ -22,7 +23,12 @@ const _Button = <T extends ElementType = 'button', C = void, S = void>(
   props: SpiritButtonProps<T, C, S>,
   ref: ForwardedRef<HTMLButtonElement>,
 ) => {
-  const { elementType: ElementTag = 'button', children, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const {
+    elementType: ElementTag = defaultProps.elementType as ElementType,
+    children,
+    ...restProps
+  } = propsWithDefaults;
 
   const { buttonProps } = useButtonAriaProps(restProps);
   const { classProps, props: modifiedProps } = useButtonStyleProps(restProps);
@@ -43,7 +49,5 @@ const _Button = <T extends ElementType = 'button', C = void, S = void>(
 };
 
 export const Button = forwardRef<HTMLButtonElement, SpiritButtonProps<ElementType>>(_Button);
-
-Button.defaultProps = defaultProps;
 
 export default Button;

--- a/packages/web-react/src/components/ButtonLink/ButtonLink.tsx
+++ b/packages/web-react/src/components/ButtonLink/ButtonLink.tsx
@@ -3,11 +3,12 @@ import React, { ElementType, ForwardedRef, forwardRef } from 'react';
 import { useStyleProps } from '../../hooks';
 import { SpiritButtonLinkProps } from '../../types';
 import { Spinner } from '../Spinner';
-import { useButtonLinkStyleProps } from './useButtonLinkStyleProps';
 import { useButtonLinkAriaProps } from './useButtonLinkAriaProps';
+import { useButtonLinkStyleProps } from './useButtonLinkStyleProps';
 
-const defaultProps = {
+const defaultProps: Partial<SpiritButtonLinkProps> = {
   color: 'primary',
+  elementType: 'a',
   isBlock: false,
   isDisabled: false,
   isLoading: false,
@@ -21,7 +22,12 @@ const _ButtonLink = <T extends ElementType = 'a', C = void, S = void>(
   props: SpiritButtonLinkProps<T, C, S>,
   ref: ForwardedRef<HTMLAnchorElement>,
 ) => {
-  const { elementType: ElementTag = 'a', children, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const {
+    elementType: ElementTag = defaultProps.elementType as ElementType,
+    children,
+    ...restProps
+  } = propsWithDefaults;
 
   const { buttonLinkProps } = useButtonLinkAriaProps(restProps);
   const { classProps, props: modifiedProps } = useButtonLinkStyleProps(restProps);
@@ -42,7 +48,5 @@ const _ButtonLink = <T extends ElementType = 'a', C = void, S = void>(
 };
 
 export const ButtonLink = forwardRef<HTMLAnchorElement, SpiritButtonLinkProps<ElementType>>(_ButtonLink);
-
-ButtonLink.defaultProps = defaultProps;
 
 export default ButtonLink;

--- a/packages/web-react/src/components/Collapse/Collapse.tsx
+++ b/packages/web-react/src/components/Collapse/Collapse.tsx
@@ -16,14 +16,21 @@ const transitioningStyles = {
   exited: '',
 };
 
-const defaultProps = {
+const defaultProps: Partial<SpiritCollapseProps> = {
+  elementType: 'div',
   isOpen: false,
   collapsibleToBreakpoint: undefined,
   transitionDuration: TRANSITION_DURATION,
 };
 
 const Collapse = (props: SpiritCollapseProps) => {
-  const { elementType: ElementTag = 'div', children, transitionDuration = TRANSITION_DURATION, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const {
+    elementType: ElementTag = defaultProps.elementType as React.ElementType,
+    children,
+    transitionDuration = TRANSITION_DURATION,
+    ...restProps
+  } = propsWithDefaults;
 
   const rootElementRef: MutableRefObject<HTMLDivElement | null> = useRef(null);
   const collapseElementRef: MutableRefObject<HTMLDivElement | null> = useRef(null);
@@ -58,7 +65,5 @@ const Collapse = (props: SpiritCollapseProps) => {
     </Transition>
   );
 };
-
-Collapse.defaultProps = defaultProps;
 
 export default Collapse;

--- a/packages/web-react/src/components/Collapse/UncontrolledCollapse.tsx
+++ b/packages/web-react/src/components/Collapse/UncontrolledCollapse.tsx
@@ -11,7 +11,8 @@ const defaultProps = {
 };
 
 const UncontrolledCollapse = (props: SpiritUncontrolledCollapseProps) => {
-  const { children, hideOnCollapse, renderTrigger, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const { children, hideOnCollapse, renderTrigger, ...restProps } = propsWithDefaults;
   const { isOpen, toggleHandler } = useCollapse(restProps.isOpen);
   const { ariaProps } = useCollapseAriaProps({ ...restProps, isOpen });
 
@@ -40,7 +41,5 @@ const UncontrolledCollapse = (props: SpiritUncontrolledCollapseProps) => {
     </>
   );
 };
-
-UncontrolledCollapse.defaultProps = defaultProps;
 
 export default UncontrolledCollapse;

--- a/packages/web-react/src/components/Collapse/__tests__/UncontrolledCollapse.test.tsx
+++ b/packages/web-react/src/components/Collapse/__tests__/UncontrolledCollapse.test.tsx
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
-import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
+import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import UncontrolledCollapse from '../UncontrolledCollapse';
 
 describe('UncontrolledCollapse', () => {

--- a/packages/web-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/web-react/src/components/Dropdown/Dropdown.tsx
@@ -17,6 +17,7 @@ const defaultProps = {
 };
 
 export const Dropdown = (props: SpiritDropdownProps) => {
+  const propsWithDefaults = { ...defaultProps, ...props };
   const {
     /** @deprecated ID will be made a required user input in the next major version. */
     id = Math.random().toString(36).slice(2, 7),
@@ -24,10 +25,10 @@ export const Dropdown = (props: SpiritDropdownProps) => {
     enableAutoClose,
     fullWidthMode,
     onAutoClose,
-    placement = defaultProps.placement,
+    placement,
     renderTrigger,
     ...rest
-  } = props;
+  } = propsWithDefaults;
 
   const dropdownRef = useRef(null);
   const triggerRef = useRef();
@@ -86,7 +87,5 @@ export const Dropdown = (props: SpiritDropdownProps) => {
     </DropdownWrapper>
   );
 };
-
-Dropdown.defaultProps = defaultProps;
 
 export default Dropdown;

--- a/packages/web-react/src/components/Field/HelperText.tsx
+++ b/packages/web-react/src/components/Field/HelperText.tsx
@@ -1,23 +1,22 @@
 import React, { ElementType, useEffect } from 'react';
-import { RegisterType } from './useAriaIds';
+import { HelperTextProps } from './types';
 
-interface Props {
-  helperText: React.ReactNode;
-  className?: string;
-  elementType?: ElementType;
-  id?: string;
-  registerAria?: RegisterType;
-}
-
-const defaultProps = {
+const defaultProps: Partial<HelperTextProps> = {
   className: undefined,
   elementType: 'div',
   id: undefined,
   registerAria: undefined,
 };
 
-const HelperText = (props: Props) => {
-  const { helperText, className, elementType: ElementTag = 'div', id, registerAria } = props;
+const HelperText = <T extends ElementType = 'div'>(props: HelperTextProps<T>) => {
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const {
+    helperText,
+    className,
+    elementType: ElementTag = defaultProps.elementType as ElementType,
+    id,
+    registerAria,
+  } = propsWithDefaults;
 
   useEffect(() => {
     registerAria?.({ add: id });
@@ -37,7 +36,5 @@ const HelperText = (props: Props) => {
 
   return null;
 };
-
-HelperText.defaultProps = defaultProps;
 
 export default HelperText;

--- a/packages/web-react/src/components/Field/ValidationText.tsx
+++ b/packages/web-react/src/components/Field/ValidationText.tsx
@@ -1,23 +1,22 @@
 import React, { ElementType, useEffect } from 'react';
-import { ValidationTextProp } from '../../types';
-import { RegisterType } from './useAriaIds';
+import { ValidationTextProps } from './types';
 
-export interface ValidationTextProps extends ValidationTextProp {
-  className?: string;
-  elementType?: ElementType;
-  id?: string;
-  registerAria?: RegisterType;
-}
-
-const defaultProps = {
+const defaultProps: Partial<ValidationTextProps> = {
   className: undefined,
   elementType: 'div',
   id: undefined,
   registerAria: undefined,
 };
 
-export const ValidationText = (props: ValidationTextProps) => {
-  const { className, validationText, elementType: ElementTag = 'div', id, registerAria } = props;
+export const ValidationText = <T extends ElementType = 'div'>(props: ValidationTextProps<T>) => {
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const {
+    className,
+    validationText,
+    elementType: ElementTag = defaultProps.elementType as ElementType,
+    id,
+    registerAria,
+  } = propsWithDefaults;
 
   useEffect(() => {
     registerAria?.({ add: id });
@@ -43,7 +42,5 @@ export const ValidationText = (props: ValidationTextProps) => {
 
   return null;
 };
-
-ValidationText.defaultProps = defaultProps;
 
 export default ValidationText;

--- a/packages/web-react/src/components/Field/types.ts
+++ b/packages/web-react/src/components/Field/types.ts
@@ -1,0 +1,24 @@
+import { ElementType, JSXElementConstructor, ReactNode } from 'react';
+import { ValidationTextProp } from '../../types';
+import { RegisterType } from './useAriaIds';
+
+export interface FieldElementTypeProps<T extends ElementType = 'div'> {
+  /**
+   * The HTML element or React element used to render the pill, e.g. 'div', 'span'.
+   *
+   * @default 'div'
+   */
+  elementType?: T | JSXElementConstructor<unknown>;
+}
+
+export interface FieldProps<T extends ElementType = 'div'> extends FieldElementTypeProps<T> {
+  className?: string;
+  id?: string;
+  registerAria?: RegisterType;
+}
+
+export interface HelperTextProps<T extends ElementType = 'div'> extends FieldProps<T> {
+  helperText: ReactNode;
+}
+
+export interface ValidationTextProps<T extends ElementType = 'div'> extends FieldProps<T>, ValidationTextProp {}

--- a/packages/web-react/src/components/Heading/Heading.tsx
+++ b/packages/web-react/src/components/Heading/Heading.tsx
@@ -4,12 +4,18 @@ import { useStyleProps } from '../../hooks';
 import { SpiritHeadingProps } from '../../types';
 import { useHeadingStyleProps } from './useHeadingStyleProps';
 
-const defaultProps = {
+const defaultProps: Partial<SpiritHeadingProps> = {
   size: 'medium',
+  elementType: 'div',
 };
 
 export const Heading = <T extends ElementType = 'div', S = void>(props: SpiritHeadingProps<T, S>): JSX.Element => {
-  const { elementType: ElementTag = 'div', children, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const {
+    elementType: ElementTag = defaultProps.elementType as ElementType,
+    children,
+    ...restProps
+  } = propsWithDefaults;
   const { classProps, props: modifiedProps } = useHeadingStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
 
@@ -19,7 +25,5 @@ export const Heading = <T extends ElementType = 'div', S = void>(props: SpiritHe
     </ElementTag>
   );
 };
-
-Heading.defaultProps = defaultProps;
 
 export default Heading;

--- a/packages/web-react/src/components/Icon/Icon.tsx
+++ b/packages/web-react/src/components/Icon/Icon.tsx
@@ -11,7 +11,8 @@ const defaultProps = {
 /* We need an exception for components exported with forwardRef */
 /* eslint no-underscore-dangle: ['error', { allow: ['_Icon'] }] */
 export const _Icon = (props: IconProps, ref: ForwardedRef<SVGSVGElement>) => {
-  const { boxSize, name, title, ariaHidden, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const { boxSize, name, title, ariaHidden, ...restProps } = propsWithDefaults;
   let icon = useIcon(name);
   const { styleProps, props: otherProps } = useStyleProps(restProps);
 
@@ -39,7 +40,4 @@ export const _Icon = (props: IconProps, ref: ForwardedRef<SVGSVGElement>) => {
 };
 
 export const Icon = forwardRef<SVGSVGElement, IconProps>(_Icon);
-
-Icon.defaultProps = defaultProps;
-
 export default Icon;

--- a/packages/web-react/src/components/Link/Link.tsx
+++ b/packages/web-react/src/components/Link/Link.tsx
@@ -1,10 +1,11 @@
-import React, { ElementType, forwardRef } from 'react';
 import classNames from 'classnames';
+import React, { ElementType, forwardRef } from 'react';
 import { useStyleProps } from '../../hooks';
-import { SpiritLinkProps, PolymorphicRef } from '../../types';
+import { PolymorphicRef, SpiritLinkProps } from '../../types';
 import { useLinkStyleProps } from './useLinkStyleProps';
 
-const defaultProps = {
+const defaultProps: Partial<SpiritLinkProps> = {
+  elementType: 'a',
   color: 'primary',
 };
 
@@ -14,7 +15,12 @@ const _Link = <E extends ElementType = 'a', T = void>(
   props: SpiritLinkProps<E, T>,
   ref: PolymorphicRef<E>,
 ): JSX.Element => {
-  const { elementType: ElementTag = 'a', children, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const {
+    elementType: ElementTag = defaultProps.elementType as ElementType,
+    children,
+    ...restProps
+  } = propsWithDefaults;
   const { classProps, props: modifiedProps } = useLinkStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
 
@@ -32,7 +38,5 @@ const _Link = <E extends ElementType = 'a', T = void>(
 };
 
 export const Link = forwardRef<HTMLAnchorElement, SpiritLinkProps<ElementType>>(_Link);
-
-Link.defaultProps = defaultProps;
 
 export default Link;

--- a/packages/web-react/src/components/Pill/Pill.tsx
+++ b/packages/web-react/src/components/Pill/Pill.tsx
@@ -1,15 +1,21 @@
-import React, { ElementType } from 'react';
 import classNames from 'classnames';
+import React, { ElementType } from 'react';
 import { useStyleProps } from '../../hooks';
 import { SpiritPillProps, StyleProps } from '../../types';
 import { usePillStyleProps } from './usePillStyleProps';
 
-const defaultProps = {
+const defaultProps: Partial<SpiritPillProps> = {
+  elementType: 'span',
   color: 'selected',
 };
 
 export const Pill = <T extends ElementType = 'span', C = void>(props: SpiritPillProps<T, C>): JSX.Element => {
-  const { elementType: ElementTag = 'span', children, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const {
+    elementType: ElementTag = defaultProps.elementType as ElementType,
+    children,
+    ...restProps
+  } = propsWithDefaults;
   const { classProps, props: modifiedProps } = usePillStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps as StyleProps);
 
@@ -19,7 +25,5 @@ export const Pill = <T extends ElementType = 'span', C = void>(props: SpiritPill
     </ElementTag>
   );
 };
-
-Pill.defaultProps = defaultProps;
 
 export default Pill;

--- a/packages/web-react/src/components/Stack/Stack.tsx
+++ b/packages/web-react/src/components/Stack/Stack.tsx
@@ -1,8 +1,8 @@
-import React, { ElementType } from 'react';
 import classNames from 'classnames';
-import { useStackStyleProps } from './useStackStyleProps';
+import React, { ElementType } from 'react';
 import { useStyleProps } from '../../hooks';
 import { SpiritStackProps } from '../../types';
+import { useStackStyleProps } from './useStackStyleProps';
 
 const defaultProps: SpiritStackProps = {
   elementType: 'div',
@@ -13,7 +13,12 @@ const defaultProps: SpiritStackProps = {
 };
 
 export const Stack = <T extends ElementType = 'div'>(props: SpiritStackProps<T>): JSX.Element => {
-  const { elementType: ElementTag = 'div', children, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const {
+    elementType: ElementTag = defaultProps.elementType as ElementType,
+    children,
+    ...restProps
+  } = propsWithDefaults;
   const { classProps, props: modifiedProps, styleProps: stackStyle } = useStackStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
 
@@ -30,7 +35,5 @@ export const Stack = <T extends ElementType = 'div'>(props: SpiritStackProps<T>)
     </ElementTag>
   );
 };
-
-Stack.defaultProps = defaultProps;
 
 export default Stack;

--- a/packages/web-react/src/components/Tag/Tag.tsx
+++ b/packages/web-react/src/components/Tag/Tag.tsx
@@ -1,10 +1,10 @@
-import React, { ElementType, ForwardedRef, forwardRef } from 'react';
 import classNames from 'classnames';
+import React, { ElementType, ForwardedRef, forwardRef } from 'react';
 import { useStyleProps } from '../../hooks';
 import { SpiritTagProps, StyleProps } from '../../types';
 import { useTagStyleProps } from './useTagStyleProps';
 
-const defaultProps = {
+const defaultProps: Partial<SpiritTagProps> = {
   color: 'neutral',
   elementType: 'span',
   isSubtle: false,
@@ -17,7 +17,12 @@ const _Tag = <T extends ElementType = 'span', C = void, S = void>(
   props: SpiritTagProps<T, C, S>,
   ref: ForwardedRef<HTMLSpanElement>,
 ): JSX.Element => {
-  const { elementType: ElementTag = 'span', children, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const {
+    elementType: ElementTag = defaultProps.elementType as ElementType,
+    children,
+    ...restProps
+  } = propsWithDefaults;
   const { classProps, props: modifiedProps } = useTagStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps as StyleProps);
 
@@ -29,7 +34,5 @@ const _Tag = <T extends ElementType = 'span', C = void, S = void>(
 };
 
 export const Tag = forwardRef<HTMLSpanElement, SpiritTagProps<ElementType>>(_Tag);
-
-Tag.defaultProps = defaultProps;
 
 export default Tag;

--- a/packages/web-react/src/components/Text/Text.tsx
+++ b/packages/web-react/src/components/Text/Text.tsx
@@ -4,12 +4,18 @@ import { useStyleProps } from '../../hooks';
 import { SpiritTextProps } from '../../types';
 import { useTextStyleProps } from './useTextStyleProps';
 
-const defaultProps = {
+const defaultProps: Partial<SpiritTextProps> = {
+  elementType: 'p',
   size: 'medium',
 };
 
 export const Text = <T extends ElementType = 'p', S = void>(props: SpiritTextProps<T, S>): JSX.Element => {
-  const { elementType: ElementTag = 'p', children, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const {
+    elementType: ElementTag = defaultProps.elementType as ElementType,
+    children,
+    ...restProps
+  } = propsWithDefaults;
   const { classProps, props: modifiedProps } = useTextStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
 
@@ -19,7 +25,5 @@ export const Text = <T extends ElementType = 'p', S = void>(props: SpiritTextPro
     </ElementTag>
   );
 };
-
-Text.defaultProps = defaultProps;
 
 export default Text;

--- a/packages/web-react/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/web-react/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,12 +1,8 @@
-import React, { ElementType } from 'react';
 import classNames from 'classnames';
+import React, { ElementType } from 'react';
 import { useStyleProps } from '../../hooks';
 import { SpiritVisuallyHiddenProps } from '../../types/visuallyHidden';
 import { useVisuallyHiddenProps } from './useVisuallyHiddenProps';
-
-const defaultProps = {
-  elementType: 'span',
-};
 
 const VisuallyHidden = <T extends ElementType = 'span'>(props: SpiritVisuallyHiddenProps<T>): JSX.Element => {
   const { children, elementType: ElementTag = 'span', ...rest } = props;
@@ -19,7 +15,5 @@ const VisuallyHidden = <T extends ElementType = 'span'>(props: SpiritVisuallyHid
     </ElementTag>
   );
 };
-
-VisuallyHidden.defaultProps = defaultProps;
 
 export default VisuallyHidden;

--- a/packages/web-react/src/types/collapse.ts
+++ b/packages/web-react/src/types/collapse.ts
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { ChildrenProps, ClickEvent, StyleProps, Booleanish } from './shared';
+import { Booleanish, ChildrenProps, ClickEvent, StyleProps } from './shared';
 
 export type CollapseElementType = 'div' | 'article' | 'section' | 'main' | 'header' | 'footer';
 
@@ -28,7 +28,8 @@ export interface TransitionCollapseProps {
 
 export interface SpiritCollapseProps extends CollapseProps, TransitionCollapseProps {}
 
-export interface SpiritUncontrolledCollapseProps extends SpiritCollapseProps {
+export interface SpiritUncontrolledCollapseProps extends Omit<SpiritCollapseProps, 'isOpen'> {
+  isOpen?: boolean;
   hideOnCollapse?: boolean;
   renderTrigger?: (render: CollapseRenderProps) => ReactNode;
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

* Support for defaultProps will be removed from function components in a future major release.
* Use JavaScript default parameters instead.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
