### PR TITLE
Fix(web-react): Forgotten hasValidationIcon prop on DOM element

### DIFF
--- a/packages/web-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/web-react/src/components/Checkbox/Checkbox.tsx
@@ -14,6 +14,7 @@ const _Checkbox = (props: SpiritCheckboxProps, ref: ForwardedRef<HTMLInputElemen
   const { classProps, props: modifiedProps } = useCheckboxStyleProps(props);
   const {
     'aria-describedby': ariaDescribedBy = '',
+    hasValidationIcon,
     helperText,
     id,
     isChecked,
@@ -25,7 +26,6 @@ const _Checkbox = (props: SpiritCheckboxProps, ref: ForwardedRef<HTMLInputElemen
     value,
     ...restProps
   } = modifiedProps;
-  const { hasValidationIcon } = props;
   const { styleProps, props: otherProps } = useStyleProps(restProps);
   const [ids, register] = useAriaIds(ariaDescribedBy);
   const validationTextRole = useValidationTextRole({

--- a/packages/web-react/src/components/TextFieldBase/TextFieldBase.tsx
+++ b/packages/web-react/src/components/TextFieldBase/TextFieldBase.tsx
@@ -28,7 +28,6 @@ const _TextFieldBase = (props: SpiritTextFieldBaseProps, ref: ForwardedRef<HTMLI
     ...restProps
   } = props;
   const { classProps, props: modifiedProps } = useTextFieldBaseStyleProps({
-    hasValidationIcon,
     id,
     label,
     validationState,

--- a/packages/web-react/src/components/UNSTABLE_Slider/UNSTABLE_Slider.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Slider/UNSTABLE_Slider.tsx
@@ -35,7 +35,6 @@ const _UnstableSlider = (props: SpiritSliderProps, ref: ForwardedRef<HTMLInputEl
 
   const { classProps, props: modifiedProps } = useSliderStyleProps({
     ...restProps,
-    hasValidationIcon,
     isDisabled,
     validationState,
   });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

`hasValidationIcon` prop was forwarded to DOM element

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
