### PR TITLE
BREAKING CHANGE(web-twig): Remove HeaderDesktopActions color prop in favor of `isAtEnd` #DS-1059

### DIFF
--- a/docs/migrations/web-react/MIGRATION-v2.md
+++ b/docs/migrations/web-react/MIGRATION-v2.md
@@ -18,6 +18,7 @@ Introducing version 2 of the _spirit-web-react_ package
   - [Dropdown: Refactored](#dropdown-refactored)
   - [Grid: Breakpoint Props](#grid-breakpoint-props)
   - [Grid: GridSpan Component](#grid-gridspan-component)
+  - [Header: HeaderDesktopActions `isAtEnd` prop](#header-headerdesktopactions-isatend-prop)
   - [Modal: ModalDialog `isExpandedOnMobile` Prop](#modal-modaldialog-isexpandedonmobile-prop)
   - [Modal: ModalDialog `isScrollable` Prop](#modal-modaldialog-isscrollable-prop)
   - [Modal: ModalDialog Custom Height](#modal-modaldialog-custom-height)
@@ -236,6 +237,31 @@ Examples:
   - `columnStart` = 1 + (12 - 8) / 2 = 3
   - `columnStart` = 1 + (12 - 6) / 2 = 4
   - `columnStart` = 1 + (12 - 4) / 2 = 5
+
+### Header: HeaderDesktopActions `isAtEnd` prop
+
+The `HeaderDesktopActions` component slots were simplified and the second slot alignment is now
+available by using the `isAtEnd` prop.
+
+The `HeaderDesktopActions` prop `color` was removed.
+
+#### Migration Guide
+
+Use our codemod to automatically migrate your code.
+
+```sh
+npx @lmc-eu/spirit-codemods -p <path> -t v2/web-react/header-headerdesktopactions-isatend
+```
+
+See [Codemods documentation][readme-codemods] for more details.
+
+Or follow these steps:
+
+Use the `HeaderDesktopActions` with `isAtEnd` prop instead of the `color="secondary"` prop.
+Remove the `color` prop from the `HeaderDesktopActions` component.
+
+- `<HeaderDesktopActions color="secondary" … />` → `<HeaderDesktopActions isAtEnd … />`
+- `<HeaderDesktopActions color="primary" … />` → `<HeaderDesktopActions … />`
 
 ### Modal: ModalDialog `isExpandedOnMobile` Prop
 

--- a/docs/migrations/web-twig/MIGRATION-v3.md
+++ b/docs/migrations/web-twig/MIGRATION-v3.md
@@ -19,6 +19,7 @@ Introducing version 3 of the _spirit-web-twig_ package
   - [Grid: Breakpoint Props](#grid-breakpoint-props)
   - [Grid: GridSpan Component](#grid-gridspan-component)
   - [Header: Abstracts Class and Style](#header-abstracts-class-and-style)
+  - [Header: HeaderDesktopActions `isAtEnd` prop](#header-headerdesktopactions-isatend-prop)
   - [Modal: ModalDialog `isScrollable` Prop](#modal-modaldialog-isscrollable-prop)
   - [Modal: ModalDialog Custom Height](#modal-modaldialog-custom-height)
   - [Modal: ModalDialog Uniform Appearance](#modal-modaldialog-uniform-appearance)
@@ -184,6 +185,21 @@ Use `UNSAFE_style` and `UNSAFE_className` instead.
 #### Migration Guide
 
 Replace `style` with `UNSAFE_style` and `class` with `UNSAFE_className`.
+
+### Header: HeaderDesktopActions `isAtEnd` prop
+
+The `HeaderDesktopActions` component slots were simplified and the second slot alignment is now
+available by using the `isAtEnd` prop.
+
+The `HeaderDesktopActions` prop `color` was removed.
+
+#### Migration Guide
+
+Use the `HeaderDesktopActions` with `isAtEnd` prop instead of the `color="secondary"` prop.
+Remove the `color` prop from the `HeaderDesktopActions` component.
+
+- `<HeaderDesktopActions color="secondary" … />` → `<HeaderDesktopActions isAtEnd … />`
+- `<HeaderDesktopActions color="primary" … />` → `<HeaderDesktopActions … />`
 
 ### Modal: ModalDialog `isScrollable` Prop
 

--- a/docs/migrations/web/MIGRATION-v2.md
+++ b/docs/migrations/web/MIGRATION-v2.md
@@ -15,6 +15,7 @@ Introducing version 2 of the _spirit-web_ package
   - [Dropdown: Classes](#dropdown-classes)
   - [Dropdown: Combined Placements](#dropdown-combined-placements)
   - [Dropdown: Shadow Feature Flag](#dropdown-shadow-feature-flag)
+  - [Header: HeaderDesktopActions Alignment](#header-headerdesktopactions-alignment)
   - [Modal: (Non)Scrollable](#modal-nonscrollable)
   - [Modal: Custom Height](#modal-custom-height)
   - [Modal: Uniform Variant Feature Flag](#modal-uniform-variant-feature-flag)
@@ -128,6 +129,20 @@ shadow is the default.
 
 You can now safely delete the CSS class `.spirit-feature-dropdown-enable-enhanced-shadow` and/or the Sass variable
 `$dropdown-enable-enhanced-shadow` from your project as they have no effect.
+
+### Header: HeaderDesktopActions Alignment
+
+The `HeaderDesktopActions` component slots were simplified and the second slot alignment is now
+available by using the `HeaderDesktopActions--end` modifier.
+
+The `HeaderDesktopActions--primary` and `HeaderDesktopActions--secondary` modifier classes were removed.
+
+#### Migration Guide
+
+Use the `.HeaderDesktopActions--end` modifier class instead of the `HeaderDesktopActions--secondary` modifier class.
+
+- `.HeaderDesktopActions.HeaderDesktopActions--primary` → `.HeaderDesktopActions`
+- `.HeaderDesktopActions.HeaderDesktopActions--secondary` → `.HeaderDesktopActions.HeaderDesktopActions--end`
 
 ### Modal: (Non)Scrollable
 

--- a/packages/codemods/src/transforms/v2/web-react/README.md
+++ b/packages/codemods/src/transforms/v2/web-react/README.md
@@ -102,6 +102,28 @@ npx @lmc-eu/spirit-codemods -p <path> -t v2/web-react/grid-gridspan
 + <GridItem columnStart={5} columnEnd="span 4" … />
 ```
 
+### `v2/web-react/header-headerdesktopactions-isatend` — HeaderDesktopActions isAtEnd Prop
+
+This codemod sets the `isAtEnd` prop instead of the removed `color="secondary"` prop.
+Also it removes the `color="primary"` prop from the `HeaderDesktopActions` component
+because it is not needed anymore.
+
+#### Usage
+
+```sh
+npx @lmc-eu/spirit-codemods -p <path> -t v2/web-react/header-headerdesktopactions-isatend
+```
+
+#### Example
+
+```diff
+- <HeaderDesktopActions color="secondary" … />
++ <HeaderDesktopActions isAtEnd … />
+
+- <HeaderDesktopActions color="primary" … />
++ <HeaderDesktopActions … />
+```
+
 ### `v2/web-react/modal-custom-height` — Modal Custom Height
 
 This codemod updates the `ModalDialog` component to use the `height` and

--- a/packages/codemods/src/transforms/v2/web-react/__testfixtures__/header-headerdesktopactions-isatend.input.tsx
+++ b/packages/codemods/src/transforms/v2/web-react/__testfixtures__/header-headerdesktopactions-isatend.input.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import { HeaderDesktopActions } from '@lmc-eu/spirit-web-react';
+
+export const MyComponent = () => (
+  <>
+    <HeaderDesktopActions />
+    <HeaderDesktopActions color="primary" />
+    <HeaderDesktopActions color="secondary" />
+  </>
+);

--- a/packages/codemods/src/transforms/v2/web-react/__testfixtures__/header-headerdesktopactions-isatend.output.tsx
+++ b/packages/codemods/src/transforms/v2/web-react/__testfixtures__/header-headerdesktopactions-isatend.output.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import { HeaderDesktopActions } from '@lmc-eu/spirit-web-react';
+
+export const MyComponent = () => (
+  <>
+    <HeaderDesktopActions />
+    <HeaderDesktopActions />
+    <HeaderDesktopActions isAtEnd />
+  </>
+);

--- a/packages/codemods/src/transforms/v2/web-react/__tests__/header-headerdesktopactions-isatend.test.ts
+++ b/packages/codemods/src/transforms/v2/web-react/__tests__/header-headerdesktopactions-isatend.test.ts
@@ -1,0 +1,3 @@
+import { testTransform } from '../../../../../tests/testUtils';
+
+testTransform(__dirname, 'header-headerdesktopactions-isatend');

--- a/packages/codemods/src/transforms/v2/web-react/header-headerdesktopactions-isatend.ts
+++ b/packages/codemods/src/transforms/v2/web-react/header-headerdesktopactions-isatend.ts
@@ -1,0 +1,58 @@
+import { API, FileInfo } from 'jscodeshift';
+
+const transform = (fileInfo: FileInfo, api: API) => {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+
+  // Find import statements for the specific module and HeaderDesktopActions specifier
+  const importStatements = root.find(j.ImportDeclaration, {
+    source: {
+      value: (value: string) => /^@lmc-eu\/spirit-web-react(\/.*)?$/.test(value),
+    },
+  });
+
+  // Check if the module is imported
+  if (importStatements.length > 0) {
+    const componentSpecifier = importStatements.find(j.ImportSpecifier, {
+      imported: {
+        type: 'Identifier',
+        name: 'HeaderDesktopActions',
+      },
+    });
+
+    // Check if HeaderDesktopActions specifier is present
+    if (componentSpecifier.length > 0) {
+      // Find HeaderDesktopActions components in the module
+      const components = root.find(j.JSXOpeningElement, {
+        name: {
+          type: 'JSXIdentifier',
+          name: 'HeaderDesktopActions',
+        },
+      });
+
+      // Replace color prop
+      components
+        .find(j.JSXAttribute, {
+          name: {
+            type: 'JSXIdentifier',
+            name: 'color',
+          },
+        })
+        .forEach((attributePath) => {
+          if (attributePath.value.value?.type === 'StringLiteral') {
+            if (attributePath.value.value.value === 'primary') {
+              attributePath.prune();
+            } else if (attributePath.value.value.value === 'secondary') {
+              // Replace color prop with isAtEnd prop without value
+              attributePath.node.name.name = 'isAtEnd';
+              attributePath.node.value = null;
+            }
+          }
+        });
+    }
+  }
+
+  return root.toSource();
+};
+
+export default transform;

--- a/packages/web-react/src/components/Header/HeaderDesktopActions.tsx
+++ b/packages/web-react/src/components/Header/HeaderDesktopActions.tsx
@@ -3,12 +3,16 @@ import classNames from 'classnames';
 import { useStyleProps } from '../../hooks';
 import { HeaderDesktopActionsProps } from '../../types';
 import { useHeaderStyleProps } from './useHeaderStyleProps';
-import { HEADER_ACTIONS_COLOR_DEFAULT } from './constants';
+
+const defaultProps = {
+  isAtEnd: false,
+};
 
 const HeaderDesktopActions = (props: HeaderDesktopActionsProps) => {
-  const { color = HEADER_ACTIONS_COLOR_DEFAULT, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const { isAtEnd, ...restProps } = propsWithDefaults;
 
-  const { classProps } = useHeaderStyleProps({ actionsColor: color });
+  const { classProps } = useHeaderStyleProps({ hasActionsAtEnd: isAtEnd });
   const { styleProps, props: otherProps } = useStyleProps(restProps);
 
   return (

--- a/packages/web-react/src/components/Header/README.md
+++ b/packages/web-react/src/components/Header/README.md
@@ -140,8 +140,7 @@ and [escape hatches][readme-escape-hatches].
 As the name suggests, desktop-only actions are intended to display on desktop screens only. They generally work as flex
 containers that define vertical alignment and spacing.
 
-There are two slots you can use: primary actions (aligned to left in LTR documents), and secondary actions (aligned to
-right).
+If you need to align actions to the end of the Header, use the `isAtEnd` prop.
 
 👉 It is critical to **make sure all your actions fit the Header on the
 desktop breakpoint**. Spirit intentionally does not provide any overflow
@@ -149,19 +148,19 @@ control here.
 
 ```jsx
 <HeaderDesktopActions aria-label="Main navigation">
-  {/* Desktop-only primary actions */}
+  {/* Desktop-only actions */}
 </HeaderDesktopActions>
-<HeaderDesktopActions color="secondary">
-  {/* Desktop-only secondary actions */}
+<HeaderDesktopActions isAtEnd>
+  {/* Desktop-only actions aligned to the end */}
 </HeaderDesktopActions>
 ```
 
 #### API
 
-| Name       | Type                       | Default   | Required | Description                 |
-| ---------- | -------------------------- | --------- | -------- | --------------------------- |
-| `children` | `ReactNode`                | —         | ✕        | Children node               |
-| `color`    | [`primary` \| `secondary`] | `primary` | ✕        | Color and alignment variant |
+| Name       | Type        | Default | Required | Description                                 |
+| ---------- | ----------- | ------- | -------- | ------------------------------------------- |
+| `children` | `ReactNode` | —       | ✕        | Children node                               |
+| `isAtEnd`  | `bool`      | `false` | ✕        | If true, the actions are aligned to the end |
 
 The component implements the [`HTMLElement`][mdn-api-html-element] interface.
 
@@ -218,7 +217,7 @@ You can avoid using the [HeaderNav](#navigation) for standalone links. That way,
 the same container:
 
 ```jsx
-<HeaderDesktopActions color="secondary">
+<HeaderDesktopActions isAtEnd>
   <HeaderButton>Marian</HeaderButton>
   <Button color="primary">Sign in</Button>
 </HeaderDesktopActions>
@@ -476,7 +475,7 @@ composition:
       {/* … */}
     </HeaderNav>
   </HeaderDesktopActions>
-  <HeaderDesktopActions color="secondary">{/* Desktop-only secondary actions */}</HeaderDesktopActions>
+  <HeaderDesktopActions isAtEnd>{/* Desktop-only secondary actions */}</HeaderDesktopActions>
 </Header>
 ```
 
@@ -531,7 +530,7 @@ const handleClose = () => setOpen(false);
       </HeaderNavItem>
     </HeaderNav>
   </HeaderDesktopActions>
-  <HeaderDesktopActions color="secondary">
+  <HeaderDesktopActions isAtEnd>
     <ButtonLink color="primary" href="/">Sign in</ButtonLink>
     <ButtonLink color="inverted" href="/">Enterprise</ButtonLink>
   </HeaderDesktopActions>

--- a/packages/web-react/src/components/Header/__tests__/HeaderDesktopActions.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDesktopActions.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import HeaderDesktopActions from '../HeaderDesktopActions';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
@@ -17,9 +17,14 @@ describe('HeaderDesktopActions', () => {
   restPropsTest((props) => <HeaderDesktopActions {...props} />, 'nav');
 
   it('should render text children', () => {
-    const dom = render(<HeaderDesktopActions id="test">Hello World</HeaderDesktopActions>);
+    render(<HeaderDesktopActions id="test">Hello World</HeaderDesktopActions>);
 
-    const element = dom.container.querySelector('nav') as HTMLElement;
-    expect(element.textContent).toBe('Hello World');
+    expect(screen.getByRole('navigation')).toHaveTextContent('Hello World');
+  });
+
+  it('should have isAtEnd class', () => {
+    render(<HeaderDesktopActions isAtEnd />);
+
+    expect(screen.getByRole('navigation')).toHaveClass('HeaderDesktopActions--end');
   });
 });

--- a/packages/web-react/src/components/Header/__tests__/useHeaderStyleProps.test.ts
+++ b/packages/web-react/src/components/Header/__tests__/useHeaderStyleProps.test.ts
@@ -9,9 +9,7 @@ describe('useHeaderStyleProps', () => {
     expect(result.current.classProps).toBeDefined();
     expect(result.current.classProps.root).toBe(`Header Header--${HEADER_COLOR_DEFAULT}`);
     expect(result.current.classProps.headerButton).toBe('HeaderLink');
-    expect(result.current.classProps.headerDesktopActions).toBe(
-      `HeaderDesktopActions HeaderDesktopActions--${HEADER_ACTIONS_COLOR_DEFAULT}`,
-    );
+    expect(result.current.classProps.headerDesktopActions).toBe('HeaderDesktopActions');
     expect(result.current.classProps.headerDialog).toBeDefined();
     expect(result.current.classProps.headerDialog.root).toBe('HeaderDialog');
     expect(result.current.classProps.headerDialog.panel).toBe('HeaderDialog__panel');

--- a/packages/web-react/src/components/Header/demo/HeaderInvertedWithActions.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderInvertedWithActions.tsx
@@ -30,7 +30,7 @@ const HeaderInvertedWithActions = () => {
           <SpiritLogo />
         </Link>
         <HeaderMobileActions dialogId="header_dialog_example" isOpen={isOpen} onOpen={handleOpen} />
-        <HeaderDesktopActions color="primary" aria-label="Main navigation">
+        <HeaderDesktopActions aria-label="Main navigation">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderLink isCurrent>Job offers</HeaderLink>
@@ -49,7 +49,7 @@ const HeaderInvertedWithActions = () => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary">
+        <HeaderDesktopActions isAtEnd>
           <Button color="primary">Sign in</Button>
           <Button color="inverted">Enterprise</Button>
         </HeaderDesktopActions>

--- a/packages/web-react/src/components/Header/demo/HeaderInvertedWithActionsAndDialog.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderInvertedWithActionsAndDialog.tsx
@@ -38,7 +38,7 @@ const HeaderInvertedWithActionsAndDialog = () => {
           <SpiritLogo />
         </Link>
         <HeaderMobileActions dialogId="header_dialog_example_1" isOpen={isMenuOpen} onOpen={handleMenuOpen} />
-        <HeaderDesktopActions color="primary" aria-label="Main navigation">
+        <HeaderDesktopActions aria-label="Main navigation">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderLink isCurrent aria-current="page">
@@ -59,7 +59,7 @@ const HeaderInvertedWithActionsAndDialog = () => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary">
+        <HeaderDesktopActions isAtEnd>
           <HeaderButton
             onClick={handleUserMenuOpen}
             aria-controls="header_dialog_example_2"

--- a/packages/web-react/src/components/Header/stories/Header.stories.tsx
+++ b/packages/web-react/src/components/Header/stories/Header.stories.tsx
@@ -71,7 +71,7 @@ const HeaderWithHooks = (args: HeaderProps) => {
           <SpiritLogo />
         </Link>
         <HeaderMobileActions dialogId="header_dialog_example_1" isOpen={isMenuOpen} onOpen={handleMenuOpen} />
-        <HeaderDesktopActions color="primary" aria-label="Main navigation">
+        <HeaderDesktopActions aria-label="Main navigation">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderLink isCurrent aria-current="page">
@@ -92,7 +92,7 @@ const HeaderWithHooks = (args: HeaderProps) => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary" aria-label="User area">
+        <HeaderDesktopActions isAtEnd aria-label="User area">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderDialogButton

--- a/packages/web-react/src/components/Header/stories/HeaderDesktopActions.stories.tsx
+++ b/packages/web-react/src/components/Header/stories/HeaderDesktopActions.stories.tsx
@@ -28,16 +28,15 @@ const meta: Meta<typeof HeaderDesktopActions> = {
     children: {
       control: 'object',
     },
-    color: {
-      control: 'radio',
-      options: ['primary', 'secondary'],
+    isAtEnd: {
+      control: 'boolean',
       table: {
-        defaultValue: { summary: 'primary' },
+        defaultValue: { summary: false },
       },
     },
   },
   args: {
-    color: 'primary',
+    isAtEnd: false,
   },
 };
 
@@ -81,7 +80,7 @@ const HeaderWithHooks = (args: HeaderDesktopActionsProps) => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary" aria-label="User area">
+        <HeaderDesktopActions isAtEnd aria-label="User area">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderDialogButton

--- a/packages/web-react/src/components/Header/stories/HeaderDialog.stories.tsx
+++ b/packages/web-react/src/components/Header/stories/HeaderDialog.stories.tsx
@@ -65,7 +65,7 @@ const HeaderWithHooks = (args: HeaderDialogProps) => {
           <SpiritLogo />
         </Link>
         <HeaderMobileActions dialogId="header_dialog_example_1" isOpen={isMenuOpen} onOpen={handleMenuOpen} />
-        <HeaderDesktopActions color="primary" aria-label="Main navigation">
+        <HeaderDesktopActions aria-label="Main navigation">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderLink isCurrent aria-current="page">
@@ -86,7 +86,7 @@ const HeaderWithHooks = (args: HeaderDialogProps) => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary" aria-label="User area">
+        <HeaderDesktopActions isAtEnd aria-label="User area">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderDialogButton

--- a/packages/web-react/src/components/Header/stories/HeaderDialogActions.stories.tsx
+++ b/packages/web-react/src/components/Header/stories/HeaderDialogActions.stories.tsx
@@ -60,7 +60,7 @@ const HeaderWithHooks = (args: HeaderDialogActionsProps) => {
           <SpiritLogo />
         </Link>
         <HeaderMobileActions dialogId="header_dialog_example_1" isOpen={isMenuOpen} onOpen={handleMenuOpen} />
-        <HeaderDesktopActions color="primary" aria-label="Main navigation">
+        <HeaderDesktopActions aria-label="Main navigation">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderLink isCurrent aria-current="page">
@@ -81,7 +81,7 @@ const HeaderWithHooks = (args: HeaderDialogActionsProps) => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary" aria-label="User area">
+        <HeaderDesktopActions isAtEnd aria-label="User area">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderDialogButton

--- a/packages/web-react/src/components/Header/stories/HeaderDialogButton.stories.tsx
+++ b/packages/web-react/src/components/Header/stories/HeaderDialogButton.stories.tsx
@@ -50,7 +50,7 @@ const HeaderWithHooks = (args: HeaderDialogButtonProps) => {
           <SpiritLogo />
         </Link>
         <HeaderMobileActions dialogId="header_dialog_example_1" isOpen={isMenuOpen} onOpen={handleMenuOpen} />
-        <HeaderDesktopActions color="primary" aria-label="Main navigation">
+        <HeaderDesktopActions aria-label="Main navigation">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderLink isCurrent aria-current="page">
@@ -71,7 +71,7 @@ const HeaderWithHooks = (args: HeaderDialogButtonProps) => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary" aria-label="User area">
+        <HeaderDesktopActions isAtEnd aria-label="User area">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderDialogButton

--- a/packages/web-react/src/components/Header/stories/HeaderDialogCloseButton.stories.tsx
+++ b/packages/web-react/src/components/Header/stories/HeaderDialogCloseButton.stories.tsx
@@ -56,7 +56,7 @@ const HeaderWithHooks = (args: HeaderDialogCloseButtonProps) => {
           <SpiritLogo />
         </Link>
         <HeaderMobileActions dialogId="header_dialog_example_1" isOpen={isMenuOpen} onOpen={handleMenuOpen} />
-        <HeaderDesktopActions color="primary" aria-label="Main navigation">
+        <HeaderDesktopActions aria-label="Main navigation">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderLink isCurrent aria-current="page">
@@ -77,7 +77,7 @@ const HeaderWithHooks = (args: HeaderDialogCloseButtonProps) => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary" aria-label="User area">
+        <HeaderDesktopActions isAtEnd aria-label="User area">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderDialogButton

--- a/packages/web-react/src/components/Header/stories/HeaderDialogLink.stories.tsx
+++ b/packages/web-react/src/components/Header/stories/HeaderDialogLink.stories.tsx
@@ -60,7 +60,7 @@ const HeaderWithHooks = (args: HeaderDialogLinkProps) => {
           <SpiritLogo />
         </Link>
         <HeaderMobileActions dialogId="header_dialog_example_1" isOpen={isMenuOpen} onOpen={handleMenuOpen} />
-        <HeaderDesktopActions color="primary" aria-label="Main navigation">
+        <HeaderDesktopActions aria-label="Main navigation">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderLink isCurrent aria-current="page">
@@ -81,7 +81,7 @@ const HeaderWithHooks = (args: HeaderDialogLinkProps) => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary" aria-label="User area">
+        <HeaderDesktopActions isAtEnd aria-label="User area">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderDialogButton

--- a/packages/web-react/src/components/Header/stories/HeaderDialogNav.stories.tsx
+++ b/packages/web-react/src/components/Header/stories/HeaderDialogNav.stories.tsx
@@ -50,7 +50,7 @@ const HeaderWithHooks = (args: HeaderDialogNavProps) => {
           <SpiritLogo />
         </Link>
         <HeaderMobileActions dialogId="header_dialog_example_1" isOpen={isMenuOpen} onOpen={handleMenuOpen} />
-        <HeaderDesktopActions color="primary" aria-label="Main navigation">
+        <HeaderDesktopActions aria-label="Main navigation">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderLink isCurrent aria-current="page">
@@ -71,7 +71,7 @@ const HeaderWithHooks = (args: HeaderDialogNavProps) => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary" aria-label="User area">
+        <HeaderDesktopActions isAtEnd aria-label="User area">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderDialogButton

--- a/packages/web-react/src/components/Header/stories/HeaderDialogNavItem.stories.tsx
+++ b/packages/web-react/src/components/Header/stories/HeaderDialogNavItem.stories.tsx
@@ -50,7 +50,7 @@ const HeaderWithHooks = (args: HeaderDialogNavItemProps) => {
           <SpiritLogo />
         </Link>
         <HeaderMobileActions dialogId="header_dialog_example_1" isOpen={isMenuOpen} onOpen={handleMenuOpen} />
-        <HeaderDesktopActions color="primary" aria-label="Main navigation">
+        <HeaderDesktopActions aria-label="Main navigation">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderLink isCurrent aria-current="page">
@@ -71,7 +71,7 @@ const HeaderWithHooks = (args: HeaderDialogNavItemProps) => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary" aria-label="User area">
+        <HeaderDesktopActions isAtEnd aria-label="User area">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderDialogButton

--- a/packages/web-react/src/components/Header/stories/HeaderDialogText.stories.tsx
+++ b/packages/web-react/src/components/Header/stories/HeaderDialogText.stories.tsx
@@ -54,7 +54,7 @@ const HeaderWithHooks = (args: HeaderDialogTextProps) => {
           <SpiritLogo />
         </Link>
         <HeaderMobileActions dialogId="header_dialog_example_1" isOpen={isMenuOpen} onOpen={handleMenuOpen} />
-        <HeaderDesktopActions color="primary" aria-label="Main navigation">
+        <HeaderDesktopActions aria-label="Main navigation">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderLink isCurrent aria-current="page">
@@ -75,7 +75,7 @@ const HeaderWithHooks = (args: HeaderDialogTextProps) => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary" aria-label="User area">
+        <HeaderDesktopActions isAtEnd aria-label="User area">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderDialogButton

--- a/packages/web-react/src/components/Header/stories/HeaderLink.stories.tsx
+++ b/packages/web-react/src/components/Header/stories/HeaderLink.stories.tsx
@@ -60,7 +60,7 @@ const HeaderWithHooks = (args: HeaderLinkProps) => {
           <SpiritLogo />
         </Link>
         <HeaderMobileActions dialogId="header_dialog_example_1" isOpen={isMenuOpen} onOpen={handleMenuOpen} />
-        <HeaderDesktopActions color="primary" aria-label="Main navigation">
+        <HeaderDesktopActions aria-label="Main navigation">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderLink {...args} />
@@ -79,7 +79,7 @@ const HeaderWithHooks = (args: HeaderLinkProps) => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary" aria-label="User area">
+        <HeaderDesktopActions isAtEnd aria-label="User area">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderDialogButton

--- a/packages/web-react/src/components/Header/stories/HeaderMobileActions.stories.tsx
+++ b/packages/web-react/src/components/Header/stories/HeaderMobileActions.stories.tsx
@@ -72,7 +72,7 @@ const HeaderWithHooks = (args: HeaderMobileActionsProps) => {
           <SpiritLogo />
         </Link>
         <HeaderMobileActions {...args} isOpen={isMenuOpen} onOpen={handleMenuOpen} />
-        <HeaderDesktopActions color="primary" aria-label="Main navigation">
+        <HeaderDesktopActions aria-label="Main navigation">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderLink isCurrent aria-current="page">
@@ -93,7 +93,7 @@ const HeaderWithHooks = (args: HeaderMobileActionsProps) => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary" aria-label="User area">
+        <HeaderDesktopActions isAtEnd aria-label="User area">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderDialogButton

--- a/packages/web-react/src/components/Header/stories/HeaderNav.stories.tsx
+++ b/packages/web-react/src/components/Header/stories/HeaderNav.stories.tsx
@@ -50,7 +50,7 @@ const HeaderWithHooks = (args: HeaderNavProps) => {
           <SpiritLogo />
         </Link>
         <HeaderMobileActions dialogId="header_dialog_example_1" isOpen={isMenuOpen} onOpen={handleMenuOpen} />
-        <HeaderDesktopActions color="primary" aria-label="Main navigation">
+        <HeaderDesktopActions aria-label="Main navigation">
           <HeaderNav {...args}>
             <HeaderNavItem>
               <HeaderLink isCurrent aria-current="page">
@@ -71,7 +71,7 @@ const HeaderWithHooks = (args: HeaderNavProps) => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary" aria-label="User area">
+        <HeaderDesktopActions isAtEnd aria-label="User area">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderDialogButton

--- a/packages/web-react/src/components/Header/stories/HeaderNavItem.stories.tsx
+++ b/packages/web-react/src/components/Header/stories/HeaderNavItem.stories.tsx
@@ -50,7 +50,7 @@ const HeaderWithHooks = (args: HeaderNavItemProps) => {
           <SpiritLogo />
         </Link>
         <HeaderMobileActions dialogId="header_dialog_example_1" isOpen={isMenuOpen} onOpen={handleMenuOpen} />
-        <HeaderDesktopActions color="primary" aria-label="Main navigation">
+        <HeaderDesktopActions aria-label="Main navigation">
           <HeaderNav>
             <HeaderNavItem {...args}>
               <HeaderLink isCurrent aria-current="page">
@@ -71,7 +71,7 @@ const HeaderWithHooks = (args: HeaderNavItemProps) => {
             </HeaderNavItem>
           </HeaderNav>
         </HeaderDesktopActions>
-        <HeaderDesktopActions color="secondary" aria-label="User area">
+        <HeaderDesktopActions isAtEnd aria-label="User area">
           <HeaderNav>
             <HeaderNavItem>
               <HeaderDialogButton

--- a/packages/web-react/src/components/Header/useHeaderStyleProps.ts
+++ b/packages/web-react/src/components/Header/useHeaderStyleProps.ts
@@ -5,6 +5,7 @@ import { HEADER_COLOR_DEFAULT, HEADER_ACTIONS_COLOR_DEFAULT } from './constants'
 
 export interface UseHeaderStyleProps {
   color?: HeaderColorType;
+  hasActionsAtEnd?: boolean;
   isSimple?: boolean;
   actionsColor?: HeaderActionsColorType;
   isCurrentLink?: boolean;
@@ -35,15 +36,17 @@ export interface UseHeaderStyleReturn {
 
 export const useHeaderStyleProps = (
   {
-    color = HEADER_COLOR_DEFAULT,
-    isSimple,
     actionsColor = HEADER_ACTIONS_COLOR_DEFAULT,
+    color = HEADER_COLOR_DEFAULT,
+    hasActionsAtEnd,
     isCurrentLink,
+    isSimple,
   }: UseHeaderStyleProps = {
-    color: HEADER_COLOR_DEFAULT,
-    isSimple: false,
     actionsColor: HEADER_ACTIONS_COLOR_DEFAULT,
+    color: HEADER_COLOR_DEFAULT,
+    hasActionsAtEnd: false,
     isCurrentLink: false,
+    isSimple: false,
   },
 ): UseHeaderStyleReturn => {
   const headerClass = useClassNamePrefix('Header');
@@ -54,7 +57,7 @@ export const useHeaderStyleProps = (
   const headerLinkClass = `${headerClass}Link`;
   const headerLinkCurrentClass = `${headerLinkClass}--current`;
   const headerDesktopActionsClass = `${headerClass}DesktopActions`;
-  const headerDesktopActionsColorClass = `${headerDesktopActionsClass}--${actionsColor}`;
+  const headerDesktopActionsAtEndClass = `${headerDesktopActionsClass}--end`;
   const headerMobileActionsClass = `${headerClass}MobileActions`;
   const headerDialogClass = `${headerClass}Dialog`;
   const headerDialogPanelClass = `${headerDialogClass}__panel`;
@@ -71,7 +74,7 @@ export const useHeaderStyleProps = (
   const classProps = {
     root: classNames(headerClass, headerColorClass, { [headerSimpleClass]: isSimple }),
     headerButton: headerLinkClass,
-    headerDesktopActions: classNames(headerDesktopActionsClass, headerDesktopActionsColorClass),
+    headerDesktopActions: classNames(headerDesktopActionsClass, { [headerDesktopActionsAtEndClass]: hasActionsAtEnd }),
     headerDialog: {
       root: headerDialogClass,
       panel: headerDialogPanelClass,

--- a/packages/web-react/src/types/header.ts
+++ b/packages/web-react/src/types/header.ts
@@ -34,7 +34,7 @@ export interface HeaderProps extends SpiritElementProps, ChildrenProps {
 export interface HeaderButtonProps extends SpiritButtonElementProps, ChildrenProps {}
 
 export interface HeaderDesktopActionsProps extends SpiritElementProps, ChildrenProps {
-  color?: HeaderActionsColorType;
+  isAtEnd?: boolean;
 }
 
 export interface HeaderDialogProps extends SpiritDialogElementProps, HeaderDialogHandlingProps, ChildrenProps {

--- a/packages/web-twig/src/Resources/components/Header/HeaderDesktopActions.twig
+++ b/packages/web-twig/src/Resources/components/Header/HeaderDesktopActions.twig
@@ -1,14 +1,14 @@
 {# API #}
 {%- set props = props | default([]) -%}
-{%- set _color = props.color | default('primary') -%}
+{%- set _isAtEnd = props.isAtEnd | default(false) -%}
 
 {# Class names #}
 {%- set _rootClassName = _spiritClassPrefix ~ 'HeaderDesktopActions' -%}
-{%- set _rootColorClassName = _spiritClassPrefix ~ 'HeaderDesktopActions--' ~ _color -%}
+{%- set _rootAtEndClassName = _isAtEnd ? _spiritClassPrefix ~ 'HeaderDesktopActions--end' : null -%}
 
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
-{%- set _classNames = [ _rootClassName, _rootColorClassName, _styleProps.className ] -%}
+{%- set _classNames = [ _rootClassName, _rootAtEndClassName, _styleProps.className ] -%}
 
 <nav {{ mainProps(props) }} {{ styleProp(_styleProps) }} {{ classProp(_classNames) }}>
     {% block content %}{% endblock %}

--- a/packages/web-twig/src/Resources/components/Header/README.md
+++ b/packages/web-twig/src/Resources/components/Header/README.md
@@ -169,8 +169,7 @@ and [escape hatches][readme-escape-hatches].
 As the name suggests, desktop-only actions are intended to display on desktop screens only. They generally work as flex
 containers that define vertical alignment and spacing.
 
-There are two slots you can use: primary actions (aligned to left in LTR documents), and secondary actions (aligned to
-right).
+If you need to align actions to the end of the Header, use the `isAtEnd` prop.
 
 👉 It is critical to **make sure all your actions fit the Header on the
 desktop breakpoint**. Spirit intentionally does not provide any overflow
@@ -178,18 +177,18 @@ control here.
 
 ```twig
 <HeaderDesktopActions aria-label="Main navigation">
-  <!-- Desktop-only primary actions -->
+  <!-- Desktop-only actions -->
 </HeaderDesktopActions>
-<HeaderDesktopActions color="secondary">
-  <!-- Desktop-only secondary actions -->
+<HeaderDesktopActions isAtEnd>
+  <!-- Desktop-only actions aligned to the end -->
 </HeaderDesktopActions>
 ```
 
 #### API
 
-| Name    | Type                       | Default   | Required | Description                 |
-| ------- | -------------------------- | --------- | -------- | --------------------------- |
-| `color` | [`primary` \| `secondary`] | `primary` | ✕        | Color and alignment variant |
+| Name      | Type   | Default | Required | Description                                 |
+| --------- | ------ | ------- | -------- | ------------------------------------------- |
+| `isAtEnd` | `bool` | `false` | ✕        | If true, the actions are aligned to the end |
 
 On top of the API options, the components accept [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]
@@ -242,7 +241,7 @@ You can avoid using the [HeaderNav](#navigation) for standalone links. That way,
 the same container:
 
 ```twig
-<HeaderDesktopActions color="secondary">
+<HeaderDesktopActions isAtEnd>
   <HeaderButton>Marian</HeaderButton>
   <Button color="primary">Sign in</Button>
 </HeaderDesktopActions>
@@ -434,7 +433,7 @@ composition:
       <!-- … -->
     </HeaderNav>
   </HeaderDesktopActions>
-  <HeaderDesktopActions color="secondary">
+  <HeaderDesktopActions isAtEnd>
     <!-- Desktop-only secondary actions -->
   </HeaderDesktopActions>
 </Header>
@@ -488,7 +487,7 @@ And the complete Header Dialog:
       </HeaderNavItem>
     </HeaderNav>
   </HeaderDesktopActions>
-  <HeaderDesktopActions color="secondary">
+  <HeaderDesktopActions isAtEnd>
     <ButtonLink color="primary" href="/">Sign in</ButtonLink>
     <ButtonLink color="inverted" href="/">Enterprise</ButtonLink>
   </HeaderDesktopActions>

--- a/packages/web-twig/src/Resources/components/Header/__tests__/__fixtures__/headerDesktopActions.twig
+++ b/packages/web-twig/src/Resources/components/Header/__tests__/__fixtures__/headerDesktopActions.twig
@@ -1,8 +1,8 @@
 <HeaderDesktopActions>
-   primary actions slot
+   desktop actions
 </HeaderDesktopActions>
 
 <!-- Render with all props -->
-<HeaderDesktopActions color="secondary">
-    secondary actions slot
+<HeaderDesktopActions isAtEnd>
+    desktop actions aligned to the end
 </HeaderDesktopActions>

--- a/packages/web-twig/src/Resources/components/Header/__tests__/__fixtures__/headerWithDialog.twig
+++ b/packages/web-twig/src/Resources/components/Header/__tests__/__fixtures__/headerWithDialog.twig
@@ -22,7 +22,7 @@
             </HeaderNavItem>
         </HeaderNav>
     </HeaderDesktopActions>
-    <HeaderDesktopActions color="secondary">
+    <HeaderDesktopActions isAtEnd>
         <ButtonLink color="primary" href="/">Sign in</ButtonLink>
         <ButtonLink color="inverted" href="/">Enterprise</ButtonLink>
     </HeaderDesktopActions>

--- a/packages/web-twig/src/Resources/components/Header/__tests__/__snapshots__/headerDesktopActions.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Header/__tests__/__snapshots__/headerDesktopActions.twig.snap.html
@@ -5,13 +5,13 @@
     </title>
   </head>
   <body>
-    <nav class="HeaderDesktopActions HeaderDesktopActions--primary">
-      primary actions slot
+    <nav class="HeaderDesktopActions">
+      desktop actions
     </nav>
     <!-- Render with all props -->
 
-    <nav class="HeaderDesktopActions HeaderDesktopActions--secondary">
-      secondary actions slot
+    <nav class="HeaderDesktopActions HeaderDesktopActions--end">
+      desktop actions aligned to the end
     </nav>
   </body>
 </html>

--- a/packages/web-twig/src/Resources/components/Header/__tests__/__snapshots__/headerWithDialog.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Header/__tests__/__snapshots__/headerWithDialog.twig.snap.html
@@ -13,7 +13,7 @@
         </path></svg> <span class="accessibility-hidden">Menu</span></button>
       </div>
 
-      <nav aria-label="Main navigation" class="HeaderDesktopActions HeaderDesktopActions--primary">
+      <nav aria-label="Main navigation" class="HeaderDesktopActions">
         <ul class="HeaderNav">
           <li class="HeaderNavItem">
             <a class="HeaderLink HeaderLink--current" href="/" aria-current="page">Job offers</a>
@@ -37,7 +37,7 @@
         </ul>
       </nav>
 
-      <nav class="HeaderDesktopActions HeaderDesktopActions--secondary">
+      <nav class="HeaderDesktopActions HeaderDesktopActions--end">
         <a class="Button Button--primary Button--medium" href="/">Sign in</a> <a class="Button Button--inverted Button--medium" href="/">Enterprise</a>
       </nav>
     </header>

--- a/packages/web-twig/src/Resources/components/Header/stories/HeaderInvertedWithActions.twig
+++ b/packages/web-twig/src/Resources/components/Header/stories/HeaderInvertedWithActions.twig
@@ -23,7 +23,7 @@
         </HeaderNav>
     </HeaderDesktopActions>
 
-    <HeaderDesktopActions color="secondary">
+    <HeaderDesktopActions isAtEnd>
         <ButtonLink color="primary" href="/">Sign in</ButtonLink>
         <ButtonLink color="inverted" href="/">Enterprise</ButtonLink>
     </HeaderDesktopActions>

--- a/packages/web-twig/src/Resources/components/Header/stories/HeaderInvertedWithActionsAndDialog.twig
+++ b/packages/web-twig/src/Resources/components/Header/stories/HeaderInvertedWithActionsAndDialog.twig
@@ -24,7 +24,7 @@
         </HeaderNav>
     </HeaderDesktopActions>
 
-    <HeaderDesktopActions color="secondary">
+    <HeaderDesktopActions isAtEnd>
         <HeaderButton
             data-spirit-toggle="offcanvas"
             data-spirit-target="#header_dialog_example_2_user_menu"

--- a/packages/web/src/scss/components/Header/README.md
+++ b/packages/web/src/scss/components/Header/README.md
@@ -155,19 +155,18 @@ and `aria-controls` attributes.
 As the name suggests, desktop-only actions are intended to display on desktop screens only. They generally work as flex
 containers that define vertical alignment and spacing.
 
-There are two slots you can use: primary actions (aligned to left in LTR documents), and secondary actions (aligned to
-right).
+If you need to align actions to the end of the Header, use the `HeaderDesktopActions--end` modifier class.
 
 👉 It is critical to **make sure all your actions fit the Header on the
 desktop breakpoint**. Spirit intentionally does not provide any overflow
 control here.
 
 ```html
-<nav class="HeaderDesktopActions HeaderDesktopActions--primary" aria-label="Main navigation">
-  <!-- Desktop-only primary actions -->
+<nav class="HeaderDesktopActions" aria-label="Main navigation">
+  <!-- Desktop-only actions -->
 </nav>
-<nav class="HeaderDesktopActions HeaderDesktopActions--secondary">
-  <!-- Desktop-only secondary actions -->
+<nav class="HeaderDesktopActions HeaderDesktopActions--end">
+  <!-- Desktop-only actions aligned to the end -->
 </nav>
 ```
 
@@ -220,7 +219,7 @@ You can avoid using the [HeaderNav](#navigation) for standalone links. That way,
 the same container:
 
 ```html
-<nav class="HeaderDesktopActions HeaderDesktopActions--secondary">
+<nav class="HeaderDesktopActions HeaderDesktopActions--end">
   <a href="#" class="HeaderLink">Marian</a>
   <a href="#" class="Button Button--primary Button--medium">Sign in</a>
 </nav>
@@ -382,7 +381,7 @@ And the complete Header Dialog:
   <!-- HeaderMobileActions: end -->
 
   <!-- HeaderDesktopActions: start -->
-  <nav class="HeaderDesktopActions HeaderDesktopActions--primary" aria-label="Main navigation">
+  <nav class="HeaderDesktopActions" aria-label="Main navigation">
     <!-- HeaderNav: start -->
     <ul class="HeaderNav">
       <li class="HeaderNavItem">
@@ -406,7 +405,7 @@ And the complete Header Dialog:
   <!-- HeaderDesktopActions: end -->
 
   <!-- HeaderDesktopActions: start -->
-  <nav class="HeaderDesktopActions HeaderDesktopActions--secondary">
+  <nav class="HeaderDesktopActions HeaderDesktopActions--end">
     <a href="#" class="Button Button--primary Button--medium">Sign in</a>
     <a href="#" class="Button Button--inverted Button--medium">Enterprise</a>
   </nav>

--- a/packages/web/src/scss/components/Header/_HeaderDesktopActions.scss
+++ b/packages/web/src/scss/components/Header/_HeaderDesktopActions.scss
@@ -13,7 +13,7 @@
     }
 }
 
-.HeaderDesktopActions--secondary {
+.HeaderDesktopActions--end {
     @include breakpoint.up(theme.$header-breakpoint) {
         margin-inline-start: auto;
     }

--- a/packages/web/src/scss/components/Header/index.html
+++ b/packages/web/src/scss/components/Header/index.html
@@ -55,7 +55,7 @@
       <!-- HeaderMobileActions: end -->
 
       <!-- HeaderDesktopActions: start -->
-      <nav class="HeaderDesktopActions HeaderDesktopActions--primary" aria-label="Main navigation">
+      <nav class="HeaderDesktopActions" aria-label="Main navigation">
 
         <!-- HeaderNav: start -->
         <ul class="HeaderNav">
@@ -81,7 +81,7 @@
       <!-- HeaderDesktopActions: end -->
 
       <!-- HeaderDesktopActions: start -->
-      <nav class="HeaderDesktopActions HeaderDesktopActions--secondary">
+      <nav class="HeaderDesktopActions HeaderDesktopActions--end">
         <a href="#" class="Button Button--primary Button--medium">Sign in</a>
         <a href="#" class="Button Button--inverted Button--medium">Enterprise</a>
       </nav>
@@ -188,7 +188,7 @@
       <!-- HeaderMobileActions: end -->
 
       <!-- HeaderDesktopActions: start -->
-      <nav class="HeaderDesktopActions HeaderDesktopActions--primary" aria-label="Main navigation">
+      <nav class="HeaderDesktopActions" aria-label="Main navigation">
 
         <!-- HeaderNav: start -->
         <ul class="HeaderNav">
@@ -214,7 +214,7 @@
       <!-- HeaderDesktopActions: end -->
 
       <!-- HeaderDesktopActions: start -->
-      <nav class="HeaderDesktopActions HeaderDesktopActions--secondary">
+      <nav class="HeaderDesktopActions HeaderDesktopActions--end">
 
         <!-- HeaderNav: start -->
         <button


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
