### PR TITLE
Fix(examples): Add postcss configuration to suppress flexbox warning #DS-1778

### DIFF
--- a/examples/next-with-app-router/README.md
+++ b/examples/next-with-app-router/README.md
@@ -123,6 +123,41 @@ Create a file `src/app/globals.scss` and add the following import:
 @forward '@lmc-eu/spirit-web/scss';
 ```
 
+### PostCSS Configuration
+
+If you encounter the following warning:
+
+`autoprefixer: start value has mixed support, consider using flex-start instead`
+
+If you don't need to support older browsers (e.g. Internet Explorer 11), you can suppress this warning by customizing the PostCSS configuration.
+The following configuration disables support for the outdated 2009 flexbox specification, which helps prevent compatibility warnings related to legacy flexbox syntax.
+
+Create a `postcss.config.js` file in the root of your project with the following content:
+
+```js
+module.exports = {
+  plugins: {
+    autoprefixer: {
+      flexbox: 'no-2009',
+    },
+  },
+};
+```
+
+Alternatively, you can use a JSON configuration by creating a `postcss.config.json` file:
+
+```json
+{
+  "plugins": {
+    "autoprefixer": {
+      "flexbox": "no-2009"
+    }
+  }
+}
+```
+
+For more information see [Next.js PostCSS documentation][nextjs-postcss-documentation].
+
 ### Updating the Application Layout
 
 Open `src/app/layout.tsx` and modify it as follows:
@@ -166,5 +201,6 @@ For instructions, see [Running the Development Server](#running-the-development-
 
 Congratulation! The application will now be running at http://localhost:3000 and using the Spirit Design System.
 
+[nextjs-postcss-documentation]: https://nextjs.org/docs/pages/building-your-application/configuring/post-css
 [npm-error-enoworkspaces]: https://github.com/vercel/turborepo/issues/4183
 [rebranding-spirit]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/design-tokens/README.md#rebranding-spirit

--- a/examples/next-with-app-router/postcss.config.json
+++ b/examples/next-with-app-router/postcss.config.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "autoprefixer": {
+      "flexbox": "no-2009"
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

This PR introduces a new rule to enforce the use of flex-start instead of start for the justify-content property in the codebase.

Due to a limitation in Next.js, the correct browserslist configuration wasn't being respected, leading to a misleading build-time warning when using start as a value for justify-content. As a workaround, this rule has been added to prevent the use of start and to ensure that flex-start is used instead.

Additionally, all occurrences of start for the justify-content property have been manually updated to flex-start to resolve this issue across the codebase.

EDIT: 


I managed to solve it using configuration in nextjs. The original solution has been removed.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
