### PR TITLE
Fix(web-react): Export `Flex` component in components index file

### DIFF
--- a/packages/web-react/src/components/index.ts
+++ b/packages/web-react/src/components/index.ts
@@ -13,6 +13,7 @@ export * from './Dropdown';
 export * from './Field';
 export * from './FieldGroup';
 export * from './FileUploader';
+export * from './Flex';
 export * from './Grid';
 export * from './Header';
 export * from './Heading';


### PR DESCRIPTION
## Description
Add the missing export of the new `Flex` component in the components index file, so it can be imported directly from `@lmc-eu/spirit-web-react`.

### Additional context
Requested by @dlouhak 

### Issue reference


