### PR TITLE
Fix(web-twig): `Dropdown` can now be placed inside a non-scrollable `Modal` #DS-939

### DIFF
--- a/packages/web-twig/src/Resources/components/Modal/README.md
+++ b/packages/web-twig/src/Resources/components/Modal/README.md
@@ -77,6 +77,13 @@ the state of the form and closing the dialog.
 </ModalDialog>
 ```
 
+### Dropdowns in Modal
+
+Dropdowns can be safely used inside **non-scrollable** Modals so that the Dropdown popover is not clipped by the Modal's
+boundaries.
+
+👉 See the [Scrolling Long Content](#scrolling-long-content) section for more information on scroll control of Modals.
+
 ### Expand on Mobile Screens
 
 We recommend expanding the dialog on mobile screens using the `isExpandedOnMobile` option. If you omit the option, the

--- a/packages/web-twig/src/Resources/components/Modal/stories/ModalDefault.twig
+++ b/packages/web-twig/src/Resources/components/Modal/stories/ModalDefault.twig
@@ -19,9 +19,9 @@
             <!-- Modal alignment demo: start -->
             <form onchange="setModalAlignment(event, '#example-basic')" class="d-none d-tablet-block mb-600">
                 <div>Modal alignment (from tablet up):</div>
-                <Radio id="modal-alignment-top" UNSAFE_className="mr-600" label="Top" value="top" name="modal-alignment" autocomplete="off" />
-                <Radio id="modal-alignment-center" UNSAFE_className="mr-600" label="Center" value="center" name="modal-alignment" autocomplete="off" isChecked />
-                <Radio id="modal-alignment-bottom" UNSAFE_className="mr-600" label="Bottom" value="bottom" name="modal-alignment" autocomplete="off" />
+                <Radio id="modal-alignment-top" marginRight="600" label="Top" value="top" name="modal-alignment" autocomplete="off" />
+                <Radio id="modal-alignment-center" marginRight="600" label="Center" value="center" name="modal-alignment" autocomplete="off" isChecked />
+                <Radio id="modal-alignment-bottom" marginRight="600" label="Bottom" value="bottom" name="modal-alignment" autocomplete="off" />
             </form>
             <!-- Modal alignment demo: end -->
 

--- a/packages/web-twig/src/Resources/components/Modal/stories/ModalScrollingLongContent.twig
+++ b/packages/web-twig/src/Resources/components/Modal/stories/ModalScrollingLongContent.twig
@@ -199,3 +199,56 @@
         </ModalFooter>
     </ModalDialog>
 </Modal>
+
+<Button data-spirit-toggle="modal" data-spirit-target="#example-dropdown">
+    Open Non-Scrolling Modal with Dropdown
+</Button>
+
+<Modal id="example-dropdown" titleId="example-dropdown-title">
+    <ModalDialog isScrollable={ false }>
+        <ModalHeader modalId="example-dropdown" titleId="example-dropdown-title">
+            Modal Title
+        </ModalHeader>
+        <ModalBody>
+
+            <!-- Content: start -->
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+                perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+                provident unde. Eveniet, iste, molestiae?
+            </p>
+            <DropdownWrapper>
+                <Button
+                    color="secondary"
+                    data-spirit-toggle="dropdown"
+                    data-spirit-target="#dropdown-in-modal"
+                    data-spirit-autoclose="true"
+                >
+                    Dropdown
+                </Button>
+                <Dropdown id="dropdown-in-modal">
+                    <Item elementType="a" href="#" label="Action" />
+                    <Item elementType="a" href="#" label="Another action" />
+                    <Item elementType="a" href="#" label="Something else here" />
+                </Dropdown>
+            </DropdownWrapper>
+            <!-- Content: end -->
+
+        </ModalBody>
+        <ModalFooter description="Optional description">
+            <Button
+                data-spirit-dismiss="modal"
+                data-spirit-target="#example-dropdown"
+            >
+                Primary action
+            </Button>
+            <Button
+                color="secondary"
+                data-spirit-dismiss="modal"
+                data-spirit-target="#example-dropdown"
+            >
+                Secondary action
+            </Button>
+        </ModalFooter>
+    </ModalDialog>
+</Modal>

--- a/packages/web-twig/src/Resources/components/Modal/stories/ModalUniformModalOnMobile.twig
+++ b/packages/web-twig/src/Resources/components/Modal/stories/ModalUniformModalOnMobile.twig
@@ -20,18 +20,18 @@
                 <!-- Modal alignment demo: start -->
                 <form onchange="setModalAlignment(event, '#example-uniform')" class="mb-600">
                     <div>Modal alignment:</div>
-                    <Radio id="modal-uniform-alignment-top" UNSAFE_className="mr-600" label="Top" value="top" name="modal-alignment" autocomplete="off" />
-                    <Radio id="modal-uniform-alignment-center" UNSAFE_className="mr-600" label="Center" value="center" name="modal-alignment" autocomplete="off" isChecked />
-                    <Radio id="modal-uniform-alignment-bottom" UNSAFE_className="mr-600" label="Bottom" value="bottom" name="modal-alignment" autocomplete="off" />
+                    <Radio id="modal-uniform-alignment-top" marginRight="600" label="Top" value="top" name="modal-alignment" autocomplete="off" />
+                    <Radio id="modal-uniform-alignment-center" marginRight="600" label="Center" value="center" name="modal-alignment" autocomplete="off" isChecked />
+                    <Radio id="modal-uniform-alignment-bottom" marginRight="600" label="Bottom" value="bottom" name="modal-alignment" autocomplete="off" />
                 </form>
                 <!-- Modal alignment demo: end -->
 
                 <!-- Footer alignment demo: start -->
                 <form onchange="setFooterAlignment(event, '#example-uniform .ModalFooter')" class="d-none d-tablet-block mb-600">
                     <div>Footer alignment (from tablet up):</div>
-                    <Radio id="footer-uniform-alignment-left" UNSAFE_className="mr-600" label="Left" value="left" name="footer-alignment" autocomplete="off" />
-                    <Radio id="footer-uniform-alignment-center" UNSAFE_className="mr-600" label="Center" value="center" name="footer-alignment" autocomplete="off" />
-                    <Radio id="footer-uniform-alignment-right" UNSAFE_className="mr-600" label="Right" value="right" name="footer-alignment" autocomplete="off" isChecked />
+                    <Radio id="footer-uniform-alignment-left" marginRight="600" label="Left" value="left" name="footer-alignment" autocomplete="off" />
+                    <Radio id="footer-uniform-alignment-center" marginRight="600" label="Center" value="center" name="footer-alignment" autocomplete="off" />
+                    <Radio id="footer-uniform-alignment-right" marginRight="600" label="Right" value="right" name="footer-alignment" autocomplete="off" isChecked />
                 </form>
                 <!-- Footer alignment demo: end -->
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

Follows PR #1332 

### Issue reference

https://jira.almacareer.tech/browse/DS-939

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
