### PR TITLE
Chore(deps): Group dependency updates into smaller PRs

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -23,6 +23,66 @@
       "matchPackageNames": ["typescript"],
       "allowedVersions": "4.7.4",
       "matchPaths": ["+(package.json)"]
+    },
+    {
+      "groupName": "monorepo:supernovaio non-major",
+      "groupSlug": "monorepo-supernovaio-non-major",
+      "matchPackagePatterns": ["^@supernovaio"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "eslint plugins and configs non-major",
+      "groupSlug": "eslint-plugins-configs-non-major",
+      "matchPackagePatterns": ["^eslint"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "compile tools non-major",
+      "groupSlug": "compile-tools-non-major",
+      "matchPackagePatterns": ["^@babel", "^@swc"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "types non-major",
+      "groupSlug": "types-non-major",
+      "matchPackagePatterns": ["^@types"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "monorepo:react non-major",
+      "groupSlug": "monorepo-react-non-major",
+      "matchPackagePatterns": ["^react"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "lint tools non-major",
+      "groupSlug": "lint-tools-non-major",
+      "matchPackagePatterns": ["^prettier", "^lint-staged", "^husky"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "stylelint non-major",
+      "groupSlug": "stylelint-non-major",
+      "matchPackagePatterns": ["^stylelint"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "build tools non-major",
+      "groupSlug": "build-tools-non-major",
+      "matchPackagePatterns": ["^rollup", "^vite", "^webpack", "`^@rollup"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "monorepo tools non-major",
+      "groupSlug": "monorepo-tools-non-major",
+      "matchPackagePatterns": ["^lerna", "^nx"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "typescript non-major",
+      "groupSlug": "typescript-non-major",
+      "matchPackagePatterns": ["^typescript"],
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ]
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

  * current state of non-major dependency updates is not managgable
  * there is a lot of different package changes
  * in the case when CI fails it take a lot of time to resolve where is the root
    of the problem and which package update is responsible
  * thus groupping the dependency updates into some smaller contexts will help us
    with dependency management to be more faster and reliable
  * and if something fails we should be able to recover fast

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

- https://github.com/lmc-eu/spirit-design-system/issues/1769
- https://jira.almacareer.tech/browse/DS-1591

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
