### PR TITLE
 Test(web-react): Mock usage of the `useIcon` hook

### DIFF
--- a/packages/web-react/jest.config.ts
+++ b/packages/web-react/jest.config.ts
@@ -9,6 +9,10 @@ const config = {
   // A list of paths to modules that run some code to configure or set up the testing framework before each test file in the suite is executed.
   // https://jestjs.io/docs/configuration#setupfilesafterenv-array
   setupFilesAfterEnv: ['<rootDir>/config/jest/setupTestingLibrary.ts'],
+
+  // Automatically clear mock calls, instances, contexts and results before every test.
+  // https://jestjs.io/docs/configuration#clearmocks-boolean
+  clearMocks: true,
 };
 
 export default config;

--- a/packages/web-react/src/components/Accordion/__tests__/AccordionHeader.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/AccordionHeader.test.tsx
@@ -1,11 +1,14 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import AccordionHeader from '../AccordionHeader';
 import AccordionItem from '../AccordionItem';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('AccordionHeader', () => {
   classNamePrefixProviderTest(AccordionHeader, 'Accordion__itemHeader');

--- a/packages/web-react/src/components/Accordion/__tests__/AccordionItem.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/AccordionItem.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
@@ -8,6 +9,8 @@ import Accordion from '../Accordion';
 import AccordionContent from '../AccordionContent';
 import AccordionHeader from '../AccordionHeader';
 import AccordionItem from '../AccordionItem';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('AccordionItem', () => {
   classNamePrefixProviderTest(AccordionItem, 'Accordion__item');

--- a/packages/web-react/src/components/Accordion/__tests__/UncontrolledAccordion.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/UncontrolledAccordion.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
@@ -8,6 +9,8 @@ import AccordionContent from '../AccordionContent';
 import AccordionHeader from '../AccordionHeader';
 import AccordionItem from '../AccordionItem';
 import UncontrolledAccordion from '../UncontrolledAccordion';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('UncontrolledAccordion', () => {
   classNamePrefixProviderTest(UncontrolledAccordion, 'Accordion');

--- a/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
+++ b/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
@@ -1,11 +1,14 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { emotionColorPropsTest } from '../../../../tests/providerTests/dictionaryPropsTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import Alert from '../Alert';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('Alert', () => {
   classNamePrefixProviderTest(Alert, 'Alert');

--- a/packages/web-react/src/components/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
@@ -1,10 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import Breadcrumbs from '../Breadcrumbs';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('Breadcrumbs', () => {
   classNamePrefixProviderTest(Breadcrumbs, 'Breadcrumbs');

--- a/packages/web-react/src/components/Breadcrumbs/__tests__/BreadcrumbsItem.test.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/__tests__/BreadcrumbsItem.test.tsx
@@ -1,10 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import BreadcrumbsItem from '../BreadcrumbsItem';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('BreadcrumbsItem', () => {
   classNamePrefixProviderTest(BreadcrumbsItem, 'd-none');

--- a/packages/web-react/src/components/Button/__tests__/Button.test.tsx
+++ b/packages/web-react/src/components/Button/__tests__/Button.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import {
   actionButtonColorPropsTest,
@@ -11,6 +12,8 @@ import { loadingPropsTest } from '../../../../tests/providerTests/loadingPropsTe
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import Button from '../Button';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('Button', () => {
   classNamePrefixProviderTest(Button, 'Button');

--- a/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
+++ b/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import {
   actionButtonColorPropsTest,
@@ -11,6 +12,8 @@ import { loadingPropsTest } from '../../../../tests/providerTests/loadingPropsTe
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import ButtonLink from '../ButtonLink';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('ButtonLink', () => {
   classNamePrefixProviderTest(ButtonLink, 'Button');

--- a/packages/web-react/src/components/Collapse/__tests__/Collapse.test.tsx
+++ b/packages/web-react/src/components/Collapse/__tests__/Collapse.test.tsx
@@ -18,7 +18,7 @@ describe('Collapse', () => {
 
   it('should render text children', () => {
     render(
-      <Collapse id="collapse" isOpen data-testId="test">
+      <Collapse id="collapse" isOpen data-testid="test">
         Hello World
       </Collapse>,
     );
@@ -34,10 +34,10 @@ describe('Collapse', () => {
 
       return (
         <>
-          <Button type="button" data-testId="test-button" onClick={() => setIsOpen(!isOpen)}>
+          <Button type="button" data-testid="test-button" onClick={() => setIsOpen(!isOpen)}>
             Toggle Collapse
           </Button>
-          <Collapse id="collapse" isOpen={isOpen} data-testId="test">
+          <Collapse id="collapse" isOpen={isOpen} data-testid="test">
             Hello World
           </Collapse>
         </>
@@ -58,7 +58,7 @@ describe('Collapse', () => {
 
   it('should have correct html element', () => {
     render(
-      <Collapse id="collapse" elementType="section" isOpen data-testId="test">
+      <Collapse id="collapse" elementType="section" isOpen data-testid="test">
         Hello World
       </Collapse>,
     );
@@ -76,10 +76,10 @@ describe('Collapse', () => {
 
       return (
         <>
-          <Button type="button" data-testId="test-button" onClick={() => setIsOpen(!isOpen)}>
+          <Button type="button" data-testid="test-button" onClick={() => setIsOpen(!isOpen)}>
             Toggle Collapse
           </Button>
-          <Collapse id="collapse" isOpen={isOpen} transitionDuration={duration} data-testId="test">
+          <Collapse id="collapse" isOpen={isOpen} transitionDuration={duration} data-testid="test">
             Hello World
           </Collapse>
         </>

--- a/packages/web-react/src/components/Dropdown/__tests__/DropdownTrigger.test.tsx
+++ b/packages/web-react/src/components/Dropdown/__tests__/DropdownTrigger.test.tsx
@@ -1,10 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import { Button } from '../../Button';
 import DropdownTrigger from '../DropdownTrigger';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('DropdownTrigger', () => {
   stylePropsTest((props) => <DropdownTrigger elementType={Button} {...props} />);

--- a/packages/web-react/src/components/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/web-react/src/components/FileUploader/__tests__/FileUploader.test.tsx
@@ -1,9 +1,12 @@
 import '@testing-library/jest-dom';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import FileUploader from '../FileUploader';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('FileUploader', () => {
   classNamePrefixProviderTest(FileUploader, 'FileUploader');

--- a/packages/web-react/src/components/FileUploader/__tests__/FileUploaderInput.test.tsx
+++ b/packages/web-react/src/components/FileUploader/__tests__/FileUploaderInput.test.tsx
@@ -1,11 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { validationTextPropsTest } from '../../../../tests/providerTests/validationTextPropsTest';
 import FileUploaderInput from '../FileUploaderInput';
 import '@testing-library/jest-dom';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('FileUploaderInput', () => {
   classNamePrefixProviderTest(FileUploaderInput, 'FileUploaderInput');

--- a/packages/web-react/src/components/FileUploader/__tests__/FileUploaderList.test.tsx
+++ b/packages/web-react/src/components/FileUploader/__tests__/FileUploaderList.test.tsx
@@ -1,8 +1,11 @@
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { SpiritFileUploaderAttachmentProps } from '../../../types';
 import FileUploader from '../FileUploader';
 import FileUploaderList from '../FileUploaderList';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('FileUploaderList', () => {
   const props = {

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogCloseButton.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogCloseButton.test.tsx
@@ -1,10 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import HeaderDialogCloseButton from '../HeaderDialogCloseButton';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('HeaderDialogCloseButton', () => {
   classNamePrefixProviderTest(HeaderDialogCloseButton, 'HeaderDialogCloseButton');

--- a/packages/web-react/src/components/Header/__tests__/HeaderMobileActions.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderMobileActions.test.tsx
@@ -1,11 +1,14 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import { HEADER_MENU_TOGGLE_LABEL_DEFAULT } from '../constants';
 import HeaderMobileActions from '../HeaderMobileActions';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('HeaderMobileActions', () => {
   classNamePrefixProviderTest(HeaderMobileActions, 'HeaderMobileActions');

--- a/packages/web-react/src/components/Icon/__tests__/Icon.test.tsx
+++ b/packages/web-react/src/components/Icon/__tests__/Icon.test.tsx
@@ -1,9 +1,12 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import Icon from '../Icon';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('Icon', () => {
   const AddIcon = (props: Record<string, unknown>) => <Icon {...props} name="add" data-testid="test-icon" />;

--- a/packages/web-react/src/components/Item/__tests__/Item.test.tsx
+++ b/packages/web-react/src/components/Item/__tests__/Item.test.tsx
@@ -1,10 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import { SpiritItemProps } from '../../../types';
 import Item from '../Item';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('Item', () => {
   stylePropsTest(Item);

--- a/packages/web-react/src/components/Modal/__tests__/ModalCloseButton.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/ModalCloseButton.test.tsx
@@ -1,10 +1,13 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import ModalCloseButton from '../ModalCloseButton';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('ModalCloseButton', () => {
   classNamePrefixProviderTest(ModalCloseButton, 'Button');

--- a/packages/web-react/src/components/Modal/__tests__/ModalHeader.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/ModalHeader.test.tsx
@@ -1,10 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import ModalHeader from '../ModalHeader';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('ModalHeader', () => {
   classNamePrefixProviderTest(ModalHeader, 'ModalHeader');

--- a/packages/web-react/src/components/Pagination/__tests__/PaginationButtonLink.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/PaginationButtonLink.test.tsx
@@ -1,8 +1,11 @@
 import '@testing-library/jest-dom';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import PaginationButtonLink from '../PaginationButtonLink';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('PaginationButtonLink', () => {
   classNamePrefixProviderTest(PaginationButtonLink, 'Button');

--- a/packages/web-react/src/components/Pagination/__tests__/PaginationLinkNext.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/PaginationLinkNext.test.tsx
@@ -1,8 +1,11 @@
 import '@testing-library/jest-dom';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import PaginationLinkNext from '../PaginationLinkNext';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('PaginationLinkNext', () => {
   classNamePrefixProviderTest(PaginationLinkNext, 'Button');

--- a/packages/web-react/src/components/Pagination/__tests__/PaginationLinkPrevious.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/PaginationLinkPrevious.test.tsx
@@ -1,8 +1,11 @@
 import '@testing-library/jest-dom';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import PaginationLinkPrevious from '../PaginationLinkPrevious';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('PaginationLinkPrevious', () => {
   classNamePrefixProviderTest(PaginationLinkPrevious, 'Button');

--- a/packages/web-react/src/components/Pagination/__tests__/UncontrolledPagination.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/UncontrolledPagination.test.tsx
@@ -1,6 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import UncontrolledPagination from '../UncontrolledPagination';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('UncontrolledPagination', () => {
   const onPageChange = jest.fn();

--- a/packages/web-react/src/components/Select/__tests__/Select.test.tsx
+++ b/packages/web-react/src/components/Select/__tests__/Select.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { validationStatePropsTest } from '../../../../tests/providerTests/dictionaryPropsTest';
 import { requiredPropsTest } from '../../../../tests/providerTests/requiredPropsTest';
@@ -8,6 +9,8 @@ import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import { validationTextPropsTest } from '../../../../tests/providerTests/validationTextPropsTest';
 import Select from '../Select';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('Select', () => {
   classNamePrefixProviderTest(Select, 'Select');

--- a/packages/web-react/src/components/Spinner/__tests__/Spinner.test.tsx
+++ b/packages/web-react/src/components/Spinner/__tests__/Spinner.test.tsx
@@ -1,11 +1,14 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { textColorPropsTest } from '../../../../tests/providerTests/dictionaryPropsTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import Spinner from '../Spinner';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('Spinner', () => {
   classNamePrefixProviderTest(Spinner, 'animation-spin-clockwise');

--- a/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
+++ b/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { validationStatePropsTest } from '../../../../tests/providerTests/dictionaryPropsTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
@@ -8,6 +9,8 @@ import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import { validationTextPropsTest } from '../../../../tests/providerTests/validationTextPropsTest';
 import { TextFieldType } from '../../../types';
 import TextField from '../TextField';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('TextField', () => {
   describe.each(['text', 'password', 'email'])('input type %s', (type) => {

--- a/packages/web-react/src/components/Toast/__tests__/ToastBar.test.tsx
+++ b/packages/web-react/src/components/Toast/__tests__/ToastBar.test.tsx
@@ -1,10 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import ToastBar from '../ToastBar';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('ToastBar', () => {
   classNamePrefixProviderTest((props) => <ToastBar {...props} id="test" />, 'ToastBar');

--- a/packages/web-react/src/components/Toast/__tests__/UncontrolledToast.test.tsx
+++ b/packages/web-react/src/components/Toast/__tests__/UncontrolledToast.test.tsx
@@ -1,9 +1,12 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { ToastLinkProps } from '../../../types';
 import { ToastContext } from '../ToastContext';
 import UncontrolledToast from '../UncontrolledToast';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 const defaultToast = {
   id: 'test-id',

--- a/packages/web-react/src/components/UNSTABLE_Avatar/__tests__/UNSTABLE_Avatar.test.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Avatar/__tests__/UNSTABLE_Avatar.test.tsx
@@ -1,12 +1,15 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { useIconMock } from '../../../../tests/mocks/hooksMock';
 import { classNamePrefixProviderTest } from '../../../../tests/providerTests/classNamePrefixProviderTest';
 import { sizeExtendedPropsTest } from '../../../../tests/providerTests/dictionaryPropsTest';
 import { restPropsTest } from '../../../../tests/providerTests/restPropsTest';
 import { stylePropsTest } from '../../../../tests/providerTests/stylePropsTest';
 import { Icon } from '../../Icon';
 import UNSTABLE_Avatar from '../UNSTABLE_Avatar';
+
+jest.mock('../../../hooks', () => useIconMock);
 
 describe('UNSTABLE_Avatar', () => {
   classNamePrefixProviderTest(UNSTABLE_Avatar, 'UNSTABLE_Avatar');

--- a/packages/web-react/tests/mocks/hooksMock.ts
+++ b/packages/web-react/tests/mocks/hooksMock.ts
@@ -1,0 +1,4 @@
+export const useIconMock = {
+  ...jest.requireActual('../../src/hooks'),
+  useIcon: () => '',
+};


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

 * so we get rid of the `console.warn` messages in our tests
 * when testing our components without using the `IconsProvider`

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
