### PR TITLE
Chore(repo): Replace the unmaintaned auto-assign GitHub action

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,2 @@
+addAssignees: author
+runOnDraft: true

--- a/.github/workflows/pr-meta.yaml
+++ b/.github/workflows/pr-meta.yaml
@@ -10,9 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Assign to author
-        uses: samspills/assign-pr-to-author@v1.0
-        with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+        uses: kentaro-m/auto-assign-action@v2.0.0 # Specify also the minor version because the `v2` tag does not exist.
 
       - name: Add labels
         uses: TimonVS/pr-labeler-action@v5.0.0


### PR DESCRIPTION
The currently action used action is no longer maintaned.
