### PR TITLE
Fix(web-react): Forgotten elementType in useStyleProps hook

### DIFF
--- a/packages/web-react/src/components/Accordion/Accordion.tsx
+++ b/packages/web-react/src/components/Accordion/Accordion.tsx
@@ -20,7 +20,7 @@ const Accordion = (props: AccordionProps) => {
   };
 
   return (
-    <ElementTag {...transferProps} {...styleProps} {...mergedStyleProps}>
+    <ElementTag {...transferProps} {...mergedStyleProps}>
       <AccordionProvider value={contextValue}>{children}</AccordionProvider>
     </ElementTag>
   );

--- a/packages/web-react/src/components/Collapse/Collapse.tsx
+++ b/packages/web-react/src/components/Collapse/Collapse.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import classNames from 'classnames';
 import React, { ElementType, MutableRefObject, useRef } from 'react';
 import { Transition, TransitionStatus } from 'react-transition-group';
 import { useStyleProps } from '../../hooks';
 import { SpiritCollapseProps } from '../../types';
+import { mergeStyleProps } from '../../utils';
 import { useCollapseAriaProps } from './useCollapseAriaProps';
 import { useCollapseStyleProps } from './useCollapseStyleProps';
 import { useResizeHeight } from './useResizeHeight';
@@ -40,7 +40,7 @@ const Collapse = (props: SpiritCollapseProps) => {
 
   const { classProps } = useCollapseStyleProps(restProps.isOpen);
   const { ariaProps, props: otherProps } = useCollapseAriaProps(restProps);
-  const { styleProps, props: transferProps } = useStyleProps({ ElementTag, ...otherProps });
+  const { styleProps, props: transferProps } = useStyleProps(otherProps);
   const collapseStyleProps = {
     className: styleProps.className,
     ...{ style: { height: restProps.isOpen ? collapseHeight : 0, ...styleProps.style } },
@@ -51,12 +51,13 @@ const Collapse = (props: SpiritCollapseProps) => {
       {(transitionState: TransitionStatus) => (
         <ElementTag
           {...transferProps}
-          {...collapseStyleProps}
           {...ariaProps.root}
-          // Element implicitly has an 'any' type because expression of type 'TransitionStatus' can't be used to index type '{ entering: string; entered: string; exiting: string; exited: string; }'.
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          className={classNames(classProps.root, styleProps.className, transitioningStyles[transitionState])}
+          {...mergeStyleProps(ElementTag, {
+            classProps: classProps.root,
+            styleProps,
+            collapseStyleProps,
+            transitioningStyles: transitioningStyles[transitionState as keyof typeof transitioningStyles],
+          })}
           ref={rootElementRef}
         >
           <ElementTag ref={collapseElementRef} className={classProps.content}>

--- a/packages/web-react/src/components/Stack/Stack.tsx
+++ b/packages/web-react/src/components/Stack/Stack.tsx
@@ -22,7 +22,7 @@ const Stack = <T extends ElementType = 'div'>(props: SpiritStackProps<T>): JSX.E
     ...restProps
   } = propsWithDefaults;
   const { classProps, props: modifiedProps, styleProps: stackStyle } = useStackStyleProps(restProps);
-  const { styleProps, props: otherProps } = useStyleProps({ ElementTag, ...modifiedProps });
+  const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
   const mergedStyleProps = mergeStyleProps(ElementTag, { classProps, stackStyle, styleProps, otherProps });
 
   return (

--- a/packages/web-react/src/components/Tabs/TabLink.tsx
+++ b/packages/web-react/src/components/Tabs/TabLink.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import React, { ElementType, forwardRef } from 'react';
 import { useStyleProps } from '../../hooks';
 import { PolymorphicRef, SpiritTabLinkProps } from '../../types';
+import { mergeStyleProps } from '../../utils';
 import { useTabsStyleProps } from './useTabsStyleProps';
 
 const defaultProps: SpiritTabLinkProps = {
@@ -16,11 +17,12 @@ const _TabLink = <E extends ElementType = 'a'>(props: SpiritTabLinkProps<E>, ref
   const propsWithDefaults = { ...defaultProps, ...props };
   const { elementType: ElementTag = 'a', children, itemProps = {}, ...restProps } = propsWithDefaults;
   const { classProps } = useTabsStyleProps();
-  const { styleProps: itemStyleProps, props: itemTransferProps } = useStyleProps({ ElementTag, ...itemProps });
+  const { styleProps: itemStyleProps, props: itemTransferProps } = useStyleProps(itemProps);
+  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps: classProps.link });
 
   return (
     <li {...itemStyleProps} {...itemTransferProps} className={classNames(classProps.item, itemStyleProps.className)}>
-      <ElementTag {...restProps} className={classProps.link} role="tab" ref={ref}>
+      <ElementTag {...restProps} {...mergedStyleProps} role="tab" ref={ref}>
         {children}
       </ElementTag>
     </li>

--- a/packages/web-react/src/components/UNSTABLE_Truncate/UNSTABLE_Truncate.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Truncate/UNSTABLE_Truncate.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import classNames from 'classnames';
 import React, { ElementType } from 'react';
 import { useStyleProps } from '../../hooks';
 import { SpiritTruncateProps } from '../../types/truncate';
 import { useTruncateStyleProps } from './useTruncateStyleProps';
+import { mergeStyleProps } from '../../utils';
 
 const defaultProps = {
   elementType: 'span',
@@ -13,19 +13,18 @@ const defaultProps = {
 const UNSTABLE_Truncate = <T extends ElementType = 'span'>(props: SpiritTruncateProps<T>): JSX.Element => {
   const propsWithDefaults = { ...defaultProps, ...props };
   const { children, elementType: ElementTag = 'span', ...restProps } = propsWithDefaults;
-
   const { classProps, props: modifiedProps, styleProps: truncateStyle } = useTruncateStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
-
   const truncateStyleProps = {
     style: {
       ...styleProps.style,
       ...truncateStyle,
     },
   };
+  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps, styleProps, truncateStyleProps });
 
   return (
-    <ElementTag {...otherProps} {...truncateStyleProps} className={classNames(classProps, styleProps.className)}>
+    <ElementTag {...otherProps} {...mergedStyleProps}>
       {children}
     </ElementTag>
   );

--- a/packages/web-react/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/web-react/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -9,7 +9,7 @@ import { useVisuallyHiddenProps } from './useVisuallyHiddenProps';
 const VisuallyHidden = <T extends ElementType = 'span'>(props: SpiritVisuallyHiddenProps<T>): JSX.Element => {
   const { children, elementType: ElementTag = 'span', ...rest } = props;
   const { classProps, props: modifiedProps } = useVisuallyHiddenProps(rest);
-  const { styleProps, props: otherProps } = useStyleProps({ ElementTag, ...modifiedProps });
+  const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
   const mergedStyleProps = mergeStyleProps(ElementTag, { classProps, styleProps, otherProps });
 
   return (


### PR DESCRIPTION
- element tag was forwarded to dom element

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
