### PR TITLE
Feat(web-react,web-twig): Remove aria-selected from Item #DS-1851

### DIFF
--- a/packages/web-react/src/components/Item/Item.tsx
+++ b/packages/web-react/src/components/Item/Item.tsx
@@ -24,12 +24,7 @@ const Item = <T extends ElementType = 'button'>(props: SpiritItemProps<T>): JSX.
   const mergedStyleProps = mergeStyleProps(ElementTag, { classProps: classProps.root, styleProps, otherProps });
 
   return (
-    <ElementTag
-      {...otherProps}
-      {...mergedStyleProps}
-      aria-selected={!!isSelected}
-      disabled={!!isDisabled && ElementTag === 'button'}
-    >
+    <ElementTag {...otherProps} {...mergedStyleProps} disabled={!!isDisabled && ElementTag === 'button'}>
       {iconName && (
         <span className={classNames(classProps.icon.root, classProps.icon.start)}>
           <Icon name={iconName} />

--- a/packages/web-twig/src/Resources/components/Item/Item.twig
+++ b/packages/web-twig/src/Resources/components/Item/Item.twig
@@ -23,7 +23,6 @@
 {%- set _labelClassName =  _spiritClassPrefix ~ 'Item__label' -%}
 
 {# Attributes #}
-{%- set _ariaSelectedAttr = 'aria-selected="' ~ (_isSelected ? 'true' : 'false') ~ '"' -%}
 {%- set _buttonDisabledAttr = (_elementType == 'button' and _isDisabled) ? 'disabled' : null -%}
 {%- set _hrefAttr = (_elementType == 'a' and _href) ? 'href=' ~ _href : null -%}
 {%- set _targetAttr = (_elementType == 'a' and _target) ? 'target=' ~ _target | escape('html_attr') : null -%}
@@ -42,7 +41,6 @@
   {{ _targetAttr }}
   {{ _typeAttr }}
   {{ _buttonDisabledAttr }}
-  {{ _ariaSelectedAttr | raw  }}
 >
   {% if _iconName %}
     <span class="{{ _startIconClassName }}">

--- a/packages/web-twig/src/Resources/components/Item/__tests__/__snapshots__/itemDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Item/__tests__/__snapshots__/itemDefault.twig.snap.html
@@ -5,10 +5,8 @@
     </title>
   </head>
   <body>
-    <button class="Item" type="button" aria-selected="false"><span class="Item__label">Item label</span></button>
-    <a class="Item" href="https://www.example.com/" aria-selected="false"><span class="Item__label">Item
-    label</span></a>
-    <div class="Item" aria-selected="false">
+    <button class="Item" type="button"><span class="Item__label">Item label</span></button> <a class="Item" href="https://www.example.com/"><span class="Item__label">Item label</span></a>
+    <div class="Item">
       <span class="Item__label">Item label</span>
     </div>
   </body>

--- a/packages/web-twig/src/Resources/components/Item/__tests__/__snapshots__/itemDisabled.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Item/__tests__/__snapshots__/itemDisabled.twig.snap.html
@@ -5,6 +5,7 @@
     </title>
   </head>
   <body>
-    <button class="Item Item--disabled" type="button" disabled aria-selected="false"><span class="Item__label">Item label</span></button> <a class="Item Item--disabled" aria-selected="false"><span class="Item__label">Item label</span></a>
+    <button class="Item Item--disabled" type="button" disabled><span class="Item__label">Item
+    label</span></button> <a class="Item Item--disabled"><span class="Item__label">Item label</span></a>
   </body>
 </html>

--- a/packages/web-twig/src/Resources/components/Item/__tests__/__snapshots__/itemHelperText.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Item/__tests__/__snapshots__/itemHelperText.twig.snap.html
@@ -5,6 +5,6 @@
     </title>
   </head>
   <body>
-    <button class="Item" type="button" aria-selected="false"><span class="Item__label">Item label</span> <span class="Item__helperText">Helper text</span></button>
+    <button class="Item" type="button"><span class="Item__label">Item label</span> <span class="Item__helperText">Helper text</span></button>
   </body>
 </html>

--- a/packages/web-twig/src/Resources/components/Item/__tests__/__snapshots__/itemIcon.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Item/__tests__/__snapshots__/itemIcon.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <button class="Item" type="button" aria-selected="false"><span class="Item__icon Item__icon--start"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" class="Icon" aria-hidden="true">
+    <button class="Item" type="button"><span class="Item__icon Item__icon--start"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" class="Icon" aria-hidden="true">
     <path d="M15.5 14H14.71L14.43 13.73C15.63 12.33 16.25 10.42 15.91 8.39002C15.44 5.61002 13.12 3.39002 10.32 3.05002C6.09001 2.53002 2.53002 6.09001 3.05002 10.32C3.39002 13.12 5.61002 15.44 8.39002 15.91C10.42 16.25 12.33 15.63 13.73 14.43L14 14.71V15.5L18.25 19.75C18.66 20.16 19.33 20.16 19.74 19.75C20.15 19.34 20.15 18.67 19.74 18.26L15.5 14ZM9.50002 14C7.01002 14 5.00002 11.99 5.00002 9.50002C5.00002 7.01002 7.01002 5.00002 9.50002 5.00002C11.99 5.00002 14 7.01002 14 9.50002C14 11.99 11.99 14 9.50002 14Z" fill="currentColor">
     </path></svg></span> <span class="Item__label">Item label</span></button>
   </body>

--- a/packages/web-twig/src/Resources/components/Item/__tests__/__snapshots__/itemSelected.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Item/__tests__/__snapshots__/itemSelected.twig.snap.html
@@ -5,8 +5,7 @@
     </title>
   </head>
   <body>
-    <button class="Item Item--selected" type="button" aria-selected="true"><span class="Item__label">Item label</span>
-    <span class="Item__icon Item__icon--end"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" class="Icon" aria-hidden="true">
+    <button class="Item Item--selected" type="button"><span class="Item__label">Item label</span> <span class="Item__icon Item__icon--end"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" class="Icon" aria-hidden="true">
     <path d="M9.00012 16.5448L5.50012 13.0448C5.11012 12.6548 4.49012 12.6548 4.10012 13.0448C3.71012 13.4348 3.71012 14.0548 4.10012 14.4448L8.29012 18.6348C8.68012 19.0248 9.31012 19.0248 9.70012 18.6348L20.3001 8.04479C20.6901 7.65479 20.6901 7.03479 20.3001 6.64479C19.9101 6.25479 19.2901 6.25479 18.9001 6.64479L9.00012 16.5448Z" fill="currentColor">
     </path></svg></span></button>
   </body>


### PR DESCRIPTION
Aria Selected attribute is only for tabs, options and some table elements.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-selected

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
