### PR TITLE
Chore(ci): Repository must be cloned first to access the composite action

### DIFF
--- a/.github/actions/has-tags/action.yaml
+++ b/.github/actions/has-tags/action.yaml
@@ -1,20 +1,15 @@
 name: 'has tags'
 description: 'Has Tags'
+
+outputs:
+  has-tag:
+    description: 'Whether there is a tag on the commit'
+    value: ${{ steps.check-tag-exists.outputs.has-tag }}
+
 runs:
   using: 'composite'
 
-  outputs:
-    has-tag: ${{ steps.check-tag-exists.outputs.has-tag }}
-
   steps:
-    - name: Clone repository
-      uses: actions/checkout@v4
-      with:
-        # Even though this is set, shallow clones do not always retrieve all tags correctly
-        fetch-tags: true
-        # So we need to fetch full history, including all tags
-        fetch-depth: 0
-
     # ⚠️ This check works only if the tag is pushed alongside the commit
     # Please, use `git push && git push --tags` or `git push --follow-tags` (works only for annotated tags)
     - name: Check Tag On Commit

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,6 +14,14 @@ jobs:
       has-tag: ${{ steps.check-tag-exists.outputs.has-tag }}
 
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          # Even though this is set, shallow clones do not always retrieve all tags correctly
+          fetch-tags: true
+          # So we need to fetch full history, including all tags
+          fetch-depth: 0
+
       - name: Check Tag On Commit
         id: check-tag-exists
         uses: ./.github/actions/has-tags

--- a/.github/workflows/supernova.yaml
+++ b/.github/workflows/supernova.yaml
@@ -14,6 +14,14 @@ jobs:
       has-tag: ${{ steps.check-tag-exists.outputs.has-tag }}
 
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          # Even though this is set, shallow clones do not always retrieve all tags correctly
+          fetch-tags: true
+          # So we need to fetch full history, including all tags
+          fetch-depth: 0
+
       - name: Check Tag On Commit
         id: check-tag-exists
         uses: ./.github/actions/has-tags


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Second run, double fun. I have tried and failed. The repository must be cloned first, so the composite action is accessible.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Tested using custom action:

```yaml
name: Test Has Tags Action

on:
  push:
    branches:
      - main

jobs:
  test-has-tags:
    runs-on: ubuntu-latest
    steps:
      - name: Clone repository
        uses: actions/checkout@v4
        with:
          # Even though this is set, shallow clones do not always retrieve all tags correctly
          fetch-tags: true
          # So we need to fetch full history, including all tags
          fetch-depth: 0

      - name: Run Has Tags Action
        uses: ./.github/actions/has-tags

```

https://github.com/nektos/act

`act push -W .github/workflows/test-has-tags.yaml --verbose`

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

https://jira.almacareer.tech/browse/DS-1801

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
