### PR TITLE
Enable rendering Symfony Forms fields in `FieldGroup`

### DIFF
--- a/packages/web-react/src/components/FieldGroup/README.md
+++ b/packages/web-react/src/components/FieldGroup/README.md
@@ -94,18 +94,19 @@ Validation states can be presented either by adding the `validationState` attrib
 
 ## API
 
-| Name              | Type                                           | Default | Required | Description                              |
-| ----------------- | ---------------------------------------------- | ------- | -------- | ---------------------------------------- |
-| `form`            | `string`                                       | `null`  | ✕        | Parent form ID                           |
-| `helperText`      | `string`                                       | `null`  | ✕        | Custom helper text                       |
-| `id`              | `string`                                       | —       | ✔        | Group and label identification           |
-| `isDisabled`      | `bool`                                         | `false` | ✕        | If true, the group is disabled           |
-| `isLabelHidden`   | `bool`                                         | `false` | ✕        | If true, label is hidden                 |
-| `isRequired`      | `bool`                                         | `false` | ✕        | If true, the group is marked as required |
-| `label`           | `string`                                       | —       | ✔        | Label text                               |
-| `name`            | `string`                                       | `null`  | ✕        | Group name                               |
-| `validationState` | [Validation dictionary][dictionary-validation] | `null`  | ✕        | Type of validation state                 |
-| `validationText`  | [`string` \| `string[]`]                       | `null`  | ✕        | Validation text                          |
+| Name              | Type                                           | Default | Required | Description                                                |
+| ----------------- | ---------------------------------------------- | ------- | -------- | ---------------------------------------------------------- |
+| `form`            | `string`                                       | `null`  | ✕        | Parent form ID                                             |
+| `helperText`      | `string`                                       | `null`  | ✕        | Custom helper text                                         |
+| `id`              | `string`                                       | —       | ✔        | Group and label identification                             |
+| `isDisabled`      | `bool`                                         | `false` | ✕        | If true, the group is disabled                             |
+| `isFluid`         | `bool`                                         | —       | ✕        | If true, the element spans to the full width of its parent |
+| `isLabelHidden`   | `bool`                                         | `false` | ✕        | If true, label is hidden                                   |
+| `isRequired`      | `bool`                                         | `false` | ✕        | If true, the group is marked as required                   |
+| `label`           | `string`                                       | —       | ✔        | Label text                                                 |
+| `name`            | `string`                                       | `null`  | ✕        | Group name                                                 |
+| `validationState` | [Validation dictionary][dictionary-validation] | `null`  | ✕        | Type of validation state                                   |
+| `validationText`  | [`string` \| `string[]`]                       | `null`  | ✕        | Validation text                                            |
 
 On top of the API options, the components accept [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]

--- a/packages/web-twig/src/Resources/components/FieldGroup/FieldGroup.twig
+++ b/packages/web-twig/src/Resources/components/FieldGroup/FieldGroup.twig
@@ -64,11 +64,9 @@
             </div>
         {% endif %}
     {% endif %}
-    {% if block('content') is not empty %}
-        <div class="{{ _fieldsClassName }}">
-            {% block content %}{% endblock %}
-        </div>
-    {% endif %}
+    <div class="{{ _fieldsClassName }}">
+        {% block content %}{% endblock %}
+    </div>
     <HelperText
         className="{{ _helperTextClassName }}"
         id="{{ _helperTextId }}"

--- a/packages/web-twig/src/Resources/components/FieldGroup/README.md
+++ b/packages/web-twig/src/Resources/components/FieldGroup/README.md
@@ -14,6 +14,9 @@ validation messages for all fields in the group.
 ⚠️ **The FieldGroup component does not provide all necessary semantics and any styling to its child fields. It is up
 to the developer to configure the child fields correctly.**
 
+⚠️ Remember the FieldGroup component is required to be used with content.
+Otherwise, it is useless. If it is used dynamically, make sure the FieldGroup component without content has been removed correctly.
+
 👉 The FieldGroup component implements the `<fieldset>` HTML element. Read more about the advantages and limitations in
 the [`web` implementation][gh-web-field-group-html] of `FieldGroup`.
 

--- a/packages/web-twig/src/Resources/components/FieldGroup/README.md
+++ b/packages/web-twig/src/Resources/components/FieldGroup/README.md
@@ -100,21 +100,22 @@ When validated on server:
 
 ## API
 
