### PR TITLE
Fix(web-twig): Remove additional Container demo causing failing Twig e2e tests

### DIFF
--- a/packages/web-twig/src/Resources/components/Container/stories/ContainerTextAlignment.twig
+++ b/packages/web-twig/src/Resources/components/Container/stories/ContainerTextAlignment.twig
@@ -7,7 +7,3 @@
 <Container textAlignment="right">
     <DocsBox>Container</DocsBox>
 </Container>
-
-<Container textAlignment="{{ { mobile: 'left', tablet: 'center', desktop: 'right' } }}">
-    <DocsBox>Container</DocsBox>
-</Container>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

It was not failing in CI because we do not test Twig e2e in CI 🙃 But locally it failed.

@curdaj 🔫 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
