### PR TITLE
Feat(web-react): Add currentId to `Tab` onSelectionChange callback

### DIFF
--- a/packages/web-react/src/components/Tabs/README.md
+++ b/packages/web-react/src/components/Tabs/README.md
@@ -86,9 +86,9 @@ Custom responsive spacing:
 | Name                | Type                                                              | Default | Required | Description                                           |
 | ------------------- | ----------------------------------------------------------------- | ------- | -------- | ----------------------------------------------------- |
 | `selectedTab`       | \[`string` \| `number`]                                           | —       | ✓        | Identification of the selected tab                    |
-| `toogle`            | `Function`                                                        | —       | ✓        | Toggle function which accept tab ID as input          |
+| `toggle`            | `Function`                                                        | —       | ✓        | Toggle function which accept tab ID as input          |
 | `children`          | `any`                                                             | —       | ✕        | Child component                                       |
-| `onSelectionChange` | `(id: TabId) => void`                                             | —       | ✕        | When the state of the selected panel changes          |
+| `onSelectionChange` | `(previousId: TabId, currentId?: TabId) => void`                  | —       | ✕        | When the state of the selected panel changes          |
 | `spacing`           | \[`SpaceToken` \| `Partial<Record<BreakpointToken, SpaceToken>>`] | —       | ✕        | Apply [custom spacing](#custom-spacing) between items |
 
 ### UncontrolledTabs
@@ -99,7 +99,7 @@ Custom responsive spacing:
 | -------------------- | ----------------------------------------------------------------- | ------- | -------- | ----------------------------------------------------- |
 | `defaultSelectedTab` | \[`string` \| `number`]                                           | —       | ✓        | Identification of default selected tab                |
 | `children`           | `any`                                                             | —       | ✕        | Child component                                       |
-| `onSelectionChange`  | `(id: TabId) => void`                                             | —       | ✕        | When the state of the selected panel changes          |
+| `onSelectionChange`  | `(previousId: TabId, currentId?: TabId) => void`                  | —       | ✕        | When the state of the selected panel changes          |
 | `spacing`            | \[`SpaceToken` \| `Partial<Record<BreakpointToken, SpaceToken>>`] | —       | ✕        | Apply [custom spacing](#custom-spacing) between items |
 
 ### TabList

--- a/packages/web-react/src/components/Tabs/TabContext.tsx
+++ b/packages/web-react/src/components/Tabs/TabContext.tsx
@@ -8,7 +8,7 @@ const defaultContext: TabsContextType = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
   selectTab: (id: TabId) => {},
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
-  onSelectionChange: (id: TabId) => {},
+  onSelectionChange: (previousId, currentId) => {},
 };
 
 const TabsContext = createContext<TabsContextType>(defaultContext);

--- a/packages/web-react/src/components/Tabs/TabItem.tsx
+++ b/packages/web-react/src/components/Tabs/TabItem.tsx
@@ -20,7 +20,7 @@ const TabItem = ({ children, forTabPane, onClick, ...restProps }: TabItemProps):
     }
 
     if (onSelectionChange) {
-      onSelectionChange(selectedId);
+      onSelectionChange(selectedId, forTabPane);
     }
   };
 

--- a/packages/web-react/src/components/Tabs/__tests__/TabItem.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabItem.test.tsx
@@ -45,4 +45,17 @@ describe('TabItem', () => {
 
     await waitFor(() => expect(selectTabMock).toHaveBeenCalled());
   });
+
+  it('should return previousId and currentId when clicked', async () => {
+    const onSelectionChangeMock = jest.fn();
+    render(
+      withTabsContext(TabItem, { selectedId: 1, selectTab: () => {}, onSelectionChange: onSelectionChangeMock })({
+        forTabPane: 2,
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('tab'));
+
+    await waitFor(() => expect(onSelectionChangeMock).toHaveBeenCalledWith(1, 2));
+  });
 });

--- a/packages/web-react/src/types/tabs.ts
+++ b/packages/web-react/src/types/tabs.ts
@@ -12,6 +12,10 @@ export type TabId = string | number;
 
 export type TabListProps = ChildrenProps & TransferProps;
 
+export interface TabsOnSelectionChange {
+  onSelectionChange?: (previousId: TabId, currentId?: TabId) => void;
+}
+
 export interface TabItemProps extends ChildrenProps, TransferProps, ClickEvents {
   forTabPane: TabId;
 }
@@ -25,10 +29,9 @@ export interface SpiritTabsProps extends SpacingProp {
   forTabPane?: TabId;
 }
 
-export interface TabsProps extends ChildrenProps, SpacingProp, TransferProps {
+export interface TabsProps extends ChildrenProps, SpacingProp, TransferProps, TabsOnSelectionChange {
   selectedTab: TabId;
   toggle: TabsToggler;
-  onSelectionChange?: (tabId: TabId) => void;
 }
 
 export type TabLinkItemProps = StyleProps & HTMLProps<HTMLLIElement>;
@@ -51,10 +54,9 @@ export type SpiritTabLinkProps<E extends ElementType = 'a'> = TabLinkProps<E> &
 
 export type TabsToggler = (id: TabId) => void;
 
-export interface TabsContextType extends SpacingProp {
+export interface TabsContextType extends SpacingProp, TabsOnSelectionChange {
   selectedId: TabId;
   selectTab: TabsToggler;
-  onSelectionChange?: (id: TabId) => void;
 }
 
 export interface TabPaneProps extends ChildrenProps, TransferProps {
@@ -63,7 +65,6 @@ export interface TabPaneProps extends ChildrenProps, TransferProps {
 
 export type TabContentProps = ChildrenProps & TransferProps;
 
-export interface UncontrolledTabsProps extends ChildrenProps, SpacingProp, TransferProps {
+export interface UncontrolledTabsProps extends ChildrenProps, SpacingProp, TransferProps, TabsOnSelectionChange {
   defaultSelectedTab: TabId;
-  onSelectionChange?: (id: TabId) => void;
 }


### PR DESCRIPTION
## Description

### Additional context

### Issue reference

[Support: Tabs - extends `onSelectionChange` with optional currentId](https://jira.almacareer.tech/browse/DS-1785)

