### PR TITLE
Fix(web): Dropdown autoclose option should be strictly checked

### DIFF
--- a/packages/web-twig/src/Resources/components/Dropdown/stories/DropdownDisabledAutoclose.twig
+++ b/packages/web-twig/src/Resources/components/Dropdown/stories/DropdownDisabledAutoclose.twig
@@ -2,7 +2,7 @@
     <Button
         data-spirit-toggle="dropdown"
         data-spirit-target="#dropdown-disabled-auto-close"
-        data-spirit-autoclose="true"
+        data-spirit-autoclose="false"
     >
         Button as anchor
     </Button>

--- a/packages/web-twig/src/Resources/components/Dropdown/stories/DropdownVariousItems.twig
+++ b/packages/web-twig/src/Resources/components/Dropdown/stories/DropdownVariousItems.twig
@@ -2,6 +2,7 @@
     <Button
         data-spirit-toggle="dropdown"
         data-spirit-target="#dropdown-various-items"
+        data-spirit-autoclose="true"
     >
         Button as anchor
     </Button>

--- a/packages/web/src/js/Dropdown.ts
+++ b/packages/web/src/js/Dropdown.ts
@@ -51,7 +51,9 @@ class Dropdown extends BaseComponent {
     const dataset = this.element?.dataset;
     const optionsAutoClose = dataset?.spiritAutoclose;
 
-    if (optionsAutoClose) options.autoClose = Boolean(!optionsAutoClose);
+    if (optionsAutoClose) {
+      options.autoClose = optionsAutoClose !== 'false';
+    }
 
     return options;
   }

--- a/packages/web/src/scss/components/Dropdown/index.html
+++ b/packages/web/src/scss/components/Dropdown/index.html
@@ -220,7 +220,7 @@
           class="Button Button--primary Button--medium"
           aria-expanded="false"
           aria-controls="dropdown-disabled-auto-close"
-          data-spirit-autoclose="true"
+          data-spirit-autoclose="false"
         >
           Button as anchor
         </button>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Set `data-spirit-autoclose` to `false` in the one demo where it should be dissabled.
Strictly check data attribute value in the Dropdown plugin.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

https://jira.almacareer.tech/browse/DS-1157

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
