### PR TITLE
BREAKING CHANGE(web): Turn off scrolling inside `ModalDialog` by default #DS-1184

### DIFF
--- a/docs/migrations/web/MIGRATION-v2.md
+++ b/docs/migrations/web/MIGRATION-v2.md
@@ -120,6 +120,9 @@ The `.ModalDialog--nonScrollable` modifier was removed and the ModalDialog is ma
 
 In the new version, use the `.ModalDialog--scrollable` modifier class to make the ModalDialog scrollable.
 
+If you use `ScrollView` for scrolling the content of your modal, you must also add the `.ModalDialog--scrollable` class
+to the `.ModalDialog` element.
+
 - `.ModalDialog` → `.ModalDialog .ModalDialog--scrollable`
 
 ### Modal: Uniform Variant Feature Flag

--- a/packages/web/DEPRECATIONS-v2.md
+++ b/packages/web/DEPRECATIONS-v2.md
@@ -1,23 +1,13 @@
 # Deprecations List
 
-Following deprecations will be removed in version 2 of the _spirit-web_ package.
+This document lists all deprecations that will be removed in the next major version of the _spirit-web_ package.
 
-> Please follow these steps to safely upgrade your design system to Spirit Design System v2 components.
-
-[What are deprecations?][readme-deprecations]
+> Please follow the migration guides to safely upgrade your design system components.
 
 ## Deprecations
 
-### Modal (Non)Scrollable
+Nothing here right now! 🎉
 
-The `.ModalDialog--nonScrollable` modifier will be removed and the ModalDialog will be made non-scrollable by default.
-
-#### Migration Guide
-
-In the new version, use the `.ModalDialog--scrollable` modifier class to make the ModalDialog scrollable.
-
-- `.ModalDialog` → `.ModalDialog .ModalDialog--scrollable`
+👉 [What are deprecations?][readme-deprecations]
 
 [readme-deprecations]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/README.md#deprecations
-[readme-feature-flags]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/README.md#feature-flags
-[dictionary-placement]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#placement

--- a/packages/web/src/scss/components/Modal/README.md
+++ b/packages/web/src/scss/components/Modal/README.md
@@ -39,56 +39,6 @@ Example:
 </dialog>
 ```
 
-### Custom Height
-
-By default, Modal expands to fit the height of its content, as long as it fits the viewport (see [more below](#custom-max-height)).
-You can override this behavior by setting a custom preferred height using a custom property:
-
-- `--modal-preferred-height-mobile` for mobile screens, and
-- `--modal-preferred-height-tablet` for tablet screens and up.
-
-This is useful for Modals with dynamic content, e.g. a list of items that can be added or removed, or a multistep wizard.
-
-```html
-<dialog
-  id="modal-example"
-  class="Modal Modal--center"
-  aria-labelledby="modal-example-title"
-  style="--modal-preferred-height-mobile: 400px; --modal-preferred-height-tablet: 500px;"
->
-  <!-- ModalDialog -->
-</dialog>
-```
-
-👉 Please note the preferred height options are ignored when scrolling inside ModalDialog is
-[turned off](#disable-scrolling-inside-modaldialog).
-
-👉 Please note the custom height values are considered **preferred:** Modal will not expand beyond the viewport height.
-
-### Custom Max Height
-
-The default maximum height of Modal is:
-
-- viewport height minus 1100 spacing on mobile screens, and
-- 600 px on tablet screens and up (shrunk if necessary).
-
-You can use the custom property `--modal-max-height-tablet` to override the max height on tablet screens and up:
-
-```html
-<dialog
-  id="modal-example"
-  class="Modal Modal--center"
-  aria-labelledby="modal-example-title"
-  style="--modal-max-height-tablet: 700px"
->
-  <!-- ModalDialog -->
-</dialog>
-```
-
-👉 Please note the max height is ignored when scrolling inside ModalDialog is [turned off](#disable-scrolling-inside-modaldialog).
-
-👉 Please note the max height on mobile screens is currently not customizable. Let us know if you need this feature! 🙏
-
 ## ModalDialog
 
 ModalDialog is the actual dialog window, a place for the header, body, and footer of the dialog.
@@ -134,7 +84,7 @@ class.
 
 #### Expanded Variant
 
-By default the docked dialog on mobile screens shrinks to fit the height of its content
+By default, the docked dialog on mobile screens shrinks to fit the height of its content
 (if smaller than the viewport). Use the `ModalDialog--expandOnMobile` class to expand the dialog on mobile.
 
 ```html
