### PR TITLE
Refactor(web-react): Use `imports` package field

### DIFF
--- a/packages/web-react/config/tsconfig.prod.json
+++ b/packages/web-react/config/tsconfig.prod.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "module": "es2020",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "rootDir": "../src",
     "target": "es2015",

--- a/packages/web-react/config/tsconfig.prod.json
+++ b/packages/web-react/config/tsconfig.prod.json
@@ -1,8 +1,9 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
+    "module": "es2020",
     "moduleResolution": "NodeNext",
+    "rootDir": "../src",
     "target": "es2015",
     "noEmit": false
   },

--- a/packages/web-react/config/tsconfig.typecheck.json
+++ b/packages/web-react/config/tsconfig.typecheck.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  }
+}

--- a/packages/web-react/jest.config.ts
+++ b/packages/web-react/jest.config.ts
@@ -13,13 +13,6 @@ const config = {
   // Automatically clear mock calls, instances, contexts and results before every test.
   // https://jestjs.io/docs/configuration#clearmocks-boolean
   clearMocks: true,
-
-  // A map from regular expressions to module names or to arrays of module names
-  // https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring
-  moduleNameMapper: {
-    '^@local/(.*)': '<rootDir>/$1',
-    '^@local/tests/(.*)': '<rootDir>/tests/$1',
-  },
 };
 
 export default config;

--- a/packages/web-react/package.json
+++ b/packages/web-react/package.json
@@ -19,6 +19,10 @@
   "main": "./index.cjs",
   "module": "./index.js",
   "types": "./index.d.ts",
