### PR TITLE
Feat(web-react): Deprecate Dropdown non flow placements DS-1132

### DIFF
--- a/packages/web-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/web-react/src/components/Dropdown/Dropdown.tsx
@@ -13,17 +13,19 @@ import { useDropdownStyleProps } from './useDropdownStyleProps';
 
 const defaultProps = {
   enableAutoClose: true,
-  placement: Placements.BOTTOM_LEFT,
+  placement: Placements.BOTTOM_START,
 };
 
 export const Dropdown = (props: SpiritDropdownProps) => {
   const {
+    /** @deprecated ID will be made a required user input in the next major version. */
     id = Math.random().toString(36).slice(2, 7),
     children,
-    renderTrigger,
     enableAutoClose,
     fullWidthMode,
     onAutoClose,
+    placement = defaultProps.placement,
+    renderTrigger,
     ...rest
   } = props;
 
@@ -32,7 +34,7 @@ export const Dropdown = (props: SpiritDropdownProps) => {
 
   const { isOpen, toggleHandler } = useDropdown({ dropdownRef, triggerRef, enableAutoClose, onAutoClose });
   const { classProps, props: modifiedProps } = useDropdownStyleProps({ isOpen, ...rest });
-  const { triggerProps, contentProps } = useDropdownAriaProps({ id, isOpen, toggleHandler, fullWidthMode });
+  const { triggerProps, contentProps } = useDropdownAriaProps({ id, isOpen, fullWidthMode, placement, toggleHandler });
 
   const { styleProps: contentStyleProps, props: contentOtherProps } = useStyleProps({ ...modifiedProps });
   const { styleProps: triggerStyleProps } = useStyleProps({

--- a/packages/web-react/src/components/Dropdown/DropdownContext.ts
+++ b/packages/web-react/src/components/Dropdown/DropdownContext.ts
@@ -19,7 +19,7 @@ const defaultContext: DropdownContextType = {
   id: '',
   isOpen: false,
   onToggle: () => {},
-  placement: Placements.BOTTOM_LEFT,
+  placement: Placements.BOTTOM_START,
   triggerRef: { current: undefined },
 };
 

--- a/packages/web-react/src/components/Dropdown/DropdownPopover.tsx
+++ b/packages/web-react/src/components/Dropdown/DropdownPopover.tsx
@@ -11,9 +11,9 @@ interface DropdownPopoverProps extends ChildrenProps, StyleProps {}
 export const DropdownPopover = (props: DropdownPopoverProps) => {
   const { children, ...rest } = props;
   const { id, isOpen, onToggle, fullWidthMode, placement } = useDropdownContext();
-  const { classProps, props: modifiedProps } = useDropdownStyleProps({ isOpen, placement, ...rest });
+  const { classProps, props: modifiedProps } = useDropdownStyleProps({ isOpen, ...rest });
   const { styleProps: contentStyleProps, props: contentOtherProps } = useStyleProps({ ...modifiedProps });
-  const { contentProps } = useDropdownAriaProps({ id, isOpen, toggleHandler: onToggle, fullWidthMode });
+  const { contentProps } = useDropdownAriaProps({ id, isOpen, toggleHandler: onToggle, placement, fullWidthMode });
 
   return (
     <div

--- a/packages/web-react/src/components/Dropdown/README.md
+++ b/packages/web-react/src/components/Dropdown/README.md
@@ -30,14 +30,14 @@ import { Dropdown, Button, Item } from '@lmc-eu/spirit-web-react/components';
 
 ## API
 
-| Name              | Type                                             | Default       | Required | Description                                    |
-| ----------------- | ------------------------------------------------ | ------------- | -------- | ---------------------------------------------- |
-| `enableAutoClose` | `bool`                                           | `true`        | ✕        | Enables close on click outside of Dropdown     |
-| `fullWidthMode`   | [`DropdownFullwidthMode`][dropdownfullwidthmode] | `off`         | ✕        | Full-width mode                                |
-| `id`              | `string`                                         | `<random>`    | ✕        | Component id                                   |
-| `onAutoClose` .   | `(event: Event) => void`                         | —             | ✕        | Callback on close on click outside of Dropdown |
-| `placement`       | [Placement dictionary][dictionary-placement]     | `bottom-left` | ✕        | Alignment of the component                     |
-| `renderTrigger`   | `(render: DropdownRenderProps) => ReactNode`     | —             | ✕        | Properties for trigger render                  |
+| Name              | Type                                             | Default        | Required | Description                                    |
+| ----------------- | ------------------------------------------------ | -------------- | -------- | ---------------------------------------------- |
+| `enableAutoClose` | `bool`                                           | `true`         | ✕        | Enables close on click outside of Dropdown     |
+| `fullWidthMode`   | [`DropdownFullwidthMode`][dropdownfullwidthmode] | `off`          | ✕        | Full-width mode                                |
+| `id`              | `string`                                         | `<random>`     | ✕        | Component id                                   |
+| `onAutoClose` .   | `(event: Event) => void`                         | —              | ✕        | Callback on close on click outside of Dropdown |
+| `placement`       | [Placement dictionary][dictionary-placement]     | `bottom-start` | ✕        | Alignment of the component                     |
+| `renderTrigger`   | `(render: DropdownRenderProps) => ReactNode`     | —              | ✕        | Properties for trigger render                  |
 
 On top of the API options, the components accept [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]
@@ -77,6 +77,14 @@ const onToggle = () => setIsOpen(!isOpen);
 </DropdownModern>;
 ```
 
+### ⚠️ DEPRECATION NOTICE
+
+Both cross-axis placements have been renamed from `top-left`, `top-right`, `right-top`, `right-bottom`,
+etc. to `top-start`, `top-end`, `right-start`, `right-end`, etc. The old names are deprecated and will be
+removed in the next major release.
+
+[What are deprecations?][readme-deprecations]
+
 ### Dropdown with Item
 
 Enhance your DropdownPopover by incorporating the versatile [Item][item] component.
@@ -111,15 +119,15 @@ import { UncontrolledDropdown, DropdownTrigger, DropdownPopover } from '@lmc-eu/
 
 ### DropdownModern
 
-| Name              | Type                                             | Default       | Required | Description                                    |
-| ----------------- | ------------------------------------------------ | ------------- | -------- | ---------------------------------------------- |
-| `enableAutoClose` | `bool`                                           | `true`        | ✕        | Enables close on click outside of Dropdown     |
-| `fullWidthMode`   | [`DropdownFullwidthMode`][dropdownfullwidthmode] | `off`         | ✕        | Full-width mode                                |
-| `id`              | `string`                                         | -             | ✔        | Component id                                   |
-| `isOpen`          | `bool`                                           | `false`       | ✔        | Open state                                     |
-| `onAutoClose`     | `(event: Event) => void`                         | —             | ✕        | Callback on close on click outside of Dropdown |
-| `onToggle`        | `() => void`                                     | —             | ✔        | Function for toggle open state of dropdown     |
-| `placement`       | [Placement dictionary][dictionary-placement]     | `bottom-left` | ✕        | Alignment of the component                     |
+| Name              | Type                                             | Default        | Required | Description                                    |
+| ----------------- | ------------------------------------------------ | -------------- | -------- | ---------------------------------------------- |
+| `enableAutoClose` | `bool`                                           | `true`         | ✕        | Enables close on click outside of Dropdown     |
+| `fullWidthMode`   | [`DropdownFullwidthMode`][dropdownfullwidthmode] | `off`          | ✕        | Full-width mode                                |
+| `id`              | `string`                                         | -              | ✔        | Component id                                   |
+| `isOpen`          | `bool`                                           | `false`        | ✔        | Open state                                     |
+| `onAutoClose`     | `(event: Event) => void`                         | —              | ✕        | Callback on close on click outside of Dropdown |
+| `onToggle`        | `() => void`                                     | —              | ✔        | Function for toggle open state of dropdown     |
+| `placement`       | [Placement dictionary][dictionary-placement]     | `bottom-start` | ✕        | Alignment of the component                     |
 
 On top of the API options, the components accept [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]
@@ -148,13 +156,13 @@ and [escape hatches][readme-escape-hatches].
 
 ### UncontrolledDropdown
 
-| Name              | Type                                             | Default       | Required | Description                                    |
-| ----------------- | ------------------------------------------------ | ------------- | -------- | ---------------------------------------------- |
-| `enableAutoClose` | `bool`                                           | `true`        | ✕        | Enables close on click outside of Dropdown     |
-| `fullWidthMode`   | [`DropdownFullwidthMode`][dropdownfullwidthmode] | `off`         | ✕        | Full-width mode                                |
-| `id`              | `string`                                         | `<random>`    | ✕        | Component id                                   |
-| `onAutoClose`     | `(event: Event) => void`                         | —             | ✕        | Callback on close on click outside of Dropdown |
-| `placement`       | [Placement dictionary][dictionary-placement]     | `bottom-left` | ✕        | Alignment of the component                     |
+| Name              | Type                                             | Default        | Required | Description                                    |
+| ----------------- | ------------------------------------------------ | -------------- | -------- | ---------------------------------------------- |
+| `enableAutoClose` | `bool`                                           | `true`         | ✕        | Enables close on click outside of Dropdown     |
+| `fullWidthMode`   | [`DropdownFullwidthMode`][dropdownfullwidthmode] | `off`          | ✕        | Full-width mode                                |
+| `id`              | `string`                                         | `<random>`     | ✕        | Component id                                   |
+| `onAutoClose`     | `(event: Event) => void`                         | —              | ✕        | Callback on close on click outside of Dropdown |
+| `placement`       | [Placement dictionary][dictionary-placement]     | `bottom-start` | ✕        | Alignment of the component                     |
 
 On top of the API options, the components accept [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]
@@ -167,5 +175,6 @@ and [escape hatches][readme-escape-hatches].
 [dropdownfullwidthmode]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-react/src/types/dropdown.ts#L19
 [item]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-react/src/components/Item/README.md
 [readme-additional-attributes]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-react/README.md#additional-attributes
+[readme-deprecations]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web-react/README.md#deprecations
 [readme-escape-hatches]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-react/README.md#escape-hatches
 [readme-style-props]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-react/README.md#style-props

--- a/packages/web-react/src/components/Dropdown/__tests__/useDropdownAriaProps.test.ts
+++ b/packages/web-react/src/components/Dropdown/__tests__/useDropdownAriaProps.test.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { PlacementDictionaryType } from '../../../types';
 import { useDropdownAriaProps } from '../useDropdownAriaProps';
 
 describe('useDropdownAriaProps', () => {
@@ -7,6 +8,7 @@ describe('useDropdownAriaProps', () => {
       fullWidthMode: undefined,
       id: 'test-dropdown-id',
       isOpen: true,
+      placement: 'bottom-start' as PlacementDictionaryType,
       toggleHandler: () => null,
     };
     const { result } = renderHook(() => useDropdownAriaProps(props));
@@ -15,5 +17,8 @@ describe('useDropdownAriaProps', () => {
     expect(result.current.triggerProps['aria-expanded']).toBeDefined();
     expect(result.current.triggerProps['aria-controls']).toBeDefined();
     expect(result.current.triggerProps.onClick).toBeDefined();
+    expect(result.current.contentProps).toBeDefined();
+    expect(result.current.contentProps['data-spirit-placement']).toBeDefined();
+    expect(result.current.contentProps['data-spirit-placement']).toBe('bottom-start');
   });
 });

--- a/packages/web-react/src/components/Dropdown/__tests__/useDropdownStyleProps.test.ts
+++ b/packages/web-react/src/components/Dropdown/__tests__/useDropdownStyleProps.test.ts
@@ -1,12 +1,11 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { PlacementDictionaryType } from '../../../types';
 import { useDropdownStyleProps, UseDropdownStyleProps } from '../useDropdownStyleProps';
 
 describe('useDropdownStyleProps', () => {
   it('should return defaults', () => {
     const { result } = renderHook(() => useDropdownStyleProps());
 
-    expect(result.current.classProps.contentClassName).toBe('Dropdown Dropdown--bottomLeft');
+    expect(result.current.classProps.contentClassName).toBe('Dropdown');
     expect(result.current.classProps.wrapperClassName).toBe('DropdownWrapper');
   });
 
@@ -16,17 +15,8 @@ describe('useDropdownStyleProps', () => {
     } as UseDropdownStyleProps;
     const { result } = renderHook(() => useDropdownStyleProps(props));
 
-    expect(result.current.classProps.contentClassName).toBe('Dropdown Dropdown--bottomLeft is-open');
+    expect(result.current.classProps.contentClassName).toBe('Dropdown is-open');
     expect(result.current.classProps.triggerClassName).toBe('is-expanded');
-  });
-
-  it('should change placement', () => {
-    const props = {
-      placement: 'top-right' as PlacementDictionaryType,
-    } as UseDropdownStyleProps;
-    const { result } = renderHook(() => useDropdownStyleProps(props));
-
-    expect(result.current.classProps.contentClassName).toBe('Dropdown Dropdown--topRight');
   });
 
   it('should transfer additional props', () => {
@@ -36,7 +26,7 @@ describe('useDropdownStyleProps', () => {
     } as UseDropdownStyleProps;
     const { result } = renderHook(() => useDropdownStyleProps(props));
 
-    expect(result.current.classProps.contentClassName).toBe('Dropdown Dropdown--bottomLeft');
+    expect(result.current.classProps.contentClassName).toBe('Dropdown');
     expect(result.current.props).toEqual({ transferProp: 'test' });
   });
 });

--- a/packages/web-react/src/components/Dropdown/demo/DropdownEnhancedShadow.tsx
+++ b/packages/web-react/src/components/Dropdown/demo/DropdownEnhancedShadow.tsx
@@ -14,7 +14,7 @@ const DropdownEnhancedShadow = () => {
 
   return (
     <div className="spirit-feature-dropdown-enable-enhanced-shadow">
-      <Dropdown renderTrigger={dropdownTrigger} placement="top-left">
+      <Dropdown renderTrigger={dropdownTrigger} placement="top-start">
         <DropdownContentFactory content={dropdownContent} />
       </Dropdown>
     </div>

--- a/packages/web-react/src/components/Dropdown/demo/DropdownFullwidthAll.tsx
+++ b/packages/web-react/src/components/Dropdown/demo/DropdownFullwidthAll.tsx
@@ -13,7 +13,7 @@ const DropdownFullwidthAll = () => {
   );
 
   return (
-    <Dropdown renderTrigger={dropdownTrigger} fullWidthMode="all" placement="top-left">
+    <Dropdown renderTrigger={dropdownTrigger} fullWidthMode="all" placement="top-start">
       <DropdownContentFactory content={dropdownContent} />
     </Dropdown>
   );

--- a/packages/web-react/src/components/Dropdown/demo/DropdownFullwidthMobileOnly.tsx
+++ b/packages/web-react/src/components/Dropdown/demo/DropdownFullwidthMobileOnly.tsx
@@ -13,7 +13,7 @@ const DropdownFullwidthMobileOnly = () => {
   );
 
   return (
-    <Dropdown renderTrigger={dropdownTrigger} fullWidthMode="mobile-only" placement="top-left">
+    <Dropdown renderTrigger={dropdownTrigger} fullWidthMode="mobile-only" placement="top-start">
       <DropdownContentFactory content={dropdownContent} />
     </Dropdown>
   );

--- a/packages/web-react/src/components/Dropdown/demo/DropdownPlacements.tsx
+++ b/packages/web-react/src/components/Dropdown/demo/DropdownPlacements.tsx
@@ -7,7 +7,7 @@ import { Radio } from '../../Radio';
 import { Dropdown } from '..';
 
 const DropdownPlacements = () => {
-  const [placement, setPlacement] = useState<PlacementDictionaryType>('bottom-left');
+  const [placement, setPlacement] = useState<PlacementDictionaryType>('bottom-start');
 
   const handlePlacementChange = (e: ChangeEvent<HTMLInputElement>) => {
     setPlacement(e.target.value as PlacementDictionaryType);
@@ -25,59 +25,59 @@ const DropdownPlacements = () => {
         <GridItem columnStart={2} rowStart={1}>
           <Radio
             name="placement"
-            isChecked={placement === 'top-left'}
+            isChecked={placement === 'top-start'}
             isLabelHidden
             onChange={handlePlacementChange}
-            id="placement_top_left"
-            label="top-left"
-            value="top-left"
+            id="placement-top-start"
+            label="top-start"
+            value="top-start"
           />{' '}
           <Radio
             name="placement"
             isChecked={placement === 'top'}
             isLabelHidden
             onChange={handlePlacementChange}
-            id="placement_top"
+            id="placement-top"
             label="top"
             value="top"
           />{' '}
           <Radio
             name="placement"
-            isChecked={placement === 'top-right'}
+            isChecked={placement === 'top-end'}
             isLabelHidden
             onChange={handlePlacementChange}
-            id="placement_top_right"
-            label="top-right"
-            value="top-right"
+            id="placement-top-end"
+            label="top-end"
+            value="top-end"
           />
         </GridItem>
         <GridItem columnStart={2} rowStart={3}>
           <Radio
             name="placement"
-            isChecked={placement === 'bottom-left'}
+            isChecked={placement === 'bottom-start'}
             isLabelHidden
             onChange={handlePlacementChange}
-            id="placement_bottom_left"
-            label="bottom-left"
-            value="bottom-left"
+            id="placement-bottom-start"
+            label="bottom-start"
+            value="bottom-start"
           />{' '}
           <Radio
             name="placement"
             isChecked={placement === 'bottom'}
             isLabelHidden
             onChange={handlePlacementChange}
-            id="placement_bottom"
+            id="placement-bottom"
             label="bottom"
             value="bottom"
           />{' '}
           <Radio
             name="placement"
-            isChecked={placement === 'bottom-right'}
+            isChecked={placement === 'bottom-end'}
             isLabelHidden
             onChange={handlePlacementChange}
-            id="placement_bottom_right"
-            label="bottom-right"
-            value="bottom-right"
+            id="placement-bottom-end"
+            label="bottom-end"
+            value="bottom-end"
           />
         </GridItem>
         <GridItem
@@ -87,30 +87,30 @@ const DropdownPlacements = () => {
         >
           <Radio
             name="placement"
-            isChecked={placement === 'left-top'}
+            isChecked={placement === 'left-start'}
             isLabelHidden
             onChange={handlePlacementChange}
-            id="placement_left_top"
-            label="left-top"
-            value="left-top"
+            id="placement-left-start"
+            label="left-start"
+            value="left-start"
           />
           <Radio
             name="placement"
             isChecked={placement === 'left'}
             isLabelHidden
             onChange={handlePlacementChange}
-            id="placement_left"
+            id="placement-left"
             label="left"
             value="left"
           />
           <Radio
             name="placement"
-            isChecked={placement === 'left-bottom'}
+            isChecked={placement === 'left-end'}
             isLabelHidden
             onChange={handlePlacementChange}
-            id="placement_left_bottom"
-            label="left-bottom"
-            value="left-bottom"
+            id="placement-left-end"
+            label="left-end"
+            value="left-end"
           />
         </GridItem>
         <GridItem
@@ -120,30 +120,30 @@ const DropdownPlacements = () => {
         >
           <Radio
             name="placement"
-            isChecked={placement === 'right-top'}
+            isChecked={placement === 'right-start'}
             isLabelHidden
             onChange={handlePlacementChange}
-            id="placement_right_top"
-            label="right-top"
-            value="right-top"
+            id="placement-right-start"
+            label="right-start"
+            value="right-start"
           />
           <Radio
             name="placement"
             isChecked={placement === 'right'}
             isLabelHidden
             onChange={handlePlacementChange}
-            id="placement_right"
+            id="placement-end"
             label="right"
             value="right"
           />
           <Radio
             name="placement"
-            isChecked={placement === 'right-bottom'}
+            isChecked={placement === 'right-end'}
             isLabelHidden
             onChange={handlePlacementChange}
-            id="placement_right_bottom"
-            label="right-bottom"
-            value="right-bottom"
+            id="placement-right-end"
+            label="right-end"
+            value="right-end"
           />
         </GridItem>
         <GridItem columnStart={2} rowStart={2}>

--- a/packages/web-react/src/components/Dropdown/stories/Dropdown.stories.tsx
+++ b/packages/web-react/src/components/Dropdown/stories/Dropdown.stories.tsx
@@ -40,7 +40,7 @@ const meta: Meta<typeof Dropdown> = {
       control: 'select',
       options: Object.values(Placements),
       table: {
-        defaultValue: { summary: Placements.BOTTOM_LEFT },
+        defaultValue: { summary: Placements.BOTTOM_START },
       },
     },
   },
@@ -66,7 +66,7 @@ const meta: Meta<typeof Dropdown> = {
       </>
     ),
     id: 'DropdownExample',
-    placement: Placements.BOTTOM_LEFT,
+    placement: Placements.BOTTOM_START,
   },
 };
 

--- a/packages/web-react/src/components/Dropdown/useDropdownAriaProps.ts
+++ b/packages/web-react/src/components/Dropdown/useDropdownAriaProps.ts
@@ -1,8 +1,11 @@
-import { Booleanish, ClickEvent, DropdownFullWidthMode } from '../../types';
+import { Placements } from '../../constants';
+import { useDeprecationMessage } from '../../hooks';
+import { Booleanish, ClickEvent, DropdownFullWidthMode, PlacementDictionaryType } from '../../types';
 
 const NAME_ARIA_EXPANDED = 'aria-expanded';
 const NAME_ARIA_CONTROLS = 'aria-controls';
 const NAME_DATA_FULLWIDTHMODE = 'data-spirit-fullwidthmode';
+const NAME_DATA_PLACEMENT = 'data-spirit-placement';
 
 export enum fullWidthModeKeys {
   'off' = 'off',
@@ -14,10 +17,12 @@ export interface UseDropdownAriaPropsProps {
   id: string;
   /** open state */
   isOpen: boolean;
-  /** toggle callback */
-  toggleHandler: (event: ClickEvent) => void;
   /** fullWidthMode */
   fullWidthMode: DropdownFullWidthMode | undefined;
+  /** placement */
+  placement?: PlacementDictionaryType;
+  /** toggle callback */
+  toggleHandler: (event: ClickEvent) => void;
 }
 
 export interface UseDropdownAriaPropsReturn {
@@ -25,6 +30,7 @@ export interface UseDropdownAriaPropsReturn {
   contentProps: {
     id: string;
     [NAME_DATA_FULLWIDTHMODE]?: keyof typeof fullWidthModeKeys | undefined;
+    [NAME_DATA_PLACEMENT]?: PlacementDictionaryType;
   };
   /** trigger returned props */
   triggerProps: {
@@ -34,8 +40,29 @@ export interface UseDropdownAriaPropsReturn {
   };
 }
 
+const deprecatedPlacements = {
+  'top-left': 'top-start',
+  'top-right': 'top-end',
+  'right-top': 'right-start',
+  'right-bottom': 'right-end',
+  'bottom-left': 'bottom-start',
+  'bottom-right': 'bottom-end',
+  'left-top': 'left-start',
+  'left-bottom': 'left-end',
+};
+
 export const useDropdownAriaProps = (props: UseDropdownAriaPropsProps): UseDropdownAriaPropsReturn => {
-  const { fullWidthMode, id, isOpen, toggleHandler } = props;
+  const { fullWidthMode, id, isOpen, placement = Placements.BOTTOM_START, toggleHandler } = props;
+  useDeprecationMessage({
+    method: 'property',
+    trigger: !!deprecatedPlacements[placement as keyof typeof deprecatedPlacements],
+    componentName: 'Tooltip',
+    propertyProps: {
+      deprecatedValue: placement,
+      newValue: deprecatedPlacements[placement as keyof typeof deprecatedPlacements],
+      propertyName: 'placement',
+    },
+  });
 
   const triggerProps = {
     id,
@@ -43,7 +70,11 @@ export const useDropdownAriaProps = (props: UseDropdownAriaPropsProps): UseDropd
     [NAME_ARIA_CONTROLS]: String(id),
     onClick: toggleHandler,
   };
-  const contentProps = { id, [NAME_DATA_FULLWIDTHMODE]: fullWidthMode };
+  const contentProps = {
+    id,
+    [NAME_DATA_FULLWIDTHMODE]: fullWidthMode,
+    [NAME_DATA_PLACEMENT]: placement,
+  };
 
   return {
     contentProps,

--- a/packages/web-react/src/components/Dropdown/useDropdownStyleProps.ts
+++ b/packages/web-react/src/components/Dropdown/useDropdownStyleProps.ts
@@ -1,8 +1,6 @@
 import classNames from 'classnames';
-import { Placements } from '../../constants';
 import { useClassNamePrefix } from '../../hooks';
 import { DropdownProps, SpiritDropdownProps } from '../../types';
-import { kebabCaseToCamelCase } from '../../utils';
 
 export interface UseDropdownStyleProps extends SpiritDropdownProps {
   /** open state */
@@ -21,15 +19,14 @@ export interface UseDropdownStylePropsReturn {
 export const useDropdownStyleProps = (
   props: UseDropdownStyleProps = { isOpen: false },
 ): UseDropdownStylePropsReturn => {
-  const { isOpen, placement = Placements.BOTTOM_LEFT, ...modifiedProps } = props;
+  const { isOpen, ...modifiedProps } = props;
 
   const dropdownClass = useClassNamePrefix('Dropdown');
   const dropdownWrapperClass = `${dropdownClass}Wrapper`;
-  const dropdownPlacementClass = `${dropdownClass}--${kebabCaseToCamelCase(placement)}`;
   const expandedClass = isOpen ? 'is-expanded' : '';
   const openClass = isOpen ? 'is-open' : '';
 
-  const dropdownClassName = classNames(dropdownClass, dropdownPlacementClass, openClass);
+  const dropdownClassName = classNames(dropdownClass, openClass);
   const triggerClassName = classNames(expandedClass);
 
   return {

--- a/packages/web-twig/src/Resources/components/Dropdown/README.md
+++ b/packages/web-twig/src/Resources/components/Dropdown/README.md
@@ -60,7 +60,7 @@ and [escape hatches][readme-escape-hatches].
 
 #### ⚠️ DEPRECATION NOTICE
 
-Both cross-axis placements are renamed from `top-left`, `top-right`, `right-top`, `right-bottom`,
+Both cross-axis placements have been renamed from `top-left`, `top-right`, `right-top`, `right-bottom`,
 etc. to `top-start`, `top-end`, `right-start`, `right-end`, etc. The old names are deprecated and will be
 removed in the next major release.
 


### PR DESCRIPTION
Use flow placement values, e.g. `top-left` is now `top-start`.

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

---

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- [ ] Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
