### PR TITLE
BC(web): Toast JS plugin `isUnderlined` changed to `underlined`

### DIFF
--- a/docs/migrations/web-twig/MIGRATION-v4.md
+++ b/docs/migrations/web-twig/MIGRATION-v4.md
@@ -32,6 +32,14 @@ We've removed this default to encourage developers to explicitly choose a more a
 
 - `<Heading … />` → `<Heading elementType="{/* Your semantic HTML element here */}" … />`
 
+### Link `isUnderlined`
+
+The `isUnderlined` property was removed, please use `underlined` instead.
+
+#### Migration Guide
+
+- `<Link isUnderlined … />` → `<Link underlined="always" … />`
+
 ---
 
 Please refer back to this guide or reach out to our team if you encounter any issues during migration.

--- a/packages/web-twig/DEPRECATIONS.md
+++ b/packages/web-twig/DEPRECATIONS.md
@@ -6,17 +6,8 @@ This document lists all deprecations that will be removed in the next major vers
 
 ## Deprecations
 
+Nothing here right now! 🎉
+
 👉 [What are deprecations?][readme-deprecations]
-
-### Link `isUnderlined`
-
-`isUnderlined` property will be replaced in the next major version. Please use `underlined` instead.
-
-#### Migration Guide
-
-```diff
-- <Link isUnderlined … />
-+ <Link underlined="always" … />
-```
 
 [readme-deprecations]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/README.md#deprecations

--- a/packages/web-twig/src/Resources/components/Toast/README.md
+++ b/packages/web-twig/src/Resources/components/Toast/README.md
@@ -370,7 +370,7 @@ const toast = new Toast(null, {
   linkProps: {
     href: 'https://example.com', // Link URL
     target: '_blank', // Optional link target attribute
-    isUnderlined: false, // Optional link underlining, default: true
+    underlined: 'never', // Optional link underlining, one of ['always' (default), 'hover', 'never']
     isDisabled: false, // Optional link disabling, default: false
     elementType: 'a', // Optional link element type, default: 'a'
   },

--- a/packages/web-twig/src/Resources/components/Toast/__tests__/__fixtures__/toastBarLink.twig
+++ b/packages/web-twig/src/Resources/components/Toast/__tests__/__fixtures__/toastBarLink.twig
@@ -4,7 +4,6 @@
 <ToastBarLink
     href="https://www.google.com"
     target="_blank"
-    isUnderlined={false}
     isDisabled={false}
     UNSAFE_className="custom-class"
     UNSAFE_style="outline: 5px solid blue; outline-offset: -5px;"

--- a/packages/web/src/js/Toast.ts
+++ b/packages/web/src/js/Toast.ts
@@ -14,6 +14,7 @@ import {
   CLASS_NAME_TRANSITIONING,
   CLASS_NAME_VISIBLE,
   DEFAULT_TOAST_AUTO_CLOSE_INTERVAL,
+  CLASS_NAME_LINK_NOT_UNDERLINED,
 } from './constants';
 import { EventHandler, SelectorEngine } from './dom';
 import { enableDismissTrigger, enableToggleTrigger, executeAfterTransition, SpiritConfig } from './utils';
@@ -35,6 +36,12 @@ const COLOR_ICON_MAP = {
   warning: 'warning',
 };
 
+const UNDERLINE_MAP = {
+  hover: 'hover',
+  always: 'always',
+  never: 'never',
+};
+
 const SELECTOR_QUEUE_ELEMENT = `[${ATTRIBUTE_DATA_ELEMENT}="toast-queue"]`;
 const SELECTOR_TEMPLATE_ELEMENT = `[${ATTRIBUTE_DATA_SNIPPET}="item"]`;
 const SELECTOR_ITEM_ELEMENT = `[${ATTRIBUTE_DATA_POPULATE_FIELD}="item"]`;
@@ -52,6 +59,7 @@ export const PROPERTY_NAME_SLOWEST_TRANSITION = {
 const PROPERTY_NAME_FALLBACK_TRANSITION = 'opacity';
 
 type Color = keyof typeof COLOR_ICON_MAP;
+type Underlined = keyof typeof UNDERLINE_MAP;
 
 type Config = {
   autoCloseInterval: number;
@@ -66,7 +74,7 @@ type Config = {
     elementType: string;
     href: string;
     isDisabled: boolean;
-    isUnderlined: boolean;
+    underlined: Underlined;
     target: '_blank' | '_self' | '_parent' | '_top';
   };
   hasIcon: boolean;
@@ -195,11 +203,14 @@ class Toast extends BaseComponent {
     if (linkContent) {
       const linkElementWithType = document.createElement(linkProps.elementType || 'a');
       linkElement.replaceWith(linkElementWithType);
-      const isUnderlined = linkProps.isUnderlined != null ? linkProps.isUnderlined : true;
+      const { underlined = UNDERLINE_MAP.always } = linkProps;
 
       linkElementWithType.classList.add('ToastBar__link');
-      if (isUnderlined) {
+      if (underlined === UNDERLINE_MAP.always) {
         linkElementWithType.classList.add(CLASS_NAME_LINK_UNDERLINED);
+      }
+      if (underlined === UNDERLINE_MAP.never) {
+        linkElementWithType.classList.add(CLASS_NAME_LINK_NOT_UNDERLINED);
       }
       if (linkProps.isDisabled) {
         linkElementWithType.classList.add(CLASS_NAME_LINK_DISABLED);

--- a/packages/web/src/js/constants.ts
+++ b/packages/web/src/js/constants.ts
@@ -13,6 +13,7 @@ export const CLASS_NAME_OPEN = 'is-open';
 export const CLASS_NAME_TRANSITIONING = 'is-transitioning';
 export const CLASS_NAME_VISIBLE = 'is-visible';
 export const CLASS_NAME_LINK_UNDERLINED = 'link-underlined';
+export const CLASS_NAME_LINK_NOT_UNDERLINED = 'link-not-underlined';
 export const CLASS_NAME_LINK_DISABLED = 'link-disabled';
 
 export const DEFAULT_TOAST_AUTO_CLOSE_INTERVAL = 3000; // milliseconds

--- a/packages/web/src/scss/components/Toast/README.md
+++ b/packages/web/src/scss/components/Toast/README.md
@@ -418,7 +418,7 @@ const toast = new Toast(null, {
   linkProps: {
     href: 'https://example.com', // Link URL
     target: '_blank', // Optional link target attribute
-    isUnderlined: false, // Optional link underlining, default: true
+    underlined: false, // Optional link underlining, one of ['always' (default), 'hover', 'never']
     isDisabled: false, // Optional link disabling, default: false
     elementType: 'a', // Optional link element type, default: 'a'
   },


### PR DESCRIPTION
## Description

Update of `Toast` JS plugin where you can set **underline** of link inside of a `Toast` component
- default is `always`, as it was `isUnderlined={true}` before

### Additional context

Moved forgotten deprecations about underline to migration guide in twig

### Issue reference

[Remove `isUnderlined` prop from Link](https://jira.almacareer.tech/browse/DS-1509)