@@ -282,47 +232,87 @@ You can still close modal with close buttons or ESC key.
 
 ## Scrolling Long Content
 
-When Modals become too long for the user's viewport or device, they scroll independently of the page itself. By default,
-ModalBody has `overflow-y: auto` applied to it, so it scrolls vertically.
+In case the content is longer than user's viewport or device, the ModalBody will expand to fit the height of its content
+and the whole ModalDialog will scroll.
 
-### Scrolling with ScrollView
+### Enable Scrolling Inside ModalDialog
 
-Alternatively, you can wrap the ModalBody content in a [ScrollView][scroll-view] to take over the responsibility for
-scrolling, e.g.:
-
-```html
-<div class="ScrollView ScrollView--vertical" data-spirit-toggle="scrollView">
-  <div class="ScrollView__viewport" data-spirit-element="viewport">
-    <div class="ScrollView__content" data-spirit-element="content">
-      <div class="ModalBody">
-        <!-- … -->
-      </div>
-    </div>
-  </div>
-  <div class="ScrollView__overflowDecorators ScrollView__overflowDecorators--borders" aria-hidden="true"></div>
-</div>
-```
-
-### Disable Scrolling Inside ModalDialog
-
-Scrolling inside ModalDialog can be turned off by adding the `ModalDialog--nonScrollable` modifier class:
+Scrolling inside ModalDialog can be turned on by adding the `ModalDialog--scrollable` modifier class:
 
 ```html
-<article class="ModalDialog ModalDialog--nonScrollable">
+<article class="ModalDialog ModalDialog--scrollable">
   <!-- … -->
 </article>
 ```
 
-This way, the ModalBody will expand to fit the height of its content and the whole ModalDialog will scroll in case the
-content is longer than user's viewport.
+### Scrolling with ScrollView
 
-👉 Please note that this modifier class can produce unexpected results when used in combination with ScrollView.
+Additionally, you can wrap the ModalBody content in a [ScrollView][scroll-view] to take over the responsibility for
+scrolling, e.g.:
 
-#### ⚠️ DEPRECATION NOTICE
+```html
+<article class="ModalDialog ModalDialog--scrollable">
+  <!-- ModalHeader -->
+  <div class="ScrollView ScrollView--vertical" data-spirit-toggle="scrollView">
+    <div class="ScrollView__viewport" data-spirit-element="viewport">
+      <div class="ScrollView__content" data-spirit-element="content">
+        <div class="ModalBody">
+          <!-- … -->
+        </div>
+      </div>
+    </div>
+    <div class="ScrollView__overflowDecorators ScrollView__overflowDecorators--borders" aria-hidden="true"></div>
+  </div>
+  <!-- ModalFooter -->
+</article>
+```
 
