### PR TITLE
Refactor(web, react, twig, validations): Remove label wrap from `Checkbox`, `Radio`, and `Toggle`

### DIFF
--- a/packages/form-validations/index.html
+++ b/packages/form-validations/index.html
@@ -80,12 +80,12 @@
             <label for="phone" class="TextField__label">Phone</label>
             <input type="tel" id="phone" class="TextField__input" placeholder="+420 733 333 333" data-spirit-pattern="/^(?:\+\d{3}\s?)?(\d{3}\s?){3}$/" data-spirit-pattern-message="Invalid phone number" />
           </div>
-          <label for="checkbox-field-1" class="Checkbox" data-spirit-validate>
-            <input type="checkbox" id="checkbox-field-1" name="checkbox1" class="Checkbox__input" required />
-            <span class="Checkbox__text">
-              <span class="Checkbox__label Checkbox__label--required">I accept the terms and conditions (required)</span>
-            </span>
-          </label>
+          <div class="Checkbox" data-spirit-validate>
+            <input type="checkbox" id="checkbox-field" name="checkbox1" class="Checkbox__input" required />
+            <div class="Checkbox__text">
+              <label class="Checkbox__label Checkbox__label--required" for="checkbox-field">I accept the terms and conditions (required)</label>
+            </div>
+          </div>
           <div>
             <button type="submit" class="Button Button--primary Button--medium Button--block">Submit</button>
           </div>
@@ -249,12 +249,12 @@
             <label for="custom-errors-number" class="TextField__label TextField__label--required">Required TextField, <code>type="number"</code>, <code>min="100"</code></label>
             <input type="number" id="custom-errors-number" class="TextField__input" value="5" required min="100" data-spirit-min-message="Anything larger than 99" />
           </div>
-          <label for="custom-errors-checkbox" class="Checkbox" data-spirit-validate>
+          <div class="Checkbox" data-spirit-validate>
             <input type="checkbox" id="custom-errors-checkbox" name="custom-errors-checkbox" class="Checkbox__input" required data-spirit-required-message="You must accept the terms and conditions" />
-            <span class="Checkbox__text">
-              <span class="Checkbox__label Checkbox__label--required">I accept the terms and conditions</span>
-            </span>
-          </label>
+            <div class="Checkbox__text">
+              <label class="Checkbox__label Checkbox__label--required" for="custom-errors-checkbox">I accept the terms and conditions</label>
+            </div>
+          </div>
           <div>
             <button type="submit" class="Button Button--primary Button--medium Button--block">Submit</button>
           </div>

--- a/packages/web-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/web-react/src/components/Checkbox/Checkbox.tsx
@@ -34,14 +34,10 @@ const _Checkbox = (props: SpiritCheckboxProps, ref: ForwardedRef<HTMLInputElemen
   });
 
   return (
-    <Label
-      htmlFor={id}
-      UNSAFE_style={styleProps.style}
-      UNSAFE_className={classNames(classProps.root, styleProps.className)}
-    >
+    <div style={styleProps.style} className={classNames(classProps.root, styleProps.className)}>
       <input
         {...otherProps}
-        aria-describedby={ids.join(' ')}
+        {...(ids.length && { 'aria-describedby': ids.join(' ') })}
         type="checkbox"
         id={id}
         className={classProps.input}
@@ -51,13 +47,12 @@ const _Checkbox = (props: SpiritCheckboxProps, ref: ForwardedRef<HTMLInputElemen
         value={value}
         ref={ref}
       />
-      <span className={classProps.text}>
-        <Label elementType="span" UNSAFE_className={classProps.label}>
+      <div className={classProps.text}>
+        <Label UNSAFE_className={classProps.label} htmlFor={id}>
           {label}
         </Label>
         <HelperText
           UNSAFE_className={classProps.helperText}
-          elementType="span"
           id={`${id}__helperText`}
           registerAria={register}
           helperText={helperText}
@@ -65,7 +60,6 @@ const _Checkbox = (props: SpiritCheckboxProps, ref: ForwardedRef<HTMLInputElemen
         {validationState && (
           <ValidationText
             UNSAFE_className={classProps.validationText}
-            elementType="span"
             id={`${id}__validationText`}
             {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
             validationText={validationText}
@@ -73,8 +67,8 @@ const _Checkbox = (props: SpiritCheckboxProps, ref: ForwardedRef<HTMLInputElemen
             role={validationTextRole}
           />
         )}
-      </span>
-    </Label>
+      </div>
+    </div>
   );
 };
 

--- a/packages/web-react/src/components/Checkbox/README.md
+++ b/packages/web-react/src/components/Checkbox/README.md
@@ -56,17 +56,21 @@ Text field classes are fabricated using `useCheckboxStyleProps` hook. You can us
 
 ```jsx
 const CustomCheckbox = (props: SpiritCheckboxProps): JSX.Element => {
+  const { id } = props;
   const { classProps, props: modifiedProps } = useCheckboxStyleProps(props);
 
+  const helperTextId = `${id}-helper-text`;
+  const validationTextId = `${id}-validation-text`;
+
   return (
-    <label htmlFor={props.id} className={classProps.root}>
-      <input {...modifiedProps} className={classProps.input} />
-      <span className={styleProps.text}>
-        <span className={styleProps.label}>{props.label}</span>
-        <span className={styleProps.helperText}>{props.helperText}</span>
-        <span className={styleProps.validationText}>{props.validationText}</span>
-      </span>
-    </label>
+    <div className={classProps.root}>
+      <input {...modifiedProps} id={id} className={classProps.input} aria-describedby={`${validationTextId} ${helperTextId}`} />
+      <div className={styleProps.text}>
+        <label className={styleProps.label} htmlFor={props.id}>{props.label}</label>
+        <div className={styleProps.helperText} id={helperTextId}>{props.helperText}</div>
+        <div className={styleProps.validationText} id={validationTextId}>{props.validationText}</div>
+      </div>
+    </div>
   );
 };
 ```

--- a/packages/web-react/src/components/Checkbox/demo/CheckboxDefault.tsx
+++ b/packages/web-react/src/components/Checkbox/demo/CheckboxDefault.tsx
@@ -1,17 +1,28 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Checkbox from '../Checkbox';
 
-const CheckboxDefault = () => (
-  <>
-    <Checkbox id="checkbox-default" name="checkboxDefault" label="Checkbox Label" onChange={() => {}} />
-    <Checkbox
-      id="checkbox-default-checked"
-      name="checkboxDefaultChecked"
-      label="Checkbox Label"
-      isChecked
-      onChange={() => {}}
-    />
-  </>
-);
+const CheckboxDefault = () => {
+  const [isFirstCheckboxChecked, setFirstCheckboxChecked] = useState(false);
+  const [isSecondCheckboxChecked, setSecondCheckboxChecked] = useState(true);
+
+  return (
+    <>
+      <Checkbox
+        id="checkbox-default"
+        name="checkboxDefault"
+        label="Checkbox Label"
+        isChecked={isFirstCheckboxChecked}
+        onChange={() => setFirstCheckboxChecked(!isFirstCheckboxChecked)}
+      />
+      <Checkbox
+        id="checkbox-default-checked"
+        name="checkboxDefaultChecked"
+        label="Checkbox Label"
+        isChecked={isSecondCheckboxChecked}
+        onChange={() => setSecondCheckboxChecked(!isSecondCheckboxChecked)}
+      />
+    </>
+  );
+};
 
 export default CheckboxDefault;

--- a/packages/web-react/src/components/Checkbox/demo/CheckboxDisabled.tsx
+++ b/packages/web-react/src/components/Checkbox/demo/CheckboxDisabled.tsx
@@ -19,7 +19,6 @@ const CheckboxDisabled = () => {
         helperText="Helper text"
         isDisabled
         isRequired
-        onChange={() => {}}
       />
       <Checkbox
         id="checkbox-disabled-indeterminate"
@@ -27,7 +26,6 @@ const CheckboxDisabled = () => {
         label="Checkbox Label"
         isDisabled
         ref={checkboxRef}
-        onChange={() => {}}
       />
     </>
   );

--- a/packages/web-react/src/components/Checkbox/demo/CheckboxHelperText.tsx
+++ b/packages/web-react/src/components/Checkbox/demo/CheckboxHelperText.tsx
@@ -2,13 +2,7 @@ import React from 'react';
 import Checkbox from '../Checkbox';
 
 const CheckboxHelperText = () => (
-  <Checkbox
-    id="checkbox-helper-text"
-    name="checkboxHelperText"
-    label="Checkbox Label"
-    helperText="Helper text"
-    onChange={() => {}}
-  />
+  <Checkbox id="checkbox-helper-text" name="checkboxHelperText" label="Checkbox Label" helperText="Helper text" />
 );
 
 export default CheckboxHelperText;

--- a/packages/web-react/src/components/Checkbox/demo/CheckboxHiddenLabel.tsx
+++ b/packages/web-react/src/components/Checkbox/demo/CheckboxHiddenLabel.tsx
@@ -2,13 +2,7 @@ import React from 'react';
 import Checkbox from '../Checkbox';
 
 const CheckboxHiddenLabel = () => (
-  <Checkbox
-    id="checkbox-hidden-label"
-    name="checkboxHiddenLabel"
-    label="Checkbox Label"
-    isLabelHidden
-    onChange={() => {}}
-  />
+  <Checkbox id="checkbox-hidden-label" name="checkboxHiddenLabel" label="Checkbox Label" isLabelHidden />
 );
 
 export default CheckboxHiddenLabel;

--- a/packages/web-react/src/components/Checkbox/demo/CheckboxIndeterminate.tsx
+++ b/packages/web-react/src/components/Checkbox/demo/CheckboxIndeterminate.tsx
@@ -8,15 +8,7 @@ const CheckboxIndeterminate = () => {
     checkboxRef.current && (checkboxRef.current.indeterminate = true);
   }, [checkboxRef]);
 
-  return (
-    <Checkbox
-      id="checkbox-indeterminate"
-      name="checkboxIndeterminate"
-      label="Checkbox Label"
-      ref={checkboxRef}
-      onChange={() => {}}
-    />
-  );
+  return <Checkbox id="checkbox-indeterminate" name="checkboxIndeterminate" label="Checkbox Label" ref={checkboxRef} />;
 };
 
 export default CheckboxIndeterminate;

--- a/packages/web-react/src/components/Checkbox/demo/CheckboxItem.tsx
+++ b/packages/web-react/src/components/Checkbox/demo/CheckboxItem.tsx
@@ -1,38 +1,55 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Checkbox from '../Checkbox';
 
-const CheckboxItem = () => (
-  <>
-    <Checkbox id="checkbox-item-default" name="checkboxItemDefault" label="Checkbox Label" isItem onChange={() => {}} />
-    <Checkbox
-      id="checkbox-item-default-checked"
-      name="checkboxItemDefaultChecked"
-      label="Checkbox Label"
-      isItem
-      isChecked
-      onChange={() => {}}
-    />
-    <Checkbox
-      id="checkbox-item-helper-text"
-      name="checkboxItemHelperText"
-      label="Checkbox Label"
-      isItem
-      helperText="Helper text"
-      onChange={() => {}}
-    />
-    <Checkbox id="checkbox-item-disabled" name="checkboxItemDisabled" label="Checkbox Label" isItem isDisabled />
-    <Checkbox
-      id="checkbox-item-disabled-helper-text"
-      name="checkboxItemDisabledHelperText"
-      label="Checkbox Label"
-      isItem
-      helperText="Helper text"
-      isDisabled
-      isRequired
-      isChecked
-      onChange={() => {}}
-    />
-  </>
-);
+const CheckboxItem = () => {
+  const [isCheckedItemDefault, setIsCheckedItemDefault] = useState(false);
+  const [isCheckedItemDefaultChecked, setIsCheckedItemDefaultChecked] = useState(true);
+  const [isCheckedItemHelperText, setIsCheckedItemHelperText] = useState(false);
+
+  return (
+    <>
+      <Checkbox
+        id="checkbox-item-default"
+        name="checkboxItemDefault"
+        label="Checkbox Label"
+        isItem
+        isChecked={isCheckedItemDefault}
+        onChange={() => setIsCheckedItemDefault(!isCheckedItemDefault)}
+      />
+
+      <Checkbox
+        id="checkbox-item-default-checked"
+        name="checkboxItemDefaultChecked"
+        label="Checkbox Label"
+        isItem
+        isChecked={isCheckedItemDefaultChecked}
+        onChange={() => setIsCheckedItemDefaultChecked(!isCheckedItemDefaultChecked)}
+      />
+
+      <Checkbox
+        id="checkbox-item-helper-text"
+        name="checkboxItemHelperText"
+        label="Checkbox Label"
+        isItem
+        helperText="Helper text"
+        isChecked={isCheckedItemHelperText}
+        onChange={() => setIsCheckedItemHelperText(!isCheckedItemHelperText)}
+      />
+
+      <Checkbox id="checkbox-item-disabled" name="checkboxItemDisabled" label="Checkbox Label" isItem isDisabled />
+
+      <Checkbox
+        id="checkbox-item-disabled-helper-text"
+        name="checkboxItemDisabledHelperText"
+        label="Checkbox Label"
+        isItem
+        helperText="Helper text"
+        isDisabled
+        isRequired
+        isChecked
+      />
+    </>
+  );
+};
 
 export default CheckboxItem;

--- a/packages/web-react/src/components/Checkbox/demo/CheckboxValidation.tsx
+++ b/packages/web-react/src/components/Checkbox/demo/CheckboxValidation.tsx
@@ -1,42 +1,52 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Checkbox from '../Checkbox';
 
-const CheckboxValidation = () => (
-  <>
-    <Checkbox
-      id="checkbox-success"
-      name="checkboxSuccess"
-      label="Checkbox Label"
-      validationState="success"
-      onChange={() => {}}
-    />
-    <Checkbox
-      id="checkbox-warning"
-      name="checkboxWarning"
-      label="Checkbox Label"
-      validationState="warning"
-      validationText="Warning validation text"
-      onChange={() => {}}
-    />
-    <Checkbox
-      id="checkbox-danger"
-      name="checkboxDanger"
-      label="Checkbox Label"
-      validationState="danger"
-      validationText={['First validation text', 'Second validation text']}
-      onChange={() => {}}
-    />
-    <Checkbox
-      id="checkbox-warning-helper-text"
-      name="checkboxWarningHelperText"
-      label="Checkbox Label"
-      validationState="warning"
-      validationText="Warning validation text"
-      helperText="Helper text"
-      isChecked
-      onChange={() => {}}
-    />
-  </>
-);
+const CheckboxValidation = () => {
+  const [isCheckedSuccess, setIsCheckedSuccess] = useState(false);
+  const [isCheckedWarning, setIsCheckedWarning] = useState(false);
+  const [isCheckedDanger, setIsCheckedDanger] = useState(false);
+  const [isCheckedWarningHelperText, setIsCheckedWarningHelperText] = useState(true);
+
+  return (
+    <>
+      <Checkbox
+        id="checkbox-success"
+        name="checkboxSuccess"
+        label="Checkbox Label"
+        validationState="success"
+        isChecked={isCheckedSuccess}
+        onChange={() => setIsCheckedSuccess(!isCheckedSuccess)}
+      />
+      <Checkbox
+        id="checkbox-warning"
+        name="checkboxWarning"
+        label="Checkbox Label"
+        validationState="warning"
+        validationText="Warning validation text"
+        isChecked={isCheckedWarning}
+        onChange={() => setIsCheckedWarning(!isCheckedWarning)}
+      />
+      <Checkbox
+        id="checkbox-danger"
+        name="checkboxDanger"
+        label="Checkbox Label"
+        validationState="danger"
+        validationText={['First validation text', 'Second validation text']}
+        isChecked={isCheckedDanger}
+        onChange={() => setIsCheckedDanger(!isCheckedDanger)}
+      />
+      <Checkbox
+        id="checkbox-warning-helper-text"
+        name="checkboxWarningHelperText"
+        label="Checkbox Label"
+        validationState="warning"
+        validationText="Warning validation text"
+        helperText="Helper text"
+        isChecked={isCheckedWarningHelperText}
+        onChange={() => setIsCheckedWarningHelperText(!isCheckedWarningHelperText)}
+      />
+    </>
+  );
+};
 
 export default CheckboxValidation;

--- a/packages/web-react/src/components/Checkbox/demo/CheckboxValidationWithIcon.tsx
+++ b/packages/web-react/src/components/Checkbox/demo/CheckboxValidationWithIcon.tsx
@@ -16,7 +16,6 @@ const CheckboxValidationWithIcon = () => {
           validationState={state}
           validationText={`This is ${state} validation text.`}
           hasValidationIcon
-          onChange={() => {}}
         />
       ))}
     </>

