### PR TITLE
Fix(web-react): Remove duplicated `id` on the `DropdownTrigger` component

### DIFF
--- a/packages/web-react/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/web-react/src/components/Dropdown/DropdownTrigger.tsx
@@ -26,7 +26,6 @@ const DropdownTrigger = <T extends ElementType = 'button'>(props: DropdownTrigge
       {...rest} // ⚠️ This is maybe a bug, when component is pass via `elementType` prop, the rest props are passed to the component
       {...otherProps}
       {...triggerProps}
-      id={id}
       ref={triggerRef}
       className={classNames(classProps.trigger, styleProps.className)}
       style={styleProps.style}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Removing `id` attribute from DropdownTrigger

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

https://github.com/lmc-eu/spirit-design-system/issues/1892

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