-| Name                    | Type                                           | Default | Required | Description                                |
-| ----------------------- | ---------------------------------------------- | ------- | -------- | ------------------------------------------ |
-| `form`                  | `string`                                       | `null`  | ✕        | Parent form ID                             |
-| `helperText`            | `string`                                       | `null`  | ✕\*\*    | Custom helper text                         |
-| `id`                    | `string`                                       | —       | ✔        | Group and label identification             |
-| `isDisabled`            | `bool`                                         | `false` | ✕        | If true, the group is disabled             |
-| `isLabelHidden`         | `bool`                                         | `false` | ✕        | If true, label is hidden                   |
-| `isRequired`            | `bool`                                         | `false` | ✕        | If true, the group is marked as required   |
-| `label`                 | `string`                                       | `null`  | ✕\*      | Label text                                 |
-| `name`                  | `string`                                       | `null`  | ✕        | Group name                                 |
-| `UNSAFE_helperText`     | `string`                                       | `null`  | ✕\*\*    | Unescaped custom helper text (allows HTML) |
-| `UNSAFE_label`          | `string`                                       | `null`  | ✕\*      | Unescaped label text (allows HTML)         |
-| `UNSAFE_validationText` | [`string` \| `string[]`]                       | `null`  | ✕\*\*    | Unescaped validation text (allows HTML)    |
-| `validationState`       | [Validation dictionary][dictionary-validation] | `null`  | ✕        | Type of validation state                   |
-| `validationText`        | [`string` \| `string[]`]                       | `null`  | ✕\*\*    | Validation text                            |
+| Name                    | Type                                           | Default | Required | Description                                                |
+| ----------------------- | ---------------------------------------------- | ------- | -------- | ---------------------------------------------------------- |
+| `form`                  | `string`                                       | `null`  | ✕        | Parent form ID                                             |
+| `helperText`            | `string`                                       | `null`  | ✕\*\*    | Custom helper text                                         |
+| `id`                    | `string`                                       | —       | ✔        | Group and label identification                             |
+| `isDisabled`            | `bool`                                         | `false` | ✕        | If true, the group is disabled                             |
+| `isFluid`               | `bool`                                         | `false` | ✕        | If true, the element spans to the full width of its parent |
+| `isLabelHidden`         | `bool`                                         | `false` | ✕        | If true, label is hidden                                   |
+| `isRequired`            | `bool`                                         | `false` | ✕        | If true, the group is marked as required                   |
+| `label`                 | `string`                                       | `null`  | ✕\*      | Label text                                                 |
+| `name`                  | `string`                                       | `null`  | ✕        | Group name                                                 |
+| `UNSAFE_helperText`     | `string`                                       | `null`  | ✕\*\*    | Unescaped custom helper text (allows HTML)                 |
+| `UNSAFE_label`          | `string`                                       | `null`  | ✕\*      | Unescaped label text (allows HTML)                         |
+| `UNSAFE_validationText` | [`string` \| `string[]`]                       | `null`  | ✕\*\*    | Unescaped validation text (allows HTML)                    |
+| `validationState`       | [Validation dictionary][dictionary-validation] | `null`  | ✕        | Type of validation state                                   |
+| `validationText`        | [`string` \| `string[]`]                       | `null`  | ✕\*\*    | Validation text                                            |
 
 (\*) To keep the component accessible, a label is always required. You can use the `label` for simple text or `UNSAFE_label` for HTML content.
 (\*\*) Props with and without `UNSAFE_` prefix are mutually exclusive.

--- a/packages/web-twig/src/Resources/components/FieldGroup/__tests__/__fixtures__/fieldGroup.twig
+++ b/packages/web-twig/src/Resources/components/FieldGroup/__tests__/__fixtures__/fieldGroup.twig
@@ -1,6 +1,3 @@
-<FieldGroup id="fieldGroup"></FieldGroup>
-
-<!-- Render with children -->
 <FieldGroup id="fieldGroupWithChildren">
     <div>Item 1</div>
     <div>Item 2</div>
@@ -12,20 +9,32 @@
     id="fieldGroupHiddenLabel"
     isLabelHidden
     label="Label"
-></FieldGroup>
+>
+    <div>Item 1</div>
+    <div>Item 2</div>
+    <div>Item 3</div>
+</FieldGroup>
 
 <!-- Render in danger state -->
 <FieldGroup
     id="fieldGroupValidationDanger"
     validationState="danger"
-></FieldGroup>
+>
+    <div>Item 1</div>
+    <div>Item 2</div>
+    <div>Item 3</div>
+</FieldGroup>
 
 <!-- Render with allowed HTML attributes -->
 <FieldGroup
     form="myFormId"
     id="fieldGroupWithAllowedHTMLAttributes"
     name="myFieldGroupName"
