### PR TITLE
React ModalDialog isExpandedOnMobile default value deprecation

### DIFF
--- a/packages/codemods/src/transforms/v2/web-react/__testfixtures__/modal-isexpandedonmobile-prop.input.tsx
+++ b/packages/codemods/src/transforms/v2/web-react/__testfixtures__/modal-isexpandedonmobile-prop.input.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import { ModalDialog } from '@lmc-eu/spirit-web-react';
+
+export const MyComponent = () => (
+  <>
+    <ModalDialog />
+    <ModalDialog isExpandedOnMobile />
+    <ModalDialog isExpandedOnMobile={true} />
+  </>
+);

--- a/packages/codemods/src/transforms/v2/web-react/__testfixtures__/modal-isexpandedonmobile-prop.output.tsx
+++ b/packages/codemods/src/transforms/v2/web-react/__testfixtures__/modal-isexpandedonmobile-prop.output.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import { ModalDialog } from '@lmc-eu/spirit-web-react';
+
+export const MyComponent = () => (
+  <>
+    <ModalDialog isExpandedOnMobile={false} />
+    <ModalDialog />
+    <ModalDialog />
+  </>
+);

--- a/packages/codemods/src/transforms/v2/web-react/__tests__/fileuploader-prop-names.test.ts
+++ b/packages/codemods/src/transforms/v2/web-react/__tests__/fileuploader-prop-names.test.ts
@@ -1,8 +1,3 @@
-// eslint-disable-next-line import/extensions
-const { defineTest } = require('jscodeshift/dist/testUtils');
+import { testTransform } from '../../../../../tests/testUtils';
 
-defineTest(__dirname, 'fileuploader-prop-names', null, 'fileuploader-prop-names', {
-  parser: 'tsx',
-  fixture: 'input',
-  snapshot: true,
-});
+testTransform(__dirname, 'fileuploader-prop-names');

--- a/packages/codemods/src/transforms/v2/web-react/__tests__/modal-isexpandedonmobile-prop.test.ts
+++ b/packages/codemods/src/transforms/v2/web-react/__tests__/modal-isexpandedonmobile-prop.test.ts
@@ -1,8 +1,3 @@
-// eslint-disable-next-line import/extensions
-const { defineTest } = require('jscodeshift/dist/testUtils');
+import { testTransform } from '../../../../../tests/testUtils';
 
-defineTest(__dirname, 'modal-isexpandedonmobile-prop', null, 'modal-isexpandedonmobile-prop', {
-  parser: 'tsx',
-  fixture: 'input',
-  snapshot: true,
-});
+testTransform(__dirname, 'modal-isexpandedonmobile-prop');

--- a/packages/codemods/src/transforms/v2/web-react/__tests__/modal-isexpandedonmobile-prop.test.ts
+++ b/packages/codemods/src/transforms/v2/web-react/__tests__/modal-isexpandedonmobile-prop.test.ts
@@ -1,0 +1,8 @@
+// eslint-disable-next-line import/extensions
+const { defineTest } = require('jscodeshift/dist/testUtils');
+
+defineTest(__dirname, 'modal-isexpandedonmobile-prop', null, 'modal-isexpandedonmobile-prop', {
+  parser: 'tsx',
+  fixture: 'input',
+  snapshot: true,
+});

--- a/packages/codemods/src/transforms/v2/web-react/modal-isexpandedonmobile-prop.ts
+++ b/packages/codemods/src/transforms/v2/web-react/modal-isexpandedonmobile-prop.ts
@@ -1,0 +1,73 @@
+import { API, FileInfo } from 'jscodeshift';
+
+const transform = (fileInfo: FileInfo, api: API) => {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+
+  // Find import statements for the specific module and ModalDialog specifier
+  const importStatements = root.find(j.ImportDeclaration, {
+    source: {
+      value: (value: string) => /^@lmc-eu\/spirit-web-react(\/.*)?$/.test(value),
+    },
+  });
+
+  // Check if the module is imported
+  if (importStatements.length > 0) {
+    const modalDialogSpecifier = importStatements.find(j.ImportSpecifier, {
+      imported: {
+        type: 'Identifier',
+        name: 'ModalDialog',
+      },
+    });
+
+    // Check if ModalDialog specifier is present
+    if (modalDialogSpecifier.length > 0) {
+      // Find ModalDialog components in the module
+      const modalDialogComponents = root.find(j.JSXOpeningElement, {
+        name: {
+          type: 'JSXIdentifier',
+          name: 'ModalDialog',
+        },
+      });
+
+      modalDialogComponents.forEach((path) => {
+        if (path.node && path.node.attributes) {
+          // Check if the component already has the isExpandedOnMobile attribute
+          const hasIsExpandedOnMobileAttribute = path.node.attributes.some(
+            (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'isExpandedOnMobile',
+          );
+
+          // If not, add isExpandedOnMobile={false} attribute
+          if (!hasIsExpandedOnMobileAttribute) {
+            path.node.attributes.push(
+              j.jsxAttribute(j.jsxIdentifier('isExpandedOnMobile'), j.jsxExpressionContainer(j.booleanLiteral(false))),
+            );
+          }
+
+          // Remove isExpandedOnMobile attribute if is set to true or without a value
+          path.node.attributes = path.node.attributes.filter((attr) => {
+            if (attr.type === 'JSXAttribute' && attr.name.name === 'isExpandedOnMobile') {
+              if (attr.value === null) {
+                return false;
+              }
+              if (
+                attr.value &&
+                attr.value.type === 'JSXExpressionContainer' &&
+                attr.value.expression.type === 'BooleanLiteral' &&
+                attr.value.expression.value
+              ) {
+                return false;
+              }
+            }
+
+            return true;
+          });
+        }
+      });
+    }
+  }
+
+  return root.toSource();
+};
+
+export default transform;

--- a/packages/codemods/tests/testUtils.ts
+++ b/packages/codemods/tests/testUtils.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line import/extensions
+const { defineTest } = require('jscodeshift/dist/testUtils');
+
+export const testTransform = (directory: string, name: string) => {
+  defineTest(directory, name, null, name, {
+    parser: 'tsx',
+    fixture: 'input',
+    snapshot: true,
+  });
+};

--- a/packages/web-react/src/components/Modal/ModalDialog.tsx
+++ b/packages/web-react/src/components/Modal/ModalDialog.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, ElementType, ForwardedRef, forwardRef } from 'react';
 import classNames from 'classnames';
