### PR TITLE
Fix(ci): Run workflows only on push to branches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,10 @@
 name: Build
 
 on:
+  # Run this workflow on push to branches only (not tags)
   push:
+    branches:
+      - '**'
     paths:
       - packages/design-tokens/**
       - packages/icons/**

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -1,7 +1,10 @@
 name: Markdown Link Check
 
 on:
+  # Run this workflow on push to branches only (not tags)
   push:
+    branches:
+      - '**'
   schedule:
     - cron: '0 9 * * *' # every day at 9:00
 

--- a/.github/workflows/test-web-twig.yaml
+++ b/.github/workflows/test-web-twig.yaml
@@ -1,7 +1,10 @@
 name: 'Web Twig: Code Quality Checks'
 
 on:
+  # Run this workflow on push to branches only (not tags)
   push:
+    branches:
+      - '**'
     paths:
       - packages/web-twig/**
       # Changes in SVG icons also affect snapshots in web-twig package

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,10 @@
 name: Code Quality Checks
 
 on:
+  # Run this workflow on push to branches only (not tags)
   push:
+    branches:
+      - '**'
   schedule:
     - cron: '0 9 * * *' # every day at 9:00
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

* pushing new tags caused hell becuase the workflows were run for every tag pushed

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
