### PR TITLE
BREAKING CHANGE(web-react): Remove deprecated buttonLabel and editBut…

### DIFF
--- a/packages/web-react/DEPRECATIONS-v2.md
+++ b/packages/web-react/DEPRECATIONS-v2.md
@@ -26,26 +26,6 @@ Related components:
 
 Add `id` prop to the form components.
 
-### FileUploaderAttachment `buttonLabel` and `editButtonLabel` Props
-
-The `buttonLabel` and `editButtonLabel` props will be removed from the `FileUploaderAttachment` component.
-Use `removeText` and `editText` props instead.
-
-#### Migration Guide
-
-Use codemod to automatically update your codebase.
-
-```sh
-npx @lmc-eu/spirit-codemods -p <path> -t v2/web-react/fileuploader-prop-names
-```
-
-See [Codemods documentation][readme-codemods] for more details.
-
-Or manually replace the props in your project.
-
-- `<FileUploaderAttachment buttonLabel="Remove this attachment" … />` → `<FileUploaderAttachment removeText="Remove this attachment" … />`
-- `<FileUploaderAttachment editButtonLabel="Edit this attachment" … />` → `<FileUploaderAttachment editText="Edit this attachment" … />`
-
 ### Dropdown and Collapse `id` Prop
 
 The `id` prop will be mandatory for the `Dropdown` and `Collapse` components.

--- a/packages/web-react/src/components/FileUploader/FileUploaderAttachment.tsx
+++ b/packages/web-react/src/components/FileUploader/FileUploaderAttachment.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import React, { MouseEvent, RefObject, useRef, useState } from 'react';
-import { useClassNamePrefix, useDeprecationMessage, useStyleProps } from '../../hooks';
+import { useClassNamePrefix, useStyleProps } from '../../hooks';
 import { SpiritFileUploaderAttachmentProps } from '../../types';
 import { Icon } from '../Icon';
 import AttachmentActionButton from './AttachmentActionButton';
