### PR TITLE
Fix(web-react): Do not process style props with `null` or `undefined` values

### DIFF
--- a/packages/web-react/src/hooks/__tests__/useStyleUtilities.test.ts
+++ b/packages/web-react/src/hooks/__tests__/useStyleUtilities.test.ts
@@ -150,4 +150,27 @@ describe('useStyleUtilities hook', () => {
       'text-desktop-right',
     ]);
   });
+
+  it('should not process null, undefined and an empty string style utilities', () => {
+    const mockProps = {
+      margin: undefined,
+      paddingY: null,
+      paddingX: '',
+      marginX: {
+        mobile: null,
+        tablet: undefined,
+        desktop: 'space-300',
+      },
+    };
+
+    /**
+     * @ts-hint
+     * `undefined` and `null` are not valid values for StyleProps
+     * that is why we are casting it to unknown
+     */
+    const { result } = renderHook(() => useStyleUtilities(mockProps as unknown as StyleProps, ''));
+
+    expect(result.current.styleUtilities).toEqual(['mx-desktop-300']);
+    expect(result.current.props).toEqual({});
+  });
 });

--- a/packages/web-react/src/hooks/__tests__/useStyleUtilities.test.ts
+++ b/packages/web-react/src/hooks/__tests__/useStyleUtilities.test.ts
@@ -163,11 +163,7 @@ describe('useStyleUtilities hook', () => {
       },
     };
 
-    /**
-     * @ts-hint
-     * `undefined` and `null` are not valid values for StyleProps
-     * that is why we are casting it to unknown
-     */
+    // Type casting to `unknown` - `undefined` and `null` are not valid values for StyleProps
     const { result } = renderHook(() => useStyleUtilities(mockProps as unknown as StyleProps, ''));
 
     expect(result.current.styleUtilities).toEqual(['mx-desktop-300']);

