### PR TITLE
Style(repo): Ignore `lock` files by Prettier formatter

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -39,3 +39,6 @@ packages/codemods/src/transforms/**/*.output.tsx
 # @see: https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
 .yarn/plugins
 .yarn/releases
+
+# Lock Files
+*.lock


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Because of this change: https://github.com/lmc-eu/spirit-design-system/pull/1396/files#diff-2ce177a30d5ea1036526fbef409dd193272e2da8d11ed52b57aaf42a6d5cdcd1

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

It look like we are not ignoring lock files 🤷 

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
