### PR TITLE
Fix(web-react): Remove `validationState` from passed props of the TextFieldBase style hook

### DIFF
--- a/packages/web-react/src/components/TextFieldBase/__tests__/useTextFieldBaseStyleProps.test.ts
+++ b/packages/web-react/src/components/TextFieldBase/__tests__/useTextFieldBaseStyleProps.test.ts
@@ -1,0 +1,63 @@
+import { renderHook } from '@testing-library/react';
+import { SpiritTextFieldBaseProps } from '../../../types';
+import { useTextFieldBaseStyleProps } from '../useTextFieldBaseStyleProps';
+
+describe('useTagStyleProps', () => {
+  it('should return defaults', () => {
+    const props = {} as SpiritTextFieldBaseProps;
+    const { result } = renderHook(() => useTextFieldBaseStyleProps(props));
+
+    expect(result.current.classProps).toStrictEqual({
+      helperText: 'TextField__helperText',
+      input: 'TextField__input',
+      label: 'TextField__label',
+      passwordToggle: 'TextField__passwordToggle',
+      passwordToggleButton: 'TextField__passwordToggle__button',
+      passwordToggleIcon: 'TextField__passwordToggle__icon',
+      root: 'TextField',
+      validationText: 'TextField__validationText',
+    });
+  });
+
+  it('should return TextField root class', () => {
+    const props = {
+      isMultiline: false,
+    } as SpiritTextFieldBaseProps;
+    const { result } = renderHook(() => useTextFieldBaseStyleProps(props));
+
+    expect(result.current.classProps.root).toBe('TextField');
+  });
+
+  it('should return TextArea root class', () => {
+    const props = {
+      isMultiline: true,
+    } as SpiritTextFieldBaseProps;
+    const { result } = renderHook(() => useTextFieldBaseStyleProps(props));
+
+    expect(result.current.classProps.root).toBe('TextArea');
+  });
+
+  it('should return required disabled warning TextField class', () => {
+    const props = {
+      isMultiline: false,
+      isRequired: true,
+      isDisabled: true,
+      validationState: 'warning',
+    } as SpiritTextFieldBaseProps;
+    const { result } = renderHook(() => useTextFieldBaseStyleProps(props));
+
+    expect(result.current.classProps.root).toBe('TextField TextField--disabled TextField--warning');
+  });
+
+  it('should return required hidden TextField label', () => {
+    const props = {
+      isRequired: true,
+      isLabelHidden: true,
+    } as SpiritTextFieldBaseProps;
+    const { result } = renderHook(() => useTextFieldBaseStyleProps(props));
+
+    expect(result.current.classProps.label).toBe(
+      'TextField__label TextField__label--required TextField__label--hidden',
+    );
+  });
+});

--- a/packages/web-react/src/components/TextFieldBase/useTextFieldBaseStyleProps.ts
+++ b/packages/web-react/src/components/TextFieldBase/useTextFieldBaseStyleProps.ts
@@ -60,7 +60,6 @@ export function useTextFieldBaseStyleProps(props: SpiritTextFieldBaseProps): Tex
     props: {
       ...restProps,
       isMultiline,
-      validationState,
     },
   };
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

  * Warning: React does not recognize the `validationState` prop on a DOM element.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
