### PR TITLE
Fix(web,web-react,web-twig): Remove aria-selected and role from TabLink #DS-1851

### DIFF
--- a/packages/web-react/src/components/Tabs/README.md
+++ b/packages/web-react/src/components/Tabs/README.md
@@ -26,6 +26,8 @@ const selectTab = useCallback((id) => {
 
 ## Tab with Links
 
+⚠️ Please note that mixing links with buttons in tab list is not recommended for accessibility reasons.
+
 ```jsx
 const [selectedId, setSelectedTab] = useState(1);
 

--- a/packages/web-react/src/components/Tabs/TabLink.tsx
+++ b/packages/web-react/src/components/Tabs/TabLink.tsx
@@ -21,8 +21,13 @@ const _TabLink = <E extends ElementType = 'a'>(props: SpiritTabLinkProps<E>, ref
   const mergedStyleProps = mergeStyleProps(ElementTag, { classProps: classProps.link });
 
   return (
-    <li {...itemStyleProps} {...itemTransferProps} className={classNames(classProps.item, itemStyleProps.className)}>
-      <ElementTag {...restProps} {...mergedStyleProps} role="tab" ref={ref}>
+    <li
+      {...itemStyleProps}
+      {...itemTransferProps}
+      className={classNames(classProps.item, itemStyleProps.className)}
+      role="presentation"
+    >
+      <ElementTag {...restProps} {...mergedStyleProps} ref={ref}>
         {children}
       </ElementTag>
     </li>

--- a/packages/web-twig/src/Resources/components/Tabs/README.md
+++ b/packages/web-twig/src/Resources/components/Tabs/README.md
@@ -79,6 +79,8 @@ There is no API for TabItem.
 
 ### TabLink
 
+⚠️ Please note that mixing links with buttons in tab list is not recommended for accessibility reasons.
+
 | Name           | Type     | Default | Required | Description                  |
 | -------------- | -------- | ------- | -------- | ---------------------------- |
 | `href`         | `string` | `null`  | ✕        | URL target of a link         |

--- a/packages/web-twig/src/Resources/components/Tabs/TabLink.twig
+++ b/packages/web-twig/src/Resources/components/Tabs/TabLink.twig
@@ -10,14 +10,15 @@
 {%- set _rootClassName = _spiritClassPrefix ~ 'Tabs__link' -%}
 
 {# Attributes #}
+{%- set _ariaSelected = _isSelected ? 'true' : 'false' -%}
 {%- set _ariaControlsAttr = _targetPaneId ? 'aria-controls="' ~ _targetPaneId | escape('html_attr') ~ '"' : null -%}
+{%- set _ariaSelectedAttr = _href ? null : 'aria-selected="' ~ _ariaSelected ~ '"' -%}
 {%- set _dataTargetAttr = _targetPaneId ? 'data-spirit-target="#' ~ _targetPaneId | escape('html_attr') ~ '"' : null -%}
 {%- set _roleAttr = _href ? null : 'role="tab"'  -%}
 {%- set _typeAttr = _href ? null : 'type="button"' -%}
 
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
-{%- set _ariaSelected = _isSelected ? 'true' : 'false' -%}
 {%- set _classNames = [ _rootClassName, _isSelectedClassName, _styleProps.className ] -%}
 {%- set _elementType = _href ? 'a' : 'button' -%}
 {%- set _allowedAttributes = _href ? [ 'href' ] : [] -%}
@@ -26,8 +27,8 @@
     {{ mainProps(props, _allowedAttributes) }}
     {{ styleProp(_styleProps) }}
     {{ classProp(_classNames) }}
-    aria-selected="{{ _ariaSelected }}"
     {{ _ariaControlsAttr | raw }}
+    {{ _ariaSelectedAttr | raw }}
     {{ _dataTargetAttr | raw }}
     {{ _roleAttr | raw }}
     {{ _typeAttr | raw }}

--- a/packages/web-twig/src/Resources/components/Tabs/__tests__/__snapshots__/tabsDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Tabs/__tests__/__snapshots__/tabsDefault.twig.snap.html
@@ -7,15 +7,15 @@
   <body>
     <ul class="Tabs" role="tablist">
       <li class="Tabs__item" role="presentation">
-        <button id="pane-1-tab" data-spirit-toggle="tabs" class="Tabs__link is-selected" aria-selected="true" aria-controls="pane-1" data-spirit-target="#pane-1" role="tab" type="button">Item selected</button>
+        <button id="pane-1-tab" data-spirit-toggle="tabs" class="Tabs__link is-selected" aria-controls="pane-1" aria-selected="true" data-spirit-target="#pane-1" role="tab" type="button">Item selected</button>
       </li>
 
       <li class="Tabs__item" role="presentation">
-        <button id="pane-2-tab" data-spirit-toggle="tabs" class="Tabs__link" aria-selected="false" aria-controls="pane-2" data-spirit-target="#pane-2" role="tab" type="button">Item</button>
+        <button id="pane-2-tab" data-spirit-toggle="tabs" class="Tabs__link" aria-controls="pane-2" aria-selected="false" data-spirit-target="#pane-2" role="tab" type="button">Item</button>
       </li>
 
       <li class="Tabs__item" role="presentation">
-        <a href="https://www.example.com" class="Tabs__link" aria-selected="false">Item link</a>
+        <a href="https://www.example.com" class="Tabs__link">Item link</a>
       </li>
     </ul>
 

--- a/packages/web-twig/src/Resources/components/Tabs/__tests__/__snapshots__/tabsWithCustomSpacing.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Tabs/__tests__/__snapshots__/tabsWithCustomSpacing.twig.snap.html
@@ -7,15 +7,15 @@
   <body>
     <ul class="Tabs" style="--tabs-spacing: var(--spirit-space-400);" role="tablist">
       <li class="Tabs__item" role="presentation">
-        <button id="pane-3-tab" data-spirit-toggle="tabs" class="Tabs__link is-selected" aria-selected="true" aria-controls="pane-3" data-spirit-target="#pane-3" role="tab" type="button">Item selected</button>
+        <button id="pane-3-tab" data-spirit-toggle="tabs" class="Tabs__link is-selected" aria-controls="pane-3" aria-selected="true" data-spirit-target="#pane-3" role="tab" type="button">Item selected</button>
       </li>
 
       <li class="Tabs__item" role="presentation">
-        <button id="pane-4-tab" data-spirit-toggle="tabs" class="Tabs__link" aria-selected="false" aria-controls="pane-4" data-spirit-target="#pane-4" role="tab" type="button">Item</button>
+        <button id="pane-4-tab" data-spirit-toggle="tabs" class="Tabs__link" aria-controls="pane-4" aria-selected="false" data-spirit-target="#pane-4" role="tab" type="button">Item</button>
       </li>
 
       <li class="Tabs__item" role="presentation">
-        <a href="https://www.example.com" class="Tabs__link" aria-selected="false">Item link</a>
+        <a href="https://www.example.com" class="Tabs__link">Item link</a>
       </li>
     </ul>
 

--- a/packages/web-twig/src/Resources/components/Tabs/__tests__/__snapshots__/tabsWithCustomSpacingForEachBreakpoint.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Tabs/__tests__/__snapshots__/tabsWithCustomSpacingForEachBreakpoint.twig.snap.html
@@ -7,15 +7,15 @@
   <body>
     <ul class="Tabs" style="--tabs-spacing: var(--spirit-space-400);--tabs-spacing-tablet: var(--spirit-space-800);--tabs-spacing-desktop: var(--spirit-space-1200);" role="tablist">
       <li class="Tabs__item" role="presentation">
-        <button id="pane-3-tab" data-spirit-toggle="tabs" class="Tabs__link is-selected" aria-selected="true" aria-controls="pane-3" data-spirit-target="#pane-3" role="tab" type="button">Item selected</button>
+        <button id="pane-3-tab" data-spirit-toggle="tabs" class="Tabs__link is-selected" aria-controls="pane-3" aria-selected="true" data-spirit-target="#pane-3" role="tab" type="button">Item selected</button>
       </li>
 
       <li class="Tabs__item" role="presentation">
-        <button id="pane-4-tab" data-spirit-toggle="tabs" class="Tabs__link" aria-selected="false" aria-controls="pane-4" data-spirit-target="#pane-4" role="tab" type="button">Item</button>
+        <button id="pane-4-tab" data-spirit-toggle="tabs" class="Tabs__link" aria-controls="pane-4" aria-selected="false" data-spirit-target="#pane-4" role="tab" type="button">Item</button>
       </li>
 
       <li class="Tabs__item" role="presentation">
-        <a href="https://www.example.com" class="Tabs__link" aria-selected="false">Item link</a>
+        <a href="https://www.example.com" class="Tabs__link">Item link</a>
       </li>
     </ul>
 

--- a/packages/web/src/scss/components/Tabs/README.md
+++ b/packages/web/src/scss/components/Tabs/README.md
@@ -48,9 +48,11 @@ A tab item can be a link that follows a URL:
 
 ```html
 <li class="Tabs__item" role="presentation">
-  <a href="https://www.example.com" class="Tabs__link"> Link item </a>
+  <a href="https://www.example.com" class="Tabs__link">Link item</a>
 </li>
 ```
+
+⚠️ Please note that mixing links with buttons in tab list is not recommended for accessibility reasons.
 
 ## Responsive Visibility
 


### PR DESCRIPTION
When the item in Tab is a link, it should not have aria-selected attribute.

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
