### PR TITLE
Feat(web-react): HelperText and ValidationText use UNSAFE_className

### DIFF
--- a/packages/web-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/web-react/src/components/Checkbox/Checkbox.tsx
@@ -56,7 +56,7 @@ const _Checkbox = (props: SpiritCheckboxProps, ref: ForwardedRef<HTMLInputElemen
           {label}
         </Label>
         <HelperText
-          className={classProps.helperText}
+          UNSAFE_className={classProps.helperText}
           elementType="span"
           id={`${id}__helperText`}
           registerAria={register}
@@ -64,7 +64,7 @@ const _Checkbox = (props: SpiritCheckboxProps, ref: ForwardedRef<HTMLInputElemen
         />
         {validationState && (
           <ValidationText
-            className={classProps.validationText}
+            UNSAFE_className={classProps.validationText}
             elementType="span"
             id={`${id}__validationText`}
             {...(hasValidationIcon && { hasValidationStateIcon: validationState })}

--- a/packages/web-react/src/components/Field/HelperText.tsx
+++ b/packages/web-react/src/components/Field/HelperText.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import React, { ElementType, useEffect } from 'react';
+import { useStyleProps } from '../../hooks';
 import { mergeStyleProps } from '../../utils';
 import { HelperTextProps } from './types';
 
 const defaultProps: Partial<HelperTextProps> = {
-  className: undefined,
   elementType: 'div',
   id: undefined,
   registerAria: undefined,
@@ -20,7 +20,8 @@ const HelperText = <T extends ElementType = 'div'>(props: HelperTextProps<T>) =>
     registerAria,
     ...restProps
   } = propsWithDefaults;
-  const mergedStyleProps = mergeStyleProps(ElementTag, { restProps });
+  const { styleProps, props: transferProps } = useStyleProps(restProps);
+  const mergedStyleProps = mergeStyleProps(ElementTag, { styleProps, transferProps });
 
   useEffect(() => {
     registerAria?.({ add: id });
@@ -32,7 +33,7 @@ const HelperText = <T extends ElementType = 'div'>(props: HelperTextProps<T>) =>
 
   if (helperText) {
     return (
-      <ElementTag {...restProps} {...mergedStyleProps} id={id}>
+      <ElementTag {...transferProps} {...mergedStyleProps} id={id}>
         {helperText}
       </ElementTag>
     );

--- a/packages/web-react/src/components/Field/README.md
+++ b/packages/web-react/src/components/Field/README.md
@@ -11,7 +11,7 @@ import { ValidationText } from '@lmc-eu/spirit-web-react/components';
 Basic example usage:
 
 ```jsx
-<ValidationText className="Component__validationText" validationText="Danger validation text" />
+<ValidationText UNSAFE_className="Component__validationText" validationText="Danger validation text" />
 ```
 
 Advanced example:
@@ -20,7 +20,7 @@ Advanced example:
 <ValidationText
   hasValidationStateIcon
   id="component__validationText"
-  className="Component__validationText"
+  UNSAFE_className="Component__validationText"
   elementType="span"
   validationText="Danger validation text"
   role="alert"
@@ -35,35 +35,46 @@ When displaying text dynamically, set [`role="alert"`][aria-alert-role] on the `
 
 | Name                     | Type                                           | Default | Required | Description                                                                                    |
 | ------------------------ | ---------------------------------------------- | ------- | -------- | ---------------------------------------------------------------------------------------------- |
-| `className`              | `string`                                       | -       | ✓        | Wrapper custom class name                                                                      |
 | `elementType`            | \[`span` \| `div`]                             | `div`   | ✕        | Type of element used as main wrapper (applied only for single validation text, otherwise `ul`) |
 | `hasValidationStateIcon` | [Validation dictionary][dictionary-validation] | -       | ✕        | Whether to show validation icon                                                                |
 | `id`                     | `string`                                       | -       | ✕        | Component id                                                                                   |
 | `role`                   | `string`                                       | -       | ✕        | The role attribute that describes the role of an element                                       |
 | `validationText`         | \[`ReactNode` \| `ReactNode[]`]                | -       | ✕        | Validation text                                                                                |
 
+On top of the API options, the components accept [additional attributes][readme-additional-attributes].
+If you need more control over the styling of a component, you can use [style props][readme-style-props]
+and [escape hatches][readme-escape-hatches].
+
 ## HelperText
 
 The HelperText subcomponent displays helper texts for Field components like TextField, TextArea, Checkbox, FileUploader, etc.
 
 ```jsx
-<HelperText className="Component__helperText" helperText="Helper text" />
+<HelperText UNSAFE_className="Component__helperText" helperText="Helper text" />
 ```
 
 Advanced example:
 
 ```jsx
-<HelperText id="component__helperText" className="Component__helperText" elementType="span" helperText="Helper text" />
+<HelperText
+  id="component__helperText"
+  UNSAFE_className="Component__helperText"
+  elementType="span"
+  helperText="Helper text"
+/>
 ```
 
 ### API
 
 | Name          | Type                            | Default | Required | Description                                                                                    |
 | ------------- | ------------------------------- | ------- | -------- | ---------------------------------------------------------------------------------------------- |
-| `className`   | `string`                        | —       | ✓        | Wrapper custom class name                                                                      |
 | `elementType` | \[`span` \| `div`]              | `div`   | ✕        | Type of element used as main wrapper (applied only for single validation text, otherwise `ul`) |
 | `helperText`  | \[`ReactNode` \| `ReactNode[]`] | —       | ✕        | Validation text, only visible if validationState is                                            |
 | `id`          | `string`                        | —       | ✕        | Component id                                                                                   |
+
+On top of the API options, the components accept [additional attributes][readme-additional-attributes].
+If you need more control over the styling of a component, you can use [style props][readme-style-props]
+and [escape hatches][readme-escape-hatches].
 
 ## Label
 

--- a/packages/web-react/src/components/Field/ValidationText.tsx
+++ b/packages/web-react/src/components/Field/ValidationText.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import React, { ElementType, useEffect } from 'react';
+import { useStyleProps } from '../../hooks';
 import { mergeStyleProps } from '../../utils';
 import { Icon } from '../Icon';
 import { ValidationTextProps } from './types';
 import { useValidationIcon } from './useValidationIcon';
 
 const defaultProps: Partial<ValidationTextProps> = {
-  className: undefined,
   elementType: 'div',
   id: undefined,
   registerAria: undefined,
@@ -25,8 +25,9 @@ const ValidationText = <T extends ElementType = 'div'>(props: ValidationTextProp
     validationText,
     ...restProps
   } = propsWithDefaults;
-  const mergedStyleProps = mergeStyleProps(ElementTag, { restProps });
   const validationIconName = useValidationIcon({ hasValidationStateIcon });
+  const { styleProps, props: transferProps } = useStyleProps(restProps);
+  const mergedStyleProps = mergeStyleProps(ElementTag, { styleProps, transferProps });
 
   useEffect(() => {
     registerAria?.({ add: id });
@@ -49,7 +50,7 @@ const ValidationText = <T extends ElementType = 'div'>(props: ValidationTextProp
   );
 
   return (
-    <ElementTag {...restProps} {...mergedStyleProps} id={id} role={role}>
+    <ElementTag {...transferProps} {...mergedStyleProps} id={id} role={role}>
       {hasValidationStateIcon && <Icon name={validationIconName} boxSize="20" />}
       {Array.isArray(validationText) ? (
         <ul>

--- a/packages/web-react/src/components/Field/__tests__/HelperText.test.tsx
+++ b/packages/web-react/src/components/Field/__tests__/HelperText.test.tsx
@@ -7,7 +7,7 @@ describe('HelperText', () => {
   const helperText = 'Helper Text';
 
   it('should render helper text', () => {
-    render(<HelperText className="HelperText__helperText" helperText={helperText} />);
+    render(<HelperText UNSAFE_className="HelperText__helperText" helperText={helperText} />);
 
     const element = screen.getByText(helperText);
 
@@ -26,7 +26,9 @@ describe('HelperText', () => {
     const helperTextId = 'test-helper-text-id';
     const helperTextClass = 'test__helperText';
 
-    render(<HelperText className={helperTextClass} id={helperTextId} helperText={helperText} data-testid="test" />);
+    render(
+      <HelperText UNSAFE_className={helperTextClass} id={helperTextId} helperText={helperText} data-testid="test" />,
+    );
 
     const element = screen.getByText(helperText);
 

--- a/packages/web-react/src/components/Field/__tests__/ValidationText.test.tsx
+++ b/packages/web-react/src/components/Field/__tests__/ValidationText.test.tsx
@@ -5,9 +5,8 @@ import { A11Y_ALERT_ROLE } from '../constants';
 import { ValidationTextProps } from '../types';
 import ValidationText from '../ValidationText';
 
-const renderValidationText = <T extends ElementType = 'div'>(props: Partial<ValidationTextProps<T>>) => {
-  return render(<ValidationText className="ValidationText__validationText" {...props} />);
-};
+const renderValidationText = <T extends ElementType = 'div'>(props: Partial<ValidationTextProps<T>>) =>
+  render(<ValidationText UNSAFE_className="ValidationText__validationText" {...props} />);
 
 describe('ValidationText', () => {
   it('should render single validation text', () => {
@@ -96,7 +95,7 @@ describe('ValidationText', () => {
 
       rerender(
         <ValidationText
-          className="ValidationText__validationText"
+          UNSAFE_className="ValidationText__validationText"
           validationText={['updated validation text', 'new validation text']}
         />,
       );

--- a/packages/web-react/src/components/Field/types.ts
+++ b/packages/web-react/src/components/Field/types.ts
@@ -1,5 +1,5 @@
-import { ElementType, JSXElementConstructor, ReactNode } from 'react';
-import { ValidationTextProp } from '../../types';
+import { ElementType, ReactNode } from 'react';
+import { ChildrenProps, StyleProps, TransferProps, ValidationTextProp } from '../../types';
 import { RegisterType } from './useAriaIds';
 
 export interface FieldElementTypeProps<T extends ElementType = 'div'> {
@@ -8,17 +8,25 @@ export interface FieldElementTypeProps<T extends ElementType = 'div'> {
    *
    * @default 'div'
    */
-  elementType?: T | JSXElementConstructor<unknown>;
+  elementType?: T;
 }
 
 export interface FieldProps<T extends ElementType = 'div'> extends FieldElementTypeProps<T> {
-  className?: string;
   id?: string;
   registerAria?: RegisterType;
 }
 
-export interface HelperTextProps<T extends ElementType = 'div'> extends FieldProps<T> {
+export interface HelperTextProps<T extends ElementType = 'div'>
+  extends FieldProps<T>,
+    StyleProps,
+    ChildrenProps,
+    TransferProps {
   helperText: ReactNode;
 }
 
-export interface ValidationTextProps<T extends ElementType = 'div'> extends FieldProps<T>, ValidationTextProp {}
+export interface ValidationTextProps<T extends ElementType = 'div'>
+  extends FieldProps<T>,
+    ValidationTextProp,
+    StyleProps,
+    ChildrenProps,
+    TransferProps {}

--- a/packages/web-react/src/components/FieldGroup/FieldGroup.tsx
+++ b/packages/web-react/src/components/FieldGroup/FieldGroup.tsx
@@ -50,14 +50,14 @@ const FieldGroup = (props: SpiritFieldGroupProps) => {
       )}
       <div className={classProps.fields}>{children}</div>
       <HelperText
-        className={classProps.helperText}
+        UNSAFE_className={classProps.helperText}
         id={`${id}__helperText`}
         registerAria={register}
         helperText={helperText}
       />
       {validationState && (
         <ValidationText
-          className={classProps.validationText}
+          UNSAFE_className={classProps.validationText}
           {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
           id={`${id}__helperText`}
           validationText={validationText}

--- a/packages/web-react/src/components/FileUploader/FileUploaderInput.tsx
+++ b/packages/web-react/src/components/FileUploader/FileUploaderInput.tsx
@@ -110,7 +110,7 @@ const FileUploaderInput = (props: SpiritFileUploaderInputProps) => {
           <span className={classProps.input.dropLabel}>{labelText}</span>
         </Label>
         <HelperText
-          className={classProps.input.helper}
+          UNSAFE_className={classProps.input.helper}
           id={`${id}__helperText`}
           registerAria={register}
           helperText={helperText}
@@ -118,7 +118,7 @@ const FileUploaderInput = (props: SpiritFileUploaderInputProps) => {
       </div>
       {validationState && (
         <ValidationText
-          className={classProps.input.validationText}
+          UNSAFE_className={classProps.input.validationText}
           elementType="span"
           {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
           id={`${id}__validationText`}

--- a/packages/web-react/src/components/Item/Item.tsx
+++ b/packages/web-react/src/components/Item/Item.tsx
@@ -36,7 +36,7 @@ const Item = <T extends ElementType = 'button'>(props: SpiritItemProps<T>): JSX.
         </span>
       )}
       <span className={classProps.label}>{label}</span>
-      <HelperText className={classProps.helperText} elementType="span" helperText={helperText} />
+      <HelperText UNSAFE_className={classProps.helperText} elementType="span" helperText={helperText} />
       {isSelected && (
         <span className={classNames(classProps.icon.root, classProps.icon.end)}>
           <Icon name="check-plain" />

--- a/packages/web-react/src/components/Radio/Radio.tsx
+++ b/packages/web-react/src/components/Radio/Radio.tsx
@@ -49,7 +49,7 @@ const _Radio = (props: SpiritRadioProps, ref: ForwardedRef<HTMLInputElement>): J
           {label}
         </Label>
         <HelperText
-          className={classProps.helperText}
+          UNSAFE_className={classProps.helperText}
           elementType="span"
           id={`${id}__helperText`}
           registerAria={register}

--- a/packages/web-react/src/components/Select/Select.tsx
+++ b/packages/web-react/src/components/Select/Select.tsx
@@ -64,14 +64,14 @@ const _Select = (props: SpiritSelectProps, ref: ForwardedRef<HTMLSelectElement>)
         </div>
       </div>
       <HelperText
-        className={classProps.helperText}
+        UNSAFE_className={classProps.helperText}
         id={`${id}__helperText`}
         registerAria={register}
         helperText={helperText}
       />
       {validationState && (
         <ValidationText
-          className={classProps.validationText}
+          UNSAFE_className={classProps.validationText}
           {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
           id={`${id}__validationText`}
           validationText={validationText}

--- a/packages/web-react/src/components/TextFieldBase/TextFieldBase.tsx
+++ b/packages/web-react/src/components/TextFieldBase/TextFieldBase.tsx
@@ -48,14 +48,14 @@ const _TextFieldBase = (props: SpiritTextFieldBaseProps, ref: ForwardedRef<HTMLI
       </Label>
       <TextFieldBaseInputWithPasswordToggle {...otherProps} id={id} aria-describedby={ids.join(' ')} ref={ref} />
       <HelperText
-        className={classProps.helperText}
+        UNSAFE_className={classProps.helperText}
         id={`${id}__helperText`}
         registerAria={register}
         helperText={helperText}
       />
       {validationState && (
         <ValidationText
-          className={classProps.validationText}
+          UNSAFE_className={classProps.validationText}
           elementType="span"
           {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
           id={`${id}__validationText`}

--- a/packages/web-react/src/components/UNSTABLE_Slider/UNSTABLE_Slider.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Slider/UNSTABLE_Slider.tsx
@@ -77,14 +77,14 @@ const _UnstableSlider = (props: SpiritSliderProps, ref: ForwardedRef<HTMLInputEl
         ref={ref}
       />
       <HelperText
-        className={classProps.helperText}
+        UNSAFE_className={classProps.helperText}
         helperText={helperText}
         id={`${id}__helperText`}
         registerAria={register}
       />
       {validationState && (
         <ValidationText
-          className={classProps.validationText}
+          UNSAFE_className={classProps.validationText}
           {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
           id={`${id}__validationText`}
           registerAria={register}

--- a/packages/web-react/src/components/UNSTABLE_Toggle/UNSTABLE_Toggle.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Toggle/UNSTABLE_Toggle.tsx
@@ -51,7 +51,7 @@ const _UNSTABLE_Toggle = (props: SpiritToggleProps, ref: ForwardedRef<HTMLInputE
           {label}
         </Label>
         <HelperText
-          className={classProps.helperText}
+          UNSAFE_className={classProps.helperText}
           elementType="span"
           id={`${id}__helperText`}
           registerAria={register}
@@ -59,7 +59,7 @@ const _UNSTABLE_Toggle = (props: SpiritToggleProps, ref: ForwardedRef<HTMLInputE
         />
         {validationState && (
           <ValidationText
-            className={classProps.validationText}
+            UNSAFE_className={classProps.validationText}
             {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
             id={`${id}__validationText`}
             validationText={validationText}


### PR DESCRIPTION
## Description  

Adding the `useStyleProps` hook to `ValidationText` and `HelperText`, so they accept `UNSAFE_className` instead of `className`, like the rest of our components.  

### Additional Context  

These components are used only internally, so this is not a breaking change.  

### Issue Reference  

[Unify UNSAFE_className/className in HelperText and ValidationText](https://jira.almacareer.tech/browse/DS-1679)  
