### PR TITLE
Docs(icons): Transpile icons #DS-987

### DIFF
--- a/examples/next-with-app-router/src/app/page.tsx
+++ b/examples/next-with-app-router/src/app/page.tsx
@@ -1,6 +1,10 @@
 import { Heading } from '@lmc-eu/spirit-web-react';
 import { NextPage } from 'next';
 
-const Home: NextPage = () => <Heading size="large">Spirit App Router</Heading>;
+const Home: NextPage = () => (
+  <Heading elementType="h2" size="large">
+    Spirit App Router
+  </Heading>
+);
 
 export default Home;

--- a/examples/next-with-pages-router/src/pages/index.tsx
+++ b/examples/next-with-pages-router/src/pages/index.tsx
@@ -1,6 +1,10 @@
 import { Heading } from '@lmc-eu/spirit-web-react';
 import { NextPage } from 'next';
 
-const Home: NextPage = () => <Heading size="large">Spirit Pages App</Heading>;
+const Home: NextPage = () => (
+  <Heading elementType="h2" size="large">
+    Spirit Pages App
+  </Heading>
+);
 
 export default Home;

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -83,4 +83,23 @@ export const Icon = ({ name, , size }) => {
 };
 ```
 
+### Next.js with Pages Router
+
+If you are using Next.js with the Pages Router, it is necessary to add the following configuration to your Next.js configuration file
+to transpile the `@lmc-eu/spirit-web-react` package, ensuring the correct functionality of the icons:
+
+```javascript
+const nextConfig = {
+  transpilePackages: ['@lmc-eu/spirit-web-react'],
+  // other configurations...
+};
+
+export default nextConfig;
+```
+
+This configuration is not required if you are using the Next.js App Router.
+
+For more information, please see the [Next.js documentation][nextjs-transpilePackages].
+
 [`spirit-web`]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web
+[nextjs-transpilePackages]: https://nextjs.org/docs/pages/api-reference/next-config-js/transpilePackages


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

I've tried both App Router and Pages Router. In the App router, transpilePackages does not need to be in the configuration, in the Pages Router it is necessary.

Additionaly I fixed missing mandatory elementType in Heading component for both next examples demo pages.


