### PR TITLE
Fix(web-react): `ActionGroup` and `Box` exports

### DIFF
--- a/packages/web-react/src/components/index.ts
+++ b/packages/web-react/src/components/index.ts
@@ -1,7 +1,9 @@
 'use client';
 
 export * from './Accordion';
+export * from './ActionGroup';
 export * from './Alert';
+export * from './Box';
 export * from './Breadcrumbs';
 export * from './Button';
 export * from './Card';


### PR DESCRIPTION
## Description

There were missing exports for `ActionGroup` and `Box` in the components index file.

### Additional context

### Issue reference