-></FieldGroup>
+>
+    <div>Item 1</div>
+    <div>Item 2</div>
+    <div>Item 3</div>
+</FieldGroup>
 
 <!-- Render with UNSAFE props -->
 <FieldGroup
@@ -34,7 +43,11 @@
     UNSAFE_label="<span>UNSAFE label text</span>"
     UNSAFE_validationText="<span>UNSAFE validation text</span>"
     validationState="danger"
-/>
+>
+    <div>Item 1</div>
+    <div>Item 2</div>
+    <div>Item 3</div>
+</FieldGroup>
 
 <!-- Render with all props -->
 <FieldGroup

--- a/packages/web-twig/src/Resources/components/FieldGroup/__tests__/__snapshots__/fieldGroup.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/FieldGroup/__tests__/__snapshots__/fieldGroup.twig.snap.html
@@ -5,10 +5,6 @@
     </title>
   </head>
   <body>
-    <fieldset id="fieldGroup" class="FieldGroup">
-    </fieldset>
-    <!-- Render with children -->
-
     <fieldset id="fieldGroupWithChildren" class="FieldGroup">
       <div class="FieldGroup__fields">
         <div>
@@ -28,14 +24,53 @@
 
     <fieldset id="fieldGroupHiddenLabel" class="FieldGroup">
       <legend class="accessibility-hidden">Label</legend>
+      <div class="FieldGroup__fields">
+        <div>
+          Item 1
+        </div>
+
+        <div>
+          Item 2
+        </div>
+
+        <div>
+          Item 3
+        </div>
+      </div>
     </fieldset>
     <!-- Render in danger state -->
 
     <fieldset id="fieldGroupValidationDanger" class="FieldGroup FieldGroup--danger">
+      <div class="FieldGroup__fields">
+        <div>
+          Item 1
+        </div>
+
+        <div>
+          Item 2
+        </div>
+
+        <div>
+          Item 3
+        </div>
+      </div>
     </fieldset>
     <!-- Render with allowed HTML attributes -->
 
     <fieldset id="fieldGroupWithAllowedHTMLAttributes" form="myFormId" name="myFieldGroupName" class="FieldGroup">
+      <div class="FieldGroup__fields">
+        <div>
+          Item 1
+        </div>
+
+        <div>
+          Item 2
+        </div>
+
+        <div>
+          Item 3
+        </div>
+      </div>
     </fieldset>
     <!-- Render with UNSAFE props -->
 
@@ -43,6 +78,20 @@
       <legend class="accessibility-hidden"><span>UNSAFE label text</span></legend>
       <div class="FieldGroup__label" aria-hidden="true">
         <span>UNSAFE label text</span>
+      </div>
+
+      <div class="FieldGroup__fields">
+        <div>
+          Item 1
+        </div>
+
+        <div>
+          Item 2
+        </div>
+
+        <div>
+          Item 3
+        </div>
       </div>
 
       <div class="FieldGroup__helperText" id="fieldGroupWithUnsafeProps__helperText">


### PR DESCRIPTION
- This is hotfix solution to be able render [Symfony Forms fields](https://symfony.com/doc/current/form/form_customization.html#form-rendering-functions)[SFF] inside FieldGroup. There is no problem to render other components such as `Text`, `Radio` or more complex `Accordion`.
- I will explain how I get to the solution below.
- Better solutions and explanations are welcomed. :pray:

--- 

There's something I don't understand.

1. ❌ Current implementation  
```
{% if block('content') is not empty %}
    <div class="{{ _fieldsClassName }}">
        {% block content %}{% endblock %}
    </div>
{% endif %}
```
- Not possible to render SFF (via `form_row` or `form_widget`), but `form_label` is rendered! 🤯
- SFF isn't even in the `dump(block('content'))` log. 


2. ❌ Store `block('content')` into the variable  
```
{% if block('content') is not empty %}
    {% set _children = block('content') %}

    <div class="{{ _fieldsClassName }}">
        {{ _children }}
    </div>
{% endif %}
```
- Still not possible to render SFF and it isn't seen in the `dump(_children)` log.


3. ✅ Store `block('content')` into the variable **outside the implementation**  
```
{# API #}
…
{% set _children = block('content') %}
…

{% if _children is not empty %}
    <div class="{{ _fieldsClassName }}">
        {{ _children | raw }}
    </div>
{% endif %}
```
- Finally – I can see the SFF in the `dump(_children)` and is it possible to render it – but because it was stored in a variable it was converted to a `string`, so `raw` filter is here to help.

