### PR TITLE
Chore(web-twig): Use Node v18 for development since the Docker image for v16 no longer exists

### DIFF
--- a/apps/web-twig-demo/docker/docker-compose.override.yml
+++ b/apps/web-twig-demo/docker/docker-compose.override.yml
@@ -24,7 +24,7 @@ services:
   web-twig-demo-encore:
     container_name: web-twig-demo-encore
     command: 'sh -c "yarn && yarn watch"'
-    image: node:16-alpine
+    image: node:18-alpine
     # ports:
     #   - '${DEV_SERVER_PORT:-8080}:8080'
     volumes:


### PR DESCRIPTION
In theory, we still support older Node versions until #DS-466 is fully resolved.