### PR TITLE
Fix(web-react): Tooltip closing by outside click when `isDismissible` prop set

### DIFF
--- a/packages/web-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/web-react/src/components/Tooltip/Tooltip.tsx
@@ -56,6 +56,7 @@ const Tooltip = (props: SpiritTooltipProps) => {
     flipFallbackAxisSideDirection,
     flipFallbackPlacements,
     flipProp,
+    isDismissible,
     isFocusableOnHover,
     isOpen,
     offset: tooltipOffset,

--- a/packages/web-react/src/components/Tooltip/__tests__/useFloatingUI.test.ts
+++ b/packages/web-react/src/components/Tooltip/__tests__/useFloatingUI.test.ts
@@ -10,6 +10,7 @@ describe('useFloatingUI', () => {
         flipFallbackAxisSideDirection: 'none',
         flipFallbackPlacements: 'bottom',
         flipProp: false,
+        isDismissible: false,
         isOpen: false,
         onToggle: jest.fn(),
         shiftProp: false,

--- a/packages/web-react/src/components/Tooltip/useFloating.ts
+++ b/packages/web-react/src/components/Tooltip/useFloating.ts
@@ -17,7 +17,7 @@ import {
   useRole,
 } from '@floating-ui/react';
 import { useState } from 'react';
-import { TooltipTriggerType, TOOLTIP_TRIGGER } from '../../types';
+import { TOOLTIP_TRIGGER, TooltipTriggerType } from '../../types';
 
 type UseTooltipUIProps = {
   arrowRef: React.MutableRefObject<HTMLElement | null>;
@@ -26,6 +26,7 @@ type UseTooltipUIProps = {
   flipFallbackAxisSideDirection: 'none' | 'start' | 'end';
   flipFallbackPlacements?: Placement | Placement[];
   flipProp: boolean;
+  isDismissible: boolean;
   isOpen?: boolean;
   offset?: number;
   onToggle: (isOpen: boolean) => void;
@@ -50,6 +51,7 @@ export const useFloating = (props: UseTooltipUIProps) => {
     flipFallbackAxisSideDirection = 'none',
     flipFallbackPlacements,
     flipProp,
+    isDismissible,
     isOpen = false,
     offset: tooltipOffset = 0,
     onToggle,
@@ -139,7 +141,7 @@ export const useFloating = (props: UseTooltipUIProps) => {
     enabled: isHoverEnabled,
     handleClose: useSafePolygons(!!isFocusableOnHover),
   });
-  const dismiss = useDismiss(context);
+  const dismiss = useDismiss(context, { outsidePress: !isDismissible });
   const role = useRole(context, { role: 'tooltip' });
   const { getReferenceProps, getFloatingProps } = useInteractions([click, hover, dismiss, role]);
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

In the web-react package the Tooltip is not closed by outside click when the `isDismissible` prop is set.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

https://jira.almacareer.tech/browse/DS-1259

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
