### PR TITLE
Chore(web-twig): Replace lmc/coding-standard with almacareer/coding-standard

### DIFF
--- a/.github/workflows/test-web-twig.yaml
+++ b/.github/workflows/test-web-twig.yaml
@@ -44,7 +44,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.1', '8.2', '8.3']
+        php-version: ['8.1', '8.2', '8.3', '8.4']
         dependencies: ['']
 
     name: 🧪 Unit Testing - PHP ${{ matrix.php-version }} ${{ matrix.dependencies }}
@@ -113,7 +113,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.4'
           extensions: json, mbstring
 
       - name: Install dependencies

--- a/packages/web-twig/composer.json
+++ b/packages/web-twig/composer.json
@@ -21,8 +21,8 @@
     "twig/twig": "^2.12.5 || ^3.0.0"
   },
   "require-dev": {
+    "almacareer/coding-standard": "^4.2",
     "ergebnis/composer-normalize": "^2.45",
-    "lmc/coding-standard": "^4.1",
     "mockery/mockery": "^1.5",
     "phpstan/extension-installer": "^1.1",
     "phpstan/phpstan": "^1.2",

--- a/packages/web-twig/ecs.php
+++ b/packages/web-twig/ecs.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Lmc\CodingStandard\Set\SetList;
 use PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
@@ -9,7 +10,7 @@ return ECSConfig::configure()
     ->withPaths([__DIR__ . '/src', __DIR__ . '/tests'])
     ->withRootFiles()
     ->withSets([
-        __DIR__ . '/vendor/lmc/coding-standard/ecs.php',
+        SetList::ALMACAREER,
     ])
     // Specify elements separation.
     ->withConfiguredRule(

--- a/packages/web-twig/src/Twig/PropsExtension.php
+++ b/packages/web-twig/src/Twig/PropsExtension.php
@@ -183,7 +183,7 @@ class PropsExtension extends AbstractExtension
             }
         }
 
-        $styleProps['className'] = is_string($styleProps['className']) ? trim($styleProps['className']) : null;
+        $styleProps['className'] = is_string($styleProps['className']) ? mb_trim($styleProps['className']) : null;
 
         return $styleProps;
     }

--- a/packages/web-twig/src/Twig/SvgExtension.php
+++ b/packages/web-twig/src/Twig/SvgExtension.php
@@ -190,7 +190,7 @@ class SvgExtension extends AbstractExtension
             $this->replaceAttribute($svg, self::ATTR_STYLE, $params[self::ATTR_STYLE]);
         }
 
-        if ($hasSize && is_string($params[self::ATTR_SIZE]) && trim($params[self::ATTR_SIZE]) !== '') {
+        if ($hasSize && is_string($params[self::ATTR_SIZE]) && mb_trim($params[self::ATTR_SIZE]) !== '') {
             $this->replaceAttribute($svg, 'width', $params[self::ATTR_SIZE]);
             $this->replaceAttribute($svg, 'height', $params[self::ATTR_SIZE]);
         }
@@ -198,14 +198,14 @@ class SvgExtension extends AbstractExtension
         if ($hasMainProps && is_array($params[self::ATTR_MAIN_PROPS])) {
             foreach ($params[self::ATTR_MAIN_PROPS] as $propName => $propValue) {
                 if (preg_match('/^(data|aria)-*/', $propName) > 0) {
-                    if (trim($propValue) !== '') {
+                    if (mb_trim($propValue) !== '') {
                         $this->replaceAttribute($svg, $propName, $propValue);
                     }
                 }
             }
         }
 
-        if ($hasTitle && is_string($params[self::ATTR_TITLE]) && trim($params[self::ATTR_TITLE]) !== '') {
+        if ($hasTitle && is_string($params[self::ATTR_TITLE]) && mb_trim($params[self::ATTR_TITLE]) !== '') {
             $svg->addChild(self::ATTR_TITLE, htmlspecialchars($params[self::ATTR_TITLE], ENT_QUOTES));
         }
     }

--- a/packages/web-twig/tests/ComponentTest.php
+++ b/packages/web-twig/tests/ComponentTest.php
@@ -81,7 +81,7 @@ final class ComponentTest extends TestCase
     private function removeWhitespace(string|array|null $html): ?string
     {
         $cleanedSpaceBetweenAttrs = $html ? preg_replace('/(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+/', "\n", $html) : null;
-        $trimmedHtml = $cleanedSpaceBetweenAttrs && !is_array($cleanedSpaceBetweenAttrs) ? trim($cleanedSpaceBetweenAttrs) : null;
+        $trimmedHtml = $cleanedSpaceBetweenAttrs && !is_array($cleanedSpaceBetweenAttrs) ? mb_trim($cleanedSpaceBetweenAttrs) : null;
 
         return $trimmedHtml;
     }


### PR DESCRIPTION
## Description

Replace deprecated lmc/coding-standard with [almacareer/coding-standard](https://github.com/alma-oss/php-coding-standard).

Also run PHP tests & codestyle on PHP 8.4. This leads to update in easy-coding-standard and detecting some previously undetected codestyle violations.