### PR TITLE
Chore(web-react): Fix missing `.js` extensions in ESM distribution

### DIFF
--- a/packages/web-react/scripts/helpers.ts
+++ b/packages/web-react/scripts/helpers.ts
@@ -6,47 +6,47 @@ import * as parser from 'recast/parsers/babel';
 
 export const distDir = path.resolve(__dirname, '..', 'dist');
 
-export function eachFile(dir: string, callback: (absPath: string, relPath: string) => unknown) {
+export async function eachFile(dir: string, callback: (absPath: string, relPath: string) => unknown) {
   const promises: Promise<unknown>[] = [];
 
-  return new Promise<void>((resolve, reject) => {
-    // @ts-expect-error -- has no properties in common with type 'GlobOptions'
-    glob(`${dir}/**/*.js`, (error: Error | null, files: string[]) => {
-      if (error) return reject(error);
+  try {
+    const files = await glob(`${dir}/**/*.js`);
 
-      files.sort().forEach((file: string) => {
-        const relPath = path.relative(dir, file);
+    files.sort().forEach((file: string) => {
+      const relPath = path.relative(dir, file);
 
-        // Outside the distDir, somehow.
-        if (relPath.startsWith('../')) return;
+      // Outside the distDir, somehow.
+      if (relPath.startsWith('../')) return;
 
-        // Avoid re-transforming CommonJS bundle files.
-        if (relPath.endsWith('.cjs.js')) return;
-        if (relPath.endsWith('.cjs')) return;
+      // Avoid re-transforming CommonJS bundle files.
+      if (relPath.endsWith('.cjs.js')) return;
+      if (relPath.endsWith('.cjs')) return;
 
-        // Avoid re-transforming CommonJS bundle files.
-        if (relPath.endsWith('.min.js')) return;
+      // Avoid re-transforming CommonJS bundle files.
+      if (relPath.endsWith('.min.js')) return;
 
-        // Avoid re-transforming UMD bundle files.
-        if (relPath.endsWith('.umd.js')) return;
+      // Avoid re-transforming UMD bundle files.
+      if (relPath.endsWith('.umd.js')) return;
 
-        // Avoid re-transforming stories files.
-        if (relPath.endsWith('.stories.js')) return;
+      // Avoid re-transforming stories files.
+      if (relPath.endsWith('.stories.js')) return;
 
-        // This file is not meant to be imported or processed.
-        if (relPath.endsWith('invariantErrorCodes.js')) return;
+      // This file is not meant to be imported or processed.
+      if (relPath.endsWith('invariantErrorCodes.js')) return;
 
-        promises.push(
-          // eslint-disable-next-line no-shadow
-          new Promise((resolve) => {
-            resolve(callback(file, relPath));
-          }),
-        );
-      });
-
-      resolve();
+      promises.push(
+        // eslint-disable-next-line no-shadow
+        new Promise((resolve) => {
+          resolve(callback(file, relPath));
+        }),
+      );
     });
-  }).then(() => Promise.all(promises));
+
+    Promise.all(promises);
+  } catch (error) {
+    // eslint-disable-next-line no-console -- This is a CLI tool.
+    console.error(error);
+  }
 }
 
 export function reparse(source: string) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

  * there were a problem with missing `glob` dependency while migrating to Yarn Modern
  * so the latest version was added but the require was not supported and glob was added using an import
  * but the API was changed a little bit too
  * this stay unnoticed because of the script did not fail
  * when released, the end user notice that build is not working due to the missing `.js` extensions
  * previous version of the `glob` - 8.10 supports the API used
  * current helper is refactored to use v10 of the `glob` - Promise to async/await

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
- https://www.npmjs.com/package/glob
- https://www.npmjs.com/package/glob/v/8.1.0
- https://github.com/apollographql/apollo-client/blob/main/config/helpers.ts

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
