### PR TITLE
Chore(web-react): Migrate from`@testing-library/react-hooks`

### DIFF
--- a/packages/web-react/package.json
+++ b/packages/web-react/package.json
@@ -42,7 +42,6 @@
     "@testing-library/dom": "9.3.4",
     "@testing-library/jest-dom": "6.4.6",
     "@testing-library/react": "16.0.0",
-    "@testing-library/react-hooks": "8.0.1",
     "@testing-library/user-event": "14.5.2",
     "@types/jest": "29.5.12",
     "@types/node": "20.14.2",

--- a/packages/web-react/src/components/Accordion/__tests__/useAccordion.test.ts
+++ b/packages/web-react/src/components/Accordion/__tests__/useAccordion.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import { useAccordion } from '../useAccordion';
 
 describe('useAccordion', () => {

--- a/packages/web-react/src/components/Accordion/__tests__/useAccordionAriaProps.test.ts
+++ b/packages/web-react/src/components/Accordion/__tests__/useAccordionAriaProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useAccordionAriaProps } from '../useAccordionAriaProps';
 
 describe('useAccordionAriaProps', () => {

--- a/packages/web-react/src/components/Accordion/__tests__/useAccordionStyleProps.test.ts
+++ b/packages/web-react/src/components/Accordion/__tests__/useAccordionStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useAccordionStyleProps } from '../useAccordionStyleProps';
 
 describe('useAccordionStyleProps', () => {

--- a/packages/web-react/src/components/Alert/__tests__/useAlertIcon.test.ts
+++ b/packages/web-react/src/components/Alert/__tests__/useAlertIcon.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritAlertProps } from '../../../types';
 import { useAlertIcon } from '../useAlertIcon';
 

--- a/packages/web-react/src/components/Alert/__tests__/useAlertStyleProps.test.ts
+++ b/packages/web-react/src/components/Alert/__tests__/useAlertStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritAlertProps } from '../../../types';
 import { useAlertStyleProps } from '../useAlertStyleProps';
 

--- a/packages/web-react/src/components/Breadcrumbs/__tests__/useBreadcrumbsStyleProps.test.ts
+++ b/packages/web-react/src/components/Breadcrumbs/__tests__/useBreadcrumbsStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useBreadcrumbsStyleProps } from '../useBreadcrumbsStyleProps';
 
 describe('useBreadcrumbsStyleProps', () => {

--- a/packages/web-react/src/components/Button/__tests__/useButtonStyleProps.test.ts
+++ b/packages/web-react/src/components/Button/__tests__/useButtonStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritButtonProps } from '../../../types';
 import { useButtonStyleProps } from '../useButtonStyleProps';
 

--- a/packages/web-react/src/components/ButtonLink/__tests__/useButtonLinkStyleProps.test.ts
+++ b/packages/web-react/src/components/ButtonLink/__tests__/useButtonLinkStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritButtonProps } from '../../../types';
 import { useButtonLinkStyleProps } from '../useButtonLinkStyleProps';
 

--- a/packages/web-react/src/components/Checkbox/__tests__/useCheckboxStyleProps.test.ts
+++ b/packages/web-react/src/components/Checkbox/__tests__/useCheckboxStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { ValidationStates } from '../../../constants';
 import { SpiritCheckboxProps } from '../../../types';
 import { useCheckboxStyleProps } from '../useCheckboxStyleProps';

--- a/packages/web-react/src/components/Collapse/__tests__/useCollapse.test.ts
+++ b/packages/web-react/src/components/Collapse/__tests__/useCollapse.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import { useCollapse } from '../useCollapse';
 
 describe('useCollapse', () => {

--- a/packages/web-react/src/components/Collapse/__tests__/useCollapseAriaProps.test.ts
+++ b/packages/web-react/src/components/Collapse/__tests__/useCollapseAriaProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritCollapseProps } from '../../../types';
 import { useCollapseAriaProps } from '../useCollapseAriaProps';
 

--- a/packages/web-react/src/components/Collapse/__tests__/useCollapseStyleProps.test.ts
+++ b/packages/web-react/src/components/Collapse/__tests__/useCollapseStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useCollapseStyleProps } from '../useCollapseStyleProps';
 
 describe('useCollapseStyleProps', () => {

--- a/packages/web-react/src/components/Collapse/useResizeHeight.ts
+++ b/packages/web-react/src/components/Collapse/useResizeHeight.ts
@@ -1,5 +1,5 @@
 import useResizeObserver from '@react-hook/resize-observer';
-import { useState, RefObject } from 'react';
+import { RefObject, useState } from 'react';
 
 export const useResizeHeight = (ref: RefObject<HTMLElement>): string => {
   const [height, setHeight] = useState<string>('0px');

--- a/packages/web-react/src/components/Dropdown/__tests__/useDropdown.test.ts
+++ b/packages/web-react/src/components/Dropdown/__tests__/useDropdown.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useDropdown } from '../useDropdown';
 
 describe('useDropdown', () => {

--- a/packages/web-react/src/components/Dropdown/__tests__/useDropdownAriaProps.test.ts
+++ b/packages/web-react/src/components/Dropdown/__tests__/useDropdownAriaProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { PlacementDictionaryType } from '../../../types';
 import { useDropdownAriaProps } from '../useDropdownAriaProps';
 

--- a/packages/web-react/src/components/Dropdown/__tests__/useDropdownStyleProps.test.ts
+++ b/packages/web-react/src/components/Dropdown/__tests__/useDropdownStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useDropdownStyleProps } from '../useDropdownStyleProps';
 
 describe('useDropdownStyleProps', () => {

--- a/packages/web-react/src/components/FieldGroup/__tests__/useFieldGroupStyleProps.test.tsx
+++ b/packages/web-react/src/components/FieldGroup/__tests__/useFieldGroupStyleProps.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritFieldGroupProps } from '../../../types';
 import { useFieldGroupStyleProps } from '../useFieldGroupStyleProps';
 

--- a/packages/web-react/src/components/FileUploader/__tests__/useFileQueue.test.ts
+++ b/packages/web-react/src/components/FileUploader/__tests__/useFileQueue.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import { useFileQueue } from '../useFileQueue';
 
 describe('useFileQueue', () => {

--- a/packages/web-react/src/components/FileUploader/__tests__/useFileUploaderStyleProps.test.ts
+++ b/packages/web-react/src/components/FileUploader/__tests__/useFileUploaderStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useFileUploaderStyleProps } from '../useFileUploaderStyleProps';
 
 describe('useFileUploaderStyleProps', () => {

--- a/packages/web-react/src/components/Grid/__tests__/useGridItemStyleProps.test.tsx
+++ b/packages/web-react/src/components/Grid/__tests__/useGridItemStyleProps.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { GridItemSpan } from '../../../types';
 import { useGridItemStyleProps } from '../useGridItemStyleProps';
 

--- a/packages/web-react/src/components/Grid/__tests__/useGridStyleProps.test.tsx
+++ b/packages/web-react/src/components/Grid/__tests__/useGridStyleProps.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritGridProps } from '../../../types';
 import { useGridStyleProps } from '../useGridStyleProps';
 

--- a/packages/web-react/src/components/Header/__tests__/useHeaderStyleProps.test.ts
+++ b/packages/web-react/src/components/Header/__tests__/useHeaderStyleProps.test.ts
@@ -1,5 +1,5 @@
-import { renderHook } from '@testing-library/react-hooks';
-import { HEADER_COLOR_DEFAULT, HEADER_ACTIONS_COLOR_DEFAULT } from '../constants';
+import { renderHook } from '@testing-library/react';
+import { HEADER_ACTIONS_COLOR_DEFAULT, HEADER_COLOR_DEFAULT } from '../constants';
 import { useHeaderStyleProps } from '../useHeaderStyleProps';
 
 describe('useHeaderStyleProps', () => {

--- a/packages/web-react/src/components/Heading/__tests__/useHeadingStyleProps.ts
+++ b/packages/web-react/src/components/Heading/__tests__/useHeadingStyleProps.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritHeadingProps } from '../../../types';
 import { useHeadingStyleProps } from '../useHeadingStyleProps';
 import headingSizeDataProvider from './headingSizeDataProvider';

--- a/packages/web-react/src/components/Item/__tests__/useItemStyleProps.ts
+++ b/packages/web-react/src/components/Item/__tests__/useItemStyleProps.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritItemProps } from '../../../types';
 import { useItemStyleProps } from '../useItemStyleProps';
 

--- a/packages/web-react/src/components/Link/__tests__/useLinkStyleProps.test.ts
+++ b/packages/web-react/src/components/Link/__tests__/useLinkStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritLinkProps } from '../../../types';
 import { useLinkStyleProps } from '../useLinkStyleProps';
 import linkPropsDataProvider from './linkPropsDataProvider';

--- a/packages/web-react/src/components/Modal/__tests__/useModalDialogStyleProps.test.ts
+++ b/packages/web-react/src/components/Modal/__tests__/useModalDialogStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useModalDialogStyleProps } from '../useModalDialogStyleProps';
 
 describe('useModalDialogStyleProps', () => {

--- a/packages/web-react/src/components/Modal/__tests__/useModalStyleProps.test.ts
+++ b/packages/web-react/src/components/Modal/__tests__/useModalStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useModalStyleProps } from '../useModalStyleProps';
 
 describe('useModalStyleProps', () => {

--- a/packages/web-react/src/components/Pagination/__tests__/usePaginationStyleProps.test.ts
+++ b/packages/web-react/src/components/Pagination/__tests__/usePaginationStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { usePaginationStyleProps } from '../usePaginationStyleProps';
 
 describe('usePaginationStyleProps', () => {

--- a/packages/web-react/src/components/Pill/__tests__/usePillStyleProps.test.ts
+++ b/packages/web-react/src/components/Pill/__tests__/usePillStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritPillProps } from '../../../types';
 import { usePillStyleProps } from '../usePillStyleProps';
 

--- a/packages/web-react/src/components/Radio/__tests__/useRadioStyleProps.test.ts
+++ b/packages/web-react/src/components/Radio/__tests__/useRadioStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { ValidationStates } from '../../../constants';
 import { SpiritRadioProps } from '../../../types';
 import { useRadioStyleProps } from '../useRadioStyleProps';

--- a/packages/web-react/src/components/ScrollView/__tests__/useScrollViewStyleProps.test.ts
+++ b/packages/web-react/src/components/ScrollView/__tests__/useScrollViewStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useScrollViewStyleProps } from '../useScrollViewStyleProps';
 
 describe('useScrollViewStyleProps', () => {

--- a/packages/web-react/src/components/Select/__tests__/useSelectStyleProps.test.ts
+++ b/packages/web-react/src/components/Select/__tests__/useSelectStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { ValidationStates } from '../../../constants';
 import { useSelectStyleProps } from '../useSelectStyleProps';
 

--- a/packages/web-react/src/components/Spinner/__tests__/useSpinnerStyleProps.test.ts
+++ b/packages/web-react/src/components/Spinner/__tests__/useSpinnerStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { TextColors } from '../../../constants';
 import { SpiritSpinnerProps } from '../../../types';
 import { useSpinnerStyleProps } from '../useSpinnerStyleProps';

--- a/packages/web-react/src/components/Stack/__tests__/useStackStyleProps.test.ts
+++ b/packages/web-react/src/components/Stack/__tests__/useStackStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritStackProps } from '../../../types';
 import { useStackStyleProps } from '../useStackStyleProps';
 

--- a/packages/web-react/src/components/Tabs/__tests__/useTab.test.ts
+++ b/packages/web-react/src/components/Tabs/__tests__/useTab.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import { useTab } from '../useTabs';
 
 describe('useTab', () => {

--- a/packages/web-react/src/components/Tabs/__tests__/useTabsStyleProps.test.ts
+++ b/packages/web-react/src/components/Tabs/__tests__/useTabsStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useTabsStyleProps } from '../useTabsStyleProps';
 
 describe('useTabsStyleProps', () => {

--- a/packages/web-react/src/components/Tag/__tests__/useTagStyleProps.test.ts
+++ b/packages/web-react/src/components/Tag/__tests__/useTagStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritTagProps } from '../../../types';
 import { useTagStyleProps } from '../useTagStyleProps';
 

--- a/packages/web-react/src/components/Text/__tests__/useTextStyleProps.test.ts
+++ b/packages/web-react/src/components/Text/__tests__/useTextStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritTextProps } from '../../../types';
 import { useTextStyleProps } from '../useTextStyleProps';
 import textPropsDataProvider from './textPropsDataProvider';

--- a/packages/web-react/src/components/TextArea/__tests__/useAdjustHeight.test.ts
+++ b/packages/web-react/src/components/TextArea/__tests__/useAdjustHeight.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import { FormEvent, MutableRefObject } from 'react';
 import { useAdjustHeight } from '../useAdjustHeight';
 

--- a/packages/web-react/src/components/Toast/__tests__/useToast.test.ts
+++ b/packages/web-react/src/components/Toast/__tests__/useToast.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useContext } from 'react';
 import { useToast } from '../useToast';
 

--- a/packages/web-react/src/components/Toast/__tests__/useToastBarStyleProps.test.ts
+++ b/packages/web-react/src/components/Toast/__tests__/useToastBarStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritToastBarProps } from '../../../types';
 import { useToastBarStyleProps } from '../useToastBarStyleProps';
 

--- a/packages/web-react/src/components/Toast/__tests__/useToastIcon.test.tsx
+++ b/packages/web-react/src/components/Toast/__tests__/useToastIcon.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritToastBarProps } from '../../../types';
 import { useToastIcon } from '../useToastIcon';
 

--- a/packages/web-react/src/components/Toast/__tests__/useToastStyleProps.test.ts
+++ b/packages/web-react/src/components/Toast/__tests__/useToastStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SpiritToastProps } from '../../../types';
 import { useToastStyleProps } from '../useToastStyleProps';
 

--- a/packages/web-react/src/components/Tooltip/__tests__/useFloatingUI.test.ts
+++ b/packages/web-react/src/components/Tooltip/__tests__/useFloatingUI.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useFloating } from '../useFloating';
 
 describe('useFloatingUI', () => {

--- a/packages/web-react/src/components/Tooltip/__tests__/useTooltipStyleProps.test.ts
+++ b/packages/web-react/src/components/Tooltip/__tests__/useTooltipStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useTooltipStyleProps } from '../useTooltipStyleProps';
 
 describe('useTooltipStyleProps', () => {

--- a/packages/web-react/src/components/UNSTABLE_Divider/__tests__/useDividerStyleProps.test.ts
+++ b/packages/web-react/src/components/UNSTABLE_Divider/__tests__/useDividerStyleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useDividerStyleProps } from '../useDividerStyleProps';
 
 describe('useDividerStyleProps', () => {

--- a/packages/web-react/src/hooks/__tests__/styleProps.test.ts
+++ b/packages/web-react/src/hooks/__tests__/styleProps.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { StyleProps } from '../../types';
 import { useStyleProps } from '../styleProps';
 

--- a/packages/web-react/src/hooks/__tests__/useClickOutside.test.ts
+++ b/packages/web-react/src/hooks/__tests__/useClickOutside.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { MutableRefObject } from 'react';
 import { useClickOutside } from '../useClickOutside';
 

--- a/packages/web-react/src/hooks/__tests__/useIcon.test.tsx
+++ b/packages/web-react/src/hooks/__tests__/useIcon.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import React, { ReactNode } from 'react';
 import warning from '../../common/utilities/warning';
 import { IconsProvider } from '../../context/IconsContext';

--- a/packages/web-react/src/hooks/__tests__/useIconName.test.ts
+++ b/packages/web-react/src/hooks/__tests__/useIconName.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useIconName } from '../useIconName';
 
 describe('useIconName', () => {

--- a/packages/web-react/src/hooks/__tests__/useScrollControl.test.ts
+++ b/packages/web-react/src/hooks/__tests__/useScrollControl.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import { MutableRefObject } from 'react';
 import { useScrollControl } from '../useScrollControl';
 

--- a/packages/web-react/src/hooks/__tests__/useStyleUtilities.test.ts
+++ b/packages/web-react/src/hooks/__tests__/useStyleUtilities.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { StyleProps } from '../../types';
 import { useStyleUtilities } from '../useStyleUtilities';
 

--- a/packages/web-react/src/hooks/__tests__/useToggle.test.tsx
+++ b/packages/web-react/src/hooks/__tests__/useToggle.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import { useToggle } from '../useToggle';
 
 describe('useToggle', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3693,7 +3693,6 @@ __metadata:
     "@testing-library/dom": 9.3.4
     "@testing-library/jest-dom": 6.4.6
     "@testing-library/react": 16.0.0
-    "@testing-library/react-hooks": 8.0.1
     "@testing-library/user-event": 14.5.2
     "@types/jest": 29.5.12
     "@types/node": 20.14.2
@@ -8405,28 +8404,6 @@ __metadata:
     vitest:
       optional: true
   checksum: d70acbfc5d842065292dc1b4113ac2b4c2a2b83f9868e454d7f24d97ee92fddf7852e0e079b6eecaf21154bfe6e9ad03eb32e72f16854f64d7ce1ff42288828b
-  languageName: node
-  linkType: hard
-
-"@testing-library/react-hooks@npm:8.0.1":
-  version: 8.0.1
-  resolution: "@testing-library/react-hooks@npm:8.0.1"
-  dependencies:
-    "@babel/runtime": ^7.12.5
-    react-error-boundary: ^3.1.0
-  peerDependencies:
-    "@types/react": ^16.9.0 || ^17.0.0
-    react: ^16.9.0 || ^17.0.0
-    react-dom: ^16.9.0 || ^17.0.0
-    react-test-renderer: ^16.9.0 || ^17.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    react-dom:
-      optional: true
-    react-test-renderer:
-      optional: true
-  checksum: 7fe44352e920deb5cb1876f80d64e48615232072c9d5382f1e0284b3aab46bb1c659a040b774c45cdf084a5257b8fe463f7e08695ad8480d8a15635d4d3d1f6d
   languageName: node
   linkType: hard
 
@@ -25148,17 +25125,6 @@ __metadata:
     react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
     react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
   checksum: c3907cc4c1d3e9ecc8ca7727058ebcba6ec89848d9e07bfd2c77ee8f28f1ad99bf55e38359dec8a1125de83d41ac09a2874f53c41415edc86ffa9840fa1b7856
-  languageName: node
-  linkType: hard
-
-"react-error-boundary@npm:^3.1.0":
-  version: 3.1.4
-  resolution: "react-error-boundary@npm:3.1.4"
-  dependencies:
-    "@babel/runtime": ^7.12.5
-  peerDependencies:
-    react: ">=16.13.1"
-  checksum: f36270a5d775a25c8920f854c0d91649ceea417b15b5bc51e270a959b0476647bb79abb4da3be7dd9a4597b029214e8fe43ea914a7f16fa7543c91f784977f1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Switch from `@testing-library/react-hooks` to `@testing-library/react`

* this will get us rid of the annoying deprecation messages from the @testing-library

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

* https://github.com/testing-library/react-hooks-testing-library?tab=readme-ov-file#a-note-about-react-18-support

* https://github.com/testing-library/react-hooks-testing-library/issues/654#issuecomment-1097276573

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
