### PR TITLE
Fix: FileUploader `isRequired` prop only marks label

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -28,6 +28,9 @@ packages/**/*.hbs
 **/vendor
 **/vendor/**
 
+# Twig files
+*.twig
+
 # Narwal NX files (cache etc.)
 .nx
 /.nx/cache

--- a/packages/web-react/src/components/FileUploader/FileUploaderInput.tsx
+++ b/packages/web-react/src/components/FileUploader/FileUploaderInput.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
 import classNames from 'classnames';
-import { SpiritFileUploaderInputProps } from '../../types';
+import React from 'react';
 import { useDeprecationMessage, useStyleProps } from '../../hooks';
+import { SpiritFileUploaderInputProps } from '../../types';
 import { HelperText, ValidationText, useAriaIds } from '../Field';
 import { Icon } from '../Icon';
 import { DEFAULT_FILE_QUEUE_LIMIT, DEFAULT_FILE_SIZE_LIMIT } from './constants';
-import { useFileUploaderStyleProps } from './useFileUploaderStyleProps';
 import { useFileUploaderInput } from './useFileUploaderInput';
+import { useFileUploaderStyleProps } from './useFileUploaderStyleProps';
 
 const FileUploaderInput = (props: SpiritFileUploaderInputProps) => {
   const {
@@ -96,7 +96,6 @@ const FileUploaderInput = (props: SpiritFileUploaderInputProps) => {
         className={classProps.input.input}
         onChange={onChange}
         multiple={isMultiple}
-        required={isRequired}
         disabled={isDisabled || isDisabledByQueueLimitBehavior}
         {...restProps}
       />

--- a/packages/web-react/src/components/FileUploader/README.md
+++ b/packages/web-react/src/components/FileUploader/README.md
@@ -397,7 +397,7 @@ and [escape hatches][readme-escape-hatches].
 
 > ⚠️ We don't use the `required` attribute on the input element. This is because it triggers the browser's default validation, which can block form submission.
 > Instead, the `FileUploaderInput` component is used to open the system file dialog, and the component itself manages the file(s).
-> Please note, the validation for required files is not automatically handled. Developers need to implement this validation independently, using our JS plugin. This approach provides more flexibility and customization to meet specific validation requirements.
+> Please note, the validation for required files is not automatically handled. Developers need to implement this validation independently. This approach provides more flexibility and customization to meet specific validation requirements.
 
 ## FileUploaderList Props
 

--- a/packages/web-react/src/components/FileUploader/README.md
+++ b/packages/web-react/src/components/FileUploader/README.md
@@ -377,7 +377,7 @@ and [escape hatches][readme-escape-hatches].
 | `isDisabled`         | `bool`                               | —        | ✕        | Whether is field disabled                                                                                                                                       |
 | `isLabelHidden`      | `bool`                               | —        | ✕        | Whether is input label hidden                                                                                                                                   |
 | `isMultiple`         | `bool`                               | —        | ✕        | When multiple files can be selected at once                                                                                                                     |
-| `isRequired`         | `bool`                               | —        | ✕        | Whether is field required                                                                                                                                       |
+| `isRequired`         | `bool`                               | —        | ✕        | Whether is field marked as required                                                                                                                             |
 | `label`              | `string`                             | —        | ✕        | Field label                                                                                                                                                     |
 | `labelText`          | `string`                             | —        | ✕        | Label for input in Drop zone                                                                                                                                    |
 | `linkText`           | `string`                             | —        | ✕        | Link text in input in Drop zone                                                                                                                                 |
@@ -394,6 +394,10 @@ The rest of the properties are created from the default `<input>` element. [More
 On top of the API options, the components accept [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]
 and [escape hatches][readme-escape-hatches].
+
+> ⚠️ We don't use the `required` attribute on the input element. This is because it triggers the browser's default validation, which can block form submission.
+> Instead, the `FileUploaderInput` component is used to open the system file dialog, and the component itself manages the file(s).
+> Please note, the validation for required files is not automatically handled. Developers need to implement this validation independently, using our JS plugin. This approach provides more flexibility and customization to meet specific validation requirements.
 
 ## FileUploaderList Props
 
@@ -481,7 +485,7 @@ via `inputProps` and `listProps`.
 | `isFluid`             | `bool`                                  | —        | ✕        | When the field is supposed to be fluid              |
 | `isLabelHidden`       | `bool`                                  | —        | ✕        | Whether is input label hidden                       |
 | `isMultiple`          | `bool`                                  | —        | ✕        | When multiple files can be selected at once         |
-| `isRequired`          | `bool`                                  | —        | ✕        | Whether is field required                           |
+| `isRequired`          | `bool`                                  | —        | ✕        | Whether is field marked as required                 |
 | `labelText`           | `string`                                | —        | ✕        | Label for input in Drop zone                        |
 | `linkText`            | `string`                                | —        | ✕        | Link text in input in Drop zone                     |
 | `listId`              | `string`                                | —        | ✔        | FileUploaderList id                                 |

--- a/packages/web-twig/src/Resources/components/FileUploader/FileUploaderInput.twig
+++ b/packages/web-twig/src/Resources/components/FileUploader/FileUploaderInput.twig
@@ -39,7 +39,6 @@
 {# Attributes #}
 {%- set _disabledAttr = _isDisabled ? 'disabled' : null -%}
 {%- set _nameAttr = _name ? 'name="' ~ _name | escape('html_attr') ~ '"' : null -%}
-{%- set _requiredAttr = _isRequired ? 'required' : null -%}
 {%- set _dataMaxFileSizeAttr = _maxFileSize ? 'data-spirit-max-file-size=' ~ _maxFileSize : null -%}
 {%- set _dataMaxUploadedFilesAttr = _maxUploadedFiles ? 'data-spirit-file-queue-limit=' ~ _maxUploadedFiles : null -%}
 {%- set _dataQueueLimitBehaviorAttr = _queueLimitBehavior ? 'data-spirit-queue-limit-behavior=' ~ _queueLimitBehavior : null -%}
@@ -75,7 +74,6 @@
         data-spirit-element="input"
         {{ _nameAttr | raw }}
         {{ _disabledAttr }}
-        {{ _requiredAttr }}
     />
     <div class="{{ _dropzoneClassName }}" data-spirit-element="dropZone">
         <Icon name="{{ _iconName }}" isReusable={ false } />

--- a/packages/web-twig/src/Resources/components/FileUploader/README.md
+++ b/packages/web-twig/src/Resources/components/FileUploader/README.md
@@ -163,6 +163,10 @@ To mark the input as required, simply add the `isRequired` attribute:
 />
 ```
 
+> ⚠️ We don't use the `required` attribute on the input element. This is because it triggers the browser's default validation, which can block form submission.
+> Instead, the `FileUploaderInput` component is used to open the system file dialog, and our [JS plugin][web-js-api] manages the file(s).
+> Please note, the validation for required files is not automatically handled. Developers need to implement this validation independently, using our JS plugin. This approach provides more flexibility and customization to meet specific validation requirements.
+
 ### Validation States
 
 Just like any other form component in Spirit, FileUploader implements the
@@ -205,7 +209,7 @@ To mark the input as disabled, simply add the `isDisabled` attribute:
 | `id`                    | `string`                                       | —                       | ✔        | Input and label identification                                        |
 | `isDisabled`            | `bool`                                         | `false`                 | ✕        | If true, input is disabled                                            |
 | `isLabelHidden`         | `bool`                                         | `false`                 | ✕        | If true, label is hidden                                              |
-| `isRequired`            | `bool`                                         | `false`                 | ✕        | If true, input is required                                            |
+| `isRequired`            | `bool`                                         | `false`                 | ✕        | If true, input is marked as required                                  |
 | `label`                 | `string`                                       | `null`                  | ✕\*      | Label text                                                            |
 | `maxFileSize`           | `number`                                       | `1000000`               | ✕        | The maximum size of the uploaded file in bytes                        |
 | `maxUploadedFiles`      | `number`                                       | `10`                    | ✕        | Maximum file upload queue size                                        |

--- a/packages/web-twig/src/Resources/components/FileUploader/__tests__/__snapshots__/fileUploaderInput.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/FileUploader/__tests__/__snapshots__/fileUploaderInput.twig.snap.html
@@ -75,7 +75,7 @@
 
     <div class="FileUploaderInput FileUploaderInput--disabled FileUploaderInput--danger" data-spirit-element="wrapper">
       <label for="example-input-all-props" class="FileUploaderInput__label FileUploaderInput__label--hidden FileUploaderInput__label--required">Label</label>
-      <input type="file" id="example-input-all-props" class="FileUploaderInput__input" data-spirit-element="input" name="example-input" disabled required="">
+      <input type="file" id="example-input-all-props" class="FileUploaderInput__input" data-spirit-element="input" name="example-input" disabled>
       <div class="FileUploaderInput__dropZone" data-spirit-element="dropZone">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" aria-hidden="true">
         <path d="M18 13H13V18C13 18.55 12.55 19 12 19C11.45 19 11 18.55 11 18V13H6C5.45 13 5 12.55 5 12C5 11.45 5.45 11 6 11H11V6C11 5.45 11.45 5 12 5C12.55 5 13 5.45 13 6V11H18C18.55 11 19 11.45 19 12C19 12.55 18.55 13 18 13Z" fill="currentColor">

--- a/packages/web/src/scss/components/FileUploader/README.md
+++ b/packages/web/src/scss/components/FileUploader/README.md
@@ -160,25 +160,21 @@ Microsoft Word documents:
 
 ### Required Input
 
-To mark the input as required, simply add the `required` attribute to the native
-`input` element and the `FileUploaderInput__label--required` to the label:
+To mark the input as required, simply add the `FileUploaderInput__label--required` to the label:
 
 ```html
 <div class="FileUploaderInput" data-spirit-element="wrapper">
   <label for="fileUploader" class="FileUploaderInput__label FileUploaderInput__label--required">Label</label>
-  <input
-    type="file"
-    id="fileUploader"
-    name="attachment"
-    class="FileUploaderInput__input"
-    data-spirit-element="input"
-    required
-  />
+  <input type="file" id="fileUploader" name="attachment" class="FileUploaderInput__input" data-spirit-element="input" />
   <div class="FileUploaderInput__dropZone" data-spirit-element="dropZone">
     <!-- … -->
   </div>
 </div>
 ```
+
+> ⚠️ We don't use the `required` attribute on the input element. This is because it triggers the browser's default validation, which can block form submission.
+> Instead, the `FileUploaderInput` component is used to open the system file dialog, and our [JS plugin](#javascript-plugin) manages the file(s).
+> Please note, the validation for required files is not automatically handled. Developers need to implement this validation independently, using our JS plugin. This approach provides more flexibility and customization to meet specific validation requirements.
 
 ### Validation States
 

--- a/packages/web/src/scss/components/FileUploader/index.html
+++ b/packages/web/src/scss/components/FileUploader/index.html
@@ -279,7 +279,6 @@
           id="fileUploaderSuccess"
           name="attachment3"
           class="FileUploaderInput__input"
-          required
           data-spirit-element="input"
         />
         <div class="FileUploaderInput__dropZone" data-spirit-element="dropZone">
@@ -334,7 +333,6 @@
           id="fileUploaderWarning"
           name="attachment4"
           class="FileUploaderInput__input"
-          required
           data-spirit-element="input"
         />
         <div class="FileUploaderInput__dropZone" data-spirit-element="dropZone">
@@ -389,7 +387,6 @@
           id="fileUploaderDanger"
           name="attachment5"
           class="FileUploaderInput__input"
-          required
           data-spirit-element="input"
         />
         <div class="FileUploaderInput__dropZone" data-spirit-element="dropZone">
@@ -452,7 +449,6 @@
           id="fileUploaderDisabled"
           name="attachment4"
           class="FileUploaderInput__input"
-          required
           disabled
           data-spirit-element="input"
         />


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

  * the FileUploaderInput input element should never have the `required` attribute
     cause it is use only for calling the dialog window
  * the files are then stored in the queue
  * for required validation is responsible the developer who is using this component

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Ignore Twig files from formatting by Prettier.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

https://jira.almacareer.tech/browse/DS-1288

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
