### PR TITLE
Fix(web-twig): Remove extra quotes causing invalid HTML of `Checkbox`

### DIFF
--- a/packages/web-twig/src/Resources/components/Checkbox/Checkbox.twig
+++ b/packages/web-twig/src/Resources/components/Checkbox/Checkbox.twig
@@ -57,7 +57,7 @@
         class="{{ _inputClassName }}"
         {{ _checkedAttr }}
         {{ _disabledAttr }}
-        {{ _nameAttr | raw }}"
+        {{ _nameAttr | raw }}
         {{ _requiredAttr }}
         {{ _valueAttr }} {# Intentionally without `raw` to prevent XSS. #}
     />


### PR DESCRIPTION
The bug was introduced in PR #1343. Interestingly enough, it does not appear in our snapshots despite being tested. 💥

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
