### PR TITLE
Fix(exporter-tokens): Camel case invariant Xlarge and Xsmall strings

### DIFF
--- a/exporters/tokens/src/generators/__tests__/stylesObjectGenerator.test.ts
+++ b/exporters/tokens/src/generators/__tests__/stylesObjectGenerator.test.ts
@@ -89,15 +89,15 @@ describe('stylesObjectGenerator', () => {
         tokens: exampleTypographyTokens,
         expectedStyles: {
           styles: {
-            headingXlargeBold: 'headingXlargeBold',
-            headingXlargeBoldUnderline: 'headingXlargeBoldUnderline',
+            headingXLargeBold: 'headingXLargeBold',
+            headingXLargeBoldUnderline: 'headingXLargeBoldUnderline',
             moveToTheEnd: 'true',
           },
-          headingXlargeBold: {
+          headingXLargeBold: {
             desktop:
               "{\nfontFamily: \"'Inter', sans-serif\",\nfontSize: '64px',\nfontStyle: 'normal',\nfontWeight: 700,\nlineHeight: 1.2,\n}",
           },
-          headingXlargeBoldUnderline: {
+          headingXLargeBoldUnderline: {
             desktop:
               "{\nfontFamily: \"'Inter', sans-serif\",\nfontSize: '64px',\nfontStyle: 'normal',\nfontWeight: 700,\nlineHeight: 1.2,\n}",
           },
@@ -169,7 +169,7 @@ describe('stylesObjectGenerator', () => {
       {
         token: exampleTypographyTokens.get('typographyRef1') as Token,
         expectedObject: {
-          headingXlargeBold: {
+          headingXLargeBold: {
             desktop:
               "{\nfontFamily: \"'Inter', sans-serif\",\nfontSize: '64px',\nfontStyle: 'normal',\nfontWeight: 700,\nlineHeight: 1.2,\n}",
             tablet:
@@ -178,7 +178,7 @@ describe('stylesObjectGenerator', () => {
         },
         description: 'should create object structure from typography token with js output',
         stylesObjectRef: {
-          headingXlargeBold: {
+          headingXLargeBold: {
             tablet:
               "{\nfontFamily: \"'Inter', sans-serif\",\nfontSize: '32px',\nfontStyle: 'normal',\nfontWeight: 500,\nlineHeight: 1,\n}",
           },
@@ -221,7 +221,7 @@ describe('stylesObjectGenerator', () => {
         tokenNameParts: ['heading', 'desktop', 'xLarge', 'bold'],
         expectedStyles: {
           exampleRef: 'exampleRef',
-          headingXlargeBold: {
+          headingXLargeBold: {
             desktop:
               "{\nfontFamily: \"'Inter', sans-serif\",\nfontSize: '64px',\nfontStyle: 'normal',\nfontWeight: 700,\nlineHeight: 1.2,\n}",
           },

--- a/exporters/tokens/src/helpers/__tests__/stringHelper.test.ts
+++ b/exporters/tokens/src/helpers/__tests__/stringHelper.test.ts
@@ -1,21 +1,41 @@
-import { toPlural } from '../stringHelper';
-
-const dataProviderItems = [
-  ['radius', 'radii'],
-  ['spacing', 'spaces'],
-  ['breakpoint', 'breakpoints'],
-  ['grid-spacing', 'grid-spacings'],
-  ['shadow', 'shadows'],
-  ['gradient', 'gradients'],
-  ['size', 'sizes'],
-  ['space', 'spaces'],
-  ['spaces', 'spaces'],
-];
+import { toPlural, toCamelCase } from '../stringHelper';
 
 describe('stringHelper', () => {
-  describe.each(dataProviderItems)('toPlural', (name, expected) => {
+  const dataProviderToPlural = [
+    ['radius', 'radii'],
+    ['spacing', 'spaces'],
+    ['breakpoint', 'breakpoints'],
+    ['grid-spacing', 'grid-spacings'],
+    ['shadow', 'shadows'],
+    ['gradient', 'gradients'],
+    ['size', 'sizes'],
+    ['space', 'spaces'],
+    ['spaces', 'spaces'],
+  ];
+
+  describe.each(dataProviderToPlural)('toPlural', (name, expected) => {
     it(`should return the expected plural form for ${name}`, () => {
       const result = toPlural(name);
+
+      expect(result).toBe(expected);
+    });
+  });
+
+  const dataProviderToCamelCase = [
+    ['test value', 'testValue'],
+    ['another TEST val', 'anotherTestVal'],
+    ['test xsmall', 'testXSmall'],
+    ['xsmall', 'xsmall'],
+    ['xlarge', 'xlarge'],
+    ['size-xsmall', 'sizeXSmall'],
+    ['size-xlarge', 'sizeXLarge'],
+    // This will not work in this implementation: `size-xxlarge`-> `sizeXXlarge`
+    // ['size-xxlarge', 'sizeXXLarge'],
+  ];
+
+  describe.each(dataProviderToCamelCase)('toCamelCase', (name, expected) => {
+    it(`should return the expected camel cased form for ${name}`, () => {
+      const result = toCamelCase(name);
 
       expect(result).toBe(expected);
     });

--- a/exporters/tokens/src/helpers/stringHelper.ts
+++ b/exporters/tokens/src/helpers/stringHelper.ts
@@ -9,4 +9,18 @@ export const toPlural = (name: string): string => {
   return specialCases[name] || (name.endsWith('s') ? name : `${name}s`);
 };
 
-export const toCamelCase = (name: string): string => NamingHelper.codeSafeVariableName(name, StringCase.camelCase);
+export const toCamelCase = (name: string): string => {
+  const safeName = NamingHelper.codeSafeVariableName(name, StringCase.camelCase);
+
+  /**
+   * Transform the next character after `X` to uppercase.
+   *
+   * Example:
+   * - `heading-xsmall` -> `headingXSmall`
+   * - `heading-xlarge` -> `headingXLarge`
+   */
+  return safeName.replace(
+    /(X+)([a-z])/g,
+    (_match, xs: string, next: string) => `${xs.toUpperCase()}${next.toUpperCase()}`,
+  );
+};


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Converts strings like `heading-xsmall` to `headingXSmall` camel case. This is applied only for characters going after the `X` so it can have some drawbacks.

For instance `xxlarge` will be transformed to the `XXlarge`. We can also address this problem. But this should be only applied to the T-shirt sizes.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