@@ -18,10 +18,6 @@ import { image2Base64Preview } from './utils';
 
 const FileUploaderAttachment = (props: SpiritFileUploaderAttachmentProps) => {
   const {
-    /** @deprecated Will be removed in the next major version. */
-    buttonLabel,
-    /** @deprecated Will be removed in the next major version. */
-    editButtonLabel,
     editText,
     file,
     hasImagePreview,
@@ -62,26 +58,6 @@ const FileUploaderAttachment = (props: SpiritFileUploaderAttachmentProps) => {
 
   useFileUploaderAttachment({ attachmentRef, file, name, meta, onError });
 
-  useDeprecationMessage({
-    method: 'property',
-    trigger: !!buttonLabel,
-    componentName: 'FileUploaderAttachment',
-    propertyProps: {
-      deprecatedName: 'buttonLabel',
-      newName: 'removeText',
-    },
-  });
-
-  useDeprecationMessage({
-    method: 'property',
-    trigger: !!editButtonLabel,
-    componentName: 'FileUploaderAttachment',
-    propertyProps: {
-      deprecatedName: 'editButtonLabel',
-      newName: 'editText',
-    },
-  });
-
   return (
     <li
       id={id}
@@ -101,13 +77,11 @@ const FileUploaderAttachment = (props: SpiritFileUploaderAttachmentProps) => {
       {onEdit && (
         <span className={classProps.attachment.slot}>
           <AttachmentActionButton onClick={onEditHandler}>
-            {editText || editButtonLabel || DEFAULT_EDIT_BUTTON_LABEL}
+            {editText || DEFAULT_EDIT_BUTTON_LABEL}
           </AttachmentActionButton>
         </span>
       )}
-      <AttachmentDismissButton onClick={dismissHandler}>
-        {removeText || buttonLabel || DEFAULT_BUTTON_LABEL}
-      </AttachmentDismissButton>
+      <AttachmentDismissButton onClick={dismissHandler}>{removeText || DEFAULT_BUTTON_LABEL}</AttachmentDismissButton>
     </li>
   );
 };

--- a/packages/web-react/src/components/FileUploader/README.md
+++ b/packages/web-react/src/components/FileUploader/README.md
@@ -413,22 +413,20 @@ and [escape hatches][readme-escape-hatches].
 
 ## FileUploaderAttachment Props
 
-| Name              | Type                                 | Default  | Required | Description                                                                 |
-| ----------------- | ------------------------------------ | -------- | -------- | --------------------------------------------------------------------------- |
-| `buttonLabel`     | `string`                             | `Remove` | ✕        | [**DEPRECATED**][deprecated] in favor of `removeText`; Dismiss button label |
-| `editButtonLabel` | `string`                             | `Edit`   | ✕        | [**DEPRECATED**][deprecated] in favor of `editText`; Edit button label      |
-| `editText`        | `string`                             | `Edit`   | ✕        | Edit button label                                                           |
-| `file`            | `File`                               | —        | ✔        | Attachment file object                                                      |
-| `hasImagePreview` | `bool`                               | false    | ✕        | Show image preview                                                          |
-| `iconName`        | `string`                             | `file`   | ✕        | Icon shown along the file                                                   |
-| `id`              | `string`                             | —        | ✔        | FileUploaderAttachment id                                                   |
-| `imageObjectFit`  | [`cover` \| `contain`]               | `cover`  | ✕        | Defines FileUploaderAttachment image fit in container                       |
-| `label`           | `string`                             | —        | ✔        | File name                                                                   |
-| `name`            | `string`                             | —        | ✔        | Input field name                                                            |
-| `onDismiss`       | `(key: string) => FileQueueMapType`  | —        | ✔        | Callback to delete an item from the queue                                   |
-| `onEdit`          | `(event: Event, file: File) => void` | —        | ✕        | Show and add function to edit button                                        |
-| `onError`         | `FileUploaderErrorCallbackType`      | —        | ✕        | Callback on error condition                                                 |
-| `removeText`      | `string`                             | `Remove` | ✕        | Dismiss button label                                                        |
+| Name              | Type                                 | Default  | Required | Description                                           |
+| ----------------- | ------------------------------------ | -------- | -------- | ----------------------------------------------------- |
+| `editText`        | `string`                             | `Edit`   | ✕        | Edit button label                                     |
+| `file`            | `File`                               | —        | ✔        | Attachment file object                                |
+| `hasImagePreview` | `bool`                               | false    | ✕        | Show image preview                                    |
+| `iconName`        | `string`                             | `file`   | ✕        | Icon shown along the file                             |
+| `id`              | `string`                             | —        | ✔        | FileUploaderAttachment id                             |
+| `imageObjectFit`  | [`cover` \| `contain`]               | `cover`  | ✕        | Defines FileUploaderAttachment image fit in container |
+| `label`           | `string`                             | —        | ✔        | File name                                             |
+| `name`            | `string`                             | —        | ✔        | Input field name                                      |
+| `onDismiss`       | `(key: string) => FileQueueMapType`  | —        | ✔        | Callback to delete an item from the queue             |
+| `onEdit`          | `(event: Event, file: File) => void` | —        | ✕        | Show and add function to edit button                  |
+| `onError`         | `FileUploaderErrorCallbackType`      | —        | ✕        | Callback on error condition                           |
+| `removeText`      | `string`                             | `Remove` | ✕        | Remove button label                                   |
 
 The rest of the properties are created from the default `<li>` element. [More about the element][list-item-element-docs]
 

--- a/packages/web-react/src/types/fileUploader.ts
+++ b/packages/web-react/src/types/fileUploader.ts
@@ -88,10 +88,6 @@ export interface FileUploaderListBaseProps extends SpiritUListElementProps {
 }
 
 export interface FileUploaderAttachmentBaseProps extends Omit<SpiritLItemElementProps, 'onError'> {
-  /** @deprecated Will be removed in the next major version. */
-  buttonLabel?: string;
-  /** @deprecated Will be removed in the next major version. */
-  editButtonLabel?: string;
   editText?: string;
   file: File;
   hasImagePreview?: boolean;


### PR DESCRIPTION
…tonLabel prop from FileUploaderAttachment #DS-916

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
