### PR TITLE
Fix(web-react): Do not pass the `placement` prop to the DOM of the TooltipPopover #DS-1790

### DIFF
--- a/packages/web-react/src/components/Tooltip/TooltipPopover.tsx
+++ b/packages/web-react/src/components/Tooltip/TooltipPopover.tsx
@@ -30,7 +30,6 @@ const TooltipPopover = (props: TooltipPopoverProps) => {
   const { classProps, props: modifiedProps } = useTooltipStyleProps({
     isOpen,
     isDismissible,
-    placement,
     ...rest,
   });
   const { styleProps: contentStyleProps, props: contentOtherProps } = useStyleProps(modifiedProps);


### PR DESCRIPTION
### Issue reference

[DS-1790](https://jira.almacareer.tech/browse/DS-1790)