### PR TITLE
BREAKING CHANGE(web-twig): Remove class and style from abstract Header components #DS-920

### DIFF
--- a/packages/web-twig/DEPRECATIONS-v3.md
+++ b/packages/web-twig/DEPRECATIONS-v3.md
@@ -101,20 +101,6 @@ Use:
 
 See [`Tooltip` documentation][tooltip-readme] for more details and examples.
 
-### Header Abstracts Class and Style
-
-The `style` and `class` props will be removed from these `Header` abstracts:
-
-- `Header/_abstracts/Button`
-- `Header/_abstracts/Element`
-- `Header/_abstracts/Link`
-
-Use `UNSAFE_style` and `UNSAFE_className` instead.
-
-#### Migration Guide
-
-Replace `style` with `UNSAFE_style` and `class` with `UNSAFE_className`.
-
 ### Grid Breakpoint Props
 
 The `cols` prop in the `Grid` now supports object values for different breakpoints.

--- a/packages/web-twig/src/Resources/components/Header/_abstracts/Button.twig
+++ b/packages/web-twig/src/Resources/components/Header/_abstracts/Button.twig
@@ -1,25 +1,13 @@
 {# API #}
 {%- set props = props | default([]) -%}
-{%- set _class = props.class | default(null) -%}
 {%- set _rootClass = props.rootClass -%}
 
 {# Class names #}
 {%- set _rootClassName = _spiritClassPrefix ~ _rootClass -%}
 
 {# Miscellaneous #}
-{## `_propsWithoutClassAndStyleProps` is a temporary prop until the `class` prop will be removed ##}
-{%- set _propsWithoutClassAndStyleProps = props | filter((value, prop) => prop not in ['class', 'style']) -%}
-
-{%- set _styleProps = useStyleProps(_propsWithoutClassAndStyleProps) -%}
-{%- set _classNames = [ _rootClassName, _class, _styleProps.className] -%}
-
-{# Deprecations #}
-{% if _class %}
-    {% deprecated 'Header/_abstracts/Button: The "class" property is deprecated and will be removed in the next major version. Please use "UNSAFE_className" instead.' %}
-{% endif %}
-{% if props.style is defined %}
-    {% deprecated 'Header/_abstracts/Button: The "style" property is deprecated and will be removed in the next major version. Please use "UNSAFE_style" instead.' %}
-{% endif %}
+{%- set _styleProps = useStyleProps(props) -%}
+{%- set _classNames = [ _rootClassName, _styleProps.className] -%}
 
 <button
     {{ mainProps(props) }}

--- a/packages/web-twig/src/Resources/components/Header/_abstracts/Element.twig
+++ b/packages/web-twig/src/Resources/components/Header/_abstracts/Element.twig
@@ -1,6 +1,5 @@
 {# API #}
 {%- set props = props | default([]) -%}
-{%- set _class = props.class | default(null) -%}
 {%- set _elementType = props.elementType -%}
 {%- set _rootClass = props.rootClass -%}
 
@@ -8,19 +7,8 @@
 {%- set _rootClassName = _spiritClassPrefix ~ _rootClass -%}
 
 {# Miscellaneous #}
-{## `_propsWithoutClassAndStyleProps` is a temporary prop until the `class` prop will be removed ##}
-{%- set _propsWithoutClassAndStyleProps = props | filter((value, prop) => prop not in ['class', 'style']) -%}
-
-{%- set _styleProps = useStyleProps(_propsWithoutClassAndStyleProps) -%}
-{%- set _classNames = [ _rootClassName, _class, _styleProps.className ] -%}
-
-{# Deprecations #}
-{% if _class %}
-    {% deprecated 'Header/_abstracts/Element: The "class" property is deprecated and will be removed in the next major version. Please use "UNSAFE_className" instead.' %}
-{% endif %}
-{% if props.style is defined %}
-    {% deprecated 'Header/_abstracts/Element: The "style" property is deprecated and will be removed in the next major version. Please use "UNSAFE_style" instead.' %}
-{% endif %}
+{%- set _styleProps = useStyleProps(props) -%}
+{%- set _classNames = [ _rootClassName, _styleProps.className ] -%}
 
 <{{ _elementType}} {{ mainProps(props) }} {{ styleProp(_styleProps) }} {{ classProp(_classNames) }}>
     {% block content %}{% endblock %}

--- a/packages/web-twig/src/Resources/components/Header/_abstracts/Link.twig
+++ b/packages/web-twig/src/Resources/components/Header/_abstracts/Link.twig
@@ -1,6 +1,5 @@
 {# API #}
 {%- set props = props | default([]) -%}
-{%- set _class = props.class | default(null) -%}
 {%- set _href = props.href -%}
 {%- set _isCurrent = props.isCurrent | default(false) -%}
 {%- set _rootClass = props.rootClass -%}
@@ -13,20 +12,9 @@
 {%- set _ariaCurrentAttr = _isCurrent ? 'aria-current=page' : null -%}
 
 {# Miscellaneous #}
-{## `_propsWithoutClassAndStyleProps` is a temporary prop until the `class` prop will be removed ##}
-{%- set _propsWithoutClassAndStyleProps = props | filter((value, prop) => prop not in ['class', 'style']) -%}
-
-{%- set _styleProps = useStyleProps(_propsWithoutClassAndStyleProps) -%}
-{%- set _classNames = [ _rootClassName, _rootCurrentClassName, _class, _styleProps.className ] -%}
+{%- set _styleProps = useStyleProps(props) -%}
+{%- set _classNames = [ _rootClassName, _rootCurrentClassName, _styleProps.className ] -%}
 {%- set _allowedAttributes = [ 'target' ] -%}
-
-{# Deprecations #}
-{% if _class %}
-    {% deprecated 'Header/_abstracts/Link: The "class" property is deprecated and will be removed in the next major version. Please use "UNSAFE_className" instead.' %}
-{% endif %}
-{% if props.style is defined %}
-    {% deprecated 'Header/_abstracts/Link: The "style" property is deprecated and will be removed in the next major version. Please  use "UNSAFE_style" instead.' %}
-{% endif %}
 
 <a
     {{ mainProps(props, _allowedAttributes) }}


### PR DESCRIPTION
See the Header: Abstracts Class and Style section in the web-twig package Migration Guide to version 3.

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
