### PR TITLE
Chore(ci): Check for the clean working directory after the build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,3 +45,11 @@ jobs:
 
       - name: Build packages
         run: yarn build
+
+      - name: Check for clean working directory
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "Error: Git working directory is not clean"
+            git status
+            exit 1
+          fi


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

* we sometimes forget to built and commit an exporter build
* this stops the publishing of the packages because of a dirty working directory

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