--- a/packages/web-react/src/components/Field/HelperText.tsx
+++ b/packages/web-react/src/components/Field/HelperText.tsx
@@ -24,12 +24,12 @@ const HelperText = <T extends ElementType = 'div'>(props: HelperTextProps<T>) =>
   const mergedStyleProps = mergeStyleProps(ElementTag, { styleProps, transferProps });
 
   useEffect(() => {
-    registerAria?.({ add: id });
+    helperText && registerAria?.({ add: id });
 
     return () => {
       registerAria?.({ remove: id });
     };
-  }, [id, registerAria]);
+  }, [id, registerAria, helperText]);
 
   if (helperText) {
     return (

--- a/packages/web-react/src/components/Field/ValidationText.tsx
+++ b/packages/web-react/src/components/Field/ValidationText.tsx
@@ -30,12 +30,12 @@ const ValidationText = <T extends ElementType = 'div'>(props: ValidationTextProp
   const mergedStyleProps = mergeStyleProps(ElementTag, { styleProps, transferProps });
 
   useEffect(() => {
-    registerAria?.({ add: id });
+    validationText && registerAria?.({ add: id });
 
     return () => {
       registerAria?.({ remove: id });
     };
-  }, [id, registerAria]);
+  }, [id, registerAria, validationText]);
 
   if (!validationText) {
     return null;

--- a/packages/web-react/src/components/Field/ValidationText.tsx
+++ b/packages/web-react/src/components/Field/ValidationText.tsx
@@ -41,13 +41,7 @@ const ValidationText = <T extends ElementType = 'div'>(props: ValidationTextProp
     return null;
   }
 
-  const ValidationTextWrapper = ElementTag === 'div' ? 'div' : 'span';
-
-  const nonArrayValidationText = hasValidationStateIcon ? (
-    <ValidationTextWrapper>{validationText}</ValidationTextWrapper>
-  ) : (
-    validationText
-  );
+  const nonArrayValidationText = hasValidationStateIcon ? <div>{validationText}</div> : validationText;
 
   return (
     <ElementTag {...transferProps} {...mergedStyleProps} id={id} role={role}>

--- a/packages/web-react/src/components/Radio/README.md
+++ b/packages/web-react/src/components/Radio/README.md
@@ -51,16 +51,20 @@ Text field classes are fabricated using `useRadioStyleProps` hook. You can use i
 
 ```jsx
 const CustomRadio = (props: SpiritRadioProps): JSX.Element => {
+  const { id } = props;
   const { classProps, props: modifiedProps } = useRadioStyleProps(props);
 
+  const labelId = `${id}-label`;
+  const helperTextId = `${id}-helper-text`;
+
   return (
-    <label htmlFor={props.id} className={classProps.root}>
-      <input {...modifiedProps} className={classProps.input} />
-      <span className={styleProps.text}>
-        <span className={styleProps.label}>{props.label}</span>
-        <span className={styleProps.helperText}>{props.helperText}</span>
-      </span>
-    </label>
+    <div className={classProps.root}>
+      <input {...modifiedProps} id={id} className={classProps.input} aria-describedby={helperTextId} />
+      <div className={styleProps.text}>
+        <label className={styleProps.label} htmlFor={id}>{props.label}</label>
+        <div className={styleProps.helperText} id={helperTextId}>{props.helperText}</div>
+      </div>
+    </div>
   );
 };
 ```

--- a/packages/web-react/src/components/Radio/Radio.tsx
+++ b/packages/web-react/src/components/Radio/Radio.tsx
@@ -27,14 +27,10 @@ const _Radio = (props: SpiritRadioProps, ref: ForwardedRef<HTMLInputElement>): J
   const [ids, register] = useAriaIds(ariaDescribedBy);
 
   return (
-    <Label
-      htmlFor={id}
-      UNSAFE_style={styleProps.style}
-      UNSAFE_className={classNames(classProps.root, styleProps.className)}
-    >
+    <div style={styleProps.style} className={classNames(classProps.root, styleProps.className)}>
       <input
         {...otherProps}
-        aria-describedby={ids.join(' ')}
+        {...(ids.length && { 'aria-describedby': ids.join(' ') })}
         type="radio"
         id={id}
         className={classProps.input}
@@ -44,19 +40,18 @@ const _Radio = (props: SpiritRadioProps, ref: ForwardedRef<HTMLInputElement>): J
         value={value}
         ref={ref}
       />
-      <span className={classProps.text}>
-        <Label elementType="span" UNSAFE_className={classProps.label}>
+      <div className={classProps.text}>
+        <Label UNSAFE_className={classProps.label} htmlFor={id}>
           {label}
         </Label>
         <HelperText
           UNSAFE_className={classProps.helperText}
-          elementType="span"
           id={`${id}__helperText`}
           registerAria={register}
           helperText={helperText}
         />
-      </span>
-    </Label>
+      </div>
+    </div>
   );
 };
 

--- a/packages/web-react/src/components/Radio/demo/RadioDefault.tsx
+++ b/packages/web-react/src/components/Radio/demo/RadioDefault.tsx
@@ -1,12 +1,32 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Radio from '../Radio';
 
-const RadioDefault = () => (
-  <>
-    <Radio id="radio-default" label="Radio Label" name="radioDefault" />
+const RadioDefault = () => {
+  const [selectedRadio, setSelectedRadio] = useState('radio-default');
 
-    <Radio id="radio-default-checked" isChecked label="Radio Label" name="radioDefault" />
-  </>
-);
+  const handleChange = (id: string) => {
+    setSelectedRadio(id);
+  };
+
+  return (
+    <>
+      <Radio
+        id="radio-default"
+        label="Radio Label"
+        name="radioDefault"
+        isChecked={selectedRadio === 'radio-default'}
+        onChange={() => handleChange('radio-default')}
+      />
+
+      <Radio
+        id="radio-default-checked"
+        label="Radio Label"
+        name="radioDefault"
+        isChecked={selectedRadio === 'radio-default-checked'}
+        onChange={() => handleChange('radio-default-checked')}
+      />
+    </>
+  );
+};
 
 export default RadioDefault;

--- a/packages/web-react/src/components/Radio/demo/RadioDefault.tsx
+++ b/packages/web-react/src/components/Radio/demo/RadioDefault.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import Radio from '../Radio';
 
 const RadioDefault = () => {
-  const [selectedRadio, setSelectedRadio] = useState('radio-default');
+  const [selectedRadio, setSelectedRadio] = useState('radio-default-checked');
 
   const handleChange = (id: string) => {
     setSelectedRadio(id);

--- a/packages/web-react/src/components/Radio/demo/RadioItem.tsx
+++ b/packages/web-react/src/components/Radio/demo/RadioItem.tsx
@@ -1,26 +1,52 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Radio from '../Radio';
 
-const RadioItem = () => (
-  <>
-    <Radio id="radio-item-default" isItem label="Radio Label" name="item" />
+const RadioItem = () => {
+  const [selectedRadio, setSelectedRadio] = useState('radio-item-default-checked');
 
-    <Radio id="radio-item-default-checked" isChecked isItem label="Radio Label" name="item" />
+  return (
+    <>
+      <Radio
+        id="radio-item-default"
+        isItem
+        label="Radio Label"
+        name="item"
+        isChecked={selectedRadio === 'radio-item-default'}
+        onChange={() => setSelectedRadio('radio-item-default')}
+      />
 
-    <Radio helperText="Helper text" id="radio-item-helper-text" isItem label="Radio Label" name="item" />
+      <Radio
+        id="radio-item-default-checked"
+        isItem
+        label="Radio Label"
+        name="item"
+        isChecked={selectedRadio === 'radio-item-default-checked'}
+        onChange={() => setSelectedRadio('radio-item-default-checked')}
+      />
 
-    <Radio id="radio-item-disabled" isDisabled isItem label="Radio Label" name="itemDisabled" />
+      <Radio
+        helperText="Helper text"
+        id="radio-item-helper-text"
+        isItem
+        label="Radio Label"
+        name="item"
+        isChecked={selectedRadio === 'radio-item-helper-text'}
+        onChange={() => setSelectedRadio('radio-item-helper-text')}
+      />
 
-    <Radio
-      helperText="Helper text"
-      id="radio-item-disabled-helper-text"
-      isDisabled
-      isChecked
-      isItem
-      label="Radio Label"
-      name="itemDisabled"
-    />
-  </>
-);
+      <Radio id="radio-item-disabled" isDisabled isItem label="Radio Label" name="itemDisabled" />
+
+      <Radio
+        helperText="Helper text"
+        id="radio-item-disabled-helper-text"
+        isDisabled
+        isItem
+        label="Radio Label"
+        name="itemDisabled"
+        isChecked
+      />
+    </>
+  );
+};
 
 export default RadioItem;

--- a/packages/web-react/src/components/Radio/demo/RadioValidation.tsx
+++ b/packages/web-react/src/components/Radio/demo/RadioValidation.tsx
@@ -1,23 +1,49 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Radio from '../Radio';
 
-const RadioValidation = () => (
-  <>
-    <Radio id="radio-success" label="Radio Label" name="validation" validationState="success" />
+const RadioValidation = () => {
+  const [selectedRadio, setSelectedRadio] = useState('radio-warning-helper-text');
 
-    <Radio id="radio-warning" label="Radio Label" name="validation" validationState="warning" />
+  return (
+    <>
+      <Radio
+        id="radio-success"
+        label="Radio Label"
+        name="validation"
+        validationState="success"
+        isChecked={selectedRadio === 'radio-success'}
+        onChange={() => setSelectedRadio('radio-success')}
+      />
 
-    <Radio id="radio-danger" isChecked label="Radio Label" name="validation" validationState="danger" />
+      <Radio
+        id="radio-warning"
+        label="Radio Label"
+        name="validation"
+        validationState="warning"
+        isChecked={selectedRadio === 'radio-warning'}
+        onChange={() => setSelectedRadio('radio-warning')}
+      />
 
-    <Radio
-      helperText="Helper text"
-      id="radio-warning-helper-text"
-      isChecked
-      label="Radio Label"
-      name="validation"
-      validationState="warning"
-    />
-  </>
-);
+      <Radio
+        id="radio-danger"
+        label="Radio Label"
+        name="validation"
+        validationState="danger"
+        isChecked={selectedRadio === 'radio-danger'}
+        onChange={() => setSelectedRadio('radio-danger')}
+      />
+
+      <Radio
+        helperText="Helper text"
+        id="radio-warning-helper-text"
+        label="Radio Label"
+        name="validation"
+        validationState="warning"
+        isChecked={selectedRadio === 'radio-warning-helper-text'}
+        onChange={() => setSelectedRadio('radio-warning-helper-text')}
+      />
+    </>
+  );
+};
 
 export default RadioValidation;

--- a/packages/web-react/src/components/Toggle/Toggle.tsx
+++ b/packages/web-react/src/components/Toggle/Toggle.tsx
@@ -41,18 +41,13 @@ const _Toggle = (props: SpiritToggleProps, ref: ForwardedRef<HTMLInputElement>) 
   };
 
   return (
-    <Label
-      htmlFor={id}
-      UNSAFE_style={styleProps.style}
-      UNSAFE_className={classNames(classProps.root, styleProps.className)}
-    >
-      <span className={classProps.text}>
-        <Label elementType="span" UNSAFE_className={classProps.label}>
+    <div style={styleProps.style} className={classNames(classProps.root, styleProps.className)}>
+      <div className={classProps.text}>
+        <Label UNSAFE_className={classProps.label} htmlFor={id}>
           {label}
         </Label>
         <HelperText
           UNSAFE_className={classProps.helperText}
-          elementType="span"
           id={`${id}__helperText`}
           registerAria={register}
           helperText={helperText}
@@ -67,10 +62,10 @@ const _Toggle = (props: SpiritToggleProps, ref: ForwardedRef<HTMLInputElement>) 
             role={validationTextRole}
           />
         )}
-      </span>
+      </div>
       <input
         {...otherProps}
-        aria-describedby={ids.join(' ')}
+        {...(ids.length && { 'aria-describedby': ids.join(' ') })}
         type="checkbox"
         id={id}
         className={classProps.input}
@@ -80,7 +75,7 @@ const _Toggle = (props: SpiritToggleProps, ref: ForwardedRef<HTMLInputElement>) 
         onChange={handleOnChange}
         ref={ref}
       />
-    </Label>
+    </div>
   );
 };
 

--- a/packages/web-react/tests/providerTests/itemPropsTest.tsx
+++ b/packages/web-react/tests/providerTests/itemPropsTest.tsx
@@ -1,14 +1,14 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
 import React, { ComponentType } from 'react';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const itemPropsTest = (Component: ComponentType<any>) => {
   it('should have item classname', async () => {
-    const dom = render(<Component isItem />);
+    render(<Component isItem data-testid="test" />);
 
     await waitFor(() => {
-      const element = dom.container.querySelector('label') as HTMLElement;
-      expect(element.getAttribute('class')).toContain('--item');
+      const element = screen.queryByTestId('test');
+      expect(element?.parentElement?.className).toContain('--item');
     });
   });
 };