+  "imports": {
+    "#local/tests": "./tests/index.ts",
+    "#local/tests/*": "./tests/*"
+  },
   "dependencies": {
     "@floating-ui/react": "^0.27.0",
     "classnames": "^2.3.1",

--- a/packages/web-react/package.json
+++ b/packages/web-react/package.json
@@ -113,7 +113,7 @@
     "build:esNext": "echo tsc --module esNext --outDir dist/_esNext --project ./config/tsconfig.prod.json",
     "build:finalize": "npm-run-all prepdist resolve build:cjs",
     "prepdist": "node ./scripts/prepareDist.js",
-    "types": "tsc",
+    "types": "tsc --project ./config/tsconfig.typecheck.json",
     "webpack:dev": "webpack --mode development --config ./config/webpack.js --progress",
     "webpack:prod": "webpack --mode production --config ./config/webpack.js --progress",
     "webpack:browser": "webpack --mode production --config ./config/webpack.browser.js --progress",

--- a/packages/web-react/src/components/Accordion/__tests__/Accordion.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/Accordion.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import Accordion from '../Accordion';
 
 describe('Accordion', () => {

--- a/packages/web-react/src/components/Accordion/__tests__/AccordionContent.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/AccordionContent.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import AccordionContent from '../AccordionContent';
 import AccordionItem from '../AccordionItem';
 

--- a/packages/web-react/src/components/Accordion/__tests__/AccordionHeader.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/AccordionHeader.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import AccordionHeader from '../AccordionHeader';
 import AccordionItem from '../AccordionItem';
 

--- a/packages/web-react/src/components/Accordion/__tests__/AccordionItem.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/AccordionItem.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import Accordion from '../Accordion';
 import AccordionContent from '../AccordionContent';
 import AccordionHeader from '../AccordionHeader';

--- a/packages/web-react/src/components/Accordion/__tests__/UncontrolledAccordion.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/UncontrolledAccordion.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import AccordionContent from '../AccordionContent';
 import AccordionHeader from '../AccordionHeader';
 import AccordionItem from '../AccordionItem';

--- a/packages/web-react/src/components/ActionGroup/__tests__/ActionGroup.test.tsx
+++ b/packages/web-react/src/components/ActionGroup/__tests__/ActionGroup.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { restPropsTest, stylePropsTest } from '@local/tests';
+import { restPropsTest, stylePropsTest } from '#local/tests';
 import ActionGroup from '../ActionGroup';
 
 describe('ActionGroup', () => {

--- a/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
+++ b/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, emotionColorPropsTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, emotionColorPropsTest, restPropsTest, stylePropsTest } from '#local/tests';
 import Alert from '../Alert';
 
 jest.mock('../../../hooks/useIcon');

--- a/packages/web-react/src/components/Avatar/__tests__/Avatar.test.tsx
+++ b/packages/web-react/src/components/Avatar/__tests__/Avatar.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, sizeExtendedPropsTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, sizeExtendedPropsTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { Icon } from '../../Icon';
 import Avatar from '../Avatar';
 

--- a/packages/web-react/src/components/Box/__tests__/Box.test.tsx
+++ b/packages/web-react/src/components/Box/__tests__/Box.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { SpiritBoxProps } from '../../../types';
 import Box from '../Box';
 

--- a/packages/web-react/src/components/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import Breadcrumbs from '../Breadcrumbs';
 
 jest.mock('../../../hooks/useIcon');

--- a/packages/web-react/src/components/Breadcrumbs/__tests__/BreadcrumbsItem.test.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/__tests__/BreadcrumbsItem.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import BreadcrumbsItem from '../BreadcrumbsItem';
 
 jest.mock('../../../hooks/useIcon');

--- a/packages/web-react/src/components/Button/__tests__/Button.test.tsx
+++ b/packages/web-react/src/components/Button/__tests__/Button.test.tsx
@@ -9,7 +9,7 @@ import {
   loadingPropsTest,
   restPropsTest,
   stylePropsTest,
-} from '@local/tests';
+} from '#local/tests';
 import Button from '../Button';
 
 jest.mock('../../../hooks/useIcon');

--- a/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
+++ b/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
@@ -9,7 +9,7 @@ import {
   loadingPropsTest,
   restPropsTest,
   stylePropsTest,
-} from '@local/tests';
+} from '#local/tests';
 import ButtonLink from '../ButtonLink';
 
 jest.mock('../../../hooks/useIcon');

--- a/packages/web-react/src/components/Card/__tests__/Card.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/Card.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import Card from '../Card';
 
 describe('Card', () => {

--- a/packages/web-react/src/components/Card/__tests__/CardArtwork.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardArtwork.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, alignmentXPropsTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, alignmentXPropsTest, restPropsTest, stylePropsTest } from '#local/tests';
 import CardArtwork from '../CardArtwork';
 
 describe('CardArtwork', () => {

--- a/packages/web-react/src/components/Card/__tests__/CardBody.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardBody.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import CardBody from '../CardBody';
 
 describe('CardBody', () => {

--- a/packages/web-react/src/components/Card/__tests__/CardEyebrow.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardEyebrow.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import CardEyebrow from '../CardEyebrow';
 
 describe('CardEyebrow', () => {

--- a/packages/web-react/src/components/Card/__tests__/CardFooter.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardFooter.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, alignmentXPropsTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, alignmentXPropsTest, restPropsTest, stylePropsTest } from '#local/tests';
 import CardFooter from '../CardFooter';
 
 describe('CardFooter', () => {

--- a/packages/web-react/src/components/Card/__tests__/CardLink.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardLink.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import CardLink from '../CardLink';
 
 describe('CardLink', () => {

--- a/packages/web-react/src/components/Card/__tests__/CardLogo.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardLogo.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import CardLogo from '../CardLogo';
 
 describe('CardLogo', () => {

--- a/packages/web-react/src/components/Card/__tests__/CardMedia.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardMedia.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, sizePropsTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, sizePropsTest, restPropsTest, stylePropsTest } from '#local/tests';
 import CardMedia from '../CardMedia';
 
 describe('CardMedia', () => {

--- a/packages/web-react/src/components/Card/__tests__/CardTitle.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardTitle.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import CardTitle from '../CardTitle';
 
 describe('CardTitle', () => {

--- a/packages/web-react/src/components/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/web-react/src/components/Checkbox/__tests__/Checkbox.test.tsx
@@ -9,7 +9,7 @@ import {
   restPropsTest,
   stylePropsTest,
   validationTextPropsTest,
-} from '@local/tests';
+} from '#local/tests';
 import Checkbox from '../Checkbox';
 
 describe('Checkbox', () => {

--- a/packages/web-react/src/components/Collapse/__tests__/Collapse.test.tsx
+++ b/packages/web-react/src/components/Collapse/__tests__/Collapse.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React, { useState } from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { Button } from '../../Button';
 import Collapse from '../Collapse';
 

--- a/packages/web-react/src/components/Collapse/__tests__/UncontrolledCollapse.test.tsx
+++ b/packages/web-react/src/components/Collapse/__tests__/UncontrolledCollapse.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { Button } from '../../Button';
 import UncontrolledCollapse from '../UncontrolledCollapse';
 

--- a/packages/web-react/src/components/Container/__tests__/Container.test.tsx
+++ b/packages/web-react/src/components/Container/__tests__/Container.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, sizeExtendedPropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, sizeExtendedPropsTest } from '#local/tests';
 import Container from '../Container';
 
 describe('Container', () => {

--- a/packages/web-react/src/components/Divider/__tests__/Divider.test.tsx
+++ b/packages/web-react/src/components/Divider/__tests__/Divider.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import Divider from '../Divider';
 
 describe('Divider', () => {

--- a/packages/web-react/src/components/Drawer/__tests__/Drawer.test.tsx
+++ b/packages/web-react/src/components/Drawer/__tests__/Drawer.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { SpiritDrawerProps } from '../../../types';
 import Drawer from '../Drawer';
 

--- a/packages/web-react/src/components/Drawer/__tests__/DrawerCloseButton.test.tsx
+++ b/packages/web-react/src/components/Drawer/__tests__/DrawerCloseButton.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import DrawerCloseButton from '../DrawerCloseButton';
 
 describe('DrawerCloseButton', () => {

--- a/packages/web-react/src/components/Drawer/__tests__/DrawerPanel.test.tsx
+++ b/packages/web-react/src/components/Drawer/__tests__/DrawerPanel.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import DrawerPanel from '../DrawerPanel';
 
 describe('DrawerPanel', () => {

--- a/packages/web-react/src/components/Dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/web-react/src/components/Dropdown/__tests__/Dropdown.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { DropdownAlignmentXType, DropdownAlignmentYType } from '../../../types';
 import Dropdown from '../Dropdown';
 import DropdownPopover from '../DropdownPopover';

--- a/packages/web-react/src/components/Dropdown/__tests__/DropdownPopover.test.tsx
+++ b/packages/web-react/src/components/Dropdown/__tests__/DropdownPopover.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import DropdownPopover from '../DropdownPopover';
 
 describe('DropdownPopover', () => {

--- a/packages/web-react/src/components/Dropdown/__tests__/DropdownTrigger.test.tsx
+++ b/packages/web-react/src/components/Dropdown/__tests__/DropdownTrigger.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { restPropsTest, stylePropsTest } from '@local/tests';
+import { restPropsTest, stylePropsTest } from '#local/tests';
 import { Button } from '../../Button';
 import DropdownTrigger from '../DropdownTrigger';
 

--- a/packages/web-react/src/components/Field/__tests__/Label.test.tsx
+++ b/packages/web-react/src/components/Field/__tests__/Label.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { restPropsTest, stylePropsTest } from '@local/tests';
+import { restPropsTest, stylePropsTest } from '#local/tests';
 import { SpiritLabelProps } from '../../../types';
 import Label from '../Label';
 

--- a/packages/web-react/src/components/FieldGroup/__tests__/FieldGroup.test.tsx
+++ b/packages/web-react/src/components/FieldGroup/__tests__/FieldGroup.test.tsx
@@ -7,7 +7,7 @@ import {
   restPropsTest,
   stylePropsTest,
   validationTextPropsTest,
-} from '@local/tests';
+} from '#local/tests';
 import FieldGroup from '../FieldGroup';
 
 describe('FieldGroup', () => {

--- a/packages/web-react/src/components/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/web-react/src/components/FileUploader/__tests__/FileUploader.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import FileUploader from '../FileUploader';
 
 jest.mock('../../../hooks/useIcon');

--- a/packages/web-react/src/components/FileUploader/__tests__/FileUploaderInput.test.tsx
+++ b/packages/web-react/src/components/FileUploader/__tests__/FileUploaderInput.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
-import { classNamePrefixProviderTest, restPropsTest, validationTextPropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, validationTextPropsTest } from '#local/tests';
 import FileUploaderInput from '../FileUploaderInput';
 import '@testing-library/jest-dom';
 

--- a/packages/web-react/src/components/Flex/__tests__/Flex.test.tsx
+++ b/packages/web-react/src/components/Flex/__tests__/Flex.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import Flex from '../Flex';
 
 describe('Flex', () => {

--- a/packages/web-react/src/components/Footer/__tests__/Footer.test.tsx
+++ b/packages/web-react/src/components/Footer/__tests__/Footer.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { BackgroundColors } from '../../../constants';
 import Footer from '../Footer';
 

--- a/packages/web-react/src/components/Grid/__tests__/Grid.test.tsx
+++ b/packages/web-react/src/components/Grid/__tests__/Grid.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import Grid from '../Grid';
 
 describe('Grid', () => {

--- a/packages/web-react/src/components/Grid/__tests__/GridItem.test.tsx
+++ b/packages/web-react/src/components/Grid/__tests__/GridItem.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import GridItem from '../GridItem';
 
 describe('Grid', () => {

--- a/packages/web-react/src/components/Header/__tests__/Header.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/Header.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import Header from '../Header';
 
 describe('Header', () => {

--- a/packages/web-react/src/components/Header/__tests__/HeaderButton.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderButton.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import HeaderButton from '../HeaderButton';
 
 describe('HeaderButton', () => {

--- a/packages/web-react/src/components/Header/__tests__/HeaderDesktopActions.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDesktopActions.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import HeaderDesktopActions from '../HeaderDesktopActions';
 
 describe('HeaderDesktopActions', () => {

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialog.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialog.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import HeaderDialog from '../HeaderDialog';
 
 describe('HeaderDialog', () => {

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogActions.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogActions.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import HeaderDialogActions from '../HeaderDialogActions';
 
 describe('HeaderDialogActions', () => {

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogButton.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogButton.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import HeaderDialogButton from '../HeaderDialogButton';
 
 describe('HeaderDialogButton', () => {

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogCloseButton.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogCloseButton.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import HeaderDialogCloseButton from '../HeaderDialogCloseButton';
 
 jest.mock('../../../hooks/useIcon');

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogLink.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogLink.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import HeaderDialogLink from '../HeaderDialogLink';
 
 describe('HeaderDialogLink', () => {

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogNav.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogNav.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import HeaderDialogNav from '../HeaderDialogNav';
 
 describe('HeaderDialogNav', () => {

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogNavItem.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogNavItem.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import HeaderDialogNavItem from '../HeaderDialogNavItem';
 
 describe('HeaderDialogNavItem', () => {

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogText.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogText.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import HeaderDialogText from '../HeaderDialogText';
 
 describe('HeaderDialogText', () => {

--- a/packages/web-react/src/components/Header/__tests__/HeaderLink.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderLink.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import HeaderLink from '../HeaderLink';
 
 describe('HeaderLink', () => {

--- a/packages/web-react/src/components/Header/__tests__/HeaderMobileActions.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderMobileActions.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { HEADER_MENU_TOGGLE_LABEL_DEFAULT } from '../constants';
 import HeaderMobileActions from '../HeaderMobileActions';
 

--- a/packages/web-react/src/components/Header/__tests__/HeaderNav.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderNav.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import HeaderNav from '../HeaderNav';
 
 describe('HeaderNav', () => {

--- a/packages/web-react/src/components/Header/__tests__/HeaderNavItem.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderNavItem.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import HeaderNavItem from '../HeaderNavItem';
 
 describe('HeaderNavItem', () => {

--- a/packages/web-react/src/components/Heading/__tests__/Heading.test.tsx
+++ b/packages/web-react/src/components/Heading/__tests__/Heading.test.tsx
@@ -8,7 +8,7 @@ import {
   restPropsTest,
   stylePropsTest,
   textColorPropsTest,
-} from '@local/tests';
+} from '#local/tests';
 import { SizesDictionaryType, SizeExtendedDictionaryType, EmphasisDictionaryType } from '../../../types';
 import Heading from '../Heading';
 import headingSizeDataProvider from './headingSizeDataProvider';

--- a/packages/web-react/src/components/Icon/__tests__/Icon.test.tsx
+++ b/packages/web-react/src/components/Icon/__tests__/Icon.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { restPropsTest, stylePropsTest } from '@local/tests';
+import { restPropsTest, stylePropsTest } from '#local/tests';
 import Icon from '../Icon';
 
 jest.mock('../../../hooks/useIcon');

--- a/packages/web-react/src/components/Item/__tests__/Item.test.tsx
+++ b/packages/web-react/src/components/Item/__tests__/Item.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { SpiritItemProps } from '../../../types';
 import Item from '../Item';
 

--- a/packages/web-react/src/components/Link/__tests__/Link.test.tsx
+++ b/packages/web-react/src/components/Link/__tests__/Link.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, actionLinkColorPropsTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, actionLinkColorPropsTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { LinkColorsDictionaryType } from '../../../types';
 import Link from '../Link';
 import linkPropsDataProvider from './linkPropsDataProvider';

--- a/packages/web-react/src/components/Modal/__tests__/Modal.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/Modal.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { SpiritModalProps } from '../../../types';
 import Modal from '../Modal';
 

--- a/packages/web-react/src/components/Modal/__tests__/ModalBody.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/ModalBody.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import ModalBody from '../ModalBody';
 
 describe('ModalBody', () => {

--- a/packages/web-react/src/components/Modal/__tests__/ModalCloseButton.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/ModalCloseButton.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import ModalCloseButton from '../ModalCloseButton';
 
 jest.mock('../../../hooks/useIcon');

--- a/packages/web-react/src/components/Modal/__tests__/ModalDialog.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/ModalDialog.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import ModalDialog from '../ModalDialog';
 
 describe('ModalDialog', () => {

--- a/packages/web-react/src/components/Modal/__tests__/ModalFooter.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/ModalFooter.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import ModalFooter from '../ModalFooter';
 
 describe('ModalFooter', () => {

--- a/packages/web-react/src/components/Modal/__tests__/ModalHeader.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/ModalHeader.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import ModalHeader from '../ModalHeader';
 
 jest.mock('../../../hooks/useIcon');

--- a/packages/web-react/src/components/Navigation/__tests__/Navigation.test.tsx
+++ b/packages/web-react/src/components/Navigation/__tests__/Navigation.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { Direction } from '../../../constants';
 import Navigation from '../Navigation';
 

--- a/packages/web-react/src/components/Navigation/__tests__/NavigationAction.test.tsx
+++ b/packages/web-react/src/components/Navigation/__tests__/NavigationAction.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import NavigationAction from '../NavigationAction';
 
 describe('NavigationAction', () => {

--- a/packages/web-react/src/components/Navigation/__tests__/NavigationAvatar.test.tsx
+++ b/packages/web-react/src/components/Navigation/__tests__/NavigationAvatar.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { Icon } from '../../Icon';
 import NavigationAvatar from '../NavigationAvatar';
 

--- a/packages/web-react/src/components/Navigation/__tests__/NavigationItem.test.tsx
+++ b/packages/web-react/src/components/Navigation/__tests__/NavigationItem.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import NavigationItem from '../NavigationItem';
 
 describe('NavigationItem', () => {

--- a/packages/web-react/src/components/Pagination/__tests__/Pagination.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/Pagination.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import Pagination from '../Pagination';
 
 describe('Pagination', () => {

--- a/packages/web-react/src/components/Pagination/__tests__/PaginationButtonLink.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/PaginationButtonLink.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import PaginationButtonLink from '../PaginationButtonLink';
 
 jest.mock('../../../hooks/useIcon');

--- a/packages/web-react/src/components/Pagination/__tests__/PaginationItem.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/PaginationItem.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import PaginationItem from '../PaginationItem';
 
 describe('PaginationItem', () => {

--- a/packages/web-react/src/components/Pagination/__tests__/PaginationLink.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/PaginationLink.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import PaginationLink from '../PaginationLink';
 
 describe('PaginationLink', () => {

--- a/packages/web-react/src/components/Pagination/__tests__/PaginationLinkNext.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/PaginationLinkNext.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import PaginationLinkNext from '../PaginationLinkNext';
 
 jest.mock('../../../hooks/useIcon');

--- a/packages/web-react/src/components/Pagination/__tests__/PaginationLinkPrevious.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/PaginationLinkPrevious.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import PaginationLinkPrevious from '../PaginationLinkPrevious';
 
 jest.mock('../../../hooks/useIcon');

--- a/packages/web-react/src/components/PartnerLogo/__tests__/PartnerLogo.test.tsx
+++ b/packages/web-react/src/components/PartnerLogo/__tests__/PartnerLogo.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { Sizes } from '../../../constants';
 import PartnerLogo from '../PartnerLogo';
 

--- a/packages/web-react/src/components/Pill/__tests__/Pill.test.tsx
+++ b/packages/web-react/src/components/Pill/__tests__/Pill.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, emotionColorPropsTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, emotionColorPropsTest, restPropsTest, stylePropsTest } from '#local/tests';
 import Pill from '../Pill';
 
 describe('Pill', () => {

--- a/packages/web-react/src/components/ProductLogo/__tests__/ProductLogo.test.tsx
+++ b/packages/web-react/src/components/ProductLogo/__tests__/ProductLogo.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import ProductLogo from '../ProductLogo';
 
 describe('ProductLogo', () => {

--- a/packages/web-react/src/components/Radio/__tests__/Radio.test.tsx
+++ b/packages/web-react/src/components/Radio/__tests__/Radio.test.tsx
@@ -8,7 +8,7 @@ import {
   requiredPropsTest,
   restPropsTest,
   stylePropsTest,
-} from '@local/tests';
+} from '#local/tests';
 import Radio from '../Radio';
 
 describe('Radio', () => {

--- a/packages/web-react/src/components/ScrollView/__tests__/ScrollView.test.tsx
+++ b/packages/web-react/src/components/ScrollView/__tests__/ScrollView.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import ScrollView from '../ScrollView';
 
 describe('ScrollView', () => {

--- a/packages/web-react/src/components/Section/__tests__/Section.test.tsx
+++ b/packages/web-react/src/components/Section/__tests__/Section.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { SizeExtendedDictionaryType, SpiritSectionProps } from '../../../types';
 import Section from '../Section';
 

--- a/packages/web-react/src/components/Select/__tests__/Select.test.tsx
+++ b/packages/web-react/src/components/Select/__tests__/Select.test.tsx
@@ -8,7 +8,7 @@ import {
   restPropsTest,
   stylePropsTest,
   validationTextPropsTest,
-} from '@local/tests';
+} from '#local/tests';
 import Select from '../Select';
 
 jest.mock('../../../hooks/useIcon');

--- a/packages/web-react/src/components/Skeleton/__tests__/SkeletonHeading.test.tsx
+++ b/packages/web-react/src/components/Skeleton/__tests__/SkeletonHeading.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { screen, render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import SkeletonHeading from '../SkeletonHeading';
 
 describe('SkeletonHeading', () => {

--- a/packages/web-react/src/components/Skeleton/__tests__/SkeletonShape.test.tsx
+++ b/packages/web-react/src/components/Skeleton/__tests__/SkeletonShape.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, renderHook, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { SpiritSkeletonShapeProps } from '../../../types';
 import SkeletonShape from '../SkeletonShape';
 import { useSkeletonShapeStyleProps } from '../useSkeletonShapeStyleProps';

--- a/packages/web-react/src/components/Skeleton/__tests__/SkeletonText.test.tsx
+++ b/packages/web-react/src/components/Skeleton/__tests__/SkeletonText.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { screen, render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import SkeletonText from '../SkeletonText';
 
 describe('SkeletonText', () => {

--- a/packages/web-react/src/components/Spinner/__tests__/Spinner.test.tsx
+++ b/packages/web-react/src/components/Spinner/__tests__/Spinner.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { TextColors } from '../../../constants';
 import { TextColorsDictionaryType } from '../../../types';
 import Spinner from '../Spinner';

--- a/packages/web-react/src/components/SplitButton/__tests__/SplitButton.test.tsx
+++ b/packages/web-react/src/components/SplitButton/__tests__/SplitButton.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, sizePropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, sizePropsTest, stylePropsTest } from '#local/tests';
 import { ComponentButtonColors } from '../../../constants';
 import { SplitButtonColorType } from '../../../types';
 import { Button } from '../../Button';

--- a/packages/web-react/src/components/SplitButton/__tests__/UncontrolledSplitButton.test.tsx
+++ b/packages/web-react/src/components/SplitButton/__tests__/UncontrolledSplitButton.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { ComponentButtonColors, Sizes } from '../../../constants';
 import { SplitButtonColorType } from '../../../types';
 import UncontrolledSplitButton from '../UncontrolledSplitButton';

--- a/packages/web-react/src/components/Stack/__tests__/Stack.test.tsx
+++ b/packages/web-react/src/components/Stack/__tests__/Stack.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import Stack from '../Stack';
 
 describe('Stack', () => {

--- a/packages/web-react/src/components/Tabs/__tests__/TabItem.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabItem.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, withTabsContext } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, withTabsContext } from '#local/tests';
 import TabItem from '../TabItem';
 
 describe('TabItem', () => {

--- a/packages/web-react/src/components/Tabs/__tests__/TabLink.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabLink.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, stylePropsTest } from '#local/tests';
 import TabLink from '../TabLink';
 
 describe('TabLink', () => {

--- a/packages/web-react/src/components/Tabs/__tests__/TabList.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabList.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, stylePropsTest } from '#local/tests';
 import TabList from '../TabList';
 import Tabs from '../Tabs';
 

--- a/packages/web-react/src/components/Tabs/__tests__/TabPane.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabPane.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, withTabsContext } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, withTabsContext } from '#local/tests';
 import TabContent from '../TabContent';
 import { TabsContextType } from '../TabContext';
 import TabPane from '../TabPane';

--- a/packages/web-react/src/components/Tag/__tests__/Tag.test.tsx
+++ b/packages/web-react/src/components/Tag/__tests__/Tag.test.tsx
@@ -7,7 +7,7 @@ import {
   sizeExtendedPropsTest,
   restPropsTest,
   stylePropsTest,
-} from '@local/tests';
+} from '#local/tests';
 import Tag from '../Tag';
 
 describe('Tag', () => {

--- a/packages/web-react/src/components/Text/__tests__/Text.test.tsx
+++ b/packages/web-react/src/components/Text/__tests__/Text.test.tsx
@@ -8,7 +8,7 @@ import {
   restPropsTest,
   stylePropsTest,
   textColorPropsTest,
-} from '@local/tests';
+} from '#local/tests';
 import { EmphasisDictionaryType, SizesDictionaryType, SizeExtendedDictionaryType } from '../../../types';
 import Text from '../Text';
 import textPropsDataProvider from './textPropsDataProvider';

--- a/packages/web-react/src/components/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/web-react/src/components/TextArea/__tests__/TextArea.test.tsx
@@ -8,7 +8,7 @@ import {
   restPropsTest,
   stylePropsTest,
   validationTextPropsTest,
-} from '@local/tests';
+} from '#local/tests';
 import TextArea from '../TextArea';
 
 describe('TextArea', () => {

--- a/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
+++ b/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
@@ -7,7 +7,7 @@ import {
   restPropsTest,
   stylePropsTest,
   validationTextPropsTest,
-} from '@local/tests';
+} from '#local/tests';
 import { TextFieldType } from '../../../types';
 import TextField from '../TextField';
 

--- a/packages/web-react/src/components/TextFieldBase/__tests__/TextFieldBase.test.tsx
+++ b/packages/web-react/src/components/TextFieldBase/__tests__/TextFieldBase.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, requiredPropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, requiredPropsTest } from '#local/tests';
 import { TextFieldType } from '../../../types';
 import TextFieldBase from '../TextFieldBase';
 

--- a/packages/web-react/src/components/Toast/__tests__/Toast.test.tsx
+++ b/packages/web-react/src/components/Toast/__tests__/Toast.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import Toast from '../Toast';
 
 describe('Toast', () => {

--- a/packages/web-react/src/components/Toast/__tests__/ToastBar.test.tsx
+++ b/packages/web-react/src/components/Toast/__tests__/ToastBar.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import ToastBar from '../ToastBar';
 
 jest.mock('../../../hooks/useIcon');

--- a/packages/web-react/src/components/Toast/__tests__/ToastBarLink.test.tsx
+++ b/packages/web-react/src/components/Toast/__tests__/ToastBarLink.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { restPropsTest, stylePropsTest } from '@local/tests';
+import { restPropsTest, stylePropsTest } from '#local/tests';
 import ToastBarLink from '../ToastBarLink';
 
 describe('ToastBarLink', () => {

--- a/packages/web-react/src/components/Toast/__tests__/ToastBarMessage.test.tsx
+++ b/packages/web-react/src/components/Toast/__tests__/ToastBarMessage.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { restPropsTest, stylePropsTest } from '@local/tests';
+import { restPropsTest, stylePropsTest } from '#local/tests';
 import ToastBarMessage from '../ToastBarMessage';
 
 describe('ToastBarMessage', () => {

--- a/packages/web-react/src/components/Tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/web-react/src/components/Tooltip/__tests__/Tooltip.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { Button } from '../../Button';
 import { Tooltip, TooltipPopover, TooltipTrigger } from '..';
 

--- a/packages/web-react/src/components/Tooltip/__tests__/TooltipPopover.test.tsx
+++ b/packages/web-react/src/components/Tooltip/__tests__/TooltipPopover.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import { TooltipPopover } from '..';
 
 describe('TooltipPopover', () => {

--- a/packages/web-react/src/components/Tooltip/__tests__/TooltipTrigger.test.tsx
+++ b/packages/web-react/src/components/Tooltip/__tests__/TooltipTrigger.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { restPropsTest, stylePropsTest } from '@local/tests';
+import { restPropsTest, stylePropsTest } from '#local/tests';
 import { Button } from '../../Button';
 import { TooltipTrigger } from '..';
 

--- a/packages/web-react/src/components/Tooltip/__tests__/UncontrolledTooltip.test.tsx
+++ b/packages/web-react/src/components/Tooltip/__tests__/UncontrolledTooltip.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { restPropsTest, stylePropsTest } from '@local/tests';
+import { restPropsTest, stylePropsTest } from '#local/tests';
 import UncontrolledTooltip from '../UncontrolledTooltip';
 
 describe('UncontrolledTooltip', () => {

--- a/packages/web-react/src/components/UNSTABLE_EmptyState/__tests__/UNSTABLE_EmptyState.test.tsx
+++ b/packages/web-react/src/components/UNSTABLE_EmptyState/__tests__/UNSTABLE_EmptyState.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import UNSTABLE_EmptyState from '../UNSTABLE_EmptyState';
 
 describe('UNSTABLE_EmptyState', () => {

--- a/packages/web-react/src/components/UNSTABLE_EmptyState/__tests__/UNSTABLE_EmptyStateSection.test.tsx
+++ b/packages/web-react/src/components/UNSTABLE_EmptyState/__tests__/UNSTABLE_EmptyStateSection.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import UNSTABLE_EmptyStateSection from '../UNSTABLE_EmptyStateSection';
 
 describe('UNSTABLE_EmptyStateSection', () => {

--- a/packages/web-react/src/components/UNSTABLE_Header/__tests__/UNSTABLE_Header.test.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Header/__tests__/UNSTABLE_Header.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import UNSTABLE_Header from '../UNSTABLE_Header';
 
 describe('UNSTABLE_Header', () => {

--- a/packages/web-react/src/components/UNSTABLE_Header/__tests__/UNSTABLE_HeaderLogo.test.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Header/__tests__/UNSTABLE_HeaderLogo.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import UNSTABLE_HeaderLogo from '../UNSTABLE_HeaderLogo';
 
 describe('UNSTABLE_HeaderLogo', () => {

--- a/packages/web-react/src/components/UNSTABLE_Slider/__tests__/UNSTABLE_Slider.test.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Slider/__tests__/UNSTABLE_Slider.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import UNSTABLE_Slider from '../UNSTABLE_Slider';
 
 describe('UNSTABLE_Slider', () => {

--- a/packages/web-react/src/components/UNSTABLE_Slider/__tests__/UNSTABLE_UncontrolledSlider.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Slider/__tests__/UNSTABLE_UncontrolledSlider.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { restPropsTest, stylePropsTest } from '@local/tests';
+import { restPropsTest, stylePropsTest } from '#local/tests';
 import UNSTABLE_UncontrolledSlider from '../UNSTABLE_UncontrolledSlider';
 
 describe('UNSTABLE_Slider', () => {

--- a/packages/web-react/src/components/UNSTABLE_Toggle/__tests__/UNSTABLE_Toggle.test.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Toggle/__tests__/UNSTABLE_Toggle.test.tsx
@@ -7,7 +7,7 @@ import {
   requiredPropsTest,
   restPropsTest,
   stylePropsTest,
-} from '@local/tests';
+} from '#local/tests';
 import UNSTABLE_Toggle from '../UNSTABLE_Toggle';
 
 describe('UNSTABLE_Toggle', () => {

--- a/packages/web-react/src/components/UNSTABLE_Truncate/__tests__/UNSTABLE_Truncate.test.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Truncate/__tests__/UNSTABLE_Truncate.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import UNSTABLE_Truncate from '../UNSTABLE_Truncate';
 
 describe('UNSTABLE_Truncate', () => {

--- a/packages/web-react/src/components/VisuallyHidden/__tests__/VisuallyHidden.test.tsx
+++ b/packages/web-react/src/components/VisuallyHidden/__tests__/VisuallyHidden.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '#local/tests';
 import VisuallyHidden from '../VisuallyHidden';
 
 describe('Visually Hidden', () => {

--- a/packages/web-react/tsconfig.json
+++ b/packages/web-react/tsconfig.json
@@ -10,11 +10,7 @@
 
     // Specify what module code is generated.
     // @see: https://www.typescriptlang.org/tsconfig/#module
-    "module": "nodenext",
-
-    // Specify how TypeScript looks up a file from a given module specifier.
-    // @see: https://www.typescriptlang.org/tsconfig/#moduleResolution
-    "moduleResolution": "nodenext"
+    "module": "ESNext"
   },
   "include": ["./src/**/*"],
   "exclude": ["./node_modules", "./dist/**/*"]

--- a/packages/web-react/tsconfig.json
+++ b/packages/web-react/tsconfig.json
@@ -14,11 +14,7 @@
 
     // Specify what module code is generated.
     // @see: https://www.typescriptlang.org/tsconfig/#module
-    "module": "ESNext",
-
-    // Specify how TypeScript looks up a file from a given module specifier.
-    // @see: https://www.typescriptlang.org/tsconfig/#moduleResolution
-    "moduleResolution": "nodenext"
+    "module": "ESNext"
   },
   "include": ["./src/**/*"],
   "exclude": ["./node_modules", "./dist/**/*"]

--- a/packages/web-react/tsconfig.json
+++ b/packages/web-react/tsconfig.json
@@ -1,6 +1,13 @@
 {
   "extends": "../../configs/typescript-config-spirit/dom",
   "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "@local/tests": ["./tests/index.ts"],
+      "@local/tests/*": ["./tests/*"]
+    },
+
     // Specify what JSX code is generated.
     // @see: https://www.typescriptlang.org/tsconfig/#jsx
     "jsx": "react",
@@ -9,12 +16,9 @@
     // @see: https://www.typescriptlang.org/tsconfig/#module
     "module": "ESNext",
 
-    "baseUrl": ".",
-
-    "paths": {
-      "@local/tests": ["./tests/index.ts"],
-      "@local/tests/*": ["./tests/*"]
-    }
+    // Specify how TypeScript looks up a file from a given module specifier.
+    // @see: https://www.typescriptlang.org/tsconfig/#moduleResolution
+    "moduleResolution": "nodenext"
   },
   "include": ["./src/**/*"],
   "exclude": ["./node_modules", "./dist/**/*"]

--- a/packages/web-react/tsconfig.json
+++ b/packages/web-react/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "rootDir": ".",
     "baseUrl": ".",
-    "paths": {
-      "@local/tests": ["./tests/index.ts"],
-      "@local/tests/*": ["./tests/*"]
-    },
 
     // Specify what JSX code is generated.
     // @see: https://www.typescriptlang.org/tsconfig/#jsx

--- a/packages/web-react/tsconfig.json
+++ b/packages/web-react/tsconfig.json
@@ -10,7 +10,11 @@
 
     // Specify what module code is generated.
     // @see: https://www.typescriptlang.org/tsconfig/#module
-    "module": "ESNext"
+    "module": "nodenext",
+
+    // Specify how TypeScript looks up a file from a given module specifier.
+    // @see: https://www.typescriptlang.org/tsconfig/#moduleResolution
+    "moduleResolution": "nodenext"
   },
   "include": ["./src/**/*"],
   "exclude": ["./node_modules", "./dist/**/*"]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I have discovered some kind of Node.js imports magic using the `imports` field. Which is respected by TypeScript, Jest and other tools, so can be used for aliasing the paths. The `#` is mandatory.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

- https://2ality.com/2025/02/typescript-esm-packages.html
- https://nodejs.org/api/packages.html#imports

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
