### PR TITLE
Feat(web-react): Deprecate `off` placement in Tooltip #DS-1078

### DIFF
--- a/packages/web-react/src/components/Dropdown/README.md
+++ b/packages/web-react/src/components/Dropdown/README.md
@@ -1,6 +1,6 @@
 # Dropdown
 
-⚠️ Dropdown component is [deprecated][deprecated] and will be removed in the next major version. Please use "DropdownModern" component instead.
+⚠️ Dropdown component is [deprecated][readme-deprecations] and will be removed in the next major version. Please use "DropdownModern" component instead.
 This is the React implementation of the [Dropdown][dropdown] component.
 
 ## Usage
@@ -59,7 +59,7 @@ and [escape hatches][readme-escape-hatches].
 
 # DropdownModern
 
-⚠️ `DropdownModern` component is [deprecated][deprecated] and will be renamed to `Dropdown` in the next major version.
+⚠️ `DropdownModern` component is [deprecated][readme-deprecations] and will be renamed to `Dropdown` in the next major version.
 
 ## Usage
 
@@ -168,7 +168,6 @@ On top of the API options, the components accept [additional attributes][readme-
 If you need more control over the styling of a component, you can use [style props][readme-style-props]
 and [escape hatches][readme-escape-hatches].
 
-[deprecated]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web-react/README.md#deprecations
 [dictionary-placement]: https://github.com/lmc-eu/spirit-design-system/tree/main/docs/DICTIONARIES.md#placement
 [dropdown]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web/src/scss/components/Dropdown
 [dropdownbreakpoint]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-react/src/types/dropdown.ts#L11

--- a/packages/web-react/src/components/DropdownModern/README.md
+++ b/packages/web-react/src/components/DropdownModern/README.md
@@ -1,6 +1,6 @@
 # DropdownModern
 
-⚠️ `DropdownModern` component is [deprecated] and will be renamed to `Dropdown` in the next major version.
+⚠️ `DropdownModern` component is [deprecated][deprecated] and will be renamed to `Dropdown` in the next major version.
 
 For more information and implementation examples, please visit the [`DropdownModern` section][dropdown-modern-section] section in the [readme][dropdown] for the `Dropdown` component.
 

--- a/packages/web-react/src/components/Tooltip/README.md
+++ b/packages/web-react/src/components/Tooltip/README.md
@@ -117,6 +117,14 @@ and [escape hatches][readme-escape-hatches].
 
 ## Advanced Positioning with Floating UI
 
+### ⚠️ DEPRECATION NOTICE
+
+The `off` placement is [deprecated][readme-deprecations] and will be removed in the next major version.
+Please use the `TooltipModern` component instead, which is the successor of the `Tooltip` component and
+provides improved functionality.
+
+[What are deprecations?][readme-deprecations]
+
 ### Basic
 
 ```javascript
@@ -230,7 +238,7 @@ const { getReferenceProps, getFloatingProps } = useInteractions([hover, focus, d
 
 # TooltipModern
 
-⚠️ `TooltipModern` component is [deprecated] and will be renamed to `Tooltip` in the next major version.
+⚠️ `TooltipModern` component is [deprecated][readme-deprecations] and will be renamed to `Tooltip` in the next major version.
 
 ## Usage
 

--- a/packages/web-react/src/components/Tooltip/useTooltipStyleProps.ts
+++ b/packages/web-react/src/components/Tooltip/useTooltipStyleProps.ts
@@ -41,6 +41,14 @@ export const useTooltipStyleProps = (props: UseTooltipStyleProps): UseTooltipSty
     },
   });
 
+  useDeprecationMessage({
+    method: 'custom',
+    trigger: placement === 'off',
+    componentName: 'Tooltip',
+    customText:
+      'The "off" value of property "placement" is deprecated and will be removed in the next major version. Use TooltipModern component instead.',
+  });
+
   const tooltipClass = useClassNamePrefix('Tooltip');
   const tooltipWrapperClass = `${tooltipClass}Wrapper`;
   const arrowClass = `${tooltipClass}__arrow`;

--- a/packages/web-react/src/types/tooltip.ts
+++ b/packages/web-react/src/types/tooltip.ts
@@ -16,11 +16,14 @@ export interface TooltipHandlingProps {
   onClose?: (event: ClickEvent) => void;
 }
 
+// @deprecated Off placement will be removed in the next major version
+type TooltipOffPlacement = 'off';
+
 export interface BaseTooltipProps extends ChildrenProps, StyleProps {
   closeLabel?: string;
   id?: string;
   isDismissible?: boolean;
-  placement?: PlacementDictionaryType | 'off';
+  placement?: PlacementDictionaryType | TooltipOffPlacement;
 }
 
 export interface TooltipWrapperProps extends ChildrenProps, StyleProps {}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
