### PR TITLE
BREAKING CHANGE(web-react): Label prop is required for `TextField` component

### DIFF
--- a/docs/migrations/web-react/MIGRATION-v2.md
+++ b/docs/migrations/web-react/MIGRATION-v2.md
@@ -19,6 +19,7 @@ Introducing version 2 of the _spirit-web-react_ package
   - [Modal: ModalDialog `isExpandedOnMobile` Prop](#modal-modaldialog-isexpandedonmobile-prop)
   - [Modal: ModalDialog `isScrollable` Prop](#modal-modaldialog-isscrollable-prop)
   - [Modal: ModalDialog Uniform Appearance](#modal-modaldialog-uniform-appearance)
+  - [TextField: `label` prop](#textfield-label-prop)
   - [Tooltip: `off` Placement](#tooltip-off-placement)
   - [Tooltip: Refactored](#tooltip-refactored)
 
@@ -255,6 +256,15 @@ npx @lmc-eu/spirit-codemods -p <path> -t v2/web-react/modal-isdockeonmobile-prop
 See [Codemods documentation][readme-codemods] for more details.
 
 Or manually add `isDockedOnMobile` prop to the `ModalDialog` component.
+
+### TextField: `label` prop
+
+The `label` prop is now required.
+
+#### Migration Guide
+
+Please ensure that `label` is added to all `TextField` components.
+If you need to hide your `label`, you can use the `isLabelHidden` prop.
 
 ### Tooltip: `off` Placement
 

--- a/packages/web-react/src/components/TextField/README.md
+++ b/packages/web-react/src/components/TextField/README.md
@@ -8,7 +8,7 @@ hidden or show if the input is required.
 Basic example usage:
 
 ```jsx
-<TextField id="textFieldDefault" name="textFieldDefault" />
+<TextField id="textFieldDefault" label="Label" name="textFieldDefault" />
 ```
 
 Advanced example usage:
@@ -54,7 +54,7 @@ TextField with password toggle (button to reveal the password):
 | `isDisabled`        | `bool`                                                                      | —       | ✕        | Whether is field disabled                                               |
 | `isLabelHidden`     | `bool`                                                                      | —       | ✕        | Whether is label hidden                                                 |
 | `isRequired`        | `bool`                                                                      | —       | ✕        | Whether is field required                                               |
-| `label`             | `string`                                                                    | —       | ✕        | Label text                                                              |
+| `label`             | `string`                                                                    | —       | ✔        | Label text                                                              |
 | `name`              | `string`                                                                    | —       | ✕        | Input name                                                              |
 | `pattern`           | `string`                                                                    | —       | ✕        | Defines regular expressions for allowed value types                     |
 | `placeholder`       | `string`                                                                    | —       | ✕        | Input placeholder                                                       |

--- a/packages/web-react/src/types/textField.ts
+++ b/packages/web-react/src/types/textField.ts
@@ -28,4 +28,6 @@ export interface TextFieldProps
   type?: TextFieldType;
 }
 
-export interface SpiritTextFieldProps extends TextFieldProps {}
+export interface SpiritTextFieldProps extends TextFieldProps {
+  label: string;
+}


### PR DESCRIPTION
## Description

### Additional context

### Issue reference

[web-react: Povinný label pro TextField](https://jira.almacareer.tech/browse/DS-888)