### PR TITLE
BREAKING CHANGE(web-react): Tooltip remove off placement #DS-1193 

### DIFF
--- a/packages/web-react/DEPRECATIONS-v2.md
+++ b/packages/web-react/DEPRECATIONS-v2.md
@@ -68,15 +68,6 @@ Use:
 
 See [`Tooltip` documentation][tooltip-readme] for more details and examples.
 
-### Tooltip `off` Placement
-
-The `off` placement is deprecated and will be removed in the next major version.
-
-#### Migration Guide
-
-Please use the `TooltipModern` component instead, which is the successor of the `Tooltip` component and
-provides improved functionality.
-
 ### ModalDialog `isScrollable` Prop
 
 The `isScrollable` prop will be set to `false` by default in the next major release and the ModalDialog will be made


### PR DESCRIPTION
## Description

Just removed from deprecation file, couldn't find anything else.

### Additional context

ℹ️ Was removed when TooltipModern was renamed to Tooltip.

### Issue reference

[Odstranit off placement v Tooltipu](https://jira.almacareer.tech/browse/DS-1193)
