### PR TITLE
Fix(web-react): Fix `underlined` prop default value name in Link

### DIFF
--- a/packages/web-react/src/components/Link/Link.tsx
+++ b/packages/web-react/src/components/Link/Link.tsx
@@ -9,7 +9,7 @@ import { useLinkStyleProps } from './useLinkStyleProps';
 const defaultProps: Partial<SpiritLinkProps> = {
   elementType: 'a',
   color: 'primary',
-  underline: 'hover',
+  underlined: 'hover',
 };
 
 /* We need an exception for components exported with forwardRef */


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

The prop is called `underlined`. This typo caused `underline="hover"` attribute in the HTML. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
