### PR TITLE
Fix(web-react): Filter out props falling into DOM in *Logo components

### DIFF
--- a/packages/web-react/src/components/Collapse/demo/CollapseDefault.tsx
+++ b/packages/web-react/src/components/Collapse/demo/CollapseDefault.tsx
@@ -8,9 +8,7 @@ const CollapseDefault = () => {
 
   return (
     <>
-      <Button isOpen={isOpen} onClick={toggleHandler}>
-        Collapse trigger
-      </Button>
+      <Button onClick={toggleHandler}>Collapse trigger</Button>
       <Collapse id="collapse-default-id" isOpen={isOpen}>
         Aliquam varius, consequat posuere a lacinia mauris eu tellus condimentum ut id ante, accumsan vehicula nulla
         neque. Mauris mi orci, in donec nullam odio leo sapien et vehicula nunc a lacinia, fermentum arcu ullamcorper

--- a/packages/web-react/src/components/Collapse/demo/CollapseHelperClass.tsx
+++ b/packages/web-react/src/components/Collapse/demo/CollapseHelperClass.tsx
@@ -26,7 +26,7 @@ const CollapseHelperClass = () => {
         bibendum nunc aenean facilisis. Phasellus euismod, donec sem odio ligula praesent finibus nibh convallis,
         tristique aliquam sed id tortor sem lobortis.
       </Collapse>
-      <Button isOpen={isOpen} onClick={toggleHandler} aria-expanded={isOpen}>
+      <Button onClick={toggleHandler} aria-expanded={isOpen}>
         <span className="accessibility-open">Show less</span>
         <span className="accessibility-closed">Show more</span>
       </Button>

--- a/packages/web-react/src/components/Collapse/demo/CollapseMultipleTriggers.tsx
+++ b/packages/web-react/src/components/Collapse/demo/CollapseMultipleTriggers.tsx
@@ -8,9 +8,7 @@ const CollapseMultipleTriggers = () => {
 
   return (
     <>
-      <Button isOpen={isOpen} onClick={toggleHandler}>
-        Collapse trigger
-      </Button>
+      <Button onClick={toggleHandler}>Collapse trigger</Button>
       <Collapse id="collapse-multiple-triggers-id" isOpen={isOpen}>
         Aliquam varius, consequat posuere a lacinia mauris eu tellus condimentum ut id ante, accumsan vehicula nulla
         neque. Mauris mi orci, in donec nullam odio leo sapien et vehicula nunc a lacinia, fermentum arcu ullamcorper
@@ -20,7 +18,7 @@ const CollapseMultipleTriggers = () => {
         bibendum nunc aenean facilisis. Phasellus euismod, donec sem odio ligula praesent finibus nibh convallis,
         tristique aliquam sed id tortor sem lobortis.
       </Collapse>
-      <Button isOpen={isOpen} onClick={toggleHandler} color="secondary">
+      <Button onClick={toggleHandler} color="secondary">
         Secondary trigger
       </Button>{' '}
       <ButtonLink onClick={toggleHandler} aria-expanded={isOpen} color="tertiary">

--- a/packages/web-react/src/components/Collapse/demo/CollapseOpenOnInit.tsx
+++ b/packages/web-react/src/components/Collapse/demo/CollapseOpenOnInit.tsx
@@ -8,9 +8,7 @@ const CollapseOpenOnInit = () => {
 
   return (
     <>
-      <Button isOpen={isOpen} onClick={toggleHandler}>
-        Collapse trigger
-      </Button>
+      <Button onClick={toggleHandler}>Collapse trigger</Button>
       <Collapse id="collapse-open-on-init-id" isOpen={isOpen}>
         Cras dictum ante, mollis ollicitudin proin bibendum nec commodo consequat fusce ante, consequat venenatis
         suscipit odio morbi. Dolor sit amet porta, placerat tristique sit amet ligula nisl risus et vehicula, suscipit

--- a/packages/web-react/src/components/Collapse/demo/CollapseVisibilityBreakpointDesktop.tsx
+++ b/packages/web-react/src/components/Collapse/demo/CollapseVisibilityBreakpointDesktop.tsx
@@ -8,7 +8,7 @@ const CollapseVisibilityBreakpointDesktop = () => {
 
   return (
     <>
-      <ButtonLink isOpen={isOpenDesktop} onClick={toggleHandlerDesktop} size="medium" UNSAFE_className="d-desktop-none">
+      <ButtonLink onClick={toggleHandlerDesktop} size="medium" UNSAFE_className="d-desktop-none">
         Collapse trigger
       </ButtonLink>
       <Collapse id="collapse-visibility-breakpoint-desktop-id" isOpen={isOpenDesktop} collapsibleToBreakpoint="desktop">

--- a/packages/web-react/src/components/Collapse/demo/CollapseVisibilityBreakpointTablet.tsx
+++ b/packages/web-react/src/components/Collapse/demo/CollapseVisibilityBreakpointTablet.tsx
@@ -8,7 +8,7 @@ const CollapseVisibilityBreakpointTablet = () => {
 
   return (
     <>
-      <ButtonLink isOpen={isOpenTablet} onClick={toggleHandlerTablet} size="medium" UNSAFE_className="d-tablet-none">
+      <ButtonLink onClick={toggleHandlerTablet} size="medium" UNSAFE_className="d-tablet-none">
         Collapse trigger
       </ButtonLink>
       <Collapse id="collapse-visibility-breakpoint-tablet-id" isOpen={isOpenTablet} collapsibleToBreakpoint="tablet">

--- a/packages/web-react/src/components/Tag/demo/TagDefault.tsx
+++ b/packages/web-react/src/components/Tag/demo/TagDefault.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import DocsSection from '../../../../docs/DocsSections';
 import { EmotionColors, SizesExtended } from '../../../constants';
 import { Grid } from '../../Grid';
@@ -14,14 +14,14 @@ const TagDefault = () => {
       {sizes.map((size) => (
         <DocsSection key={size} title={`Size ${size}`}>
           {colors.map((color) => (
-            <>
+            <Fragment key={`tag-${color}-${size}`}>
               <Tag color={color} size={size} isSubtle>
                 Tag {color}
               </Tag>
               <Tag color={color} size={size}>
                 Tag {color}
               </Tag>
-            </>
+            </Fragment>
           ))}
         </DocsSection>
       ))}

--- a/packages/web-react/src/components/UNSTABLE_PartnerLogo/__tests__/usePartnerLogoStyleProps.test.ts
+++ b/packages/web-react/src/components/UNSTABLE_PartnerLogo/__tests__/usePartnerLogoStyleProps.test.ts
@@ -10,17 +10,31 @@ describe('usePartnerLogoStyleProps', () => {
     expect(result.current.classProps).toBe('UNSTABLE_PartnerLogo');
   });
 
-  it.each(Object.values(Sizes))('should return %s size PartnerLogo', (size) => {
+  describe('hasSafeAreaDisabled prop', () => {
+    const props = {
+      hasSafeAreaDisabled: true,
+    };
+    const { result } = renderHook(() => usePartnerLogoStyleProps(props));
+
+    it('should return hasSafeAreaDisabled class names', () => {
+      expect(result.current.classProps).toBe('UNSTABLE_PartnerLogo UNSTABLE_PartnerLogo--hasSafeAreaDisabled');
+    });
+
+    it('should not return hasSafeAreaDisabled prop', () => {
+      expect(result.current.props).toStrictEqual({});
+    });
+  });
+
+  describe.each(Object.values(Sizes))('size prop', (size) => {
     const props = { size };
     const { result } = renderHook(() => usePartnerLogoStyleProps(props));
 
-    expect(result.current.classProps).toBe(`UNSTABLE_PartnerLogo UNSTABLE_PartnerLogo--${size}`);
-  });
+    it('should return %s size PartnerLogo', () => {
+      expect(result.current.classProps).toBe(`UNSTABLE_PartnerLogo UNSTABLE_PartnerLogo--${size}`);
+    });
 
-  it('should return without safe area', () => {
-    const props = { hasSafeAreaDisabled: true };
-    const { result } = renderHook(() => usePartnerLogoStyleProps(props));
-
-    expect(result.current.classProps).toBe('UNSTABLE_PartnerLogo UNSTABLE_PartnerLogo--hasSafeAreaDisabled');
+    it('should not return size prop', () => {
+      expect(result.current.props).toStrictEqual({});
+    });
   });
 });

--- a/packages/web-react/src/components/UNSTABLE_PartnerLogo/usePartnerLogoStyleProps.ts
+++ b/packages/web-react/src/components/UNSTABLE_PartnerLogo/usePartnerLogoStyleProps.ts
@@ -8,7 +8,7 @@ export interface PartnerLogoStyles<T> {
 }
 
 export function usePartnerLogoStyleProps(props: SpiritPartnerLogoProps): PartnerLogoStyles<SpiritPartnerLogoProps> {
-  const { size, hasSafeAreaDisabled } = props;
+  const { size, hasSafeAreaDisabled, ...restProps } = props;
 
   const partnerLogoClass = useClassNamePrefix('UNSTABLE_PartnerLogo');
   const partnerLogoSizeClass = `${partnerLogoClass}--${size}`;
@@ -20,6 +20,6 @@ export function usePartnerLogoStyleProps(props: SpiritPartnerLogoProps): Partner
 
   return {
     classProps,
-    props,
+    props: restProps,
   };
 }

--- a/packages/web-react/src/components/UNSTABLE_ProductLogo/__tests__/useProductLogoStyleProps.test.ts
+++ b/packages/web-react/src/components/UNSTABLE_ProductLogo/__tests__/useProductLogoStyleProps.test.ts
@@ -9,12 +9,18 @@ describe('useProductLogoStyleProps', () => {
     expect(result.current.classProps).toBe('UNSTABLE_ProductLogo');
   });
 
-  it('should return inverted', () => {
+  describe('isInverted prop', () => {
     const props = {
       isInverted: true,
     };
     const { result } = renderHook(() => useProductLogoStyleProps(props));
 
-    expect(result.current.classProps).toBe('UNSTABLE_ProductLogo UNSTABLE_ProductLogo--inverted');
+    it('should return inverted class names', () => {
+      expect(result.current.classProps).toBe('UNSTABLE_ProductLogo UNSTABLE_ProductLogo--inverted');
+    });
+
+    it('should not return isInverted prop', () => {
+      expect(result.current.props).toStrictEqual({});
+    });
   });
 });

--- a/packages/web-react/src/components/UNSTABLE_ProductLogo/useProductLogoStyleProps.ts
+++ b/packages/web-react/src/components/UNSTABLE_ProductLogo/useProductLogoStyleProps.ts
@@ -8,7 +8,7 @@ export interface ProductLogoStyles<T> {
 }
 
 export function useProductLogoStyleProps(props: SpiritProductLogoProps): ProductLogoStyles<SpiritProductLogoProps> {
-  const { isInverted } = props;
+  const { isInverted, ...restProps } = props;
 
   const productLogoClass = useClassNamePrefix('UNSTABLE_ProductLogo');
   const productLogoInvertedColorClass = `${productLogoClass}--inverted`;
@@ -18,6 +18,6 @@ export function useProductLogoStyleProps(props: SpiritProductLogoProps): Product
 
   return {
     classProps,
-    props,
+    props: restProps,
   };
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Quick fix of the props falling down to the DOM on ProductLogo and PartnerLogo components.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

https://jira.almacareer.tech/browse/DS-1440

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
