### PR TITLE
Test: Make Playwright UI mode work with Docker environment

### DIFF
--- a/bin/make/e2e.sh
+++ b/bin/make/e2e.sh
@@ -6,12 +6,13 @@ if ! command -v jq &> /dev/null; then
   echo "jq could not be found, please install it."
   exit 1
 else
-  PLAYWRIGHT_VERSION=$(jq -r '.devDependencies["@playwright/test"]' $(dirname "$0")/../../package.json)
+  PLAYWRIGHT_VERSION=$(jq -r '.devDependencies["@playwright/test"]' "$(dirname "$0")/../../package.json")
 fi
 UBUNTU_VERSION=jammy
 
 E2E_FLAG=""
-XVFB=""
+DOCKER_ARGS="--network=host"
+PORT_ARGS=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -20,14 +21,15 @@ while [[ $# -gt 0 ]]; do
             ;;
         --ui)
             E2E_FLAG=":ui"
-            # https://playwright.dev/docs/next/ci#running-headed
-            XVFB="xvfb-run"
+            # For UI mode on Docker for Mac, we cannot use host networking.
+            DOCKER_ARGS=""
+            # Map the UI port (9323) from container to host.
+            PORT_ARGS="-p 9323:9323"
             ;;
         --report)
             E2E_FLAG=":report"
             ;;
         *)
-            # Unknown option
             echo "Unknown option: $1"
             exit 1
             ;;
@@ -35,4 +37,12 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-docker run --rm --network=host --ipc=host  -v $(pwd):/work/ -w /work/ -it mcr.microsoft.com/playwright:v$PLAYWRIGHT_VERSION-$UBUNTU_VERSION $XVFB sh -c "corepack install && corepack enable && yarn test:e2e$E2E_FLAG"
+# If running in UI mode, print the URL users should visit.
+if [ "$E2E_FLAG" = ":ui" ]; then
+  echo "Open http://localhost:9323 in your browser."
+fi
+
+docker run --rm $DOCKER_ARGS --ipc=host $PORT_ARGS \
+  -v "$(pwd)":/work/ -w /work/ -it \
+  mcr.microsoft.com/playwright:v$PLAYWRIGHT_VERSION-$UBUNTU_VERSION \
+  sh -c "corepack install && corepack enable && yarn test:e2e$E2E_FLAG"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:e2e": "yarn playwright test",
     "test:e2e:update": "yarn playwright test --update-snapshots",
     "test:e2e:report": "yarn playwright show-report",
-    "test:e2e:ui": "yarn playwright test --ui",
+    "test:e2e:ui": "yarn playwright test --ui-port=9323 --ui-host=0.0.0.0",
     "types": "yarn packages:types",
     "lint": "npm-run-all --parallel es:lint lint:markdown packages:lint",
     "lint:fix": "npm-run-all --parallel es:lint:fix packages:lint:fix",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

So. We had these problems:

1. We need to run UI mode in docker as in non UI mode because otherwise the outputs differ.
2. The `make test-e2e-ui` command with XVFB just hangs and never does anything. 
3. When run without XVFB, Playwright complains that it needs an Xserver or to be run in headless mode. 

I didn't want to install XQuartz or anything (because I don't really understand it :D). So I tried to make it work so that the npm command is pointed into the Docker, and Docker expects it on some port. 

Now it works, except:
1. Maybe only MacOS solution (but as discovered earlier, we are not cross-platform compatible in e2e anyway).
2. It does not work for Twig tests. It will need another networking magic because the Twig runs in another Docker.

I didn't need to modify any tests, and I didn't need to install any other packages. 🪄 

It would be great if anyone else could test this on their machine :) 
1. Pull this branch
2. Run `make test-e2e-ui`
3. Open `http://localhost:9323`
4. Try to run some (non-Twig) tests.

Thanks!

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