--- a/packages/web-twig/src/Resources/components/Checkbox/Checkbox.twig
+++ b/packages/web-twig/src/Resources/components/Checkbox/Checkbox.twig
@@ -41,14 +41,16 @@
 {%- set _validationTextId = _validationText or _unsafeValidationText ? _id ~ '-validation-text' : null -%}
 
 {# Attributes #}
-{%- set _ariaDescribedByAttr = _helperTextId or _validationTextId ? 'aria-describedby="' ~ [ _helperTextId, _validationTextId ] | join (' ') | trim ~ '"' : null -%}
+{%- set _ariaDescribedByAttr = _helperTextId or _validationTextId ? 'aria-describedby="' ~ [ _validationTextId, _helperTextId  ] | join (' ') | trim ~ '"' : null -%}
 {%- set _checkedAttr = _isChecked ? 'checked' : null -%}
 {%- set _disabledAttr = _isDisabled ? 'disabled' : null -%}
 {%- set _nameAttr = _name ? 'name="' ~ _name | escape('html_attr') ~ '"' : null -%}
 {%- set _requiredAttr = _isRequired ? 'required' : null -%}
 {%- set _valueAttr = _value ? 'value=' ~ _value : null -%}
 
-<label for="{{ _id }}" {{ mainProps(_mainPropsWithoutId) }} {{ styleProp(_styleProps) }} {{ classProp(_classNames) }}>
+{# Render #}
+
+<div {{ mainProps(_mainPropsWithoutId) }} {{ styleProp(_styleProps) }} {{ classProp(_classNames) }}>
     <input
         {{ inputProps(props, _allowedInputAttributes, _inputProps) }}
         type="checkbox"
@@ -61,29 +63,27 @@
         {{ _valueAttr }} {# Intentionally without `raw` to prevent XSS. #}
         {{ _ariaDescribedByAttr | raw }}
     />
-    <span class="{{ _textClassName }}">
-        <span {{ classProp(_labelClassName) }}>
+    <div class="{{ _textClassName }}">
+        <label {{ classProp(_labelClassName) }} for="{{ _id }}">
             {%- if _unsafeLabel -%}
                 {{ _unsafeLabel | raw }}
             {%- else -%}
                 {{ _label }}
             {%- endif -%}
-        </span>
+        </label>
         <HelperText
             className="{{ _helperTextClassName }}"
-            elementType="span"
             helperText="{{ _helperText }}"
             id="{{ _helperTextId }}"
             UNSAFE_helperText="{{ _unsafeHelperText }}"
         />
         <ValidationText
             className="{{ _validationTextClassName }}"
-            elementType="span"
             hasValidationStateIcon="{{ _hasValidationIcon ? _validationState : null }}"
             id="{{ _validationTextId }}"
             validationState="{{ _validationState }}"
             validationText="{{ _validationText }}"
             UNSAFE_validationText="{{ _unsafeValidationText }}"
         />
-    </span>
-</label>
+    </div>
+</div>

--- a/packages/web-twig/src/Resources/components/Checkbox/__tests__/__snapshots__/checkboxDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Checkbox/__tests__/__snapshots__/checkboxDefault.twig.snap.html
@@ -5,20 +5,66 @@
     </title>
   </head>
   <body>
-    <label for="" class="Checkbox"><input type="checkbox" id="" class="Checkbox__input"></label> 
+    <div class="Checkbox">
+      <input type="checkbox" id="" class="Checkbox__input">
+      <div class="Checkbox__text">
+      </div>
+    </div>
     <!-- Render with minimum props -->
-     <label for="example-id-min" class="Checkbox"><input type="checkbox" id="example-id-min" class="Checkbox__input">
-    <span class="Checkbox__text"><span class="Checkbox__label">Example label</span></span></label> 
+
+    <div class="Checkbox">
+      <input type="checkbox" id="example-id-min" class="Checkbox__input">
+      <div class="Checkbox__text">
+        <label class="Checkbox__label" for="example-id-min">Example label</label>
+      </div>
+    </div>
     <!-- Render checked -->
-     <label for="example-id-checked" class="Checkbox"><input type="checkbox" id="example-id-checked" class="Checkbox__input" checked> <span class="Checkbox__text"><span class="Checkbox__label">Example
-    label</span></span></label> <!-- Render with helper text -->
-     <label for="example-id-helper" class="Checkbox"><input type="checkbox" id="example-id-helper" class="Checkbox__input" aria-describedby="example-id-helper-helper-text"> <span class="Checkbox__text"><span class="Checkbox__label">Example label</span> <span class="Checkbox__helperText" id="example-id-helper-helper-text">Example helper text</span></span></label> <!-- Render with hidden label -->
-     <label for="example-id-hidden" class="Checkbox"><input type="checkbox" id="example-id-hidden" class="Checkbox__input"> <span class="Checkbox__text"><span class="Checkbox__label Checkbox__label--hidden">Example
-    label</span></span></label> <!-- Render with all props -->
-     <label for="example-id-all" class="Checkbox Checkbox--disabled Checkbox--item Checkbox--danger"><input data-validate="true" type="checkbox" id="example-id-all" class="Checkbox__input" checked disabled name="example-name" required="" value="" aria-describedby="example-id-all-helper-text example-id-all-validation-text"> <span class="Checkbox__text"><span class="Checkbox__label Checkbox__label--hidden Checkbox__label--required">UNSAFE
-    label</span> <span class="Checkbox__helperText" id="example-id-all-helper-text">UNSAFE helper text</span>
-    <span class="Checkbox__validationText" id="example-id-all-validation-text"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewbox="0 0 24 24" fill="none" id="svg_b9dd7d040cc17e885d046cf711e416db" class="Icon" aria-hidden="true">
-    <path d="M2.73004 21.0001H21.26C22.03 21.0001 22.51 20.1701 22.13 19.5001L12.86 3.50006C12.47 2.83006 11.51 2.83006 11.13 3.50006L1.86004 19.5001C1.48004 20.1701 1.96004 21.0001 2.73004 21.0001ZM13 18.0001H11V16.0001H13V18.0001ZM12 14.0001C11.45 14.0001 11 13.5501 11 13.0001V11.0001C11 10.4501 11.45 10.0001 12 10.0001C12.55 10.0001 13 10.4501 13 11.0001V13.0001C13 13.5501 12.55 14.0001 12 14.0001Z" fill="currentColor">
-    </path></svg> <span>Example validation text</span></span></span></label>
+
+    <div class="Checkbox">
+      <input type="checkbox" id="example-id-checked" class="Checkbox__input" checked>
+      <div class="Checkbox__text">
+        <label class="Checkbox__label" for="example-id-checked">Example label</label>
+      </div>
+    </div>
+    <!-- Render with helper text -->
+
+    <div class="Checkbox">
+      <input type="checkbox" id="example-id-helper" class="Checkbox__input" aria-describedby="example-id-helper-helper-text">
+      <div class="Checkbox__text">
+        <label class="Checkbox__label" for="example-id-helper">Example label</label>
+        <div class="Checkbox__helperText" id="example-id-helper-helper-text">
+          Example helper text
+        </div>
+      </div>
+    </div>
+    <!-- Render with hidden label -->
+
+    <div class="Checkbox">
+      <input type="checkbox" id="example-id-hidden" class="Checkbox__input">
+      <div class="Checkbox__text">
+        <label class="Checkbox__label Checkbox__label--hidden" for="example-id-hidden">Example label</label>
+      </div>
+    </div>
+    <!-- Render with all props -->
+
+    <div class="Checkbox Checkbox--disabled Checkbox--item Checkbox--danger">
+      <input data-validate="true" type="checkbox" id="example-id-all" class="Checkbox__input" checked disabled name="example-name" required="" value="" aria-describedby="example-id-all-validation-text example-id-all-helper-text">
+      <div class="Checkbox__text">
+        <label class="Checkbox__label Checkbox__label--hidden Checkbox__label--required" for="example-id-all">UNSAFE
+        label</label>
+        <div class="Checkbox__helperText" id="example-id-all-helper-text">
+          UNSAFE helper text
+        </div>
+
+        <div class="Checkbox__validationText" id="example-id-all-validation-text">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewbox="0 0 24 24" fill="none" id="svg_b9dd7d040cc17e885d046cf711e416db" class="Icon" aria-hidden="true">
+          <path d="M2.73004 21.0001H21.26C22.03 21.0001 22.51 20.1701 22.13 19.5001L12.86 3.50006C12.47 2.83006 11.51 2.83006 11.13 3.50006L1.86004 19.5001C1.48004 20.1701 1.96004 21.0001 2.73004 21.0001ZM13 18.0001H11V16.0001H13V18.0001ZM12 14.0001C11.45 14.0001 11 13.5501 11 13.0001V11.0001C11 10.4501 11.45 10.0001 12 10.0001C12.55 10.0001 13 10.4501 13 11.0001V13.0001C13 13.5501 12.55 14.0001 12 14.0001Z" fill="currentColor">
+          </path></svg>
+          <div>
+            Example validation text
+          </div>
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/packages/web-twig/src/Resources/components/Checkbox/__tests__/__snapshots__/checkboxDefaultPure.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Checkbox/__tests__/__snapshots__/checkboxDefaultPure.twig.snap.html
@@ -5,6 +5,14 @@
     </title>
   </head>
   <body>
-    <label for="example" class="Checkbox Checkbox--danger"><input type="checkbox" id="example" class="Checkbox__input" name="example" required="" aria-describedby="example-validation-text"> <span class="Checkbox__text"><span class="Checkbox__label Checkbox__label--required">some label</span> <span class="Checkbox__validationText" id="example-validation-text">validation failed</span></span></label>
+    <div class="Checkbox Checkbox--danger">
+      <input type="checkbox" id="example" class="Checkbox__input" name="example" required="" aria-describedby="example-validation-text">
+      <div class="Checkbox__text">
+        <label class="Checkbox__label Checkbox__label--required" for="example">some label</label>
+        <div class="Checkbox__validationText" id="example-validation-text">
+          validation failed
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/packages/web-twig/src/Resources/components/Checkbox/__tests__/__snapshots__/checkboxItem.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Checkbox/__tests__/__snapshots__/checkboxItem.twig.snap.html
@@ -5,6 +5,14 @@
     </title>
   </head>
   <body>
-    <label for="example" class="Checkbox Checkbox--item"><input type="checkbox" id="example" class="Checkbox__input" name="example" aria-describedby="example-helper-text"> <span class="Checkbox__text"><span class="Checkbox__label">item</span> <span class="Checkbox__helperText" id="example-helper-text">helperText</span></span></label>
+    <div class="Checkbox Checkbox--item">
+      <input type="checkbox" id="example" class="Checkbox__input" name="example" aria-describedby="example-helper-text">
+      <div class="Checkbox__text">
+        <label class="Checkbox__label" for="example">item</label>
+        <div class="Checkbox__helperText" id="example-helper-text">
+          helperText
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/packages/web-twig/src/Resources/components/Radio/Radio.twig
+++ b/packages/web-twig/src/Resources/components/Radio/Radio.twig
@@ -41,7 +41,7 @@
 {%- set _idAttr = _id ? 'id="' ~ _id | escape('html_attr') ~ '"' : null -%}
 {%- set _labelForAttr = _id ? 'for="' ~ _id | escape('html_attr') ~ '"' : null -%}
 
-<label {{ _labelForAttr | raw }} {{ mainProps(_mainPropsWithoutId) }} {{ styleProp(_styleProps) }} {{ classProp(_classNames) }}>
+<div {{ mainProps(_mainPropsWithoutId) }} {{ styleProp(_styleProps) }} {{ classProp(_classNames) }}>
     <input
         {{ inputProps(props, _allowedInputAttributes, _inputProps) }}
         type="radio"
@@ -53,20 +53,19 @@
         {{ _valueAttr }} {# Intentionally without `raw` to prevent XSS. #}
         {{ _ariaDescribedByAttr | raw }}
     />
-    <span class="{{ _textClassName }}">
-        <span {{ classProp(_labelClassName) }}>
+    <div class="{{ _textClassName }}">
+        <label {{ classProp(_labelClassName) }} {{ _labelForAttr | raw }}>
             {%- if _unsafeLabel -%}
                 {{ _unsafeLabel | raw }}
             {%- else -%}
                 {{ _label }}
             {%- endif -%}
-        </span>
+        </label>
         <HelperText
             className="{{ _helperTextClassName }}"
-            elementType="span"
             helperText="{{ _helperText }}"
             id="{{ _helperTextId }}"
             UNSAFE_helperText="{{ _unsafeHelperText }}"
         />
-    </span>
-</label>
+    </div>
+</div>

--- a/packages/web-twig/src/Resources/components/Radio/__tests__/__snapshots__/radioDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Radio/__tests__/__snapshots__/radioDefault.twig.snap.html
@@ -5,6 +5,10 @@
     </title>
   </head>
   <body>
-    <label for="example" class="Radio"><input data-validate="true" type="radio" name="example" class="Radio__input" id="example" checked> </label>
+    <div class="Radio">
+      <input data-validate="true" type="radio" name="example" class="Radio__input" id="example" checked>
+      <div class="Radio__text">
+      </div>
+    </div>
   </body>
 </html>

--- a/packages/web-twig/src/Resources/components/Radio/__tests__/__snapshots__/radioDefaultPure.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Radio/__tests__/__snapshots__/radioDefaultPure.twig.snap.html
@@ -5,6 +5,11 @@
     </title>
   </head>
   <body>
-    <label for="example" class="Radio"><input type="radio" name="example" class="Radio__input" id="example" checked> <span class="Radio__text"><span class="Radio__label">some label</span></span></label>
+    <div class="Radio">
+      <input type="radio" name="example" class="Radio__input" id="example" checked>
+      <div class="Radio__text">
+        <label class="Radio__label" for="example">some label</label>
+      </div>
+    </div>
   </body>
 </html>

--- a/packages/web-twig/src/Resources/components/Radio/__tests__/__snapshots__/radioItem.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Radio/__tests__/__snapshots__/radioItem.twig.snap.html
@@ -5,6 +5,11 @@
     </title>
   </head>
   <body>
-    <label for="example" class="Radio Radio--item"><input type="radio" name="example" class="Radio__input" id="example"> <span class="Radio__text"><span class="Radio__label">item</span></span></label>
+    <div class="Radio Radio--item">
+      <input type="radio" name="example" class="Radio__input" id="example">
+      <div class="Radio__text">
+        <label class="Radio__label" for="example">item</label>
+      </div>
+    </div>
   </body>
 </html>

--- a/packages/web/src/scss/components/Checkbox/README.md
+++ b/packages/web/src/scss/components/Checkbox/README.md
@@ -3,23 +3,23 @@
 ## Basic Usage
 
 ```html
-<label for="checkbox-default" class="Checkbox">
+<div class="Checkbox">
   <input type="checkbox" id="checkbox-default" class="Checkbox__input" name="default" />
-  <span class="Checkbox__text">
-    <span class="Checkbox__label">Checkbox Label</span>
-  </span>
-</label>
+  <div class="Checkbox__text">
+    <label class="Checkbox__label" for="checkbox-default">Checkbox Label</label>
+  </div>
+</div>
 ```
 
 ## Required Input
 
 ```html
-<label for="checkbox-required" class="Checkbox">
+<div class="Checkbox">
   <input type="checkbox" id="checkbox-required" class="Checkbox__input" name="required" required />
-  <span class="Checkbox__text">
-    <span class="Checkbox__label Checkbox__label--required">Checkbox Label</span>
-  </span>
-</label>
+  <div class="Checkbox__text">
+    <label class="Checkbox__label Checkbox__label--required" for="checkbox-required">Checkbox Label</label>
+  </div>
+</div>
 ```
 
 ## Validation State with Validation Text
@@ -30,84 +30,108 @@ See Validation state [dictionary][dictionary-validation].
 - To render validation text with an icon, add `<svg>` icon inside of `.Checkbox__validationText`.
 
 ```html
-<label for="checkbox-warning" class="Checkbox Checkbox--warning">
-  <input type="checkbox" id="checkbox-warning" class="Checkbox__input" name="warning" />
-  <span class="Checkbox__text">
-    <span class="Checkbox__label">Checkbox Label</span>
-    <span class="Checkbox__validationText">Warning validation text</span>
-  </span>
-</label>
+<div class="Checkbox Checkbox--warning">
+  <input
+    type="checkbox"
+    id="checkbox-warning"
+    class="Checkbox__input"
+    name="warning"
+    aria-describedby="checkbox-warning-helper-text"
+  />
+  <div class="Checkbox__text">
+    <label class="Checkbox__label" for="checkbox-warning">Checkbox Label</label>
+    <div class="Checkbox__validationText" id="checkbox-warning-helper-text">Warning validation text</div>
+  </div>
+</div>
 
-<label for="checkbox-danger" class="Checkbox Checkbox--danger">
-  <input type="checkbox" id="checkbox-danger" class="Checkbox__input" name="danger" />
-  <span class="Checkbox__text">
-    <span class="Checkbox__label">Checkbox Label</span>
-    <div class="Checkbox__validationText">
+<div class="Checkbox Checkbox--danger">
+  <input
+    type="checkbox"
+    id="checkbox-danger"
+    class="Checkbox__input"
+    name="danger"
+    aria-describedby="checkbox-danger-helper-text"
+  />
+  <div class="Checkbox__text">
+    <label class="Checkbox__label" for="checkbox-danger">Checkbox Label</label>
+    <div class="Checkbox__validationText" id="checkbox-danger-helper-text">
       <ul>
         <li>First validation text</li>
         <li>Second validation text</li>
       </ul>
     </div>
-  </span>
-</label>
+  </div>
+</div>
 
-<label for="checkbox-warning" class="Checkbox Checkbox--warning">
-  <input type="checkbox" id="checkbox-warning" class="Checkbox__input" name="warning" />
-  <span class="Checkbox__text">
-    <span class="Checkbox__label">Checkbox Label</span>
-    <span class="Checkbox__validationText">
+<div class="Checkbox Checkbox--warning">
+  <input
+    type="checkbox"
+    id="checkbox-warning"
+    class="Checkbox__input"
+    name="warning"
+    aria-describedby="checkbox-warning-helper-text"
+  />
+  <div class="Checkbox__text">
+    <label class="Checkbox__label" for="checkbox-warning">Checkbox Label</label>
+    <div class="Checkbox__validationText" id="checkbox-warning-helper-text">
       <svg width="20" height="20" aria-hidden="true">
         <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
       </svg>
       <span>Warning validation text with icon</span>
-    </span>
-  </span>
-</label>
+    </div>
+  </div>
+</div>
 ```
 
 ## Hidden Label
 
 ```html
-<label for="checkbox-hidden-label" class="Checkbox">
+<div class="Checkbox">
   <input type="checkbox" id="checkbox-hidden-label" class="Checkbox__input" name="hiddenLabel" required />
-  <span class="Checkbox__text">
-    <span class="Checkbox__label Checkbox__label--hidden">Checkbox Label</span>
-  </span>
-</label>
+  <div class="Checkbox__text">
+    <label class="Checkbox__label Checkbox__label--hidden" for="checkbox-hidden-label">Checkbox Label</label>
+  </div>
+</div>
 ```
 
 ## Helper Text
 
 ```html
-<label for="checkbox-helper-text" class="Checkbox">
-  <input type="checkbox" id="checkbox-helper-text" class="Checkbox__input" name="helperText" />
-  <span class="Checkbox__text">
-    <span class="Checkbox__label">Checkbox Label</span>
-    <span class="Checkbox__helperText">Helper text</span>
-  </span>
-</label>
+<div class="Checkbox">
+  <input
+    type="checkbox"
+    id="checkbox-helper-text"
+    class="Checkbox__input"
+    name="helperText"
+    aria-describedby="checkbox-helper-text-helper-text"
+  />
+  <div class="Checkbox__text">
+    <label class="Checkbox__label" for="checkbox-helper-text">Checkbox Label</label>
+    <div class="Checkbox__helperText" id="checkbox-helper-text-helper-text">Helper text</div>
+  </div>
+</div>
 ```
 
 ## Disabled State
 
 ```html
-<label for="checkbox-disabled" class="Checkbox Checkbox--disabled">
+<div class="Checkbox Checkbox--disabled">
   <input type="checkbox" id="checkbox-disabled" class="Checkbox__input" name="disabled" disabled />
-  <span class="Checkbox__text">
-    <span class="Checkbox__label">Checkbox Label</span>
-  </span>
-</label>
+  <div class="Checkbox__text">
+    <label class="Checkbox__label" for="checkbox-disabled">Checkbox Label</label>
+  </div>
+</div>
 ```
 
 ## As an Item
 
 ```html
-<label for="checkbox-item-default" class="Checkbox Checkbox--item">
+<div class="Checkbox Checkbox--item">
   <input type="checkbox" id="checkbox-item-default" class="Checkbox__input" name="item" />
-  <span class="Checkbox__text">
-    <span class="Checkbox__label">Checkbox Label</span>
-  </span>
-</label>
+  <div class="Checkbox__text">
+    <label class="Checkbox__label" for="checkbox-item-default">Checkbox Label</label>
+  </div>
+</div>
 ```
 
 [dictionary-validation]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation

--- a/packages/web/src/scss/components/Checkbox/_Checkbox.scss
+++ b/packages/web/src/scss/components/Checkbox/_Checkbox.scss
@@ -2,6 +2,7 @@
 //    and therefore bloating the CSS.
 // 2. We need to set the background-color of the non-disabled Checkbox input to initial color when it is hovered
 //    or active, because we need it contrasting with the background color.
+// 3. Make the text selectable and allow links to be clickable in the helper and validation texts.
 
 @use 'theme';
 @use '../../theme/form-fields' as form-fields-theme;
@@ -12,6 +13,8 @@ $_field-name: 'Checkbox';
 
 .Checkbox {
     @include form-fields-tools.inline-field-root();
+
+    position: relative;
 }
 
 .Checkbox__text {
@@ -20,6 +23,7 @@ $_field-name: 'Checkbox';
 
 .Checkbox__label {
     @include form-fields-tools.inline-field-label();
+    @include form-fields-tools.stretch();
 }
 
 .Checkbox__label--hidden {
@@ -67,10 +71,18 @@ $_field-name: 'Checkbox';
     @include form-fields-tools.helper-text();
 }
 
+.Checkbox__validationText,
+.Checkbox__helperText {
+    position: relative; // 3.
+    z-index: 1; // 3.
+}
+
 @include form-fields-tools.input-field-validation-states($_field-name);
 
 .Checkbox--item {
     @include form-fields-tools.item();
+
+    position: relative;
 }
 
 .Checkbox--item .Checkbox__label {
@@ -94,7 +106,7 @@ $_field-name: 'Checkbox';
 }
 
 :is(.Checkbox--disabled, .Checkbox.is-disabled) .Checkbox__label {
-    @include form-fields-tools.label-disabled();
+    @include form-fields-tools.inline-field-label-disabled();
 }
 
 :is(.Checkbox--disabled, .Checkbox.is-disabled) .Checkbox__validationText {

--- a/packages/web/src/scss/components/Checkbox/index.html
+++ b/packages/web/src/scss/components/Checkbox/index.html
@@ -19,19 +19,19 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="checkbox-default" class="Checkbox">
+      <div class="Checkbox">
         <input type="checkbox" id="checkbox-default" class="Checkbox__input" name="default" />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label">Checkbox Label</span>
-        </span>
-      </label>
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="checkbox-default">Checkbox Label</label>
+        </div>
+      </div>
 
-      <label for="checkbox-default-checked" class="Checkbox">
+      <div class="Checkbox">
         <input type="checkbox" id="checkbox-default-checked" class="Checkbox__input" name="defaultChecked" checked />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label">Checkbox Label</span>
-        </span>
-      </label>
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="checkbox-default-checked">Checkbox Label</label>
+        </div>
+      </div>
 
     </div>
 
@@ -47,12 +47,12 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="checkbox-indeterminate" class="Checkbox">
+      <div class="Checkbox">
         <input type="checkbox" id="checkbox-indeterminate" class="Checkbox__input" name="indeterminate" />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label">Checkbox Label</span>
-        </span>
-      </label>
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="checkbox-indeterminate">Checkbox Label</label>
+        </div>
+      </div>
 
     </div>
 
@@ -68,12 +68,12 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="checkbox-required" class="Checkbox">
+      <div class="Checkbox">
         <input type="checkbox" id="checkbox-required" class="Checkbox__input" name="required" required />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label Checkbox__label--required">Checkbox Label</span>
-        </span>
-      </label>
+        <div class="Checkbox__text">
+          <label class="Checkbox__label Checkbox__label--required" for="checkbox-required">Checkbox Label</label>
+        </div>
+      </div>
 
     </div>
 
@@ -89,12 +89,12 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="checkbox-hidden-label" class="Checkbox">
+      <div class="Checkbox">
         <input type="checkbox" id="checkbox-hidden-label" class="Checkbox__input" name="hiddenLabel" />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label Checkbox__label--hidden">Checkbox Label</span>
-        </span>
-      </label>
+        <div class="Checkbox__text">
+          <label class="Checkbox__label Checkbox__label--hidden" for="checkbox-hidden-label">Checkbox Label</label>
+        </div>
+      </div>
 
     </div>
 
@@ -110,13 +110,13 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="checkbox-helper-text" class="Checkbox">
-        <input type="checkbox" id="checkbox-helper-text" class="Checkbox__input" name="helperText" />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label">Checkbox Label</span>
-          <span class="Checkbox__helperText">Helper text</span>
-        </span>
-      </label>
+      <div class="Checkbox">
+        <input type="checkbox" id="checkbox-helper-text" class="Checkbox__input" name="helperText" aria-describedby="checkbox-helper-text-helper-text" />
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="checkbox-helper-text">Checkbox Label</label>
+          <div class="Checkbox__helperText" id="checkbox-helper-text-helper-text">Helper text</div>
+        </div>
+      </div>
 
     </div>
 
@@ -132,35 +132,42 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="checkbox-disabled" class="Checkbox Checkbox--disabled">
+      <div class="Checkbox Checkbox--disabled">
         <input type="checkbox" id="checkbox-disabled" class="Checkbox__input" name="disabled" disabled />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label">Checkbox Label</span>
-        </span>
-      </label>
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="checkbox-disabled">Checkbox Label</label>
+        </div>
+      </div>
 
-      <label for="checkbox-disabled-helper-text" class="Checkbox Checkbox--disabled">
+      <div class="Checkbox Checkbox--disabled">
         <input
           type="checkbox"
           id="checkbox-disabled-helper-text"
           class="Checkbox__input"
           name="disabledWithText"
+          aria-describedby="checkbox-disabled-helper-text-helper-text"
           disabled
           checked
           required
         />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label Checkbox__label--required">Checkbox Label</span>
-          <span class="Checkbox__helperText">Helper text</span>
-        </span>
-      </label>
+        <div class="Checkbox__text">
+          <label class="Checkbox__label Checkbox__label--required" for="checkbox-disabled-helper-text">Checkbox Label</label>
+          <div class="Checkbox__helperText" id="checkbox-disabled-helper-text-helper-text">Helper text</div>
+        </div>
+      </div>
 
-      <label for="checkbox-disabled-indeterminate" class="Checkbox Checkbox--disabled">
-        <input type="checkbox" id="checkbox-disabled-indeterminate" class="Checkbox__input" name="disabledIndeterminate" disabled />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label">Checkbox Label</span>
-        </span>
-      </label>
+      <div class="Checkbox Checkbox--disabled">
+        <input
+          type="checkbox"
+          id="checkbox-disabled-indeterminate"
+          class="Checkbox__input"
+          name="disabledIndeterminate"
+          disabled
+        />
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="checkbox-disabled-indeterminate">Checkbox Label</label>
+        </div>
+      </div>
 
     </div>
 
@@ -176,26 +183,26 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="checkbox-success" class="Checkbox Checkbox--success">
+      <div class="Checkbox Checkbox--success">
         <input type="checkbox" id="checkbox-success" class="Checkbox__input" name="success" />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label">Checkbox Label</span>
-        </span>
-      </label>
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="checkbox-success">Checkbox Label</label>
+        </div>
+      </div>
 
-      <label for="checkbox-warning" class="Checkbox Checkbox--warning">
-        <input type="checkbox" id="checkbox-warning" class="Checkbox__input" name="warning" />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label">Checkbox Label</span>
-          <span class="Checkbox__validationText">Warning validation text</span>
-        </span>
-      </label>
+      <div class="Checkbox Checkbox--warning">
+        <input type="checkbox" id="checkbox-warning" class="Checkbox__input" name="warning" aria-describedby="checkbox-warning-validation-text" />
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="checkbox-warning">Checkbox Label</label>
+          <div class="Checkbox__validationText" id="checkbox-warning-validation-text">Warning validation text</div>
+        </div>
+      </div>
 
       <div class="Checkbox Checkbox--danger">
-        <input type="checkbox" id="checkbox-danger" class="Checkbox__input" name="danger" />
+        <input type="checkbox" id="checkbox-danger" class="Checkbox__input" name="danger" aria-describedby="checkbox-danger-validation-text" />
         <div class="Checkbox__text">
           <label for="checkbox-danger" class="Checkbox__label">Checkbox Label</label>
-          <div class="Checkbox__validationText">
+          <div class="Checkbox__validationText" id="checkbox-danger-validation-text">
             <ul>
               <li>First validation text</li>
               <li>Second validation text</li>
@@ -204,14 +211,22 @@
         </div>
       </div>
 
-      <label for="checkbox-warning-helper-text" class="Checkbox Checkbox--warning">
-        <input type="checkbox" id="checkbox-warning-helper-text" class="Checkbox__input" name="warningWithText" checked />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label">Checkbox Label</span>
-          <span class="Checkbox__helperText">Helper text</span>
-          <span class="Checkbox__validationText">Warning validation text</span>
-        </span>
-      </label>
+      <div class="Checkbox Checkbox--warning">
+        <input
+          type="checkbox"
+          id="checkbox-warning-helper-text"
+          class="Checkbox__input"
+          name="warningWithText"
+          aria-describedby="checkbox-warning-helper-text-helper-text checkbox-warning-helper-text-validation-text"
+          checked
+        />
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="checkbox-warning-helper-text">Checkbox Label</label>
+          <div class="Checkbox__helperText" id="checkbox-warning-helper-text-helper-text">Helper text</div>
+          <div class="Checkbox__validationText" id="checkbox-warning-helper-text-validation-text">Warning validation text</div>
+        </div>
+      </div>
+
     </div>
 
   </div>
@@ -219,34 +234,43 @@
 </section>
 
 <section class="py-900 py-tablet-1000">
+
   <div class="Container">
+
     <h2 class="docs-Heading">Validation Text with Icon</h2>
+
     <div class="docs-Stack docs-Stack--start">
 
       {{setVar "states" "success" "warning" "danger" }}
       {{#each @root.states as |state|}}
-
-      <label for="checkbox-{{state}}-validation-icon" class="Checkbox Checkbox--{{state}}">
-        <input type="checkbox" id="checkbox-{{state}}-validation-icon" class="Checkbox__input" name="warningWithText" />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label">Checkbox Label</span>
-          <span class="Checkbox__validationText">
+      <div class="Checkbox Checkbox--{{ state }}">
+        <input
+          type="checkbox"
+          id="checkbox-{{ state }}-validation-icon"
+          class="Checkbox__input"
+          name="warningWithText"
+          aria-describedby="checkbox-{{ state }}-validation-icon-validation-text"
+        />
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="checkbox-{{ state }}-validation-icon">Checkbox Label</label>
+          <div class="Checkbox__validationText" id="checkbox-{{ state }}-validation-icon-validation-text">
             <svg width="20" height="20" aria-hidden="true">
               {{#if (eq state "success")}}
               <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
               {{else}}
-              <use xlink:href="/assets/icons/svg/sprite.svg#{{state}}" />
+              <use xlink:href="/assets/icons/svg/sprite.svg#{{ state }}" />
               {{/if}}
             </svg>
-            <span>This is {{state}} validation text.</span>
-          </span>
-        </span>
-      </label>
-
+            <span>This is {{ state }} validation text.</span>
+          </div>
+        </div>
+      </div>
       {{/each}}
 
     </div>
+
   </div>
+
 </section>
 
 <section class="py-900 py-tablet-1000">
@@ -257,50 +281,51 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="checkbox-item-default" class="Checkbox Checkbox--item">
+      <div class="Checkbox Checkbox--item">
         <input type="checkbox" id="checkbox-item-default" class="Checkbox__input" name="item" />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label">Checkbox Label</span>
-        </span>
-      </label>
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="checkbox-item-default">Checkbox Label</label>
+        </div>
+      </div>
 
-      <label for="checkbox-item-default-checked" class="Checkbox Checkbox--item">
+      <div class="Checkbox Checkbox--item">
         <input type="checkbox" id="checkbox-item-default-checked" class="Checkbox__input" name="itemChecked" checked />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label">Checkbox Label</span>
-        </span>
-      </label>
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="checkbox-item-default-checked">Checkbox Label</label>
+        </div>
+      </div>
 
-      <label for="checkbox-item-helper-text" class="Checkbox Checkbox--item">
-        <input type="checkbox" id="checkbox-item-helper-text" class="Checkbox__input" name="itemWithText" />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label">Checkbox Label</span>
-          <span class="Checkbox__helperText">Helper text</span>
-        </span>
-      </label>
+      <div class="Checkbox Checkbox--item">
+        <input type="checkbox" id="checkbox-item-helper-text" class="Checkbox__input" name="itemWithText" aria-describedby="checkbox-item-helper-text-helper-text" />
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="checkbox-item-helper-text">Checkbox Label</label>
+          <div class="Checkbox__helperText" id="checkbox-item-helper-text-helper-text">Helper text</div>
+        </div>
+      </div>
 
-      <label for="checkbox-item-disabled" class="Checkbox Checkbox--item Checkbox--disabled">
+      <div class="Checkbox Checkbox--item Checkbox--disabled">
         <input type="checkbox" id="checkbox-item-disabled" class="Checkbox__input" name="itemDisabled" disabled />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label">Checkbox Label</span>
-        </span>
-      </label>
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="checkbox-item-disabled">Checkbox Label</label>
+        </div>
+      </div>
 
-      <label for="checkbox-item-disabled-helper-text" class="Checkbox Checkbox--item Checkbox--disabled">
+      <div class="Checkbox Checkbox--item Checkbox--disabled">
         <input
           type="checkbox"
           id="checkbox-item-disabled-helper-text"
           class="Checkbox__input"
           name="itemDisabledChecked"
+          aria-describedby="checkbox-item-disabled-helper-text-helper-text"
           disabled
           checked
           required
         />
-        <span class="Checkbox__text">
-          <span class="Checkbox__label Checkbox__label--required">Checkbox Label</span>
-          <span class="Checkbox__helperText">Helper text</span>
-        </span>
-      </label>
+        <div class="Checkbox__text">
+          <label class="Checkbox__label Checkbox__label--required" for="checkbox-item-disabled-helper-text">Checkbox Label</label>
+          <div class="Checkbox__helperText" id="checkbox-item-disabled-helper-text-helper-text">Helper text</div>
+        </div>
+      </div>
 
     </div>
 

--- a/packages/web/src/scss/components/Drawer/index.html
+++ b/packages/web/src/scss/components/Drawer/index.html
@@ -75,41 +75,41 @@
       <form class="mb-600">
         <fieldset class="border-0">
           <legend>Drawer alignment:</legend>
-          <label for="drawer-alignment-left" class="Radio mr-600">
+          <div class="Radio mr-600">
             <input name="drawer-alignment" autocomplete="off" aria-describedby="drawer-alignment-left__helperText" type="radio" id="drawer-alignment-left" class="Radio__input" value="left">
-            <span class="Radio__text">
-              <span class="Radio__label">
+            <div class="Radio__text">
+              <label class="Radio__label" for="drawer-alignment-left">
                 Left
-              </span>
-            </span>
-          </label>
-          <label for="drawer-alignment-right" class="Radio">
+              </label>
+            </div>
+          </div>
+          <div class="Radio">
             <input name="drawer-alignment" autocomplete="off" aria-describedby="drawer-alignment-right__helperText" type="radio" id="drawer-alignment-right" class="Radio__input" value="right" checked="">
-            <span class="Radio__text">
-              <span class="Radio__label">
+            <div class="Radio__text">
+              <label class="Radio__label" for="drawer-alignment-right">
                 Right
-              </span>
-            </span>
-          </label>
+              </label>
+            </div>
+          </div>
         </fieldset>
         <fieldset class="border-0">
           <div class="Stack Stack--hasSpacing">
-            <label class="Checkbox" for="drawer-is-closable-on-backdrop-click">
+            <div class="Checkbox">
               <input name="is-closable-on-backdrop-click" aria-describedby="drawer-is-closable-on-backdrop-click__helperText" type="checkbox" id="drawer-is-closable-on-backdrop-click" class="Checkbox__input" value="" checked="">
-              <span class="Checkbox__text">
-                <span class="Checkbox__label">
+              <div class="Checkbox__text">
+                <label class="Checkbox__label" for="drawer-is-closable-on-backdrop-click">
                   Closable on Backdrop Click
-                </span>
-              </span>
-            </label>
-            <label class="Checkbox" for="drawer-is-closable-on-escape-key">
+                </label>
+              </div>
+            </div>
+            <div class="Checkbox">
               <input name="is-closable-on-escape-key" aria-describedby="drawer-is-closable-on-escape-key__helperText" type="checkbox" id="drawer-is-closable-on-escape-key" class="Checkbox__input" value="" checked="">
-              <span class="Checkbox__text">
-                <span class="Checkbox__label">
+              <div class="Checkbox__text">
+                <label class="Checkbox__label" for="drawer-is-closable-on-escape-key">
                   Closable on Escape Key Down
-                </span>
-              </span>
-            </label>
+                </label>
+              </div>
+            </div>
             <div class="TextArea">
               <label for="drawer-content" class="TextArea__label">Drawer content</label>
               <textarea name="content" class="TextArea__input" id="drawer-content">This is a Drawer content.</textarea>

--- a/packages/web/src/scss/components/Dropdown/index.html
+++ b/packages/web/src/scss/components/Dropdown/index.html
@@ -12,46 +12,46 @@
         <div class="Grid Grid--cols-3 mx-auto" style="align-items: center; justify-items: center; max-width: 40rem;">
           <div class="GridItem" style="--grid-item-column-start: 2; --grid-item-row-start: 1">
 
-            <label for="placement-top-start" class="Radio">
+            <div class="Radio">
               <input type="radio" name="placement" value="top-start" id="placement-top-start" class="Radio__input" />
-              <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">top-start</span>
-              </span>
-            </label>
-            <label for="placement-top" class="Radio">
+              <div class="Radio__text">
+                <label class="Radio__label Radio__label--hidden" for="placement-top-start">top-start</label>
+              </div>
+            </div>
+            <div class="Radio">
               <input type="radio" name="placement" value="top" id="placement-top" class="Radio__input" />
-              <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">top</span>
-              </span>
-            </label>
-            <label for="placement-top-end" class="Radio">
+              <div class="Radio__text">
+                <label class="Radio__label Radio__label--hidden" for="placement-top">top</label>
+              </div>
+            </div>
+            <div class="Radio">
               <input type="radio" name="placement" value="top-end" id="placement-top-end" class="Radio__input" />
-              <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">top-end</span>
-              </span>
-            </label>
+              <div class="Radio__text">
+                <label class="Radio__label Radio__label--hidden" for="placement-top-end">top-end</label>
+              </div>
+            </div>
 
           </div>
           <div class="GridItem" style="--grid-item-column-start: 2; --grid-item-row-start: 3">
 
-            <label for="placement-bottom-start" class="Radio">
+            <div class="Radio">
               <input type="radio" name="placement" value="bottom-start" id="placement-bottom-start" class="Radio__input" checked />
-              <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">bottom-start</span>
-              </span>
-            </label>
-            <label for="placement-bottom" class="Radio">
+              <div class="Radio__text">
+                <label class="Radio__label Radio__label--hidden" for="placement-bottom-start">bottom-start</label>
+              </div>
+            </div>
+            <div class="Radio">
               <input type="radio" name="placement" value="bottom" id="placement-bottom" class="Radio__input" />
-              <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">bottom</span>
-              </span>
-            </label>
-            <label for="placement-bottom-end" class="Radio">
+              <div class="Radio__text">
+                <label class="Radio__label Radio__label--hidden" for="placement-bottom">bottom</label>
+              </div>
+            </div>
+            <div class="Radio">
               <input type="radio" name="placement" value="bottom-end" id="placement-bottom-end" class="Radio__input" />
-              <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">bottom-end</span>
-              </span>
-            </label>
+              <div class="Radio__text">
+                <label class="Radio__label Radio__label--hidden" for="placement-bottom-end">bottom-end</label>
+              </div>
+            </div>
 
           </div>
           <div
@@ -65,24 +65,24 @@
             "
           >
 
-            <label for="placement-left-start" class="Radio">
+            <div class="Radio">
               <input type="radio" name="placement" value="left-start" id="placement-left-start" class="Radio__input" />
-              <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">left-start</span>
-              </span>
-            </label>
-            <label for="placement-left" class="Radio">
+              <div class="Radio__text">
+                <label class="Radio__label Radio__label--hidden" for="placement-left-start">left-start</label>
+              </div>
+            </div>
+            <div class="Radio">
               <input type="radio" name="placement" value="left" id="placement-left" class="Radio__input" />
-              <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">left</span>
-              </span>
-            </label>
-            <label for="placement-left-end" class="Radio">
+              <div class="Radio__text">
+                <label class="Radio__label Radio__label--hidden" for="placement-left">left</label>
+              </div>
+            </div>
+            <div class="Radio">
               <input type="radio" name="placement" value="left-end" id="placement-left-end" class="Radio__input" />
-              <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">left-end</span>
-              </span>
-            </label>
+              <div class="Radio__text">
+                <label class="Radio__label Radio__label--hidden" for="placement-left-end">left-end</label>
+              </div>
+            </div>
 
           </div>
           <div
@@ -96,24 +96,24 @@
             "
           >
 
-            <label for="placement-right-start" class="Radio">
+            <div class="Radio">
               <input type="radio" name="placement" value="right-start" id="placement-right-start" class="Radio__input" />
-              <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">right-start</span>
-              </span>
-            </label>
-            <label for="placement-right" class="Radio">
+              <div class="Radio__text">
+                <label class="Radio__label Radio__label--hidden" for="placement-right-start">right-start</label>
+              </div>
+            </div>
+            <div class="Radio">
               <input type="radio" name="placement" value="right" id="placement-right" class="Radio__input" />
-              <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">right</span>
-              </span>
-            </label>
-            <label for="placement-right-end" class="Radio">
+              <div class="Radio__text">
+                <label class="Radio__label Radio__label--hidden" for="placement-right">right</label>
+              </div>
+            </div>
+            <div class="Radio">
               <input type="radio" name="placement" value="right-end" id="placement-right-end" class="Radio__input" />
-              <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">right-end</span>
-              </span>
-            </label>
+              <div class="Radio__text">
+                <label class="Radio__label Radio__label--hidden" for="placement-right-end">right-end</label>
+              </div>
+            </div>
 
           </div>
           <div class="GridItem" style="--grid-item-column-start: 2; --grid-item-row-start: 2">
@@ -243,16 +243,18 @@
             </span>
             <span class="Item__label">Item with icon</span>
           </a>
-          <label for="checkbox-item" class="Checkbox Checkbox--item">
+          <div class="Checkbox Checkbox--item">
             <input type="checkbox" id="checkbox-item" name="checkbox-item" class="Checkbox__input" />
-            <span class="Checkbox__text">
-              <span class="Checkbox__label">Item with checkbox</span>
-            </span>
-          </label>
-          <label for="radio-item" class="Radio Radio--item">
+            <div class="Checkbox__text">
+              <label class="Checkbox__label" for="checkbox-item">Item with checkbox</label>
+            </div>
+          </div>
+          <div class="Radio Radio--item">
             <input type="radio" id="radio-item" name="radio-item" class="Radio__input" checked />
-            <span class="Radio__label">Item with radio</span>
-          </label>
+            <div class="Radio__text">
+              <label class="Radio__label" for="radio-item">Item with radio</label>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/packages/web/src/scss/components/FieldGroup/index.html
+++ b/packages/web/src/scss/components/FieldGroup/index.html
@@ -263,19 +263,19 @@
         <div class="FieldGroup__label" aria-hidden="true">Label</div>
         <div class="FieldGroup__fields">
           <!-- Custom items: start -->
-          <label for="checkbox-default-checked" class="Checkbox">
+          <div class="Checkbox">
             <input type="checkbox" id="checkbox-default-checked" class="Checkbox__input" name="checkbox-default-checked" checked />
-            <span class="Checkbox__text">
-            <span class="Checkbox__label">Checkbox Label</span>
-          </span>
-          </label>
+            <div class="Checkbox__text">
+              <label class="Checkbox__label" for="checkbox-default-checked">Checkbox Label</label>
+            </div>
+          </div>
 
-          <label for="checkbox-default" class="Checkbox">
+          <div class="Checkbox">
             <input type="checkbox" id="checkbox-default" class="Checkbox__input" name="checkbox-default" />
-            <span class="Checkbox__text">
-            <span class="Checkbox__label">Checkbox Label</span>
-          </span>
-          </label>
+            <div class="Checkbox__text">
+              <label class="Checkbox__label" for="checkbox-default">Checkbox Label</label>
+            </div>
+          </div>
           <!-- Custom items: end -->
         </div>
       </fieldset>
@@ -299,19 +299,19 @@
         <div class="FieldGroup__label" aria-hidden="true">Label</div>
         <div class="FieldGroup__fields">
           <!-- Custom items: start -->
-          <label for="radio-default-checked" class="Radio">
+          <div class="Radio">
             <input type="radio" id="radio-default-checked" class="Radio__input" name="radio-default" checked />
-            <span class="Radio__text">
-            <span class="Radio__label">Radio Label</span>
-          </span>
-          </label>
+            <div class="Radio__text">
+              <label class="Radio__label" for="radio-default-checked">Radio Label</label>
+            </div>
+          </div>
 
-          <label for="radio-default" class="Radio">
+          <div class="Radio">
             <input type="radio" id="radio-default" class="Radio__input" name="radio-default" />
-            <span class="Radio__text">
-            <span class="Radio__label">Radio Label</span>
-          </span>
-          </label>
+            <div class="Radio__text">
+              <label class="Radio__label" for="radio-default">Radio Label</label>
+            </div>
+          </div>
           <!-- Custom items: end -->
         </div>
       </fieldset>

--- a/packages/web/src/scss/components/Footer/index.html
+++ b/packages/web/src/scss/components/Footer/index.html
@@ -588,24 +588,24 @@
       <form class="mb-600">
         <fieldset class="border-0">
           <legend>Please choose text alignment:</legend>
-          <label class="Radio mr-600" for="footer-alignment-left">
+          <div class="Radio mr-600">
             <input name="text-alignment" autocomplete="off" type="radio" id="footer-alignment-left" class="Radio__input" value="left" checked>
-            <span class="Radio__text">
-              <span class="Radio__label">Left</span>
-            </span>
-          </label>
-          <label class="Radio mr-600" for="footer-alignment-center">
+            <div class="Radio__text">
+              <label class="Radio__label" for="footer-alignment-left">Left</label>
+            </div>
+          </div>
+          <div class="Radio mr-600">
             <input name="text-alignment" autocomplete="off" type="radio" id="footer-alignment-center" class="Radio__input" value="center">
-            <span class="Radio__text">
-              <span class="Radio__label">Center</span>
-            </span>
-          </label>
-          <label class="Radio" for="footer-alignment-right">
+            <div class="Radio__text">
+              <label class="Radio__label" for="footer-alignment-center">Center</label>
+            </div>
+          </div>
+          <div class="Radio">
             <input name="text-alignment" autocomplete="off" type="radio" id="footer-alignment-right" class="Radio__input" value="right">
-            <span class="Radio__text">
-              <span class="Radio__label">Right</span>
-            </span>
-          </label>
+            <div class="Radio__text">
+              <label class="Radio__label" for="footer-alignment-right">Right</label>
+            </div>
+          </div>
         </fieldset>
       </form>
     </div>

--- a/packages/web/src/scss/components/Header/index.html
+++ b/packages/web/src/scss/components/Header/index.html
@@ -441,12 +441,12 @@
         }
       </script>
 
-      <label for="rtl" class="Checkbox">
+      <div class="Checkbox">
         <input type="checkbox" id="rtl" class="Checkbox__input" onclick="toggleRtl()" />
-        <span class="Checkbox__text">
-        <span class="Checkbox__label">Switch writing mode to RTL</span>
-      </span>
-      </label>
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="rtl">Switch writing mode to RTL</label>
+        </div>
+      </div>
 
     </div>
 

--- a/packages/web/src/scss/components/Item/README.md
+++ b/packages/web/src/scss/components/Item/README.md
@@ -87,21 +87,23 @@ Item as a link example:
 Radio as a Item:
 
 ```html
-<label for="radio-item" class="Radio Radio--item">
+<div class="Radio Radio--item">
   <input type="radio" id="radio-item" name="example" class="Radio__input" checked />
-  <span class="Radio__label">Item</span>
-</label>
+  <div class="Radio__text">
+    <label class="Radio__label" for="radio-item">Item</label>
+  </div>
+</div>
 ```
 
 Checkbox as a Item:
 
 ```html
-<label for="checkbox-item" class="Checkbox Checkbox--item">
+<div class="Checkbox Checkbox--item">
   <input type="checkbox" id="checkbox-item" class="Checkbox__input" />
-  <span class="Checkbox__text">
-    <span class="Checkbox__label">Item</span>
-  </span>
-</label>
+  <div class="Checkbox__text">
+    <label class="Checkbox__label" for="checkbox-item">Item</label>
+  </div>
+</div>
 ```
 
 Usage in [Dropdown][dropdown] component:

--- a/packages/web/src/scss/components/Item/index.html
+++ b/packages/web/src/scss/components/Item/index.html
@@ -165,12 +165,12 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="checkbox-item" class="Checkbox Checkbox--item">
+      <div class="Checkbox Checkbox--item">
         <input type="checkbox" id="checkbox-item" class="Checkbox__input" />
-        <span class="Checkbox__text">
-        <span class="Checkbox__label">Checkbox Item</span>
-      </span>
-      </label>
+        <div class="Checkbox__text">
+          <label class="Checkbox__label" for="checkbox-item">Checkbox Item</label>
+        </div>
+      </div>
 
     </div>
 
@@ -186,10 +186,12 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="radio-item" class="Radio Radio--item">
+      <div class="Radio Radio--item">
         <input type="radio" id="radio-item" name="example3" class="Radio__input" />
-        <span class="Radio__label">Radio Item</span>
-      </label>
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-item">Radio Item</label>
+        </div>
+      </div>
 
     </div>
 

--- a/packages/web/src/scss/components/Modal/index.html
+++ b/packages/web/src/scss/components/Modal/index.html
@@ -98,57 +98,69 @@
             <!-- Modal alignment demo: start -->
             <form onchange="setModalAlignment(event, '#example-basic')" class="mb-600">
               <div>Modal alignment:</div>
-              <label for="modal-demo-alignment-top" class="Radio mr-600">
+              <div class="Radio mr-600">
                 <input type="radio" id="modal-demo-alignment-top" name="modal-alignment" value="top" class="Radio__input" autocomplete="off" />
-                <span class="Radio__label">Top</span>
-              </label>
-              <label for="modal-demo-alignment-center" class="Radio mr-600">
+                <div class="Radio__text">
+                  <label class="Radio__label" for="modal-demo-alignment-top">Top</label>
+                </div>
+              </div>
+              <div class="Radio mr-600">
                 <input type="radio" id="modal-demo-alignment-center" name="modal-alignment" value="center" class="Radio__input" autocomplete="off" checked />
-                <span class="Radio__label">Center</span>
-              </label>
-              <label for="modal-demo-alignment-bottom" class="Radio mr-600">
+                <div class="Radio__text">
+                  <label class="Radio__label" for="modal-demo-alignment-center">Center</label>
+                </div>
+              </div>
+              <div class="Radio mr-600">
                 <input type="radio" id="modal-demo-alignment-bottom" name="modal-alignment" value="bottom" class="Radio__input" autocomplete="off" />
-                <span class="Radio__label">Bottom</span>
-              </label>
+                <div class="Radio__text">
+                  <label class="Radio__label" for="modal-demo-alignment-bottom">Bottom</label>
+                </div>
+              </div>
             </form>
             <!-- Modal alignment demo: end -->
             <!-- Footer alignment demo: start -->
             <form onchange="setFooterAlignment(event, '#example-basic .ModalFooter')" class="d-none d-tablet-block mb-600">
               <div>Footer alignment (from tablet up):</div>
-              <label for="footer-uniform-alignment-left" class="Radio mr-600">
+              <div class="Radio mr-600">
                 <input type="radio" id="footer-uniform-alignment-left" name="footer-alignment" value="left" class="Radio__input" autocomplete="off" />
-                <span class="Radio__label">Left</span>
-              </label>
-              <label for="footer-uniform-alignment-center" class="Radio mr-600">
+                <div class="Radio__text">
+                  <label class="Radio__label" for="footer-uniform-alignment-left">Left</label>
+                </div>
+              </div>
+              <div class="Radio mr-600">
                 <input type="radio" id="footer-uniform-alignment-center" name="footer-alignment" value="center" class="Radio__input" autocomplete="off" />
-                <span class="Radio__label">Center</span>
-              </label>
-              <label for="footer-uniform-alignment-right" class="Radio mr-600">
+                <div class="Radio__text">
+                  <label class="Radio__label" for="footer-uniform-alignment-center">Center</label>
+                </div>
+              </div>
+              <div class="Radio mr-600">
                 <input type="radio" id="footer-uniform-alignment-right" name="footer-alignment" value="right" class="Radio__input" autocomplete="off" checked />
-                <span class="Radio__label">Right</span>
-              </label>
+                <div class="Radio__text">
+                  <label class="Radio__label" for="footer-uniform-alignment-right">Right</label>
+                </div>
+              </div>
             </form>
             <!-- Footer alignment demo: end -->
             <!-- Modal features demo: start -->
             <form class="Stack Stack--hasSpacing">
-              <label for="modal-demo-docked" class="Checkbox">
+              <div class="Checkbox">
                 <input type="checkbox" id="modal-demo-docked" class="Checkbox__input" onchange="toggleDockOnMobile('#example-basic > .ModalDialog', '#modal-demo-expanded')" autocomplete="off" />
-                <span class="Checkbox__text">
-                <span class="Checkbox__label">Dock on mobile</span>
-              </span>
-              </label>
-              <label for="modal-demo-expanded" class="Checkbox Checkbox--disabled" id="modal-demo-expanded-label">
+                <div class="Checkbox__text">
+                  <label class="Checkbox__label" for="modal-demo-docked">Dock on mobile</label>
+                </div>
+              </div>
+              <div class="Checkbox Checkbox--disabled" id="modal-demo-expanded-label">
                 <input type="checkbox" id="modal-demo-expanded" class="Checkbox__input" onchange="toggleExpandOnMobile('#example-basic > .ModalDialog')" autocomplete="off" checked disabled />
-                <span class="Checkbox__text">
-                <span class="Checkbox__label">Expand on mobile (docked only)</span>
-              </span>
-              </label>
-              <label for="modal-demo-scrolling" class="Checkbox">
+                <div class="Checkbox__text">
+                  <label class="Checkbox__label" for="modal-demo-expanded">Expand on mobile (docked only)</label>
+                </div>
+              </div>
+              <div class="Checkbox">
                 <input type="checkbox" id="modal-demo-scrolling" class="Checkbox__input" onchange="toggleScrolling('#example-basic > .ModalDialog')" autocomplete="off" />
-                <span class="Checkbox__text">
-                <span class="Checkbox__label">Scrolling inside</span>
-              </span>
-              </label>
+                <div class="Checkbox__text">
+                  <label class="Checkbox__label" for="modal-demo-scrolling">Scrolling inside</label>
+                </div>
+              </div>
             </form>
             <!-- Modal features demo: end -->
             <!-- Content: end -->
@@ -783,7 +795,7 @@
             <form>
               <fieldset class="Stack Stack--hasSpacing mb-800" style="border: 0;">
                 <legend hidden>Mobile</legend>
-                <label for="custom-height-mobile-enabled" class="Checkbox">
+                <div class="Checkbox">
                   <input
                     type="checkbox"
                     id="custom-height-mobile-enabled"
@@ -792,10 +804,10 @@
                     checked
                     autocomplete="off"
                   />
-                  <span class="Checkbox__text">
-                  <span class="Checkbox__label">Mobile</span>
-                </span>
-                </label>
+                  <div class="Checkbox__text">
+                    <label class="Checkbox__label" for="custom-height-mobile-enabled">Mobile</label>
+                  </div>
+                </div>
                 <div class="Grid" style="column-gap: var(--spirit-space-600)">
                   <label for="custom-height-mobile" class="GridItem" style="--grid-item-column-start: 1; --grid-item-column-end: 6; --grid-item-column-end-tablet: 4;">
                     Height
@@ -839,7 +851,7 @@
               </fieldset>
               <fieldset class="Stack Stack--hasSpacing d-none d-tablet-grid mb-tablet-800" style="border: 0;">
                 <legend hidden>Tablet</legend>
-                <label for="custom-height-tablet-enabled" class="Checkbox">
+                <div class="Checkbox">
                   <input
                     type="checkbox"
                     id="custom-height-tablet-enabled"
@@ -847,11 +859,12 @@
                     onchange="toggleCustomHeight(event, '#example-custom-height > .ModalDialog', 'tablet')"
                     checked
                     autocomplete="off"
+                    aria-labelledby="custom-height-tablet-enabled-label"
                   />
-                  <span class="Checkbox__text">
-                  <span class="Checkbox__label">Tablet</span>
-                </span>
-                </label>
+                  <div class="Checkbox__text">
+                    <label class="Checkbox__label" for="custom-height-tablet-enabled" id="custom-height-tablet-enabled-label">Tablet</label>
+                  </div>
+                </div>
                 <div class="Grid" style="column-gap: var(--spirit-space-600)">
                   <label for="custom-height-tablet" class="GridItem" style="--grid-item-column-start: 1; --grid-item-column-end: 6; --grid-item-column-end-tablet: 4;">
                     Height
@@ -895,7 +908,7 @@
               </fieldset>
               <fieldset class="Stack Stack--hasSpacing d-none d-desktop-grid" style="border: 0;">
                 <legend hidden>Desktop</legend>
-                <label for="custom-height-desktop-enabled" class="Checkbox">
+                <div class="Checkbox">
                   <input
                     type="checkbox"
                     id="custom-height-desktop-enabled"
@@ -903,11 +916,12 @@
                     onchange="toggleCustomHeight(event, '#example-custom-height > .ModalDialog', 'desktop')"
                     checked
                     autocomplete="off"
+                    aria-labelledby="custom-height-desktop-enabled-label"
                   />
-                  <span class="Checkbox__text">
-                  <span class="Checkbox__label">Desktop</span>
-                </span>
-                </label>
+                  <div class="Checkbox__text">
+                    <label class="Checkbox__label" for="custom-height-desktop-enabled" id="custom-height-desktop-enabled-label">Desktop</label>
+                  </div>
+                </div>
                 <div class="Grid" style="column-gap: var(--spirit-space-600)">
                   <label for="custom-height-desktop" class="GridItem" style="--grid-item-column-start: 1; --grid-item-column-end: 6; --grid-item-column-end-tablet: 4;">
                     Height

--- a/packages/web/src/scss/components/Radio/README.md
+++ b/packages/web/src/scss/components/Radio/README.md
@@ -3,34 +3,34 @@
 ## Basic Usage
 
 ```html
-<label for="radio-default" class="Radio">
+<div class="Radio">
   <input type="radio" id="radio-default" class="Radio__input" name="default" />
-  <span class="Radio__text">
-    <span class="Radio__label">Radio Label</span>
-  </span>
-</label>
+  <div class="Radio__text">
+    <label class="Radio__label" for="radio-default">Radio Label</label>
+  </div>
+</div>
 ```
 
 ## Selected State
 
 ```html
-<label for="radio-default-checked" class="Radio">
+<div class="Radio">
   <input type="radio" id="radio-default-checked" class="Radio__input" name="default" checked />
-  <span class="Radio__text">
-    <span class="Radio__label">Radio Label</span>
-  </span>
-</label>
+  <div class="Radio__text">
+    <label class="Radio__label" for="radio-default-checked">Radio Label</label>
+  </div>
+</div>
 ```
 
 ## Disabled State
 
 ```html
-<label for="radio-disabled" class="Radio Radio--disabled">
+<div class="Radio Radio--disabled">
   <input type="radio" id="radio-disabled" class="Radio__input" name="default" disabled />
-  <span class="Radio__text">
-    <span class="Radio__label">Radio Label</span>
-  </span>
-</label>
+  <div class="Radio__text">
+    <label class="Radio__label" for="radio-disabled">Radio Label</label>
+  </div>
+</div>
 ```
 
 ## Validation States
@@ -38,61 +38,73 @@
 See Validation state [dictionary][dictionary-validation].
 
 ```html
-<label for="radio-success" class="Radio Radio--success">
+<div class="Radio Radio--success">
   <input type="radio" id="radio-success" class="Radio__input" name="validation" />
-  <span class="Radio__text">
-    <span class="Radio__label">Radio Label</span>
-  </span>
-</label>
+  <div class="Radio__text">
+    <label class="Radio__label" for="radio-success">Radio Label</label>
+  </div>
+</div>
 
-<label for="radio-warning" class="Radio Radio--warning">
+<div class="Radio Radio--warning">
   <input type="radio" id="radio-warning" class="Radio__input" name="validation" />
-  <span class="Radio__text">
-    <span class="Radio__label">Radio Label</span>
-  </span>
-</label>
+  <div class="Radio__text">
+    <label class="Radio__label" for="radio-warning">Radio Label</label>
+  </div>
+</div>
 
-<label for="radio-danger" class="Radio Radio--danger">
+<div class="Radio Radio--danger">
   <input type="radio" id="radio-danger" class="Radio__input" name="validation" />
-  <span class="Radio__text">
-    <span class="Radio__label">Radio Label</span>
-  </span>
-</label>
+  <div class="Radio__text">
+    <label class="Radio__label" for="radio-danger" for="radio-danger">Radio Label</label>
+  </div>
+</div>
 ```
 
 ## With Helper Text
 
 ```html
-<label for="radio-helper-text" class="Radio">
-  <input type="radio" id="radio-helper-text" class="Radio__input" name="helperText" />
-  <span class="Radio__text">
-    <span class="Radio__label">Radio Label</span>
-    <span class="Radio__helperText">Helper text</span>
-  </span>
-</label>
+<div class="Radio">
+  <input
+    type="radio"
+    id="radio-helper-text"
+    class="Radio__input"
+    name="helperText"
+    aria-describedby="radio-helper-text-helper-text"
+  />
+  <div class="Radio__text">
+    <label class="Radio__label" for="radio-helper-text" for="radio-helper-text">Radio Label</label>
+    <div class="Radio__helperText" id="radio-helper-text-helper-text">Helper text</div>
+  </div>
+</div>
 ```
 
 ## As an Item
 
 ```html
-<label for="radio-item-default" class="Radio Radio--item">
+<div class="Radio Radio--item">
   <input type="radio" id="radio-item-default" class="Radio__input" name="item" />
-  <span class="Radio__text">
-    <span class="Radio__label">Radio Label</span>
-  </span>
-</label>
+  <div class="Radio__text">
+    <label class="Radio__label" for="radio-item-default">Radio Label</label>
+  </div>
+</div>
 ```
 
 ## As an Item Wrapped with Helper Text
 
 ```html
-<label for="radio-item-helper-text" class="Radio Radio--item">
-  <input type="radio" id="radio-item-helper-text" class="Radio__input" name="item" />
-  <span class="Radio__text">
-    <span class="Radio__label">Radio Label</span>
-    <span class="Radio__helperText">Helper text</span>
-  </span>
-</label>
+<div class="Radio Radio--item">
+  <input
+    type="radio"
+    id="radio-item-helper-text"
+    class="Radio__input"
+    name="item"
+    aria-describedby="radio-item-helper-text-helper-text"
+  />
+  <div class="Radio__text">
+    <label class="Radio__label" for="radio-item-helper-text">Radio Label</label>
+    <div class="Radio__helperText" id="radio-item-helper-text-helper-text">Helper text</div>
+  </div>
+</div>
 ```
 
 [dictionary-validation]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation

--- a/packages/web/src/scss/components/Radio/_Radio.scss
+++ b/packages/web/src/scss/components/Radio/_Radio.scss
@@ -1,5 +1,6 @@
 // 1. We need to set the background-color of the non-disabled Radio input to initial color when it is hovered
 //    or active, because we need it contrasting with the background color.
+// 2. Make the text selectable and allow links to be clickable in the helper text.
 
 @use 'sass:map';
 @use '../../theme/form-fields' as form-fields-theme;
@@ -10,6 +11,8 @@ $_field-name: 'Radio';
 
 .Radio {
     @include form-fields-tools.inline-field-root();
+
+    position: relative;
 }
 
 .Radio__input {
@@ -49,6 +52,8 @@ $_field-name: 'Radio';
 .Radio__helperText {
     @include form-fields-tools.helper-text();
 
+    position: relative; // 2.
+    z-index: 1; // 2.
     margin-left: form-fields-theme.$inline-field-gap;
 }
 
@@ -56,6 +61,7 @@ $_field-name: 'Radio';
 
 .Radio__label {
     @include form-fields-tools.inline-field-label();
+    @include form-fields-tools.stretch();
 
     margin-left: form-fields-theme.$inline-field-gap;
 }
@@ -70,6 +76,8 @@ $_field-name: 'Radio';
 
 .Radio--item {
     @include form-fields-tools.item();
+
+    position: relative;
 }
 
 .Radio--item:is(.Radio--disabled, .Radio.is-disabled),
@@ -92,7 +100,7 @@ $_field-name: 'Radio';
 
 :is(.Radio--disabled, .Radio.is-disabled) .Radio__label,
 .Radio:has(.Radio__input:disabled) .Radio__label {
-    @include form-fields-tools.label-disabled();
+    @include form-fields-tools.inline-field-label-disabled();
 }
 
 :is(.Radio--disabled, .Radio.is-disabled) .Radio__helperText,

--- a/packages/web/src/scss/components/Radio/index.html
+++ b/packages/web/src/scss/components/Radio/index.html
@@ -8,19 +8,19 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="radio-default" class="Radio">
+      <div class="Radio">
         <input type="radio" id="radio-default" class="Radio__input" name="default" />
-        <span class="Radio__text">
-          <span class="Radio__label">Radio Label</span>
-        </span>
-      </label>
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-default">Radio Label</label>
+        </div>
+      </div>
 
-      <label for="radio-default-checked" class="Radio">
+      <div class="Radio">
         <input type="radio" id="radio-default-checked" class="Radio__input" name="default" checked />
-        <span class="Radio__text">
-          <span class="Radio__label">Radio Label</span>
-        </span>
-      </label>
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-default-checked">Radio Label</label>
+        </div>
+      </div>
 
     </div>
 
@@ -36,17 +36,17 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="radio-default" class="Radio">
-        <input type="radio" id="radio-long-label" class="Radio__input" name="default" />
-        <span class="Radio__text">
-          <span class="Radio__label">
+      <div class="Radio">
+        <input type="radio" id="radio-long-label" class="Radio__input" name="long" />
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-long-label">
             This is an example of a very long label text for a radio button. It is specifically designed to test how well the layout handles
             text wrapping when the content becomes significantly longer. The purpose of this text is to confirm that the radio button's composition
             remains intact, visually aligned, and free from any unexpected breakage or misalignment. Ensuring proper spacing and alignment for
             multiline labels is essential for creating a consistent and user-friendly interface across different screen sizes and resolutions.
-          </span>
-        </span>
-      </label>
+          </label>
+        </div>
+      </div>
 
     </div>
 
@@ -62,12 +62,12 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="radio-hidden-label" class="Radio">
+      <div class="Radio">
         <input type="radio" id="radio-hidden-label" class="Radio__input" name="hiddenLabel" />
-        <span class="Radio__text">
-          <span class="Radio__label Radio__label--hidden">Radio Label</span>
-        </span>
-      </label>
+        <div class="Radio__text">
+          <label class="Radio__label Radio__label--hidden" for="radio-hidden-label">Radio Label</label>
+        </div>
+      </div>
 
     </div>
 
@@ -83,13 +83,13 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="radio-helper-text" class="Radio">
-        <input type="radio" id="radio-helper-text" class="Radio__input" name="helperText" />
-        <span class="Radio__text">
-          <span class="Radio__label">Radio Label</span>
-          <span class="Radio__helperText">Helper text</span>
-        </span>
-      </label>
+      <div class="Radio">
+        <input type="radio" id="radio-helper-text" class="Radio__input" name="helperText" aria-describedby="radio-helper-text-helper-text" />
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-helper-text">Radio Label</label>
+          <div class="Radio__helperText" id="radio-helper-text-helper-text">Helper text</div>
+        </div>
+      </div>
 
     </div>
 
@@ -105,20 +105,20 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="radio-disabled" class="Radio Radio--disabled">
+      <div class="Radio Radio--disabled">
         <input type="radio" id="radio-disabled" class="Radio__input" name="disabled" disabled />
-        <span class="Radio__text">
-          <span class="Radio__label">Radio Label</span>
-        </span>
-      </label>
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-disabled">Radio Label</label>
+        </div>
+      </div>
 
-      <label for="radio-disabled-helper-text" class="Radio Radio--disabled">
-        <input type="radio" id="radio-disabled-helper-text" class="Radio__input" name="disabledHelperText" disabled checked />
-        <span class="Radio__text">
-          <span class="Radio__label">Radio Label</span>
-          <span class="Radio__helperText">Helper text</span>
-        </span>
-      </label>
+      <div class="Radio Radio--disabled">
+        <input type="radio" id="radio-disabled-helper-text" class="Radio__input" name="disabledHelperText" aria-describedby="radio-disabled-helper-text-helper-text" disabled checked />
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-disabled-helper-text">Radio Label</label>
+          <div class="Radio__helperText" id="radio-disabled-helper-text-helper-text">Helper text</div>
+        </div>
+      </div>
 
     </div>
 
@@ -134,34 +134,34 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="radio-success" class="Radio Radio--success">
+      <div class="Radio Radio--success">
         <input type="radio" id="radio-success" class="Radio__input" name="validation" />
-        <span class="Radio__text">
-          <span class="Radio__label">Radio Label</span>
-        </span>
-      </label>
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-success">Radio Label</label>
+        </div>
+      </div>
 
-      <label for="radio-warning" class="Radio Radio--warning">
+      <div class="Radio Radio--warning">
         <input type="radio" id="radio-warning" class="Radio__input" name="validation" />
-        <span class="Radio__text">
-          <span class="Radio__label">Radio Label</span>
-        </span>
-      </label>
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-warning">Radio Label</label>
+        </div>
+      </div>
 
-      <label for="radio-danger" class="Radio Radio--danger">
+      <div class="Radio Radio--danger">
         <input type="radio" id="radio-danger" class="Radio__input" name="validation" />
-        <span class="Radio__text">
-          <span class="Radio__label">Radio Label</span>
-        </span>
-      </label>
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-danger">Radio Label</label>
+        </div>
+      </div>
 
-      <label for="radio-warning-helper-text" class="Radio Radio--warning">
+      <div class="Radio Radio--warning">
         <input type="radio" id="radio-warning-helper-text" class="Radio__input" name="validation" checked />
-        <span class="Radio__text">
-          <span class="Radio__label">Radio Label</span>
-          <span class="Radio__helperText">Helper text</span>
-        </span>
-      </label>
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-warning-helper-text">Radio Label</label>
+          <div class="Radio__helperText" id="radio-warning-helper-text-helper-text">Helper text</div>
+        </div>
+      </div>
 
     </div>
 
@@ -177,49 +177,50 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <label for="radio-item-default" class="Radio Radio--item">
+      <div class="Radio Radio--item">
         <input type="radio" id="radio-item-default" class="Radio__input" name="item" />
-        <span class="Radio__text">
-          <span class="Radio__label">Radio Label</span>
-        </span>
-      </label>
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-item-default">Radio Label</label>
+        </div>
+      </div>
 
-      <label for="radio-item-default-checked" class="Radio Radio--item">
+      <div class="Radio Radio--item">
         <input type="radio" id="radio-item-default-checked" class="Radio__input" name="item" checked />
-        <span class="Radio__text">
-          <span class="Radio__label">Radio Label</span>
-        </span>
-      </label>
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-item-default-checked">Radio Label</label>
+        </div>
+      </div>
 
-      <label for="radio-item-helper-text" class="Radio Radio--item">
-        <input type="radio" id="radio-item-helper-text" class="Radio__input" name="item" />
-        <span class="Radio__text">
-          <span class="Radio__label">Radio Label</span>
-          <span class="Radio__helperText">Helper text</span>
-        </span>
-      </label>
+      <div class="Radio Radio--item">
+        <input type="radio" id="radio-item-helper-text" class="Radio__input" name="item" aria-describedby="radio-item-helper-text-helper-text" />
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-item-helper-text">Radio Label</label>
+          <div class="Radio__helperText" id="radio-item-helper-text-helper-text">Helper text</div>
+        </div>
+      </div>
 
-      <label for="radio-item-disabled" class="Radio Radio--item Radio--disabled">
+      <div class="Radio Radio--item Radio--disabled">
         <input type="radio" id="radio-item-disabled" class="Radio__input" name="itemDisabled" disabled />
-          <span class="Radio__text">
-          <span class="Radio__label">Radio Label</span>
-        </span>
-      </label>
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-item-disabled">Radio Label</label>
+        </div>
+      </div>
 
-      <label for="radio-item-disabled-helper-text" class="Radio Radio--item Radio--disabled">
+      <div class="Radio Radio--item Radio--disabled">
         <input
           type="radio"
           id="radio-item-disabled-helper-text"
           class="Radio__input"
           name="itemDisabled"
+          aria-describedby="radio-item-disabled-helper-text-helper-text"
           disabled
           checked
         />
-        <span class="Radio__text">
-          <span class="Radio__label">Radio Label</span>
-          <span class="Radio__helperText">Helper text</span>
-        </span>
-      </label>
+        <div class="Radio__text">
+          <label class="Radio__label" for="radio-item-disabled-helper-text">Radio Label</label>
+          <div class="Radio__helperText" id="radio-item-disabled-helper-text-helper-text">Helper text</div>
+        </div>
+      </div>
 
     </div>
 

--- a/packages/web/src/scss/components/Toast/index.html
+++ b/packages/web/src/scss/components/Toast/index.html
@@ -94,54 +94,54 @@
 
       <form>
         <fieldset onchange="setToastCollapsing(event, '#toast-example')" style="border: 0;">
-          <label for="toast-is-collapsible" class="Checkbox">
+          <div class="Checkbox">
             <input type="checkbox" id="toast-is-collapsible" class="Checkbox__input" name="is-collapsible"
                    autocomplete="off" checked/>
-            <span class="Checkbox__text">
-            <span class="Checkbox__label">Collapsible</span>
-          </span>
-          </label>
+            <div class="Checkbox__text">
+              <label class="Checkbox__label" for="toast-is-collapsible">Collapsible</label>
+            </div>
+          </div>
         </fieldset>
         <fieldset onchange="setToastAlignmentY(event, '#toast-example')" style="border: 0;">
           <legend>Vertical alignment:</legend>
-          <label for="toast-alignment-top" class="Radio mr-600">
+          <div class="Radio mr-600">
             <input type="radio" id="toast-alignment-top" name="toast-alignment-y" value="top" class="Radio__input"
-                   autocomplete="off"/>
-            <span class="Radio__text">
-            <span class="Radio__label">Top</span>
-          </span>
-          </label>
-          <label for="toast-alignment-bottom" class="Radio mr-600">
+                   autocomplete="off" />
+            <div class="Radio__text">
+              <label class="Radio__label" for="toast-alignment-top">Top</label>
+            </div>
+          </div>
+          <div class="Radio mr-600">
             <input type="radio" id="toast-alignment-bottom" name="toast-alignment-y" value="bottom" class="Radio__input"
                    autocomplete="off" checked/>
-            <span class="Radio__text">
-            <span class="Radio__label">Bottom</span>
-          </span>
-          </label>
+            <div class="Radio__text">
+              <label class="Radio__label" for="toast-alignment-bottom">Bottom</label>
+            </div>
+          </div>
         </fieldset>
         <fieldset onchange="setToastAlignmentX(event, '#toast-example')" style="border: 0;">
           <legend>Horizontal alignment:</legend>
-          <label for="toast-alignment-left" class="Radio mr-600">
+          <div class="Radio mr-600">
             <input type="radio" id="toast-alignment-left" name="toast-alignment-x" value="left" class="Radio__input"
-                   autocomplete="off"/>
-            <span class="Radio__text">
-            <span class="Radio__label">Left</span>
-          </span>
-          </label>
-          <label for="toast-alignment-center" class="Radio mr-600">
+                   autocomplete="off" />
+            <div class="Radio__text">
+              <label class="Radio__label" for="toast-alignment-left">Left</label>
+            </div>
+          </div>
+          <div class="Radio mr-600">
             <input type="radio" id="toast-alignment-center" name="toast-alignment-x" value="center" class="Radio__input"
                    autocomplete="off" checked/>
-            <span class="Radio__text">
-            <span class="Radio__label">Center</span>
-          </span>
-          </label>
-          <label for="toast-alignment-right" class="Radio mr-600">
+            <div class="Radio__text">
+              <label class="Radio__label" for="toast-alignment-center">Center</label>
+            </div>
+          </div>
+          <div class="Radio mr-600">
             <input type="radio" id="toast-alignment-right" name="toast-alignment-x" value="right" class="Radio__input"
-                   autocomplete="off"/>
-            <span class="Radio__text">
-            <span class="Radio__label">Right</span>
-          </span>
-          </label>
+                   autocomplete="off" />
+            <div class="Radio__text">
+              <label class="Radio__label" for="toast-alignment-right">Right</label>
+            </div>
+          </div>
         </fieldset>
       </form>
       <!-- Toast alignment demo: end -->
@@ -197,27 +197,27 @@
                 </div>
               </div>
             </div>
-            <label for="toast-has-icon" class="Checkbox">
+            <div class="Checkbox">
               <input type="checkbox" id="toast-has-icon" class="Checkbox__input" name="is-dismissible" autocomplete="off"
                      checked/>
-              <span class="Checkbox__text">
-              <span class="Checkbox__label">Has icon</span>
-            </span>
-            </label>
-            <label for="toast-is-dismissible" class="Checkbox">
+              <div class="Checkbox__text">
+                <label class="Checkbox__label" for="toast-has-icon">Has icon</label>
+              </div>
+            </div>
+            <div class="Checkbox">
               <input type="checkbox" id="toast-is-dismissible" class="Checkbox__input" name="is-dismissible"
                      autocomplete="off" checked/>
-              <span class="Checkbox__text">
-              <span class="Checkbox__label">Dismissible</span>
-            </span>
-            </label>
-            <label for="toast-enable-auto-close" class="Checkbox">
+              <div class="Checkbox__text">
+                <label class="Checkbox__label" for="toast-is-dismissible">Dismissible</label>
+              </div>
+            </div>
+            <div class="Checkbox">
               <input type="checkbox" id="toast-enable-auto-close" class="Checkbox__input" name="enable-auto-close"
                      autocomplete="off" checked/>
-              <span class="Checkbox__text">
-              <span class="Checkbox__label">Enable AutoClose</span>
-            </span>
-            </label>
+              <div class="Checkbox__text">
+                <label class="Checkbox__label" for="toast-enable-auto-close">Enable AutoClose</label>
+              </div>
+            </div>
             <div class="TextField">
               <label for="toast-auto-close-interval" class="TextField__label">AutoClose interval (ms)</label>
               <input type="number" min="0" max="60000" step="500" value="3000" id="toast-auto-close-interval"
@@ -229,13 +229,13 @@
                         autocomplete="off">This is a new toast message.</textarea>
               <div class="TextArea__helperText">Can contain HTML.</div>
             </div>
-            <label for="toast-enable-link" class="Checkbox">
+            <div class="Checkbox">
               <input type="checkbox" id="toast-enable-link" class="Checkbox__input" name="enable-link" autocomplete="off"
                      checked/>
-              <span class="Checkbox__text">
-              <span class="Checkbox__label">Add link</span>
-            </span>
-            </label>
+              <div class="Checkbox__text">
+                <label class="Checkbox__label" for="toast-enable-link">Add link</label>
+              </div>
+            </div>
             <div class="TextArea">
               <label for="toast-link" class="TextArea__label">Link</label>
               <textarea id="toast-link" class="TextArea__input" autocomplete="off">This is a toast link.</textarea>

--- a/packages/web/src/scss/components/Toggle/README.md
+++ b/packages/web/src/scss/components/Toggle/README.md
@@ -8,12 +8,12 @@ The Toggle component implements the HTML [checkbox input][mdn-checkbox] element.
 the native input element and styles it to look like a toggle switch.
 
 ```html
-<label for="toggle-default" class="Toggle">
-  <span class="Toggle__text">
-    <span class="Toggle__label">Toggle Label</span>
+<div class="Toggle">
+  <div class="Toggle__text">
+    <label class="Toggle__label" for="toggle-default">Toggle Label</label>
   </span>
   <input type="checkbox" id="toggle-default" class="Toggle__input" name="default" />
-</label>
+</div>
 ```
 
 ## Indicators
@@ -22,12 +22,12 @@ If you need to indicate the state of the toggle, you can add the `Toggle__input-
 modifier class to the input. This will add a visual indicators to the toggle switch.
 
 ```html
-<label for="toggle-indicators" class="Toggle">
-  <span class="Toggle__text">
-    <span class="Toggle__label">Toggle Label</span>
-  </span>
+<div class="Toggle">
+  <div class="Toggle__text">
+    <label class="Toggle__label" for="toggle-indicators">Toggle Label</label>
+  </div>
   <input type="checkbox" id="toggle-indicators" class="Toggle__input Toggle__input--indicators" name="default" />
-</label>
+</div>
 ```
 
 ## Required
@@ -36,44 +36,44 @@ Add the `required` attribute to the input to mark it as required and add the
 `Toggle__label--required` modifier class to the label to indicate the state.
 
 ```html
-<label for="toggle-required" class="Toggle">
-  <span class="Toggle__text">
-    <span class="Toggle__label Toggle__label--required">Toggle Label</span>
-  </span>
+<div class="Toggle">
+  <div class="Toggle__text">
+    <label class="Toggle__label Toggle__label--required" for="toggle-required">Toggle Label</label>
+  </div>
   <input type="checkbox" id="toggle-required" class="Toggle__input" name="required" required />
-</label>
+</div>
 ```
 
 ## Hidden Label
 
 ```html
-<label for="toggle-hidden-label" class="Toggle">
-  <span class="Toggle__text">
-    <span class="Toggle__label Toggle__label--hidden">Toggle Label</span>
-  </span>
+<div class="Toggle">
+  <div class="Toggle__text">
+    <label class="Toggle__label Toggle__label--hidden" for="toggle-hidden-label">Toggle Label</label>
+  </div>
   <input type="checkbox" id="toggle-hidden-label" class="Toggle__input" name="hidden-label" />
-</label>
+</div>
 ```
 
 ## Fluid
 
 ```html
-<label for="toggle-fluid" class="Toggle Toggle--fluid">
-  <span class="Toggle__text">
-    <span class="Toggle__label">Toggle Label</span>
-  </span>
+<div class="Toggle Toggle--fluid">
+  <div class="Toggle__text">
+    <label class="Toggle__label" for="toggle-fluid">Toggle Label</label>
+  </div>
   <input type="checkbox" id="toggle-fluid" class="Toggle__input" name="fluid" />
-</label>
+</div>
 ```
 
 ## Helper Text
 
 ```html
-<label for="toggle-helper-text" class="Toggle">
-  <span class="Toggle__text">
-    <span class="Toggle__label">Toggle Label</span>
-    <span class="Toggle__helperText" id="toggle-helper-text-helper-text">Helper text</span>
-  </span>
+<div class="Toggle">
+  <div class="Toggle__text">
+    <label class="Toggle__label" for="toggle-helper-text">Toggle Label</label>
+    <div class="Toggle__helperText" id="toggle-helper-text-helper-text">Helper text</div>
+  </div>
   <input
     type="checkbox"
     id="toggle-helper-text"
@@ -81,7 +81,7 @@ Add the `required` attribute to the input to mark it as required and add the
     name="helper-text"
     aria-describedby="toggle-helper-text-helper-text"
   />
-</label>
+</div>
 ```
 
 ## Validation States
@@ -95,18 +95,18 @@ a JS interaction class when controlled by JavaScript (`has-success`,
 - To render validation text with an icon, add `<svg>` icon inside of `.Toggle__validationText`.
 
 ```html
-<label for="toggle-success" class="Toggle Toggle--success">
-  <span class="Toggle__text">
-    <span class="Toggle__label">Toggle Label</span>
-  </span>
+<div class="Toggle Toggle--success">
+  <div class="Toggle__text">
+    <label class="Toggle__label" for="toggle-success">Toggle Label</label>
+  </div>
   <input type="checkbox" id="toggle-success" class="Toggle__input" name="default" />
-</label>
+</div>
 
-<label for="toggle-warning" class="Toggle Toggle--warning">
-  <span class="Toggle__text">
-    <span class="Toggle__label">Toggle Label</span>
-    <span class="Toggle__validationText" id="toggle-warning-validation-text">Validation text</span>
-  </span>
+<div class="Toggle Toggle--warning">
+  <div class="Toggle__text">
+    <label class="Toggle__label" for="toggle-warning">Toggle Label</label>
+    <div class="Toggle__validationText" id="toggle-warning-validation-text">Validation text</div>
+  </div>
   <input
     type="checkbox"
     id="toggle-warning"
@@ -115,7 +115,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
     aria-describedby="toggle-warning-validation-text"
     checked
   />
-</label>
+</div>
 
 <div class="Toggle Toggle--danger">
   <div class="Toggle__text">
@@ -134,16 +134,16 @@ a JS interaction class when controlled by JavaScript (`has-success`,
   />
 </div>
 
-<label for="toggle-warning" class="Toggle Toggle--warning">
-  <span class="Toggle__text">
-    <span class="Toggle__label">Toggle Label</span>
-    <span class="Toggle__validationText" id="toggle-warning-validation-text">
+<div class="Toggle Toggle--warning">
+  <div class="Toggle__text">
+    <label class="Toggle__label" for="toggle-warning">Toggle Label</label>
+    <div class="Toggle__validationText" id="toggle-warning-validation-text">
       <svg width="20" height="20" aria-hidden="true">
         <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
       </svg>
       <span>Validation text with icon</span>
-    </span>
-  </span>
+    </div>
+  </div>
   <input
     type="checkbox"
     id="toggle-warning"
@@ -152,7 +152,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
     aria-describedby="toggle-warning-validation-text"
     checked
   />
-</label>
+</div>
 ```
 
 ### JavaScript-Controlled Validation Text
@@ -167,13 +167,13 @@ attribute. This way your JS remains disconnected from CSS that may or may not be
 components mix CSS with JS by design and handle prefixes their own way.**
 
 ```html
-<label for="toggle-success" class="Toggle has-success">
-  <span class="Toggle__text">
-    <span class="Toggle__label">Toggle Label</span>
+<div class="Toggle has-success">
+  <div class="Toggle__text">
+    <label class="Toggle__label" for="toggle-success">Toggle Label</label>
     <div class="Toggle__validationText" id="toggle-success-validation-text" data-spirit-element="validation_text">
       Validation text
     </div>
-  </span>
+  </div>
   <input
     type="checkbox"
     id="toggle-success"
@@ -181,7 +181,7 @@ components mix CSS with JS by design and handle prefixes their own way.**
     name="default"
     aria-describedby="toggle-success-validation-text"
   />
-</label>
+</div>
 ```
 
 To render validation text as a list, use `<ul>` element inside of `<div>`.
@@ -202,12 +202,12 @@ be marked by adding `Toggle--disabled` modifier class, or with `is-disabled`
 JS interaction class when controlled by JavaScript:
 
 ```html
-<label for="toggle-disabled" class="Toggle Toggle--disabled">
-  <span class="Toggle__text">
-    <span class="Toggle__label">Toggle Label</span>
-  </span>
+<div class="Toggle Toggle--disabled">
+  <div class="Toggle__text">
+    <label class="Toggle__label" for="toggle-disabled">Toggle Label</label>
+  </div>
   <input type="checkbox" id="toggle-disabled" class="Toggle__input" name="default" disabled />
-</label>
+</div>
 ```
 
 [dictionary-validation]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation

--- a/packages/web/src/scss/components/Toggle/_Toggle.scss
+++ b/packages/web/src/scss/components/Toggle/_Toggle.scss
@@ -7,12 +7,12 @@
 $_field-name: 'Toggle';
 
 .Toggle {
+    position: relative;
     display: flex;
     align-items: start;
     justify-content: space-between;
     max-width: theme.$max-width;
     margin-block: form-fields-theme.$inline-field-margin-y;
-    cursor: cursors.$form-fields;
 }
 
 .Toggle--fluid {
@@ -20,11 +20,13 @@ $_field-name: 'Toggle';
 }
 
 .Toggle__text {
+    flex: 1;
     margin-right: form-fields-theme.$inline-field-gap;
 }
 
 .Toggle__label {
     @include form-fields-tools.inline-field-label();
+    @include form-fields-tools.stretch();
 }
 
 .Toggle__label--hidden {

--- a/packages/web/src/scss/components/Toggle/index.html
+++ b/packages/web/src/scss/components/Toggle/index.html
@@ -8,19 +8,19 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <label for="toggle-default" class="Toggle">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-      </span>
+      <div class="Toggle">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-default">Toggle Label</label>
+        </div>
         <input type="checkbox" id="toggle-default" class="Toggle__input" name="default" />
-      </label>
+      </div>
 
-      <label for="toggle-default-checked" class="Toggle">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-      </span>
+      <div class="Toggle">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-default-checked">Toggle Label</label>
+        </div>
         <input type="checkbox" id="toggle-default-checked" class="Toggle__input" name="default" checked />
-      </label>
+      </div>
 
     </div>
 
@@ -36,19 +36,19 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <label for="toggle-indicators" class="Toggle">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-      </span>
+      <div class="Toggle">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-indicators">Toggle Label</label>
+        </div>
         <input type="checkbox" id="toggle-indicators" class="Toggle__input Toggle__input--indicators" name="default" />
-      </label>
+      </div>
 
-      <label for="toggle-indicators-checked" class="Toggle">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-      </span>
+      <div class="Toggle">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-indicators-checked">Toggle Label</label>
+        </div>
         <input type="checkbox" id="toggle-indicators-checked" class="Toggle__input Toggle__input--indicators" name="default" checked />
-      </label>
+      </div>
 
     </div>
 
@@ -64,12 +64,12 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <label for="toggle-required" class="Toggle">
-      <span class="Toggle__text">
-        <span class="Toggle__label Toggle__label--required">Toggle Label</span>
-      </span>
+      <div class="Toggle">
+        <div class="Toggle__text">
+          <label class="Toggle__label Toggle__label--required" for="toggle-required">Toggle Label</label>
+        </div>
         <input type="checkbox" id="toggle-required" class="Toggle__input" name="default" required />
-      </label>
+      </div>
 
     </div>
 
@@ -85,12 +85,12 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <label for="toggle-hidden-label" class="Toggle">
-      <span class="Toggle__text">
-        <span class="Toggle__label Toggle__label--hidden">Toggle Label</span>
-      </span>
+      <div class="Toggle">
+        <div class="Toggle__text">
+          <label class="Toggle__label Toggle__label--hidden" for="toggle-hidden-label">Toggle Label</label>
+        </div>
         <input type="checkbox" id="toggle-hidden-label" class="Toggle__input" name="default" />
-      </label>
+      </div>
 
     </div>
 
@@ -106,12 +106,12 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <label for="toggle-fluid" class="Toggle Toggle--fluid">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-      </span>
+      <div class="Toggle Toggle--fluid">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-fluid">Toggle Label</label>
+        </div>
         <input type="checkbox" id="toggle-fluid" class="Toggle__input" name="default" />
-      </label>
+      </div>
 
     </div>
 
@@ -127,50 +127,50 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <label for="toggle-default-disabled" class="Toggle Toggle--disabled">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-      </span>
+      <div class="Toggle Toggle--disabled">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-default-disabled">Toggle Label</label>
+        </div>
         <input type="checkbox" id="toggle-default-disabled" class="Toggle__input" name="default" disabled />
-      </label>
+      </div>
 
-      <label for="toggle-default-checked-disabled" class="Toggle Toggle--disabled">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-      </span>
+      <div class="Toggle Toggle--disabled">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-default-checked-disabled">Toggle Label</label>
+        </div>
         <input type="checkbox" id="toggle-default-checked-disabled" class="Toggle__input" name="default" checked disabled />
-      </label>
+      </div>
 
-      <label for="toggle-helper-text-disabled" class="Toggle Toggle--disabled">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-        <span class="Toggle__helperText" id="toggle-helper-text-disabled-helper-text">Helper text</span>
-      </span>
+      <div class="Toggle Toggle--disabled">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-helper-text-disabled">Toggle Label</label>
+          <div class="Toggle__helperText" id="toggle-helper-text-disabled-helper-text">Helper text</div>
+        </div>
         <input type="checkbox" id="toggle-helper-text-disabled" class="Toggle__input" name="default" aria-describedby="toggle-helper-text-disabled-helper-text" disabled />
-      </label>
+      </div>
 
-      <label for="toggle-warning-helper-text-disabled" class="Toggle Toggle--warning Toggle--disabled">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-        <span class="Toggle__helperText" id="toggle-warning-helper-text-helper-text-disabled">Helper text</span>
-        <span class="Toggle__validationText" id="toggle-warning-helper-text-validation-text-disabled">Validation text</span>
-      </span>
+      <div class="Toggle Toggle--warning Toggle--disabled">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-warning-helper-text-disabled">Toggle Label</label>
+          <div class="Toggle__helperText" id="toggle-warning-helper-text-helper-text-disabled">Helper text</div>
+          <div class="Toggle__validationText" id="toggle-warning-helper-text-validation-text-disabled">Validation text</div>
+        </div>
         <input type="checkbox" id="toggle-warning-helper-text-disabled" class="Toggle__input" name="default" aria-describedby="toggle-warning-helper-text-helper-text toggle-warning-helper-text-validation-text" checked disabled />
-      </label>
+      </div>
 
-      <label for="toggle-indicators-disabled" class="Toggle Toggle--disabled">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-      </span>
+      <div class="Toggle Toggle--disabled">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-indicators-disabled">Toggle Label</label>
+        </div>
         <input type="checkbox" id="toggle-indicators-disabled" class="Toggle__input Toggle__input--indicators" name="default" disabled />
-      </label>
+      </div>
 
-      <label for="toggle-indicators-disabled-checked" class="Toggle Toggle--disabled">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-      </span>
+      <div class="Toggle Toggle--disabled">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-indicators-disabled-checked">Toggle Label</label>
+        </div>
         <input type="checkbox" id="toggle-indicators-disabled-checked" class="Toggle__input Toggle__input--indicators" name="default" disabled checked />
-      </label>
+      </div>
 
     </div>
 
@@ -186,21 +186,21 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <label for="toggle-helper-text" class="Toggle">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-        <span class="Toggle__helperText" id="toggle-helper-text-helper-text">Helper text</span>
-      </span>
+      <div class="Toggle">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-helper-text">Toggle Label</label>
+          <div class="Toggle__helperText" id="toggle-helper-text-helper-text">Helper text</div>
+        </div>
         <input type="checkbox" id="toggle-helper-text" class="Toggle__input" name="default" aria-describedby="toggle-helper-text-helper-text" />
-      </label>
+      </div>
 
-      <label for="toggle-helper-text-checked" class="Toggle">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-        <span class="Toggle__helperText" id="toggle-helper-text-checked-helper-text">Helper text</span>
-      </span>
+      <div class="Toggle">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-helper-text-checked">Toggle Label</label>
+          <div class="Toggle__helperText" id="toggle-helper-text-checked-helper-text">Helper text</div>
+        </div>
         <input type="checkbox" id="toggle-helper-text-checked" class="Toggle__input" name="default" aria-describedby="toggle-helper-text-checked-helper-text" checked />
-      </label>
+      </div>
 
     </div>
 
@@ -216,20 +216,20 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <label for="toggle-success" class="Toggle Toggle--success">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-      </span>
+      <div class="Toggle Toggle--success">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-success">Toggle Label</label>
+        </div>
         <input type="checkbox" id="toggle-success" class="Toggle__input" name="default" />
-      </label>
+      </div>
 
-      <label for="toggle-warning" class="Toggle Toggle--warning">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-        <span class="Toggle__validationText" id="toggle-warning-validation-text">Validation text</span>
-      </span>
+      <div class="Toggle Toggle--warning">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-warning">Toggle Label</label>
+          <div class="Toggle__validationText" id="toggle-warning-validation-text">Validation text</div>
+        </div>
         <input type="checkbox" id="toggle-warning" class="Toggle__input" name="default" aria-describedby="toggle-warning-validation-text" checked />
-      </label>
+      </div>
 
       <div class="Toggle Toggle--danger">
         <div class="Toggle__text">
@@ -244,14 +244,14 @@
         <input type="checkbox" id="toggle-danger" class="Toggle__input" name="default" aria-describedby="toggle-danger-validation-text" />
       </div>
 
-      <label for="toggle-warning-helper-text" class="Toggle Toggle--warning">
-      <span class="Toggle__text">
-        <span class="Toggle__label">Toggle Label</span>
-        <span class="Toggle__helperText" id="toggle-warning-helper-text-helper-text">Helper text</span>
-        <span class="Toggle__validationText" id="toggle-warning-helper-text-validation-text">Validation text</span>
-      </span>
+      <div class="Toggle Toggle--warning">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-warning-helper-text">Toggle Label</label>
+          <div class="Toggle__helperText" id="toggle-warning-helper-text-helper-text">Helper text</div>
+          <div class="Toggle__validationText" id="toggle-warning-helper-text-validation-text">Validation text</div>
+        </div>
         <input type="checkbox" id="toggle-warning-helper-text" class="Toggle__input" name="default" aria-describedby="toggle-warning-helper-text-helper-text toggle-warning-helper-text-validation-text" checked />
-      </label>
+      </div>
 
     </div>
   </div>
@@ -266,22 +266,22 @@
       {{setVar "states" "success" "warning" "danger" }}
       {{#each @root.states as |state|}}
 
-      <label for="toggle-{{state}}-validation-icon" class="Toggle Toggle--{{state}}">
-        <span class="Toggle__text">
-          <span class="Toggle__label">Toggle Label</span>
-          <span class="Toggle__validationText" id="toggle-{{state}}-validation-textIcon">
+      <div class="Toggle Toggle--{{state}}">
+        <div class="Toggle__text">
+          <label class="Toggle__label" for="toggle-{{state}}-validation-icon">Toggle Label</label>
+          <div class="Toggle__validationText" id="toggle-{{state}}-validation-textIcon">
             <svg width="20" height="20" aria-hidden="true">
             {{#if (eq state "success")}}
             <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
             {{else}}
             <use xlink:href="/assets/icons/svg/sprite.svg#{{state}}" />
             {{/if}}
-          </svg>
+            </svg>
             <span>This is {{state}} validation text. Long validation text to show how it wraps.</span>
-          </span>
-        </span>
+          </div>
+        </div>
         <input type="checkbox" id="toggle-{{state}}-validation-icon" class="Toggle__input" name="default" aria-describedby="toggle-{{state}}-validation-text-icon" checked />
-      </label>
+      </div>
 
       {{/each}}
 

--- a/packages/web/src/scss/components/Tooltip/index.html
+++ b/packages/web/src/scss/components/Tooltip/index.html
@@ -330,46 +330,46 @@
           <div class="Grid Grid--cols-3 mx-auto" style="align-items: center; justify-items: center; max-width: 30rem;">
             <div class="GridItem" style="--grid-item-column-start: 2; --grid-item-row-start: 1">
 
-              <label for="placement-top-start" class="Radio">
+              <div class="Radio">
                 <input type="radio" name="placement" value="top-start" id="placement-top-start" class="Radio__input" />
-                <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">top-start</span>
-              </span>
-              </label>
-              <label for="placement-top" class="Radio">
+                <div class="Radio__text">
+                  <label class="Radio__label Radio__label--hidden" for="placement-top-start">top-start</label>
+                </div>
+              </div>
+              <div class="Radio">
                 <input type="radio" name="placement" value="top" id="placement-top" class="Radio__input" />
-                <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">top</span>
-              </span>
-              </label>
-              <label for="placement-top-end" class="Radio">
+                <div class="Radio__text">
+                  <label class="Radio__label Radio__label--hidden" for="placement-top">top</label>
+                </div>
+              </div>
+              <div class="Radio">
                 <input type="radio" name="placement" value="top-end" id="placement-top-end" class="Radio__input" />
-                <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">top-end</span>
-              </span>
-              </label>
+                <div class="Radio__text">
+                  <label class="Radio__label Radio__label--hidden" for="placement-top-end">top-end</label>
+                </div>
+              </div>
 
             </div>
             <div class="GridItem" style="--grid-item-column-start: 2; --grid-item-row-start: 3">
 
-              <label for="placement-bottom-start" class="Radio">
+              <div class="Radio">
                 <input type="radio" name="placement" value="bottom-start" id="placement-bottom-start" class="Radio__input" />
-                <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">bottom-start</span>
-              </span>
-              </label>
-              <label for="placement-bottom" class="Radio">
+                <div class="Radio__text">
+                  <label class="Radio__label Radio__label--hidden" for="placement-bottom-start">bottom-start</label>
+                </div>
+              </div>
+              <div class="Radio">
                 <input type="radio" name="placement" value="bottom" id="placement-bottom" class="Radio__input" checked />
-                <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">bottom</span>
-              </span>
-              </label>
-              <label for="placement-bottom-end" class="Radio">
+                <div class="Radio__text">
+                  <label class="Radio__label Radio__label--hidden" for="placement-bottom">bottom</label>
+                </div>
+              </div>
+              <div class="Radio">
                 <input type="radio" name="placement" value="bottom-end" id="placement-bottom-end" class="Radio__input" />
-                <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">bottom-end</span>
-              </span>
-              </label>
+                <div class="Radio__text">
+                  <label class="Radio__label Radio__label--hidden" for="placement-bottom-end">bottom-end</label>
+                </div>
+              </div>
 
             </div>
             <div
@@ -383,24 +383,24 @@
             "
             >
 
-              <label for="placement-left-start" class="Radio">
+              <div class="Radio">
                 <input type="radio" name="placement" value="left-start" id="placement-left-start" class="Radio__input" />
-                <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">left-start</span>
-              </span>
-              </label>
-              <label for="placement-left" class="Radio">
+                <div class="Radio__text">
+                  <label class="Radio__label Radio__label--hidden" for="placement-left-start">left-start</label>
+                </div>
+              </div>
+              <div class="Radio">
                 <input type="radio" name="placement" value="left" id="placement-left" class="Radio__input" />
-                <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">left</span>
-              </span>
-              </label>
-              <label for="placement-left-end" class="Radio">
+                <div class="Radio__text">
+                  <label class="Radio__label Radio__label--hidden" for="placement-left">left</label>
+                </div>
+              </div>
+              <div class="Radio">
                 <input type="radio" name="placement" value="left-end" id="placement-left-end" class="Radio__input" />
-                <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">left-end</span>
-              </span>
-              </label>
+                <div class="Radio__text">
+                  <label class="Radio__label Radio__label--hidden" for="placement-left-end">left-end</label>
+                </div>
+              </div>
 
             </div>
             <div
@@ -414,24 +414,24 @@
             "
             >
 
-              <label for="placement-right-start" class="Radio">
+              <div class="Radio">
                 <input type="radio" name="placement" value="right-start" id="placement-right-start" class="Radio__input" />
-                <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">right-start</span>
-              </span>
-              </label>
-              <label for="placement-right" class="Radio">
+                <div class="Radio__text">
+                  <label class="Radio__label Radio__label--hidden" for="placement-right-start">right-start</label>
+                </div>
+              </div>
+              <div class="Radio">
                 <input type="radio" name="placement" value="right" id="placement-right" class="Radio__input" />
-                <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">right</span>
-              </span>
-              </label>
-              <label for="placement-right-end" class="Radio">
+                <div class="Radio__text">
+                  <label class="Radio__label Radio__label--hidden" for="placement-right">right</label>
+                </div>
+              </div>
+              <div class="Radio">
                 <input type="radio" name="placement" value="right-end" id="placement-right-end" class="Radio__input" />
-                <span class="Radio__text">
-                <span class="Radio__label Radio__label--hidden">right-end</span>
-              </span>
-              </label>
+                <div class="Radio__text">
+                  <label class="Radio__label Radio__label--hidden" for="placement-right-end">right-end</label>
+                </div>
+              </div>
 
             </div>
             <div class="GridItem" style="--grid-item-column-start: 2; --grid-item-row-start: 2">
@@ -492,36 +492,36 @@
 
         <div class="Grid Grid--cols-1 Grid--tablet--cols-4 mb-700">
           <div>
-            <label for="my-advanced-flip" class="Checkbox">
+            <div class="Checkbox">
               <input type="checkbox" id="my-advanced-flip" class="Checkbox__input" name="advanced-flip" checked />
-              <span class="Checkbox__text">
-              <span class="Checkbox__label">Enable flipping</span>
-            </span>
-            </label>
+              <div class="Checkbox__text">
+                <label class="Checkbox__label" for="my-advanced-flip">Enable flipping</label>
+              </div>
+            </div>
           </div>
           <div>
-            <label for="my-advanced-flip-cross-axis" class="Checkbox">
+            <div class="Checkbox">
               <input type="checkbox" id="my-advanced-flip-cross-axis" class="Checkbox__input" name="advanced-flip-cross-axis" checked />
-              <span class="Checkbox__text">
-              <span class="Checkbox__label">Enable flipping cross axis</span>
-            </span>
-            </label>
+              <div class="Checkbox__text">
+                <label class="Checkbox__label" for="my-advanced-flip-cross-axis">Enable flipping cross axis</label>
+              </div>
+            </div>
           </div>
           <div>
-            <label for="my-advanced-shift" class="Checkbox">
+            <div class="Checkbox">
               <input type="checkbox" id="my-advanced-shift" class="Checkbox__input" name="advanced-shift" checked />
-              <span class="Checkbox__text">
-              <span class="Checkbox__label">Enable shifting</span>
-            </span>
-            </label>
+              <div class="Checkbox__text">
+                <label class="Checkbox__label" for="my-advanced-shift">Enable shifting</label>
+              </div>
+            </div>
           </div>
           <div>
-            <label for="my-advanced-size" class="Checkbox">
+            <div class="Checkbox">
               <input type="checkbox" id="my-advanced-size" class="Checkbox__input" name="advanced-size" checked />
-              <span class="Checkbox__text">
-              <span class="Checkbox__label">Enable sizing</span>
-            </span>
-            </label>
+              <div class="Checkbox__text">
+                <label class="Checkbox__label" for="my-advanced-size">Enable sizing</label>
+              </div>
+            </div>
           </div>
         </div>
         <div class="Grid Grid--cols-1 Grid--tablet--cols-2 mb-700">

--- a/packages/web/src/scss/tools/_form-fields.scss
+++ b/packages/web/src/scss/tools/_form-fields.scss
@@ -1,4 +1,5 @@
 // 1. Force the color to be printed as-is, without any color adjustment.
+// 2. Put the input above the stretched label.
 
 @use 'sass:map';
 @use '../settings/cursors';
@@ -59,7 +60,6 @@
 @mixin inline-field-root() {
     display: inline-flex;
     margin-block: form-fields-theme.$inline-field-margin-y;
-    cursor: cursors.$form-fields;
 }
 
 @mixin inline-field-root-disabled() {
@@ -74,8 +74,15 @@
 @mixin inline-field-label() {
     @include typography.generate(form-fields-theme.$input-typography);
 
-    display: inline-block;
+    display: block;
     color: form-fields-theme.$label-color-state-default;
+    cursor: cursors.$form-fields;
+}
+
+@mixin inline-field-label-disabled() {
+    @include label-disabled();
+
+    cursor: cursors.$disabled;
 }
 
 @mixin box-field-label() {
@@ -87,6 +94,7 @@
 }
 
 @mixin inline-field-input() {
+    z-index: 1; // 2.
     appearance: none;
     border: form-fields-theme.$inline-field-input-border-width solid form-fields-theme.$input-border-color;
     background-color: form-fields-theme.$input-background-color;
@@ -264,4 +272,13 @@
 
 @mixin item-helper-text() {
     @include typography.generate(form-fields-theme.$item-helper-text-typography);
+}
+
+@mixin stretch($pseudo-element: before) {
+    &::#{$pseudo-element} {
+        content: '';
+        position: absolute;
+        inset: 0;
+        z-index: 0;
+    }
 }


### PR DESCRIPTION
## Description  

- Removed the `<label>` that wrapped the entire input and all texts, placing the label only on the appropriate element.  

### Additional Context  

- Fixed an issue where the input referenced a non-existent helper text in `aria-describedby`.  
- Updated `aria-labelledby` to correctly reference the label and `aria-describedby` to include validation and helper texts.  

### Issue Reference  

[Form elements: Do not wrap Checkbox, Radio, and Toggle in `<label>`](https://jira.almacareer.tech/browse/DS-1703)  
