### PR TITLE
Chore(GA): Send slack message on e2e test failure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   test:
-    if: ${{ (github.event.label.name == 'run visual tests') || (github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event.label.name == 'run-visual-tests') || (github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-22.04
     container:
       image: mcr.microsoft.com/playwright:v1.40.1-jammy
@@ -31,6 +31,69 @@ jobs:
 
       - name: Run Playwright tests
         run: HOME=/root yarn playwright test
+
+      - name: Notify slack if tests fail
+        id: Slack
+        uses: slackapi/slack-github-action@v1.25.0
+        if: ${{ failure() }}
+        with:
+          channel-id: 'C050BHERJTW' # Slack channel-id of #spirit-design-system-notifications_en
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#ff0000",
+                  "blocks": [
+                    {
+                      "type": "header",
+                      "text": {
+                        "type": "plain_text",
+                        "text": ":boom: GitHub Action failed",
+                        "emoji": true
+                      }
+                    },
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "*Pull request title:* `${{ github.event.pull_request.title }}`"
+                      }
+                    },
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "*E2E tests result:* `${{ job.status }}`"
+                      }
+                    },
+                    {
+                      "type": "actions",
+                      "elements": [
+                        {
+                          "type": "button",
+                          "text": {
+                            "type": "plain_text",
+                            "text": ":github: Open pull request"
+                          },
+                          "url": "${{ github.event.pull_request.html_url }}"
+                        },
+                        {
+                          "type": "button",
+                          "text": {
+                            "type": "plain_text",
+                            "text": ":github: Open failed github action"
+                          },
+                          "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATIONS_TOKEN }} # Webhook from Slack Application
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Description

- GitHub action should send message to our slack channel (_#spirit-design-system-notifications_en_)
- Created new app in Slack called `Spirit Design System Notification` - can be renamed, change color, add icon...
  - Spirit team added as colaborators, so they can change and set things if needed

Links:
- [slackapi/slack-github-action](https://github.com/slackapi/slack-github-action)
- [slack api](https://api.slack.com/apps)
- [slack message builder](https://app.slack.com/block-kit-builder/)

### Additional context

<img width="575" alt="image" src="https://github.com/lmc-eu/spirit-design-system/assets/26870554/884574e5-b0f4-4878-b1a5-a2559a146b20">

TODO:

- [x] Add new secret `SLACK_NOTIFICATIONS_TOKEN` (from Slack app - webhooks)
- [x] Add `channel-id`

### Issue reference

[Když zbuchnout e2e testy, tak nám to napíše do Slacku?](https://jira.almacareer.tech/browse/DS-1130)
