### PR TITLE
Fix(web-react): Pass aria props rel and target based on element type to the dom element

### DIFF
--- a/packages/web-react/src/components/ButtonLink/ButtonLink.tsx
+++ b/packages/web-react/src/components/ButtonLink/ButtonLink.tsx
@@ -31,7 +31,7 @@ const _ButtonLink = <T extends ElementType = 'a', C = void, S = void>(
     ...restProps
   } = propsWithDefaults;
 
-  const { buttonLinkProps } = useButtonLinkAriaProps(restProps);
+  const { buttonLinkProps } = useButtonLinkAriaProps(propsWithDefaults);
   const { classProps, props: modifiedProps } = useButtonLinkStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
 

--- a/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
+++ b/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
@@ -71,4 +71,18 @@ describe('ButtonLink', () => {
     const element = container.querySelector('a') as HTMLElement;
     expect(element).not.toHaveAttribute('type');
   });
+
+  it('should pass rel attribute', () => {
+    const { container } = render(<ButtonLink rel="noopener" />);
+
+    const element = container.querySelector('a') as HTMLElement;
+    expect(element).toHaveAttribute('rel', 'noopener');
+  });
+
+  it('should pass target attribute', () => {
+    const { container } = render(<ButtonLink target="_blank" />);
+
+    const element = container.querySelector('a') as HTMLElement;
+    expect(element).toHaveAttribute('target', '_blank');
+  });
 });

--- a/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
+++ b/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import {
@@ -28,61 +28,61 @@ describe('ButtonLink', () => {
   restPropsTest(ButtonLink, 'a');
 
   it('should have default classname', () => {
-    const { container } = render(<ButtonLink />);
+    render(<ButtonLink />);
 
-    const element = container.querySelector('a') as HTMLElement;
+    const element = screen.getByRole('button');
     expect(element).toHaveClass('Button--primary');
   });
 
   it('should have disabled classname', () => {
-    const { container } = render(<ButtonLink isDisabled />);
+    render(<ButtonLink isDisabled />);
 
-    const element = container.querySelector('a') as HTMLElement;
+    const element = screen.getByRole('button');
     expect(element).toHaveClass('Button');
     expect(element).toHaveClass('Button--disabled');
   });
 
   it('should have block classname', () => {
-    const { container } = render(<ButtonLink isBlock />);
+    render(<ButtonLink isBlock />);
 
-    const element = container.querySelector('a') as HTMLElement;
+    const element = screen.getByRole('button');
     expect(element).toHaveClass('Button');
     expect(element).toHaveClass('Button--block');
   });
 
   it('should have size classname', () => {
-    const { container } = render(<ButtonLink size="medium" />);
+    render(<ButtonLink size="medium" />);
 
-    const element = container.querySelector('a') as HTMLElement;
+    const element = screen.getByRole('button');
     expect(element).toHaveClass('Button');
     expect(element).toHaveClass('Button--medium');
   });
 
   it('should render text children', () => {
-    const dom = render(<ButtonLink>Hello World</ButtonLink>);
+    render(<ButtonLink>Hello World</ButtonLink>);
 
-    const element = dom.container.querySelector('a') as HTMLElement;
+    const element = screen.getByRole('button');
     expect(element.textContent).toBe('Hello World');
   });
 
   it('should not have default type attribute', () => {
-    const { container } = render(<ButtonLink />);
+    render(<ButtonLink />);
 
-    const element = container.querySelector('a') as HTMLElement;
+    const element = screen.getByRole('button');
     expect(element).not.toHaveAttribute('type');
   });
 
   it('should pass rel attribute', () => {
-    const { container } = render(<ButtonLink rel="noopener" />);
+    render(<ButtonLink rel="noopener" />);
 
-    const element = container.querySelector('a') as HTMLElement;
+    const element = screen.getByRole('button');
     expect(element).toHaveAttribute('rel', 'noopener');
   });
 
   it('should pass target attribute', () => {
-    const { container } = render(<ButtonLink target="_blank" />);
+    render(<ButtonLink target="_blank" />);
 
-    const element = container.querySelector('a') as HTMLElement;
+    const element = screen.getByRole('button');
     expect(element).toHaveAttribute('target', '_blank');
   });
 });

--- a/packages/web-react/src/components/ButtonLink/__tests__/useButtonLinkAriaProps.test.ts
+++ b/packages/web-react/src/components/ButtonLink/__tests__/useButtonLinkAriaProps.test.ts
@@ -1,0 +1,80 @@
+import { renderHook } from '@testing-library/react';
+import { UseButtonLinkAriaProps, useButtonLinkAriaProps } from '../useButtonLinkAriaProps';
+
+describe('useButtonAriaProps', () => {
+  it('should return aria props for anchor tag', () => {
+    const props = {
+      elementType: 'a',
+      href: '/',
+      isDisabled: false,
+      target: '_blank',
+      rel: 'noopener',
+    } as UseButtonLinkAriaProps;
+    const { result } = renderHook(() => useButtonLinkAriaProps(props));
+
+    expect(result.current.buttonLinkProps).toEqual({
+      'aria-label': undefined,
+      disabled: undefined,
+      href: '/',
+      onClick: expect.any(Function),
+      rel: 'noopener',
+      role: 'button',
+      target: '_blank',
+    });
+  });
+
+  it('should return aria props for disabled anchor tag', () => {
+    const props = {
+      elementType: 'a',
+      href: '/',
+      isDisabled: true,
+      target: '_blank',
+      rel: 'noopener',
+    } as UseButtonLinkAriaProps;
+    const { result } = renderHook(() => useButtonLinkAriaProps(props));
+
+    expect(result.current.buttonLinkProps).toEqual({
+      'aria-label': undefined,
+      disabled: true,
+      href: undefined,
+      onClick: expect.any(Function),
+      rel: 'noopener',
+      role: 'button',
+      target: '_blank',
+    });
+  });
+
+  it('should return aria props for button tag', () => {
+    const props = {
+      elementType: 'button',
+      isDisabled: false,
+    } as unknown as UseButtonLinkAriaProps;
+    const { result } = renderHook(() => useButtonLinkAriaProps(props));
+
+    expect(result.current.buttonLinkProps).toEqual({
+      'aria-label': undefined,
+      disabled: undefined,
+      onClick: expect.any(Function),
+      rel: undefined,
+      role: 'button',
+      target: undefined,
+    });
+  });
+
+  it('should return aria props for disabled button tag', () => {
+    const props = {
+      elementType: 'button',
+      isDisabled: true,
+    } as unknown as UseButtonLinkAriaProps;
+    const { result } = renderHook(() => useButtonLinkAriaProps(props));
+
+    expect(result.current.buttonLinkProps).toEqual({
+      'aria-label': undefined,
+      disabled: true,
+      onClick: expect.any(Function),
+      rel: undefined,
+      role: 'button',
+      target: undefined,
+    });
+  });
+});


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The `elementType` prop was not passed to the `useButtonLinkAriaProps` hook and this attributes like `rel` and `target` were overridden by `undefined` value. So those could never reach the DOM element.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