-import { useStyleProps } from '../../hooks';
+import { useDeprecationMessage, useStyleProps } from '../../hooks';
 import { ModalDialogProps, ModalDialogElementType } from '../../types';
 import { useModalStyleProps } from './useModalStyleProps';
 
@@ -28,6 +28,13 @@ const ModalDialog = <E extends ElementType = ModalDialogElementType>(
 
   const { classProps } = useModalStyleProps({ isDockedOnMobile, isExpandedOnMobile, isScrollable });
   const { styleProps, props: otherProps } = useStyleProps(restProps);
+
+  useDeprecationMessage({
+    method: 'custom',
+    trigger: isExpandedOnMobile === undefined,
+    componentName: 'ModalDialog',
+    customText: 'The "isExpandedOnMobile" property will be enabled by default in the next major version.',
+  });
 
   const customizedHeightStyle: CustomizedHeightCSSProperties = {
     '--modal-max-height-tablet': maxHeightFromTabletUp,

--- a/packages/web-react/src/components/Modal/README.md
+++ b/packages/web-react/src/components/Modal/README.md
@@ -100,6 +100,12 @@ dialog shrinks to fit the height of its content (if smaller than the viewport).
 <ModalDialog isExpandedOnMobile>…</ModalDialog>
 ```
 
+#### ⚠️ DEPRECATION NOTICE
+
+The `isExpandedOnMobile` prop will be set to `true` by default in the next major release and the ModalDialog will be
+expanded on mobile by default. It will be possible to re-collapse the inside by setting the `isExpandedOnMobile` prop
+to `false` value.
+
 ### Custom Height
 
 By default, Modal expands to fit the height of its content, as long as it fits the viewport (see [more below](#custom-max-height)).
@@ -140,16 +146,16 @@ You can use the `maxHeightFromTabletUp` option to override the max height on tab
 
 ### API
 
-| Name                          | Type                  | Default   | Required | Description                                                                                                                              |
-| ----------------------------- | --------------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `children`                    | `ReactNode`           | —         | ✕        | Children node                                                                                                                            |
-| `elementType`                 | [`article` \| `form`] | `article` | ✕        | ModalDialog element type                                                                                                                 |
-| `isDockedOnMobile`            | `bool`                | `false`   | ✕        | [REQUIRES FEATURE FLAG](#feature-flag-uniform-appearance-on-all-breakpoints): Dock the ModalDialog to the bottom of the screen on mobile |
-| `isExpandedOnMobile`          | `bool`                | `false`   | ✕        | ModalDialog shrinks to fit the height of its content                                                                                     |
-| `isScrollable`                | `bool`                | `true`    | ✕        | If the ModalDialog should be scrollable. If set to `false`, the dialog will not scroll and will expand to fit the content.               |
-| `maxHeightFromTabletUp`       | `string`              | `null`    | ✕        | Max height of the modal. Accepts any valid CSS value.                                                                                    |
-| `preferredHeightFromTabletUp` | `string`              | `null`    | ✕        | Preferred height of the modal on tablet and larger. Accepts any valid CSS value.                                                         |
-| `preferredHeightOnMobile`     | `string`              | `null`    | ✕        | Preferred height of the modal on mobile. Accepts any valid CSS value.                                                                    |
+| Name                          | Type                  | Default   | Required | Description                                                                                                                                                 |
+| ----------------------------- | --------------------- | --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `children`                    | `ReactNode`           | —         | ✕        | Children node                                                                                                                                               |
+| `elementType`                 | [`article` \| `form`] | `article` | ✕        | ModalDialog element type                                                                                                                                    |
+| `isDockedOnMobile`            | `bool`                | `false`   | ✕        | [REQUIRES FEATURE FLAG](#feature-flag-uniform-appearance-on-all-breakpoints): Dock the ModalDialog to the bottom of the screen on mobile                    |
+| `isExpandedOnMobile`          | `bool`                | `false`   | ✕        | ModalDialog shrinks to fit the height of its content. [**DEPRECATED**][readme-deprecations] the default value will be set to true in the next major version |
+| `isScrollable`                | `bool`                | `true`    | ✕        | If the ModalDialog should be scrollable. If set to `false`, the dialog will not scroll and will expand to fit the content.                                  |
+| `maxHeightFromTabletUp`       | `string`              | `null`    | ✕        | Max height of the modal. Accepts any valid CSS value.                                                                                                       |
+| `preferredHeightFromTabletUp` | `string`              | `null`    | ✕        | Preferred height of the modal on tablet and larger. Accepts any valid CSS value.                                                                            |
+| `preferredHeightOnMobile`     | `string`              | `null`    | ✕        | Preferred height of the modal on mobile. Accepts any valid CSS value.                                                                                       |
 
 Also, all properties of the [`<article>` element][mdn-article] and [`<form>` element][mdn-form] are supported.
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
