### PR TITLE
Style(web-react): Correcting the import order

### DIFF
--- a/configs/eslint-config-spirit/index.js
+++ b/configs/eslint-config-spirit/index.js
@@ -69,7 +69,6 @@ module.exports = {
       },
     ],
 
-
     /**
      * Allow reassignment of params in properties
      *

--- a/packages/web-react/.eslintrc.js
+++ b/packages/web-react/.eslintrc.js
@@ -85,6 +85,54 @@ module.exports = {
     // we need this for meeting our component API conventions
     // @see: https://typescript-eslint.io/rules/no-empty-interface/
     '@typescript-eslint/no-empty-interface': ['error', { allowSingleExtends: true }],
+
+    /**
+     * Set sorting of imports
+     *
+     * @see { @link https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md }
+     */
+    'import/order': [
+      'error',
+      {
+        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+        pathGroups: [
+          {
+            pattern: 'react',
+            group: 'external',
+            position: 'before',
+          },
+          {
+            pattern: '@testing-library/**',
+            group: 'external',
+            position: 'before',
+          },
+          {
+            pattern: '@local/**',
+            group: 'internal',
+            position: 'after',
+          },
+          {
+            pattern: '..',
+            group: 'parent',
+            position: 'after',
+          },
+          {
+            pattern: '**',
+            group: 'external',
+          },
+          {
+            pattern: '@**',
+            group: 'external',
+          },
+        ],
+        pathGroupsExcludedImportTypes: ['external'],
+        alphabetize: {
+          order: 'asc',
+          caseInsensitive: true,
+        },
+        'newlines-between': 'never',
+      },
+    ],
   },
 
   overrides: [

--- a/packages/web-react/config/rollup.config.js
+++ b/packages/web-react/config/rollup.config.js
@@ -1,4 +1,3 @@
-import path from 'path';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 // ES lint is disabled because there is a conflict between 2 rules
@@ -6,6 +5,8 @@ import replace from '@rollup/plugin-replace';
 // 2) should be empty line after last import (required is not considered as import)
 // eslint-disable-next-line import/order
 import minify from '@rollup/plugin-terser';
+// eslint-disable-next-line import/order -- empty line between imports
+import path from 'path';
 
 const entryPoints = require('../scripts/entryPoints');
 

--- a/packages/web-react/scripts/helpers.ts
+++ b/packages/web-react/scripts/helpers.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import * as path from 'path';
 import { glob } from 'glob';
+import * as path from 'path';
 import * as recast from 'recast';
 import * as parser from 'recast/parsers/babel';
 

--- a/packages/web-react/src/components/Text/__tests__/Text.test.tsx
+++ b/packages/web-react/src/components/Text/__tests__/Text.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import '@testing-library/jest-dom';
+import React from 'react';
 import {
   classNamePrefixProviderTest,
   sizeExtendedPropsTest,

--- a/packages/web-react/src/components/Text/demo/index.tsx
+++ b/packages/web-react/src/components/Text/demo/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import DocsSection from '../../../../docs/DocsSection';
+import TextAlignment from './TextAlignment';
 import TextColor from './TextColor';
 import TextDefault from './TextDefault';
 import TextEmphasis from './TextEmphasis';
 import TextSizes from './TextSizes';
-import TextAlignment from './TextAlignment';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/packages/web-react/src/components/UNSTABLE_Truncate/UNSTABLE_Truncate.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Truncate/UNSTABLE_Truncate.tsx
@@ -3,8 +3,8 @@
 import React, { ElementType } from 'react';
 import { useStyleProps } from '../../hooks';
 import { SpiritTruncateProps } from '../../types/truncate';
-import { useTruncateStyleProps } from './useTruncateStyleProps';
 import { mergeStyleProps } from '../../utils';
+import { useTruncateStyleProps } from './useTruncateStyleProps';
 
 const defaultProps = {
   elementType: 'span',

--- a/packages/web-react/src/components/VisuallyHidden/__tests__/VisuallyHidden.test.tsx
+++ b/packages/web-react/src/components/VisuallyHidden/__tests__/VisuallyHidden.test.tsx
@@ -1,6 +1,6 @@
+import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import '@testing-library/jest-dom';
 import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
 import VisuallyHidden from '../VisuallyHidden';
 

--- a/packages/web-react/src/hooks/__tests__/useStyleUtilities.test.ts
+++ b/packages/web-react/src/hooks/__tests__/useStyleUtilities.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
+import { TextAlignments, TextStyleProps } from '../../constants';
 import { StyleProps } from '../../types';
 import { useStyleUtilities } from '../useStyleUtilities';
-import { TextAlignments, TextStyleProps } from '../../constants';
 
 describe('useStyleUtilities hook', () => {
   it('should process style utilities correctly', () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Import order ruleset is now applied back to the web-react package with  some additional setting of ordering `@local/` scope to appropriate location between imports.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
