### PR TITLE
BREAKING CHANGE(web): Enhance custom height and max height options of `ModalDialog` #DS-1134

### DIFF
--- a/docs/migrations/web/MIGRATION-v2.md
+++ b/docs/migrations/web/MIGRATION-v2.md
@@ -16,6 +16,7 @@ Introducing version 2 of the _spirit-web_ package
   - [Dropdown: Combined Placements](#dropdown-combined-placements)
   - [Dropdown: Shadow Feature Flag](#dropdown-shadow-feature-flag)
   - [Modal: (Non)Scrollable](#modal-nonscrollable)
+  - [Modal: Custom Height](#modal-custom-height)
   - [Modal: Uniform Variant Feature Flag](#modal-uniform-variant-feature-flag)
   - [Grid: GridSpan Component](#grid-gridspan-component)
   - [Tooltip: Data Selector Controlled Placement Feature Flag](#tooltip-data-selector-controlled-placement-feature-flag)
@@ -140,6 +141,19 @@ If you use `ScrollView` for scrolling the content of your modal, you must also a
 to the `.ModalDialog` element.
 
 - `.ModalDialog` → `.ModalDialog .ModalDialog--scrollable`
+
+### Modal: Custom Height
+
+The `--modal-preferred-height-mobile`, `--modal-preferred-height-tablet`,
+`--modal-max-height-tablet` custom properties were renamed.
+
+#### Migration Guide
+
+Update the custom properties in your project to use the new names:
+
+- `--modal-preferred-height-mobile` → `--modal-dialog-height`
+- `--modal-preferred-height-tablet` → `--modal-dialog-height-tablet`
+- `--modal-max-height-tablet` → `--modal-dialog-max-height-tablet`
 
 ### Modal: Uniform Variant Feature Flag
 

--- a/packages/web/src/scss/components/Modal/README.md
+++ b/packages/web/src/scss/components/Modal/README.md
@@ -274,15 +274,20 @@ limit.
 
 You can set a custom preferred height of ModalDialog using a custom property:
 
-- `--modal-preferred-height-mobile` for mobile screens, and
-- `--modal-preferred-height-tablet` for tablet screens and up.
+- `--modal-dialog-height` for mobile screens and up,
+- `--modal-dialog-height-tablet` for tablet screens and up.
+- `--modal-dialog-height-desktop` for desktop screens and up.
+
+The custom properties fall back to the previous breakpoint using the mobile-first approach. For example, if you set
+`--modal-dialog-height-tablet` while leaving `--modal-dialog-height-desktop` unset, the value will be used for
+both tablet and desktop screens.
 
 This is useful for Modals with dynamic content, e.g. a list of items that can be added or removed, or a multistep wizard.
 
 ```html
 <article
   class="ModalDialog ModalDialog--scrollable"
-  style="--modal-preferred-height-mobile: 400px; --modal-preferred-height-tablet: 500px;"
+  style="--modal-dialog-height: 400px; --modal-dialog-height-tablet: 500px; --modal-dialog-height-desktop: 600px;"
 >
   <!-- … -->
 </article>
@@ -300,11 +305,21 @@ The default maximum height of a scrollable ModalDialog is **600 px**, as long as
 If the viewport is smaller, scrollable ModalDialog will shrink to fit the viewport. In such case, the ModalDialog height
 will calculate as "viewport height (`100dvh`) minus 1100 spacing".
 
-You can use the custom property `--modal-max-height-tablet` to override the default maximum height limit on tablet
-screens and up:
+You can set a custom preferred height of ModalDialog using a custom property:
+
+- `--modal-dialog-max-height` for mobile screens and up,
+- `--modal-dialog-max-height-tablet` for tablet screens and up.
+- `--modal-dialog-max-height-desktop` for desktop screens and up.
+
+The custom properties fall back to the previous breakpoint using the mobile-first approach. For example, if you set
+`--modal-dialog-max-height-tablet` while leaving `--modal-dialog-max-height-desktop` unset, the value will be used for both tablet and
+desktop screens.
 
 ```html
-<article class="ModalDialog ModalDialog--scrollable" style="--modal-max-height-tablet: 400px">
+<article
+  class="ModalDialog ModalDialog--scrollable"
+  style="--modal-dialog-max-height: 300px; --modal-dialog-max-height-tablet: 400px; --modal-dialog-max-height-desktop: 500px;"
+>
   <!-- … -->
 </article>
 ```

--- a/packages/web/src/scss/components/Modal/_ModalDialog.scss
+++ b/packages/web/src/scss/components/Modal/_ModalDialog.scss
@@ -55,6 +55,11 @@
         height: theme.$dialog-scrollable-height-tablet;
         max-height: theme.$dialog-scrollable-max-height-tablet;
     }
+
+    @include breakpoint.up(map.get(theme.$breakpoints, desktop)) {
+        height: theme.$dialog-scrollable-height-desktop;
+        max-height: theme.$dialog-scrollable-max-height-desktop;
+    }
 }
 
 .ModalDialog--dockOnMobile {

--- a/packages/web/src/scss/components/Modal/_theme.scss
+++ b/packages/web/src/scss/components/Modal/_theme.scss
@@ -25,14 +25,31 @@ $dialog-border-radius: tokens.$radius-200;
 $dialog-background-color: tokens.$background-basic;
 $dialog-shadow: tokens.$shadow-300;
 
-$dialog-scrollable-height: var(--modal-preferred-height-mobile, min-content);
+$_dialog-scrollable-default-height: min-content;
+$_dialog-scrollable-default-max-height: 600px;
+
+$dialog-scrollable-height: var(--modal-dialog-height, #{$_dialog-scrollable-default-height});
 $dialog-scrollable-height-tablet: var(
-    --modal-preferred-height-tablet,
-    var(--modal-preferred-height-mobile, min-content)
+    --modal-dialog-height-tablet,
+    var(--modal-dialog-height, #{$_dialog-scrollable-default-height})
 );
-$dialog-scrollable-max-height: min(var(--modal-max-height-mobile, 600px), calc(100dvh - #{2 * $padding-y}));
+$dialog-scrollable-height-desktop: var(
+    --modal-dialog-height-desktop,
+    var(--modal-dialog-height-tablet, var(--modal-dialog-height, #{$_dialog-scrollable-default-height}))
+);
+$dialog-scrollable-max-height: min(
+    var(--modal-dialog-max-height, #{$_dialog-scrollable-default-max-height}),
+    calc(100dvh - #{2 * $padding-y})
+);
 $dialog-scrollable-max-height-tablet: min(
-    var(--modal-max-height-tablet, var(--modal-max-height-mobile, 600px)),
+    var(--modal-dialog-max-height-tablet, var(--modal-dialog-max-height, #{$_dialog-scrollable-default-max-height})),
+    calc(100dvh - #{2 * $padding-y})
+);
+$dialog-scrollable-max-height-desktop: min(
+    var(
+        --modal-dialog-max-height-desktop,
+        var(--modal-dialog-max-height-tablet, var(--modal-dialog-max-height, #{$_dialog-scrollable-default-max-height}))
+    ),
     calc(100dvh - #{2 * $padding-y})
 );
 
@@ -41,7 +58,7 @@ $dialog-docked-margin-top: tokens.$space-1100;
 
 $dialog-docked-expanded-min-height: calc(100dvh - #{$dialog-docked-margin-top});
 
-$dialog-docked-scrollable-height: var(--modal-preferred-height-mobile, min-content);
+$dialog-docked-scrollable-height: var(--modal-dialog-height, #{$_dialog-scrollable-default-height});
 $dialog-docked-scrollable-max-height: $dialog-docked-expanded-min-height;
 
 // ModalHeader

--- a/packages/web/src/scss/components/Modal/index.html
+++ b/packages/web/src/scss/components/Modal/index.html
@@ -694,7 +694,7 @@
       <!-- ModalDialog: start -->
       <article
         class="ModalDialog ModalDialog--scrollable"
-        style="--modal-preferred-height-mobile: 400px; --modal-preferred-height-tablet: 500px"
+        style="--modal-dialog-height: 400px; --modal-dialog-height-tablet: 500px; --modal-dialog-height-desktop: 600px"
       >
 
         <!-- ModalHeader: start -->
@@ -719,16 +719,224 @@
         <!-- ModalBody: start -->
         <div class="ModalBody">
           <!-- Content: start -->
-          <p class="d-tablet-none">
-            This modal has a custom height of <code>400px</code> set via the <code>--modal-preferred-height-mobile</code> CSS
-            custom property.
-          </p>
-          <p class="d-none d-tablet-block">
-            This modal has a custom height of <code>500px</code> set via the <code>--modal-preferred-height-tablet</code> CSS
-            custom property.
-          </p>
-          <!-- TODO: add a checkbox "show more content to force scrolling" -->
-          <!-- TODO: add text fields to manually set values of available custom properties -->
+          <!-- Modal custom height demo: start -->
+          <script>
+            const toggleCustomHeight = (event, selector, breakpoint) => {
+              const isCustomHeightEnabled = event.target.checked;
+              const breakpointSuffix = breakpoint === 'mobile' ? '' : `-${breakpoint}`;
+
+              const modalElement = document.querySelector(selector);
+              const modalHeightInputElement = document.querySelector(`#custom-height-${breakpoint}`);
+              const modalHeightValueElement = document.querySelector(`#custom-height-${breakpoint}-value`);
+              const modalMaxHeightInputElement = document.querySelector(`#custom-max-height-${breakpoint}`);
+              const modalMaxHeightValueElement = document.querySelector(`#custom-max-height-${breakpoint}-value`);
+
+              if (isCustomHeightEnabled) {
+                modalElement.style.setProperty(`--modal-dialog-height${breakpointSuffix}`, `${modalHeightInputElement.value}px`);
+                modalElement.style.setProperty(`--modal-dialog-max-height${breakpointSuffix}`, `${modalMaxHeightInputElement.value}px`);
+                modalHeightInputElement.disabled = false;
+                modalHeightValueElement.textContent = `${modalHeightInputElement.value} px`;
+                modalMaxHeightInputElement.disabled = false;
+                modalMaxHeightValueElement.textContent = `${modalMaxHeightInputElement.value} px`;
+              } else {
+                modalElement.style.setProperty(`--modal-dialog-height${breakpointSuffix}`, 'unset');
+                modalElement.style.setProperty(`--modal-dialog-max-height${breakpointSuffix}`, 'unset');
+                modalHeightInputElement.disabled = true;
+                modalHeightValueElement.textContent = '—';
+                modalMaxHeightInputElement.disabled = true;
+                modalMaxHeightValueElement.textContent = '—';
+              }
+            };
+
+            const setModalHeight = (event, selector, breakpoint) => {
+              const breakpointSuffix = breakpoint === 'mobile' ? '' : `-${breakpoint}`;
+              const modalElement = document.querySelector(selector);
+              const modalHeightValueElement = document.querySelector(`#custom-height-${breakpoint}-value`);
+
+              modalElement.style.setProperty(`--modal-dialog-height${breakpointSuffix}`, `${event.target.value}px`);
+              modalHeightValueElement.textContent = `${event.target.value} px`;
+            };
+
+            const setModalMaxHeight = (event, selector, breakpoint) => {
+              const breakpointSuffix = breakpoint === 'mobile' ? '' : `-${breakpoint}`;
+              const modalElement = document.querySelector(selector);
+              const modalHeightValueElement = document.querySelector(`#custom-max-height-${breakpoint}-value`);
+
+              modalElement.style.setProperty(`--modal-dialog-max-height${breakpointSuffix}`, `${event.target.value}px`);
+              modalHeightValueElement.textContent = `${event.target.value} px`;
+            };
+          </script>
+          <form>
+            <fieldset class="Stack Stack--hasSpacing mb-800" style="border: 0;">
+              <legend hidden>Mobile</legend>
+              <label for="custom-height-mobile-enabled" class="Checkbox">
+                <input
+                  type="checkbox"
+                  id="custom-height-mobile-enabled"
+                  class="Checkbox__input"
+                  onchange="toggleCustomHeight(event, '#example-custom-height > .ModalDialog', 'mobile')"
+                  checked
+                  autocomplete="off"
+                />
+                <span class="Checkbox__text">
+                  <span class="Checkbox__label">Mobile</span>
+                </span>
+              </label>
+              <div class="Grid" style="column-gap: var(--spirit-space-600)">
+                <label for="custom-height-mobile" class="GridItem" style="--grid-item-column-start: 1; --grid-item-column-end: 6; --grid-item-column-end-tablet: 4;">
+                  Height
+                </label>
+                <span id="custom-height-mobile-value" class="GridItem" style="--grid-item-column-start: 6; --grid-item-column-end: 13; --grid-item-column-start-tablet: 4; --grid-item-column-end-tablet: 7;">
+                  400 px
+                </span>
+                <input
+                  type="range"
+                  id="custom-height-mobile"
+                  class="GridItem"
+                  style="--grid-item-column-start: 1; --grid-item-column-end: 13; --grid-item-column-start-tablet: 7;"
+                  onchange="setModalHeight(event, '#example-custom-height > .ModalDialog', 'mobile')"
+                  min="200"
+                  max="1000"
+                  step="100"
+                  value="400"
+                  autocomplete="off"
+                />
+              </div>
+              <div class="Grid" style="column-gap: var(--spirit-space-600)">
+                <label for="custom-max-height-mobile" class="GridItem" style="--grid-item-column-start: 1; --grid-item-column-end: 6; --grid-item-column-end-tablet: 4;">
+                  Max height
+                </label>
+                <span id="custom-max-height-mobile-value" class="GridItem" style="--grid-item-column-start: 6; --grid-item-column-end: 13; --grid-item-column-start-tablet: 4; --grid-item-column-end-tablet: 7;">
+                  600 px
+                </span>
+                <input
+                  type="range"
+                  id="custom-max-height-mobile"
+                  class="GridItem"
+                  style="--grid-item-column-start: 1; --grid-item-column-end: 13; --grid-item-column-start-tablet: 7;"
+                  onchange="setModalMaxHeight(event, '#example-custom-height > .ModalDialog', 'mobile')"
+                  min="200"
+                  max="1000"
+                  step="100"
+                  value="600"
+                  autocomplete="off"
+                />
+              </div>
+            </fieldset>
+            <fieldset class="Stack Stack--hasSpacing d-none d-tablet-grid mb-tablet-800" style="border: 0;">
+              <legend hidden>Tablet</legend>
+              <label for="custom-height-tablet-enabled" class="Checkbox">
+                <input
+                  type="checkbox"
+                  id="custom-height-tablet-enabled"
+                  class="Checkbox__input"
+                  onchange="toggleCustomHeight(event, '#example-custom-height > .ModalDialog', 'tablet')"
+                  checked
+                  autocomplete="off"
+                />
+                <span class="Checkbox__text">
+                  <span class="Checkbox__label">Tablet</span>
+                </span>
+              </label>
+              <div class="Grid" style="column-gap: var(--spirit-space-600)">
+                <label for="custom-height-tablet" class="GridItem" style="--grid-item-column-start: 1; --grid-item-column-end: 6; --grid-item-column-end-tablet: 4;">
+                  Height
+                </label>
+                <span id="custom-height-tablet-value" class="GridItem" style="--grid-item-column-start: 6; --grid-item-column-end: 13; --grid-item-column-start-tablet: 4; --grid-item-column-end-tablet: 7;">
+                  500 px
+                </span>
+                <input
+                  type="range"
+                  id="custom-height-tablet"
+                  class="GridItem"
+                  style="--grid-item-column-start: 1; --grid-item-column-end: 13; --grid-item-column-start-tablet: 7;"
+                  onchange="setModalHeight(event, '#example-custom-height > .ModalDialog', 'tablet')"
+                  min="200"
+                  max="1000"
+                  step="100"
+                  value="500"
+                  autocomplete="off"
+                />
+              </div>
+              <div class="Grid" style="column-gap: var(--spirit-space-600)">
+                <label for="custom-max-height-tablet" class="GridItem" style="--grid-item-column-start: 1; --grid-item-column-end: 6; --grid-item-column-end-tablet: 4;">
+                  Max height
+                </label>
+                <span id="custom-max-height-tablet-value" class="GridItem" style="--grid-item-column-start: 6; --grid-item-column-end: 13; --grid-item-column-start-tablet: 4; --grid-item-column-end-tablet: 7;">
+                  600 px
+                </span>
+                <input
+                  type="range"
+                  id="custom-max-height-tablet"
+                  class="GridItem"
+                  style="--grid-item-column-start: 1; --grid-item-column-end: 13; --grid-item-column-start-tablet: 7;"
+                  onchange="setModalMaxHeight(event, '#example-custom-height > .ModalDialog', 'tablet')"
+                  min="200"
+                  max="1000"
+                  step="100"
+                  value="600"
+                  autocomplete="off"
+                />
+              </div>
+            </fieldset>
+            <fieldset class="Stack Stack--hasSpacing d-none d-desktop-grid" style="border: 0;">
+              <legend hidden>Desktop</legend>
+              <label for="custom-height-desktop-enabled" class="Checkbox">
+                <input
+                  type="checkbox"
+                  id="custom-height-desktop-enabled"
+                  class="Checkbox__input"
+                  onchange="toggleCustomHeight(event, '#example-custom-height > .ModalDialog', 'desktop')"
+                  checked
+                  autocomplete="off"
+                />
+                <span class="Checkbox__text">
+                  <span class="Checkbox__label">Desktop</span>
+                </span>
+              </label>
+              <div class="Grid" style="column-gap: var(--spirit-space-600)">
+                <label for="custom-height-desktop" class="GridItem" style="--grid-item-column-start: 1; --grid-item-column-end: 6; --grid-item-column-end-tablet: 4;">
+                  Height
+                </label>
+                <span id="custom-height-desktop-value" class="GridItem" style="--grid-item-column-start: 6; --grid-item-column-end: 13; --grid-item-column-start-tablet: 4; --grid-item-column-end-tablet: 7;">
+                  600 px
+                </span>
+                <input
+                  type="range"
+                  id="custom-height-desktop"
+                  class="GridItem"
+                  style="--grid-item-column-start: 1; --grid-item-column-end: 13; --grid-item-column-start-tablet: 7;"
+                  onchange="setModalHeight(event, '#example-custom-height > .ModalDialog', 'desktop')"
+                  min="200"
+                  max="1000"
+                  step="100"
+                  value="600"
+                  autocomplete="off"
+                />
+              </div>
+              <div class="Grid" style="column-gap: var(--spirit-space-600)">
+                <label for="custom-max-height-desktop" class="GridItem" style="--grid-item-column-start: 1; --grid-item-column-end: 6; --grid-item-column-end-tablet: 4;">
+                  Max height
+                </label>
+                <span id="custom-max-height-desktop-value" class="GridItem" style="--grid-item-column-start: 6; --grid-item-column-end: 13; --grid-item-column-start-tablet: 4; --grid-item-column-end-tablet: 7;">
+                  600 px
+                </span>
+                <input
+                  type="range"
+                  id="custom-max-height-desktop"
+                  class="GridItem"
+                  style="--grid-item-column-start: 1; --grid-item-column-end: 13; --grid-item-column-start-tablet: 7;"
+                  onchange="setModalMaxHeight(event, '#example-custom-height > .ModalDialog', 'desktop')"
+                  min="200"
+                  max="1000"
+                  step="100"
+                  value="600"
+                  autocomplete="off"
+                />
+              </div>
+            </fieldset>
+          </form>
+          <!-- Modal custom height demo: end -->
           <!-- Content: end -->
         </div>
         <!-- ModalBody: end -->


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

1. Custom height and custom max height can be set individually on all breakpoints now.
2. The `--modal-preferred-height-mobile` and `--modal-preferred-height-tablet` custom properties were renamed.

### Additional context

![image](https://github.com/lmc-eu/spirit-design-system/assets/5614085/a86990a7-6d78-4b5c-b2ec-fd3ed200f78d)

### Issue reference

https://jira.almacareer.tech/browse/DS-1134

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