--- a/packages/web-react/src/hooks/useStyleUtilities.ts
+++ b/packages/web-react/src/hooks/useStyleUtilities.ts
@@ -10,14 +10,37 @@ import {
 import { applyClassNamePrefix } from '../utils';
 import { isEmpty } from '../utils/assert';
 
+/** The breakpoint property value. */
+type BreakpointPropValue = Partial<Record<BreakpointToken, string | SpaceToken | StyleSpacingAuto>>;
+
+/** The nullable string. */
+type NullableString = string | null | undefined;
+
+/** The prefix for the class name. */
+type ClassNamePrefix = NullableString;
+
+/** The utility name. */
+type UtilityName = string;
+
+/** The props shape. */
+type PropsShape = Record<string, string>;
+
+/** The style utilities result. */
 export type StyleUtilitiesResult = {
+  /** The parsed style utilities. */
   styleUtilities: string[];
+  /** The updated props. */
   props: StyleProps;
 };
 
 const CLASS_SEPARATOR = '-';
 
-// Return just a number from the value if not `auto`
+/**
+ * Normalize the spacing value.
+ *
+ * @param {string} value - The value to normalize.
+ * @returns {string} - Just a number from the value if not `auto.
+ */
 const normalizeSpacingValue = (value: string): string =>
   value === STYLE_SPACING_AUTO ? STYLE_SPACING_AUTO : value.replace(/[^0-9]/g, '');
 
@@ -28,16 +51,16 @@ const getUtilityValue = (value: string): string => (isSpaceToken(value) ? normal
 /**
  * Check if the key is included in the object.
  *
- * @param {object} object The object to check in.
- * @param {string} key The key to find.
- * @returns {boolean} `true` if the key is included, `false` otherwise.
+ * @param {object} object - The object to check in.
+ * @param {string} key - The key to find.
+ * @returns {boolean} - `true` if the key is included, `false` otherwise.
  */
 const isKeyIncluded = (object: Record<string, unknown>, key: string): boolean => Object.keys(object).includes(key);
 
 const processBreakpointProperties = (
-  utilityName: string,
-  propValue: Partial<Record<BreakpointToken, string | SpaceToken | StyleSpacingAuto>>,
-  prefix: string | null | undefined,
+  utilityName: UtilityName,
+  propValue: BreakpointPropValue,
+  prefix: ClassNamePrefix,
 ): string[] =>
   Object.keys(propValue).reduce((accumulatedBreakpointUtilities: string[], breakpoint: string) => {
     const breakpointValue = propValue[breakpoint as keyof typeof propValue];
@@ -54,9 +77,9 @@ const processBreakpointProperties = (
   }, []);
 
 const processProperties = (
-  utilityName: string,
-  propValue: string | Partial<Record<BreakpointToken, string | SpaceToken | StyleSpacingAuto>>,
-  prefix: string | null | undefined,
+  utilityName: UtilityName,
+  propValue: string | BreakpointPropValue,
+  prefix: ClassNamePrefix,
 ): string[] =>
   typeof propValue === 'string'
     ? [applyClassNamePrefix(prefix)(`${utilityName}-${getUtilityValue(propValue)}`)]
@@ -101,8 +124,8 @@ const isStylePropProcessable = (
 
 export const useStyleUtilities = (
   props: StyleProps,
-  prefix: string | null | undefined = '',
-  additionalProps: Record<string, string> = {},
+  prefix: ClassNamePrefix = '',
+  additionalProps: PropsShape = {},
 ): StyleUtilitiesResult => {
   const styleProps = { ...DefaultSpacingStyleProp, ...additionalProps };
 

--- a/packages/web-react/src/utils/__tests__/assert.test.ts
+++ b/packages/web-react/src/utils/__tests__/assert.test.ts
@@ -1,0 +1,75 @@
+import { isNullish, isEmptyString, isEmptyArray, isEmptyObject, isEnumerable, isEmpty } from '../assert';
+
+describe('assert', () => {
+  describe('isNullish', () => {
+    it.each([
+      [null, true],
+      [undefined, true],
+      ['', false],
+      [0, false],
+      [false, false],
+      [{}, false],
+    ])('should return %s for value %p', (value, expected) => {
+      expect(isNullish(value)).toBe(expected);
+    });
+  });
+
+  describe('isEmptyString', () => {
+    it.each([
+      ['', true],
+      ['   ', true],
+      ['hello', false],
+      [' ', true],
+    ])('should return %s for value %p', (value, expected) => {
+      expect(isEmptyString(value)).toBe(expected);
+    });
+  });
+
+  describe('isEmptyArray', () => {
+    it.each([
+      [[], true],
+      [[1, 2, 3], false],
+    ])('should return %s for value %p', (value, expected) => {
+      expect(isEmptyArray(value)).toBe(expected);
+    });
+  });
+
+  describe('isEmptyObject', () => {
+    it.each([
+      [{}, true],
+      [{ key: 'value' }, false],
+    ])('should return %s for value %p', (value, expected) => {
+      expect(isEmptyObject(value)).toBe(expected);
+    });
+  });
+
+  describe('isEnumerable', () => {
+    it.each([
+      [{ key: 'value' }, true],
+      [{}, false],
+      [null, false],
+      [undefined, false],
+    ])('should return %s for value %p', (value, expected) => {
+      expect(isEnumerable(value)).toBe(expected);
+    });
+  });
+
+  describe('isEmpty', () => {
+    it.each([
+      [null, true],
+      [undefined, true],
+      ['', true],
+      ['   ', true],
+      [[], true],
+      [{}, true],
+      ['hello', false],
+      [1, false],
+      [true, false],
+      [false, false],
+      [[1, 2, 3], false],
+      [{ key: 'value' }, false],
+    ])('should return %s for value %p', (value, expected) => {
+      expect(isEmpty(value)).toBe(expected);
+    });
+  });
+});

--- a/packages/web-react/src/utils/assert.ts
+++ b/packages/web-react/src/utils/assert.ts
@@ -1,0 +1,100 @@
+/**
+ * Check if the value is `null` or `undefined`.
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} - `true` if the value is `null` or `undefined`, `false` otherwise.
+ */
+export const isNullish = (value: unknown): value is null | undefined => value == null;
+
+/**
+ * Check if the value is an empty string.
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} - `true` if the value is an empty string, `false` otherwise.
+ */
+export const isEmptyString = (value: unknown): boolean => typeof value === 'string' && value.trim() === '';
+
+/**
+ * Check if the value is an empty array.
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} - `true` if the value is an empty array, `false` otherwise.
+ */
+export const isEmptyArray = (value: unknown): boolean => Array.isArray(value) && value.length === 0;
+
+/**
+ * Check if the value is an empty object.
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} - `true` if the value is an empty object, `false` otherwise.
+ */
+export const isEmptyObject = (value: unknown): boolean =>
+  typeof value === 'object' && value !== null && Object.keys(value).length === 0;
+
+/**
+ * Check if the value is an object with at least one own enumerable property.
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} - `true` if the object has own enumerable properties, `false` otherwise.
+ */
+export const isEnumerable = (value: unknown): boolean => {
+  if (typeof value === 'object' && value !== null) {
+    for (const key in value) {
+      if (Object.hasOwnProperty.call(value, key)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+/**
+ * Check if the value is empty.
+ *
+ * Objects are considered empty if they have no own enumerable string keyed
+ * properties.
+ * Arrays are considered empty if they have a length of 0.
+ * Strings are considered empty if they are empty or contain only whitespace.
+ * Nullish values are considered empty.
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} - `true` if the value is empty, `false` otherwise.
+ * @example
+ * ```js
+ * isEmpty(null); // => true
+ * isEmpty(undefined); // => true
+ * isEmpty(''); // => true
+ * isEmpty([]); // => true
+ * isEmpty({}); // => true
+ * isEmpty('hello'); // => false
+ * isEmpty(1); // => false
+ * isEmpty(true); // => false
+ * isEmpty(false); // => false
+ * isEmpty([1, 2, 3]); // => false
+ * isEmpty({ key: 'value' }); // => false
+ * ```
+ */
+export const isEmpty = (value: unknown): boolean => {
+  if (isNullish(value)) {
+    return true;
+  }
+
+  if (isEmptyString(value)) {
+    return true;
+  }
+
+  if (isEmptyArray(value)) {
+    return true;
+  }
+
+  if (isEmptyObject(value)) {
+    return true;
+  }
+
+  if (isEnumerable(value)) {
+    return false;
+  }
+
+  return false;
+};


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Check the value of the style props and do not process the one without value or nullable one.

Example of the condition that causes this.
```diff
---	  marginBottom={!showTogglerAfterCollapse ? 'space-300' : undefined}
+++   {...(!showTogglerAfterCollapse && { marginBottom: 'space-300' })}
```

I have not changed the types, because I think that the `undefined` or `null` value should not be passed. However I do not want to our code fail, if `marginBottom: undefined` will be used. This value will only not be passed as a final utility class.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Somehow, on the application side, the TypeScript types did not help here.

I have also added some JSDoc comments for better Intelisense in our code.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

https://jira.almacareer.tech/browse/DS-1715

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
