### PR TITLE
Fix(codemods): FileuploaderAttachment codemods

### DIFF
--- a/packages/codemods/CONTRIBUTING.md
+++ b/packages/codemods/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+## Table of Contents
+
+1. [Naming](#naming)
+2. [File Structure](#file-structure)
+3. [Testing](#testing)
+
+## Naming
+
+Codemods adhere to a clear and organized naming convention, following the kebab case format. The naming structure consists of two parts:
+
+<component-name>: Represents the specific component or root component.
+<purpose-of-codemod>: Describes the purpose or objective of the codemod.
+
+This naming convention ensures consistency and ease of understanding, facilitating seamless integration and maintenance of codemods within the project.
+
+### Example naming
+
+```
+<component-name>-<purpose-of-codemod>.ts
+        |                 |
+        |                 └─⫸ Codemod purpose
+        |
+        └─⫸ Component name
+```
+
+## File Structure
+
+The file structure below outlines a standard organization for codemods within the project:
+
+```
+─── src
+    └── transforms
+        └── v2
+            └── web-react
+                └── __testfixtures__
+                │   ├── <CodemodName>.input.tsx
+                │   └── <CodemodName>.output.tsx
+                └── __tests__
+                │   └── <CodemodName>.test.ts
+                └── <CodemodName>.ts
+```
+
+This structure enhances clarity and organization, making it easier to navigate and comprehend the components associated with each codemod. The separation of fixtures, tests, and the main codemod file contributes to a streamlined development and testing process.
+
+## Testing
+
+- `% cd <your-local-path>/spirit-design-system/packages/codemods`
+- `% yarn test` for test package (lint, format, unit testing, types)
+- `% yarn test:unit` for unit tests

--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -36,7 +36,7 @@ Other optional arguments include:
 For example, this could be the command you will run:
 
 ```shell
-npx @lmc-eu/spirit-codemods -p ./src -t v2/web-react/button-text -e js,jsx --parser babel
+npx @lmc-eu/spirit-codemods -p ./src -t v2/web-react/fileuploader-prop-names -e js,jsx --parser babel
 ```
 
 [jscodeshift]: https://github.com/facebook/jscodeshift

--- a/packages/codemods/src/transforms/v2/web-react/__testfixtures__/button-text.input.tsx
+++ b/packages/codemods/src/transforms/v2/web-react/__testfixtures__/button-text.input.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
-import { Button } from '@lmc-eu/spirit-web-react';
-
-export const MyComponent = () => <Button buttonLabel="Click me" />;

--- a/packages/codemods/src/transforms/v2/web-react/__testfixtures__/button-text.output.tsx
+++ b/packages/codemods/src/transforms/v2/web-react/__testfixtures__/button-text.output.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
-import { Button } from '@lmc-eu/spirit-web-react';
-
-export const MyComponent = () => <Button buttonText="Click me" />;

--- a/packages/codemods/src/transforms/v2/web-react/__testfixtures__/fileuploader-prop-names.input.tsx
+++ b/packages/codemods/src/transforms/v2/web-react/__testfixtures__/fileuploader-prop-names.input.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import { FileUploaderAttachment } from '@lmc-eu/spirit-web-react';
+
+export const MyComponent = () => <FileUploaderAttachment buttonLabel="Remove me" editButtonLabel="Edit me" />;

--- a/packages/codemods/src/transforms/v2/web-react/__testfixtures__/fileuploader-prop-names.output.tsx
+++ b/packages/codemods/src/transforms/v2/web-react/__testfixtures__/fileuploader-prop-names.output.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import { FileUploaderAttachment } from '@lmc-eu/spirit-web-react';
+
+export const MyComponent = () => <FileUploaderAttachment removeText="Remove me" editText="Edit me" />;

--- a/packages/codemods/src/transforms/v2/web-react/__tests__/fileuploader-prop-names.test.ts
+++ b/packages/codemods/src/transforms/v2/web-react/__tests__/fileuploader-prop-names.test.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/extensions
 const { defineTest } = require('jscodeshift/dist/testUtils');
 
-defineTest(__dirname, 'button-text', null, 'button-text', {
+defineTest(__dirname, 'fileuploader-prop-names', null, 'fileuploader-prop-names', {
   parser: 'tsx',
   fixture: 'input',
   snapshot: true,

--- a/packages/codemods/src/transforms/v2/web-react/fileuploader-prop-names.ts
+++ b/packages/codemods/src/transforms/v2/web-react/fileuploader-prop-names.ts
@@ -13,25 +13,25 @@ const transform = (fileInfo: FileInfo, api: API) => {
 
   // Check if the module is imported
   if (importStatements.length > 0) {
-    const buttonSpecifier = importStatements.find(j.ImportSpecifier, {
+    const componentSpecifier = importStatements.find(j.ImportSpecifier, {
       imported: {
         type: 'Identifier',
-        name: 'Button',
+        name: 'FileUploaderAttachment',
       },
     });
 
     // Check if Button specifier is present
-    if (buttonSpecifier.length > 0) {
+    if (componentSpecifier.length > 0) {
       // Find Button components in the module
-      const buttonComponents = root.find(j.JSXOpeningElement, {
+      const components = root.find(j.JSXOpeningElement, {
         name: {
           type: 'JSXIdentifier',
-          name: 'Button',
+          name: 'FileUploaderAttachment',
         },
       });
 
-      // Rename 'buttonLabel' attribute to 'buttonText'
-      buttonComponents
+      // Rename 'buttonLabel' attribute to 'removeText'
+      components
         .find(j.JSXAttribute, {
           name: {
             type: 'JSXIdentifier',
@@ -39,8 +39,19 @@ const transform = (fileInfo: FileInfo, api: API) => {
           },
         })
         .forEach((attributePath) => {
-          // Change attribute name to 'buttonText'
-          attributePath.node.name.name = 'buttonText';
+          attributePath.node.name.name = 'removeText';
+        });
+
+      // Rename 'editButtonLabel' attribute to 'editText'
+      components
+        .find(j.JSXAttribute, {
+          name: {
+            type: 'JSXIdentifier',
+            name: 'editButtonLabel',
+          },
+        })
+        .forEach((attributePath) => {
+          attributePath.node.name.name = 'editText';
         });
     }
   }


### PR DESCRIPTION
## Description

- Renamed `button-text` codemod to `fileuploader-prop-names`
- Updated test fixtures and tests
- Updated `README` and `CONTRIBUTING` files

### Additional context

Fix of https://github.com/lmc-eu/spirit-design-system/pull/1303

### Issue reference

[DS-1142 Codemod button label -> button text v codemod balíčku](https://jira.almacareer.tech/browse/DS-1142)