### PR TITLE
Make publishing packages on GitHub working

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: 🚀 Publish
+name: 🚢 Publish
 
 on:
   push:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '**'
 
 jobs:
   publish:
@@ -30,4 +28,5 @@ jobs:
       - name: Publish
         run: make publish
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,10 +6,36 @@ on:
       - main
 
 jobs:
-  publish:
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    name: 📦 Publish Package
+  has-tags:
+    name: 🏷️ Analyze Tags
     runs-on: ubuntu-24.04
+
+    outputs:
+      has-tag: ${{ steps.check-tag-exists.outputs.has-tag }}
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+
+      # ⚠️ This check works only if the tag is pushed alongside the commit
+      # Please, use `git push && git push --tags` or `git push --follow-tags` (works only for annonated tags)
+      - name: Check Tag On Commit
+        id: check-tag-exists
+        run: |
+          if [ -n "$(git tag --points-at HEAD)" ]; then
+            echo "has-tag=true" >> $GITHUB_OUTPUT
+          else
+            echo "has-tag=false" >> $GITHUB_OUTPUT
+          fi
+
+  publish:
+    name: 📦 Publish Packages
+    needs: has-tags
+    if: ${{ needs.has-tags.outputs.has-tag == 'true' }}
+    runs-on: ubuntu-24.04
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,14 +255,20 @@ For more, please read the article [How to Run GitHub Actions Locally with the ac
 
 ## Publishing
 
-This project uses GitHub Actions to publish the packages automatically to npm. New packages are published after the new tag is pushed to the main branch. PR can be merged only by the appropriate group of maintainers.
+This project uses GitHub Actions to publish the packages automatically to npm.
+New packages are published after the new tag is pushed to the main branch.
+PR can be merged only by the appropriate group of maintainers.
 
 ### Steps to Create a New Package Version
 
-1. Merge all appropriate PRs you want to publish into the main branch
+1. Merge all appropriate PRs you want to publish into the appropriate branch
+   - branches:
+     - `main` - for the latest stable version
 2. Run the `make version` command to bump the version number in packages (a new version number is determined automatically based on commit history)
 3. Check that the version number is correct and everything looks good
-4. Run manually `git push && git push --tags` to push the changes to the remote
+4. Push changes and tags to repository
+   4a. Run manually `git push && git push --tags` to push the changes to the remote
+   4b. or use `git push --follow-tags` to push the changes and tags at once (works only when tags are annotated).
 5. Publishing is done automatically by GitHub Actions (uses `build` script and `make publish` command)
 
 > If you have further questions do not hesitate to open an issue and ask us! ❤️

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ version: ## Create new version of packages
 # @see https://github.com/lerna/lerna/tree/main/commands/version#readme
 # Bump version of packages changed since the last release
 # --yes` - skip all confirmation prompts
-	$(PKG_MANAGER) $(MONOREPO_TOOL) version --yes --no-push $(MONOREPO_TOOL_FLAGS) $(MONOREPO_TOOL_NO_PUSH)
+	$(PKG_MANAGER) $(MONOREPO_TOOL) version --create-release github --yes --no-push $(MONOREPO_TOOL_FLAGS) $(MONOREPO_TOOL_NO_PUSH)
 
 build: ## Builds all packages
 	$(PKG_MANAGER) build

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,8 @@ publish: ## Publish packages to repository, pass the parameter "pkg=" to publish
 else
 publish:
 	@$(eval pkg ?=)
-	$(PKG_EXECUTE) $(MONOREPO_TOOL) publish from-package --yes $(MONOREPO_TOOL_FLAGS)
+	@$(eval dist-tag ?= latest)
+	$(PKG_EXECUTE) $(MONOREPO_TOOL) publish dist-tag=$(dist-tag) from-package --yes $(MONOREPO_TOOL_FLAGS)
 endif
 
 ## —— Miscellaneous 🛠️ ——————————————————————————————————————————————————————————————


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The publishing workflow was not working correctly due to the fact that the workflow was run on every push. Not even to branch, but the tag as well. This causes running multiple actions at once, because Lerna pushes multiple tags, one for each package.

So I have prepared a condition for checking push to a branch with the tags on it. So only when there is a push to the main branch and the latest commit has tags the workflow will be run.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

https://jira.almacareer.tech/browse/DS-1434

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
