### PR TITLE
Chore(demo): Correctly resolve alias to the icons in demos

### DIFF
--- a/apps/demo/config/vite/app.ts
+++ b/apps/demo/config/vite/app.ts
@@ -21,6 +21,11 @@ export default defineConfig({
     port: 3456,
     strictPort: true,
   },
+  resolve: {
+    alias: {
+      '@lmc-eu/spirit-icons': join(pathRelativeToRepositoryRoot, 'packages/icons/dist'),
+    },
+  },
   plugins: [
     handlebars({
       partialDirectory: [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

  * there was a missing danger icon in the Alert and Toast component
  * icons were resolved from node_modules instead of actual package path

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

- https://vitejs.dev/config/shared-options#resolve-alias
- Failed End-2-End tests: https://github.com/lmc-eu/spirit-design-system/actions/runs/8782655795/job/24097185986
- Screenshot from production demo:
![Screenshot 2024-04-22 at 17 02 46](https://github.com/lmc-eu/spirit-design-system/assets/2481010/3c576cae-2fa1-4734-b9aa-e8daee7bd773)
![Screenshot 2024-04-22 at 17 02 57](https://github.com/lmc-eu/spirit-design-system/assets/2481010/27760a37-ada5-4dd1-bf42-4a99c39a5a44)


### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
