### PR TITLE
Fix(web, web-twig): Demo - Checkbox indeterminate

### DIFF
--- a/packages/web-twig/src/Resources/components/Checkbox/Checkbox.stories.twig
+++ b/packages/web-twig/src/Resources/components/Checkbox/Checkbox.stories.twig
@@ -3,7 +3,7 @@
 {% block content %}
 
     <script>
-        const inputs = ['checkboxIndeterminate', 'checkboxDisabledIndeterminate'];
+        const inputs = ['checkbox-indeterminate', 'checkbox-disabled-indeterminate'];
 
         window.addEventListener('DOMContentLoaded', function () {
             inputs.forEach(function (input) {

--- a/packages/web/src/scss/components/Checkbox/index.html
+++ b/packages/web/src/scss/components/Checkbox/index.html
@@ -1,7 +1,7 @@
 {{#> web/layout/plain }}
 
 <script>
-  const inputs = ['checkbox-indeterminate', 'checkboxDisabledIndeterminate'];
+  const inputs = ['checkbox-indeterminate', 'checkbox-disabled-indeterminate'];
 
   window.addEventListener('DOMContentLoaded', function () {
     inputs.forEach(function (input) {


### PR DESCRIPTION
## Description

- In the demo, there were incorrect IDs in the JavaScript to target the checkboxes

### Additional context
