### PR TITLE
Fix(web-react): Remove duplicated id on the DropdownTrigger component

### DIFF
--- a/packages/web-react/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/web-react/src/components/Dropdown/DropdownTrigger.tsx
@@ -24,7 +24,7 @@ const DropdownTrigger = <T extends ElementType = 'button'>(props: DropdownTrigge
   const { triggerProps } = useDropdownAriaProps({ id, isOpen, toggleHandler: onToggle, fullWidthMode });
 
   return (
-    <ElementTag {...transferProps} {...triggerProps} {...triggerStyleProps} id={id} ref={triggerRef}>
+    <ElementTag {...transferProps} {...triggerProps} {...triggerStyleProps} ref={triggerRef}>
       {typeof children === 'function' ? children({ isOpen }) : children}
     </ElementTag>
   );

--- a/packages/web-react/src/components/Dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/web-react/src/components/Dropdown/__tests__/Dropdown.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
 import Dropdown from '../Dropdown';
@@ -19,48 +19,57 @@ describe('Dropdown', () => {
   restPropsTest(Dropdown, '.Dropdown');
 
   it('should render text children', () => {
-    const dom = render(
+    render(
       <Dropdown id="dropdown" isOpen={false} onToggle={() => {}}>
         <DropdownTrigger>Trigger</DropdownTrigger>
-        <DropdownPopover>Hello World</DropdownPopover>
+        <DropdownPopover data-testid="test-popover">Hello World</DropdownPopover>
       </Dropdown>,
     );
-    const trigger = screen.getByRole('button');
-    const element = dom.container.querySelector('.DropdownPopover') as HTMLElement;
 
-    expect(trigger).toHaveTextContent('Trigger');
-    expect(element).toHaveTextContent('Hello World');
+    expect(screen.getByRole('button')).toHaveTextContent('Trigger');
+    expect(screen.getByTestId('test-popover')).toHaveTextContent('Hello World');
   });
 
   it('should be opened', () => {
     const onToggle = jest.fn();
 
-    const dom = render(
+    render(
       <Dropdown id="dropdown" isOpen onToggle={onToggle}>
         <DropdownTrigger>trigger</DropdownTrigger>
-        <DropdownPopover>Hello World</DropdownPopover>
+        <DropdownPopover data-testid="test-popover">Hello World</DropdownPopover>
       </Dropdown>,
     );
-    const element = dom.container.querySelector('.DropdownPopover') as HTMLElement;
-    const trigger = screen.getByRole('button');
 
-    expect(element).toHaveClass('is-open');
-    expect(trigger).toHaveClass('is-expanded');
+    expect(screen.getByRole('button')).toHaveClass('is-expanded');
+    expect(screen.getByTestId('test-popover')).toHaveClass('is-open');
   });
 
   it('should call toggle function', () => {
     const onToggle = jest.fn();
 
-    const dom = render(
+    render(
       <Dropdown id="dropdown" isOpen={false} onToggle={onToggle}>
         <DropdownTrigger>trigger</DropdownTrigger>
         <DropdownPopover>Hello World</DropdownPopover>
       </Dropdown>,
     );
-    const trigger = dom.container.querySelector('button') as HTMLElement;
+
+    const trigger = screen.getByRole('button');
 
     fireEvent.click(trigger);
 
     expect(onToggle).toHaveBeenCalled();
+  });
+
+  it('should not have same id on trigger and popover', () => {
+    render(
+      <Dropdown id="dropdown" isOpen={false} onToggle={() => {}}>
+        <DropdownTrigger>trigger</DropdownTrigger>
+        <DropdownPopover data-testid="test-popover">Hello World</DropdownPopover>
+      </Dropdown>,
+    );
+
+    expect(screen.getByRole('button')).not.toHaveAttribute('id', 'dropdown');
+    expect(screen.getByTestId('test-popover')).toHaveAttribute('id', 'dropdown');
   });
 });

--- a/packages/web-react/src/components/Dropdown/__tests__/useDropdownAriaProps.test.ts
+++ b/packages/web-react/src/components/Dropdown/__tests__/useDropdownAriaProps.test.ts
@@ -1,24 +1,64 @@
 import { renderHook } from '@testing-library/react';
 import { PlacementDictionaryType } from '../../../types';
-import { useDropdownAriaProps } from '../useDropdownAriaProps';
+import { fullWidthModeKeys, useDropdownAriaProps } from '../useDropdownAriaProps';
+
+const defaultProps = {
+  fullWidthMode: undefined,
+  id: 'test-dropdown-id',
+  isOpen: true,
+  placement: 'bottom-start' as PlacementDictionaryType,
+  toggleHandler: () => null,
+};
+
+const defaultTriggerPropsResult = {
+  'aria-expanded': true,
+  'aria-controls': 'test-dropdown-id',
+  onClick: expect.any(Function),
+};
+
+const defaultContentPropsResult = {
+  id: 'test-dropdown-id',
+  'data-spirit-placement': 'bottom-start',
+};
 
 describe('useDropdownAriaProps', () => {
   it('should return defaults', () => {
+    const { result } = renderHook(() => useDropdownAriaProps(defaultProps));
+
+    expect(result.current.triggerProps).toEqual(defaultTriggerPropsResult);
+    expect(result.current.contentProps).toEqual(defaultContentPropsResult);
+  });
+
+  it('should return with full width mode prop', () => {
     const props = {
-      fullWidthMode: undefined,
-      id: 'test-dropdown-id',
-      isOpen: true,
-      placement: 'bottom-start' as PlacementDictionaryType,
-      toggleHandler: () => null,
+      ...defaultProps,
+      fullWidthMode: 'all' as fullWidthModeKeys,
     };
     const { result } = renderHook(() => useDropdownAriaProps(props));
 
-    expect(result.current.triggerProps).toBeDefined();
-    expect(result.current.triggerProps['aria-expanded']).toBeDefined();
-    expect(result.current.triggerProps['aria-controls']).toBeDefined();
-    expect(result.current.triggerProps.onClick).toBeDefined();
-    expect(result.current.contentProps).toBeDefined();
-    expect(result.current.contentProps['data-spirit-placement']).toBeDefined();
-    expect(result.current.contentProps['data-spirit-placement']).toBe('bottom-start');
+    expect(result.current.triggerProps).toEqual(defaultTriggerPropsResult);
+    expect(result.current.contentProps).toEqual({ ...defaultContentPropsResult, 'data-spirit-fullwidthmode': 'all' });
+  });
+
+  it('should return correct props when isOpen is false', () => {
+    const props = {
+      ...defaultProps,
+      isOpen: false,
+    };
+    const { result } = renderHook(() => useDropdownAriaProps(props));
+
+    expect(result.current.triggerProps).toEqual({ ...defaultTriggerPropsResult, 'aria-expanded': false });
+    expect(result.current.contentProps).toEqual(defaultContentPropsResult);
+  });
+
+  it('should return correct props when placement is top', () => {
+    const props = {
+      ...defaultProps,
+      placement: 'top' as PlacementDictionaryType,
+    };
+    const { result } = renderHook(() => useDropdownAriaProps(props));
+
+    expect(result.current.triggerProps).toEqual(defaultTriggerPropsResult);
+    expect(result.current.contentProps).toEqual({ ...defaultContentPropsResult, 'data-spirit-placement': 'top' });
   });
 });

--- a/packages/web-react/src/components/Dropdown/useDropdownAriaProps.ts
+++ b/packages/web-react/src/components/Dropdown/useDropdownAriaProps.ts
@@ -43,7 +43,6 @@ export const useDropdownAriaProps = (props: UseDropdownAriaPropsProps): UseDropd
   const { fullWidthMode, id, isOpen, placement = Placements.BOTTOM_START, toggleHandler } = props;
 
   const triggerProps = {
-    id,
     [NAME_ARIA_EXPANDED]: isOpen,
     [NAME_ARIA_CONTROLS]: String(id),
     onClick: toggleHandler,


### PR DESCRIPTION
## Description

**Fixed duplicate `Dropdown` `id` on both `DropdownTrigger` and `DropdownPopover`**  

1. Removed `id` from `DropdownTrigger` props.  
2. Removed `id` from the `useDropdownAriaProps` hook, which was sending it again via `triggerProps`.  
3. Updated tests accordingly.  

### Additional context

Slack support ticket
https://almamedia.slack.com/archives/C068XPSDWQN/p1739283201863299?thread_ts=1738072882.361189&cid=C068XPSDWQN

### Github links
- https://github.com/lmc-eu/spirit-design-system/issues/1892
- https://github.com/lmc-eu/spirit-design-system/commit/f418ef66f709376bfd7adfb099edbb1917a8ac48