-The `.ModalDialog--nonScrollable` modifier will be removed in the next major release and the ModalDialog will be made
-non-scrollable by default. It will be possible to re-enable the inside scrolling by adding the
-`.ModalDialog--scrollable` modifier class (which will remain the recommended default usage).
+### Custom Height
+
+By default, ModalDialog grows to the height of its content until it reaches the [maximum height](#custom-max-height)
+limit.
+
+You can set a custom preferred height of ModalDialog using a custom property:
+
+- `--modal-preferred-height-mobile` for mobile screens, and
+- `--modal-preferred-height-tablet` for tablet screens and up.
+
+This is useful for Modals with dynamic content, e.g. a list of items that can be added or removed, or a multistep wizard.
+
+```html
+<article
+  class="ModalDialog ModalDialog--scrollable"
+  style="--modal-preferred-height-mobile: 400px; --modal-preferred-height-tablet: 500px;"
+>
+  <!-- … -->
+</article>
+```
+
+⚠️ This feature is only available for ModalDialogs with the `ModalDialog--scrollable` modifier class.
+
+👉 Please note the custom height values are considered **preferred**. Scrollable ModalDialog will never expand beyond
+the viewport height. See the [Custom Max Height](#custom-max-height) section for more information.
+
+### Custom Max Height
+
+The default maximum height of a scrollable ModalDialog is **600 px**, as long as it can fit the viewport.
+
+If the viewport is smaller, scrollable ModalDialog will shrink to fit the viewport. In such case, the ModalDialog height
+will calculate as "viewport height (`100dvh`) minus 1100 spacing".
+
+You can use the custom property `--modal-max-height-tablet` to override the default maximum height limit on tablet
+screens and up:
+
+```html
+<article class="ModalDialog ModalDialog--scrollable" style="--modal-max-height-tablet: 400px">
+  <!-- … -->
+</article>
+```
+
+⚠️ This feature is only available for ModalDialogs with the `ModalDialog--scrollable` modifier class.
+
+👉 If a [custom height](#custom-height) is set, the custom max height is only applied if it's smaller than the custom
+height.
 
 ## Stacking Modals
 

--- a/packages/web/src/scss/components/Modal/_Modal.scss
+++ b/packages/web/src/scss/components/Modal/_Modal.scss
@@ -7,8 +7,6 @@
 // 5. Allow scrolling through the modal. Has no effect unless the modal is taller than the viewport.
 // 6. Restore text selection after `all: unset`.
 
-@use 'sass:map';
-@use '../../tools/breakpoint';
 @use 'theme';
 
 .Modal {
@@ -20,7 +18,7 @@
     z-index: 1;
     display: flex; // 1.
     padding-block: theme.$padding-y;
-    overflow: hidden; // 4.
+    overflow-y: auto; // 5.
     background: linear-gradient(#{theme.$backdrop-background-color}, #{theme.$backdrop-background-color}); // 2., 3.
     visibility: hidden; // 1.
     opacity: 0; // 1.
@@ -38,8 +36,8 @@
     }
 }
 
-.Modal:has(.ModalDialog--nonScrollable) {
-    overflow-y: auto; // 5.
+.Modal:has(.ModalDialog--scrollable) {
+    overflow: hidden; // 4.
 }
 
 .Modal--center,

--- a/packages/web/src/scss/components/Modal/_ModalBody.scss
+++ b/packages/web/src/scss/components/Modal/_ModalBody.scss
@@ -10,8 +10,8 @@
     min-height: map.get(theme.$typography, mobile, font-size) * map.get(theme.$typography, mobile, line-height); // 1.
     padding-inline: theme.$common-padding-x;
     padding-block: theme.$body-padding-y;
-    overflow-x: var(--modal-body-overflow-x, hidden);
-    overflow-y: var(--modal-body-overflow-y, auto);
+    overflow-x: var(--modal-body-overflow-x, visible);
+    overflow-y: var(--modal-body-overflow-y, visible);
     overscroll-behavior: contain;
 
     @include breakpoint.up(map.get(theme.$breakpoints, tablet)) {

--- a/packages/web/src/scss/components/Modal/_ModalDialog.scss
+++ b/packages/web/src/scss/components/Modal/_ModalDialog.scss
@@ -24,8 +24,8 @@
     margin-inline: auto;
     margin-top: var(--modal-top);
     margin-bottom: var(--modal-bottom);
-    overflow-x: var(--modal-body-overflow-x, hidden);
-    overflow-y: var(--modal-body-overflow-y, auto);
+    overflow-x: var(--modal-body-overflow-x, visible);
+    overflow-y: var(--modal-body-overflow-y, visible);
     color: theme.$dialog-text-color;
     border-radius: theme.$dialog-border-radius;
     background-color: theme.$dialog-background-color;
@@ -34,11 +34,6 @@
     transform-origin: var(--modal-transform-origin);
     overscroll-behavior: contain;
 
-    @include breakpoint.up(map.get(theme.$breakpoints, tablet)) {
-        height: theme.$dialog-height-tablet;
-        max-height: theme.$dialog-max-height-tablet;
-    }
-
     @include breakpoint.up(map.get(theme.$breakpoints, desktop)) {
         width: theme.$dialog-width-desktop;
     }
@@ -46,6 +41,19 @@
     @media (prefers-reduced-motion: no-preference) {
         transition-property: width, height, max-height, border-radius, transform; // 3.
         transition-duration: inherit;
+    }
+}
+
+.ModalDialog--scrollable {
+    --modal-body-overflow-x: hidden;
+    --modal-body-overflow-y: auto;
+
+    height: theme.$dialog-scrollable-height;
+    max-height: theme.$dialog-scrollable-max-height;
+
+    @include breakpoint.up(map.get(theme.$breakpoints, tablet)) {
+        height: theme.$dialog-scrollable-height-tablet;
+        max-height: theme.$dialog-scrollable-max-height-tablet;
     }
 }
 
@@ -58,9 +66,14 @@
 
         width: theme.$dialog-docked-width;
         max-width: none;
-        height: theme.$dialog-docked-height;
-        max-height: theme.$dialog-docked-expanded-height;
         border-radius: theme.$dialog-border-radius theme.$dialog-border-radius 0 0;
+    }
+}
+
+.ModalDialog--dockOnMobile.ModalDialog--scrollable {
+    @include breakpoint.down(map.get(theme.$breakpoints, tablet)) {
+        height: theme.$dialog-docked-scrollable-height;
+        max-height: theme.$dialog-docked-scrollable-max-height;
     }
 }
 
@@ -72,16 +85,6 @@
 
 .ModalDialog--dockOnMobile.ModalDialog--expandOnMobile {
     @include breakpoint.down(map.get(theme.$breakpoints, tablet)) {
-        min-height: theme.$dialog-docked-expanded-height;
+        min-height: theme.$dialog-docked-expanded-min-height;
     }
-}
-
-// @deprecated The non-scrollable modal dialog is deprecated and will be removed in the next major release.
-// Migration: In CSS, make the modal dialog non-scrollable by default so scrolling inside is turned on by a modifier class.
-.ModalDialog--nonScrollable {
-    --modal-body-overflow-x: visible;
-    --modal-body-overflow-y: visible;
-
-    height: auto;
-    max-height: none;
 }

--- a/packages/web/src/scss/components/Modal/_theme.scss
+++ b/packages/web/src/scss/components/Modal/_theme.scss
@@ -18,19 +18,31 @@ $common-padding-x-tablet: tokens.$space-800;
 // ModalDialog
 $dialog-width: 640px;
 $dialog-width-desktop: 680px;
-$dialog-height: var(--modal-preferred-height-mobile, min-content);
-$dialog-height-tablet: var(--modal-preferred-height-tablet, min-content);
-$dialog-max-height: min(var(--modal-max-height-mobile, 600px), calc(100dvh - #{2 * $padding-y}));
-$dialog-max-height-tablet: min(var(--modal-max-height-tablet, 600px), calc(100dvh - #{2 * $padding-y}));
+$dialog-height: auto;
+$dialog-max-height: none;
 $dialog-text-color: tokens.$text-primary-default;
 $dialog-border-radius: tokens.$radius-200;
 $dialog-background-color: tokens.$background-basic;
 $dialog-shadow: tokens.$shadow-300;
 
+$dialog-scrollable-height: var(--modal-preferred-height-mobile, min-content);
+$dialog-scrollable-height-tablet: var(
+    --modal-preferred-height-tablet,
+    var(--modal-preferred-height-mobile, min-content)
+);
+$dialog-scrollable-max-height: min(var(--modal-max-height-mobile, 600px), calc(100dvh - #{2 * $padding-y}));
+$dialog-scrollable-max-height-tablet: min(
+    var(--modal-max-height-tablet, var(--modal-max-height-mobile, 600px)),
+    calc(100dvh - #{2 * $padding-y})
+);
+
 $dialog-docked-width: 100%;
-$dialog-docked-height: var(--modal-preferred-height-mobile, min-content);
 $dialog-docked-margin-top: tokens.$space-1100;
-$dialog-docked-expanded-height: calc(100dvh - #{$dialog-docked-margin-top});
+
+$dialog-docked-expanded-min-height: calc(100dvh - #{$dialog-docked-margin-top});
+
+$dialog-docked-scrollable-height: var(--modal-preferred-height-mobile, min-content);
+$dialog-docked-scrollable-max-height: $dialog-docked-expanded-min-height;
 
 // ModalHeader
 $header-gap: tokens.$space-400;

--- a/packages/web/src/scss/components/Modal/index.html
+++ b/packages/web/src/scss/components/Modal/index.html
@@ -38,7 +38,7 @@
   }
 
   const toggleScrolling = (selector) => {
-    document.querySelector(selector).classList.toggle('ModalDialog--nonScrollable');
+    document.querySelector(selector).classList.toggle('ModalDialog--scrollable');
   }
 </script>
 
@@ -140,8 +140,8 @@
                 <span class="Checkbox__label">Expand on mobile (docked only)</span>
               </span>
             </label>
-            <label for="modal-demo-non-scrolling" class="Checkbox">
-              <input type="checkbox" id="modal-demo-non-scrolling" class="Checkbox__input" onchange="toggleScrolling('#example-basic > .ModalDialog')" autocomplete="off" checked />
+            <label for="modal-demo-scrolling" class="Checkbox">
+              <input type="checkbox" id="modal-demo-scrolling" class="Checkbox__input" onchange="toggleScrolling('#example-basic > .ModalDialog')" autocomplete="off" />
               <span class="Checkbox__text">
                 <span class="Checkbox__label">Scrolling inside</span>
               </span>
@@ -192,7 +192,7 @@
       aria-controls="example-form"
       aria-expanded="false"
     >
-      Open Modal with a Form
+      Open Modal with Form
     </button>
 
     <!-- Modal: start -->
@@ -262,33 +262,28 @@
       type="button"
       class="Button Button--primary Button--medium"
       data-spirit-toggle="modal"
-      data-spirit-target="#example-custom-height"
-      aria-controls="example-custom-height"
+      data-spirit-target="#example-dropdown"
+      aria-controls="example-dropdown"
       aria-expanded="false"
     >
-      Open Modal with Custom Height
+      Open Modal with Dropdown
     </button>
 
     <!-- Modal: start -->
-    <dialog
-      id="example-custom-height"
-      class="Modal Modal--center"
-      aria-labelledby="example-custom-height-title"
-      style="--modal-preferred-height-mobile: 400px; --modal-preferred-height-tablet: 500px; --modal-max-height-tablet: 700px"
-    >
+    <dialog id="example-dropdown" class="Modal Modal--center" aria-labelledby="example-dropdown-title">
 
       <!-- ModalDialog: start -->
-      <article class="ModalDialog">
+      <article class="ModalDialog ModalDialog--expandOnMobile">
 
         <!-- ModalHeader: start -->
         <header class="ModalHeader">
-          <h2 id="example-custom-height-title" class="ModalHeader__title">Modal with Custom Height</h2>
+          <h2 id="example-dropdown-title" class="ModalHeader__title">Modal Title</h2>
           <button
             type="button"
             class="Button Button--tertiary Button--square Button--medium"
             data-spirit-dismiss="modal"
-            data-spirit-target="#example-custom-height"
-            aria-controls="example-custom-height"
+            data-spirit-target="#example-dropdown"
+            aria-controls="example-dropdown"
             aria-expanded="false"
           >
             <svg width="24" height="24" aria-hidden="true">
@@ -302,31 +297,49 @@
         <!-- ModalBody: start -->
         <div class="ModalBody">
           <!-- Content: start -->
-          <p class="d-tablet-none">
-            This modal has a custom height of <code>400px</code> set via the <code>--modal-preferred-height-mobile</code> CSS
-            custom property.
-            <br /><br />
-            The max height cannot be customized on mobile though.
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+            provident unde. Eveniet, iste, molestiae?
           </p>
-          <p class="d-none d-tablet-block">
-            This modal has a custom height of <code>500px</code> set via the <code>--modal-preferred-height-tablet</code> CSS
-            custom property.
-            <br /><br />
-            The max height of this modal is <code>700px</code> set via the <code>--modal-max-height-tablet</code> CSS custom
-            property.
-          </p>
+          <div class="DropdownWrapper">
+            <button
+              type="button"
+              data-spirit-toggle="dropdown"
+              data-spirit-target="#dropdown-in-modal"
+              class="Button Button--secondary Button--medium"
+              aria-expanded="false"
+              aria-controls="dropdown-in-modal"
+            >
+              Dropdown
+            </button>
+            <div class="Dropdown" data-spirit-placement="bottom-start" id="dropdown-in-modal">
+              <a href="#" class="Item">
+                <span class="Item__label">Action</span>
+              </a>
+              <a href="#" class="Item">
+                <span class="Item__label">Another action</span>
+              </a>
+              <a href="#" class="Item">
+                <span class="Item__label">Something else here</span>
+              </a>
+            </div>
+          </div>
           <!-- Content: end -->
         </div>
         <!-- ModalBody: end -->
 
         <!-- ModalFooter: start -->
         <footer class="ModalFooter ModalFooter--right">
+          <div class="ModalFooter__description">
+            Optional description
+          </div>
           <div class="ModalFooter__actions">
             <button
               type="button"
               class="Button Button--primary Button--medium"
               data-spirit-dismiss="modal"
-              data-spirit-target="#example-custom-height"
+              data-spirit-target="#example-dropdown"
             >
               Primary action
             </button>
@@ -334,7 +347,7 @@
               type="button"
               class="Button Button--secondary Button--medium"
               data-spirit-dismiss="modal"
-              data-spirit-target="#example-custom-height"
+              data-spirit-target="#example-dropdown"
             >
               Secondary action
             </button>
@@ -351,6 +364,7 @@
   </div>
 
 </section>
+
 <section class="docs-Section">
   <h2 class="docs-Heading">Scrolling Long Content</h2>
 
@@ -396,48 +410,18 @@
 
         <!-- ModalBody: start -->
         <div class="ModalBody">
+
           <!-- Content: start -->
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-            provident unde. Eveniet, iste, molestiae?
-          </p>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-            provident unde. Eveniet, iste, molestiae?
-          </p>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-            provident unde. Eveniet, iste, molestiae?
-          </p>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-            provident unde. Eveniet, iste, molestiae?
-          </p>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-            provident unde. Eveniet, iste, molestiae?
-          </p>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-            provident unde. Eveniet, iste, molestiae?
-          </p>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-            provident unde. Eveniet, iste, molestiae?
-          </p>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-            provident unde. Eveniet, iste, molestiae?
-          </p>
+          {{setVar "blocks" 1 2 3 4 5 6 7 8 9 }}
+          {{#each @root.blocks}}
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+              perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+              provident unde. Eveniet, iste, molestiae?
+            </p>
+          {{/each}}
           <!-- Content: end -->
+
         </div>
         <!-- ModalBody: end -->
 
@@ -474,6 +458,100 @@
       type="button"
       class="Button Button--primary Button--medium"
       data-spirit-toggle="modal"
+      data-spirit-target="#example-non-scrolling-modal"
+      aria-controls="example-non-scrolling-modal"
+      aria-expanded="false"
+    >
+      Open Modal with Scrolling Inside
+    </button>
+
+    <!-- Modal: start -->
+    <dialog id="example-non-scrolling-modal" class="Modal Modal--center" aria-labelledby="example-non-scrolling-modal-title">
+
+      <!-- ModalDialog: start -->
+      <article class="ModalDialog ModalDialog--scrollable">
+
+        <!-- ModalHeader: start -->
+        <header class="ModalHeader">
+          <h2 id="example-non-scrolling-modal-title" class="ModalHeader__title">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia perferendis reprehenderit, voluptate. Cum delectus dicta
+          </h2>
+          <button
+            type="button"
+            class="Button Button--tertiary Button--square Button--medium"
+            data-spirit-dismiss="modal"
+            data-spirit-target="#example-non-scrolling-modal"
+            aria-controls="example-non-scrolling-modal"
+            aria-expanded="false"
+          >
+            <svg width="24" height="24" aria-hidden="true">
+              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+            </svg>
+            <span class="accessibility-hidden">Close</span>
+          </button>
+        </header>
+        <!-- ModalHeader: end -->
+
+        <!-- ModalBody: start -->
+        <div class="ModalBody">
+          <!-- Content: start -->
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+            provident unde. Eveniet, iste, molestiae?
+          </p>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+            provident unde. Eveniet, iste, molestiae?
+          </p>
+          <p style="margin-bottom: 100vh">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+            provident unde. Eveniet, iste, molestiae?
+          </p>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
+            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
+            provident unde. Eveniet, iste, molestiae?
+          </p>
+          <!-- Content: end -->
+        </div>
+        <!-- ModalBody: end -->
+
+        <!-- ModalFooter: start -->
+        <footer class="ModalFooter ModalFooter--right">
+          <div class="ModalFooter__actions">
+            <button
+              type="button"
+              class="Button Button--primary Button--medium"
+              data-spirit-dismiss="modal"
+              data-spirit-target="#example-non-scrolling-modal"
+            >
+              Primary action
+            </button>
+            <button
+              type="button"
+              class="Button Button--secondary Button--medium"
+              data-spirit-dismiss="modal"
+              data-spirit-target="#example-non-scrolling-modal"
+            >
+              Secondary action
+            </button>
+          </div>
+        </footer>
+        <!-- ModalFooter: end -->
+
+      </article>
+      <!-- ModalDialog: end -->
+
+    </dialog>
+    <!-- Modal: end -->
+
+    <button
+      type="button"
+      class="Button Button--primary Button--medium"
+      data-spirit-toggle="modal"
       data-spirit-target="#example-scroll-view"
       aria-controls="example-scroll-view"
       aria-expanded="false"
@@ -485,7 +563,7 @@
     <dialog id="example-scroll-view" class="Modal Modal--center" aria-labelledby="example-scroll-view-title">
 
       <!-- ModalDialog: start -->
-      <article class="ModalDialog">
+      <article class="ModalDialog ModalDialog--scrollable">
 
         <!-- ModalHeader: start -->
         <header class="ModalHeader">
@@ -599,30 +677,35 @@
       type="button"
       class="Button Button--primary Button--medium"
       data-spirit-toggle="modal"
-      data-spirit-target="#example-non-scrolling-modal"
-      aria-controls="example-non-scrolling-modal"
+      data-spirit-target="#example-custom-height"
+      aria-controls="example-custom-height"
       aria-expanded="false"
     >
-      Open Modal with Disabled Scrolling Inside
+      Open Modal with Custom Height
     </button>
 
     <!-- Modal: start -->
-    <dialog id="example-non-scrolling-modal" class="Modal Modal--center" aria-labelledby="example-non-scrolling-modal-title">
+    <dialog
+      id="example-custom-height"
+      class="Modal Modal--center"
+      aria-labelledby="example-custom-height-title"
+    >
 
       <!-- ModalDialog: start -->
-      <article class="ModalDialog ModalDialog--nonScrollable">
+      <article
+        class="ModalDialog ModalDialog--scrollable"
+        style="--modal-preferred-height-mobile: 400px; --modal-preferred-height-tablet: 500px"
+      >
 
         <!-- ModalHeader: start -->
         <header class="ModalHeader">
-          <h2 id="example-non-scrolling-modal-title" class="ModalHeader__title">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia perferendis reprehenderit, voluptate. Cum delectus dicta
-          </h2>
+          <h2 id="example-custom-height-title" class="ModalHeader__title">Modal with Custom Height</h2>
           <button
             type="button"
             class="Button Button--tertiary Button--square Button--medium"
             data-spirit-dismiss="modal"
-            data-spirit-target="#example-non-scrolling-modal"
-            aria-controls="example-non-scrolling-modal"
+            data-spirit-target="#example-custom-height"
+            aria-controls="example-custom-height"
             aria-expanded="false"
           >
             <svg width="24" height="24" aria-hidden="true">
@@ -636,26 +719,16 @@
         <!-- ModalBody: start -->
         <div class="ModalBody">
           <!-- Content: start -->
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-            provident unde. Eveniet, iste, molestiae?
+          <p class="d-tablet-none">
+            This modal has a custom height of <code>400px</code> set via the <code>--modal-preferred-height-mobile</code> CSS
+            custom property.
           </p>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-            provident unde. Eveniet, iste, molestiae?
+          <p class="d-none d-tablet-block">
+            This modal has a custom height of <code>500px</code> set via the <code>--modal-preferred-height-tablet</code> CSS
+            custom property.
           </p>
-          <p style="margin-bottom: 100vh">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-            provident unde. Eveniet, iste, molestiae?
-          </p>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-            provident unde. Eveniet, iste, molestiae?
-          </p>
+          <!-- TODO: add a checkbox "show more content to force scrolling" -->
+          <!-- TODO: add text fields to manually set values of available custom properties -->
           <!-- Content: end -->
         </div>
         <!-- ModalBody: end -->
@@ -667,7 +740,7 @@
               type="button"
               class="Button Button--primary Button--medium"
               data-spirit-dismiss="modal"
-              data-spirit-target="#example-non-scrolling-modal"
+              data-spirit-target="#example-custom-height"
             >
               Primary action
             </button>
@@ -675,110 +748,7 @@
               type="button"
               class="Button Button--secondary Button--medium"
               data-spirit-dismiss="modal"
-              data-spirit-target="#example-non-scrolling-modal"
-            >
-              Secondary action
-            </button>
-          </div>
-        </footer>
-        <!-- ModalFooter: end -->
-
-      </article>
-      <!-- ModalDialog: end -->
-
-    </dialog>
-    <!-- Modal: end -->
-
-    <button
-      type="button"
-      class="Button Button--primary Button--medium"
-      data-spirit-toggle="modal"
-      data-spirit-target="#example-dropdown"
-      aria-controls="example-dropdown"
-      aria-expanded="false"
-    >
-      Open Non-Scrolling Modal with Dropdown
-    </button>
-
-    <!-- Modal: start -->
-    <dialog id="example-dropdown" class="Modal Modal--center" aria-labelledby="example-dropdown-title">
-
-      <!-- ModalDialog: start -->
-      <article class="ModalDialog ModalDialog--nonScrollable ModalDialog--expandOnMobile">
-
-        <!-- ModalHeader: start -->
-        <header class="ModalHeader">
-          <h2 id="example-dropdown-title" class="ModalHeader__title">Modal Title</h2>
-          <button
-            type="button"
-            class="Button Button--tertiary Button--square Button--medium"
-            data-spirit-dismiss="modal"
-            data-spirit-target="#example-dropdown"
-            aria-controls="example-dropdown"
-            aria-expanded="false"
-          >
-            <svg width="24" height="24" aria-hidden="true">
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
-            </svg>
-            <span class="accessibility-hidden">Close</span>
-          </button>
-        </header>
-        <!-- ModalHeader: end -->
-
-        <!-- ModalBody: start -->
-        <div class="ModalBody">
-          <!-- Content: start -->
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
-            perferendis reprehenderit, voluptate. Cum delectus dicta ducimus eligendi excepturi natus perferendis
-            provident unde. Eveniet, iste, molestiae?
-          </p>
-          <div class="DropdownWrapper">
-            <button
-              type="button"
-              data-spirit-toggle="dropdown"
-              data-spirit-target="#dropdown-in-modal"
-              class="Button Button--secondary Button--medium"
-              aria-expanded="false"
-              aria-controls="dropdown-in-modal"
-            >
-              Dropdown
-            </button>
-            <div class="Dropdown" data-spirit-placement="bottom-start" id="dropdown-in-modal">
-              <a href="#" class="Item">
-                <span class="Item__label">Action</span>
-              </a>
-              <a href="#" class="Item">
-                <span class="Item__label">Another action</span>
-              </a>
-              <a href="#" class="Item">
-                <span class="Item__label">Something else here</span>
-              </a>
-            </div>
-          </div>
-          <!-- Content: end -->
-        </div>
-        <!-- ModalBody: end -->
-
-        <!-- ModalFooter: start -->
-        <footer class="ModalFooter ModalFooter--right">
-          <div class="ModalFooter__description">
-            Optional description
-          </div>
-          <div class="ModalFooter__actions">
-            <button
-              type="button"
-              class="Button Button--primary Button--medium"
-              data-spirit-dismiss="modal"
-              data-spirit-target="#example-dropdown"
-            >
-              Primary action
-            </button>
-            <button
-              type="button"
-              class="Button Button--secondary Button--medium"
-              data-spirit-dismiss="modal"
-              data-spirit-target="#example-dropdown"
+              data-spirit-target="#example-custom-height"
             >
               Secondary action
             </button>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

- Make `ModalDialog` non-scrollable by default, i.e. the whole `Modal` scrolls when larger than viewport.
- Clarify how custom height and max height works, limit this feature only to scrollable `ModalDialog`.

### TODO

- [x] Make custom height demo more interactive

### Issue reference

https://jira.almacareer.tech/browse/DS-1184

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
