### PR TITLE
Fix(web-twig): Use `docker compose` instead of removed `docker-compose`

### DIFF
--- a/packages/web-twig/Makefile
+++ b/packages/web-twig/Makefile
@@ -1,5 +1,5 @@
 # Executables (local)
-DOCKER_COMP						= docker-compose
+DOCKER_COMP						= docker compose
 DOCKER_PHP_SERVICE		= web-twig-demo-php
 DOCKER_ENCORE_SERVICE	= web-twig-demo-encore
 DOCKER_SERVER_SERVICE	= web-twig-demo-server


### PR DESCRIPTION
The `docker-compose` from Compose v1 is now removed and `docker compose` should be used instead.

https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose

`docker-compose` doesn't work on Docker for Mac from version 4.32.0.
https://github.com/docker/for-mac/issues/7345


<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
