### PR TITLE
Refactor(web): Refactor component size variants to use custom properties for typography #DS-1689

### DIFF
--- a/packages/web/src/scss/components/Alert/_Alert.scss
+++ b/packages/web/src/scss/components/Alert/_Alert.scss
@@ -28,7 +28,7 @@
 @include dictionaries.generate-colors(
     $class-name: 'Alert',
     $dictionary-values: theme.$color-dictionary,
-    $config: theme.$color-dictionary-config
+    $config: theme.$color-config
 );
 
 .Alert :where(a) {

--- a/packages/web/src/scss/components/Alert/_theme.scss
+++ b/packages/web/src/scss/components/Alert/_theme.scss
@@ -16,7 +16,7 @@ $color-dictionary: (
     emotion: dictionaries.$emotion-colors,
 );
 
-$color-dictionary-config: (
+$color-config: (
     color: 'content-basic',
     border-color: 'border-basic',
     background-color: 'background-subtle',

--- a/packages/web/src/scss/components/Avatar/_Avatar.scss
+++ b/packages/web/src/scss/components/Avatar/_Avatar.scss
@@ -1,8 +1,11 @@
 @use 'theme';
 @use '@tokens' as tokens;
 @use '../../tools/dictionaries';
+@use '../../tools/typography';
 
 .Avatar {
+    @include typography.from-css-variables($infix: 'avatar');
+
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -37,4 +40,8 @@
     object-fit: cover;
 }
 
-@include dictionaries.generate-sizes('Avatar', theme.$sizes);
+@include dictionaries.generate-sizes(
+    $class-name: 'Avatar',
+    $dictionary-values: theme.$size-dictionary,
+    $config: theme.$size-config
+);

--- a/packages/web/src/scss/components/Avatar/_theme.scss
+++ b/packages/web/src/scss/components/Avatar/_theme.scss
@@ -1,4 +1,5 @@
 @use '@tokens' as tokens;
+@use '../../settings/dictionaries';
 
 $color: tokens.$text-primary;
 $border-width: tokens.$border-width-100;
@@ -8,7 +9,8 @@ $border-radius: tokens.$radius-full;
 $border-radius-square: tokens.$radius-200;
 $background-color: tokens.$background-primary;
 
-$sizes: (
+$size-dictionary: dictionaries.$size-extended;
+$size-config: (
     xsmall: (
         width: tokens.$space-900,
         height: tokens.$space-900,

--- a/packages/web/src/scss/components/Button/_Button.scss
+++ b/packages/web/src/scss/components/Button/_Button.scss
@@ -1,13 +1,18 @@
 // 1. Clip the loading spinner to fix button flickering during spinner animation.
 
 @use 'sass:map';
+@use 'sass:string';
 @use 'theme';
 @use '@tokens' as tokens;
 @use '../../settings/cursors';
 @use '../../tools/dictionaries';
 @use '../../tools/typography';
 
+$_component-name: 'Button';
+
 .Button {
+    @include typography.from-css-variables($infix: string.to-lower-case($_component-name));
+
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -54,16 +59,20 @@
 }
 
 @include dictionaries.generate-colors(
-    $class-name: 'Button',
+    $class-name: $_component-name,
     $dictionary-values: theme.$color-component-button-dictionary,
-    $config: theme.$color-action-button-dictionary-config
+    $config: theme.$color-action-button-config
 );
 @include dictionaries.generate-colors(
-    $class-name: 'Button',
+    $class-name: $_component-name,
     $dictionary-values: theme.$color-emotion-dictionary,
-    $config: theme.$color-emotion-dictionary-config
+    $config: theme.$color-emotion-config
 );
-@include dictionaries.generate-sizes('Button', theme.$sizes);
+@include dictionaries.generate-sizes(
+    $class-name: $_component-name,
+    $dictionary-values: theme.$size-dictionary,
+    $config: theme.$size-config
+);
 
 .Button--block {
     display: block;

--- a/packages/web/src/scss/components/Button/_theme.scss
+++ b/packages/web/src/scss/components/Button/_theme.scss
@@ -1,9 +1,8 @@
 @use 'sass:map';
 @use '@tokens' as tokens;
 @use '../../settings/dictionaries';
+@use '../../settings/form-fields' as form-fields-settings;
 
-$typography: tokens.$body-small-semibold;
-$typography-large: tokens.$body-medium-semibold;
 $border-width: tokens.$border-width-100;
 $border-style: solid;
 $border-radius: tokens.$radius-full;
@@ -21,7 +20,7 @@ $color-emotion-dictionary: (
     emotion: dictionaries.$emotion-colors,
 );
 
-$color-action-button-dictionary-config: (
+$color-action-button-config: (
     color: 'content',
     border-color: 'border',
     background-color: 'state-default',
@@ -29,7 +28,7 @@ $color-action-button-dictionary-config: (
     background-color-state-active: 'state-active',
 );
 
-$color-emotion-dictionary-config: (
+$color-emotion-config: (
     color: 'content-subtle',
     border-color: 'border-basic',
     background-color: 'state-default',
@@ -37,7 +36,7 @@ $color-emotion-dictionary-config: (
     background-color-state-active: 'state-active',
 );
 
-$loading-color-dictionary-config: (
+$loading-color-config: (
     color: 'content',
 );
 
@@ -48,24 +47,24 @@ $loading-color-dictionary-overrides: (
     ),
 );
 
-// We subtract the border width to achieve the same dimensions as other form elements
-$sizes: (
-    small: (
-        height: 32px,
-        padding-x: calc(#{tokens.$space-700} - #{tokens.$border-width-100}),
-        padding-y: calc(#{tokens.$space-300} - #{tokens.$border-width-100}),
-        typography: $typography,
-    ),
-    medium: (
-        height: 40px,
-        padding-x: calc(#{tokens.$space-900} - #{tokens.$border-width-100}),
-        padding-y: calc(#{tokens.$space-500} - #{tokens.$border-width-100}),
-        typography: $typography,
-    ),
-    large: (
-        height: 48px,
-        padding-x: calc(#{tokens.$space-900} - #{tokens.$border-width-100}),
-        padding-y: calc(#{tokens.$space-500} - #{tokens.$border-width-100}),
-        typography: $typography-large,
-    ),
+$size-dictionary: dictionaries.$size;
+$size-config: map.deep-merge(
+    form-fields-settings.$box-field-size-config,
+    (
+        small: (
+            padding-x: calc(#{tokens.$space-700} - #{tokens.$border-width-100}),
+            padding-y: calc(#{tokens.$space-300} - #{tokens.$border-width-100}),
+            typography: tokens.$body-small-semibold,
+        ),
+        medium: (
+            padding-x: calc(#{tokens.$space-900} - #{tokens.$border-width-100}),
+            padding-y: calc(#{tokens.$space-500} - #{tokens.$border-width-100}),
+            typography: tokens.$body-small-semibold,
+        ),
+        large: (
+            padding-x: calc(#{tokens.$space-900} - #{tokens.$border-width-100}),
+            padding-y: calc(#{tokens.$space-500} - #{tokens.$border-width-100}),
+            typography: tokens.$body-medium-semibold,
+        ),
+    )
 );

--- a/packages/web/src/scss/components/Card/_CardMedia.scss
+++ b/packages/web/src/scss/components/Card/_CardMedia.scss
@@ -39,11 +39,19 @@
         $infix: breakpoint.get-modifier(infix, $breakpoint-name, $breakpoint-value);
 
         .Card--#{$infix}vertical > {
-            @include dictionaries.generate-sizes($class-name: 'CardMedia', $sizes: theme.$media-sizes-vertical);
+            @include dictionaries.generate-sizes(
+                $class-name: 'CardMedia',
+                $dictionary-values: theme.$size-dictionary,
+                $config: theme.$media-vertical-size-config
+            );
         }
 
         :is(.Card--#{$infix}horizontal, .Card--#{$infix}horizontalReversed) > {
-            @include dictionaries.generate-sizes($class-name: 'CardMedia', $sizes: theme.$media-sizes-horizontal);
+            @include dictionaries.generate-sizes(
+                $class-name: 'CardMedia',
+                $dictionary-values: theme.$size-dictionary,
+                $config: theme.$media-horizontal-size-config
+            );
         }
 
         .Card--#{$infix}vertical > .CardMedia {

--- a/packages/web/src/scss/components/Card/_theme.scss
+++ b/packages/web/src/scss/components/Card/_theme.scss
@@ -1,3 +1,4 @@
+@use 'sass:list';
 @use '@tokens' as tokens;
 @use '../../settings/dictionaries';
 @use '../../settings/transitions';
@@ -64,7 +65,8 @@ $transition-timing: transitions.$timing-eased-in-out;
 
 $artwork-alignment-dictionary: dictionaries.$alignments-x;
 
-$media-sizes-vertical: (
+$size-dictionary: list.join(dictionaries.$size, 'auto');
+$media-vertical-size-config: (
     auto: (
         size: auto,
     ),
@@ -78,7 +80,7 @@ $media-sizes-vertical: (
         size: 280px,
     ),
 );
-$media-sizes-horizontal: (
+$media-horizontal-size-config: (
     auto: (
         size: auto,
     ),

--- a/packages/web/src/scss/components/Checkbox/_Checkbox.scss
+++ b/packages/web/src/scss/components/Checkbox/_Checkbox.scss
@@ -5,7 +5,7 @@
 // 3. Make the text selectable and allow links to be clickable in the helper and validation texts.
 
 @use 'theme';
-@use '../../theme/form-fields' as form-fields-theme;
+@use '../../settings/form-fields' as form-fields-settings;
 @use '../../tools/form-fields' as form-fields-tools;
 @use '../../tools/svg';
 
@@ -18,7 +18,7 @@ $_field-name: 'Checkbox';
 }
 
 .Checkbox__text {
-    margin-left: form-fields-theme.$inline-field-gap;
+    margin-left: form-fields-settings.$inline-field-gap;
 }
 
 .Checkbox__label {
@@ -45,12 +45,12 @@ $_field-name: 'Checkbox';
     background-position: center;
     background-size: contain;
     background-repeat: no-repeat;
-    background-color: form-fields-theme.$input-background-color;
+    background-color: form-fields-settings.$input-background-color;
 
     &:checked,
     &:indeterminate {
-        border-color: form-fields-theme.$inline-field-input-border-color-checked;
-        background-color: form-fields-theme.$inline-field-input-background-color-checked;
+        border-color: form-fields-settings.$inline-field-input-border-color-checked;
+        background-color: form-fields-settings.$inline-field-input-background-color-checked;
     }
 
     &:checked {
@@ -121,12 +121,12 @@ $_field-name: 'Checkbox';
 .Checkbox > .Checkbox__input:disabled {
     @include form-fields-tools.input-disabled();
 
-    border-color: form-fields-theme.$input-border-color-state-disabled;
-    background-color: form-fields-theme.$input-background-color-state-disabled;
+    border-color: form-fields-settings.$input-border-color-state-disabled;
+    background-color: form-fields-settings.$input-background-color-state-disabled;
 
     &:checked,
     &:indeterminate {
-        border-color: form-fields-theme.$inline-field-input-border-color-checked-disabled;
+        border-color: form-fields-settings.$inline-field-input-border-color-checked-disabled;
     }
 
     &:checked {
@@ -141,5 +141,5 @@ $_field-name: 'Checkbox';
 
 // stylelint-disable-next-line selector-max-specificity -- 2.
 .Checkbox--item:not(.Checkbox--disabled, .Checkbox.is-disabled) .Checkbox__input:is(:hover, :active):not(:checked) {
-    background-color: form-fields-theme.$input-background-color;
+    background-color: form-fields-settings.$input-background-color;
 }

--- a/packages/web/src/scss/components/Container/_Container.scss
+++ b/packages/web/src/scss/components/Container/_Container.scss
@@ -11,7 +11,11 @@
     @include tools.paddings(theme.$container-paddings, theme.$container-breakpoints);
 }
 
-@include dictionaries.generate-sizes('Container', theme.$container-sizes);
+@include dictionaries.generate-sizes(
+    $class-name: 'Container',
+    $dictionary-values: theme.$size-dictionary,
+    $config: theme.$size-config
+);
 
 .Container:not(.Container--fluid) {
     max-width: var(--#{tokens.$css-variable-prefix}container-max-width, #{theme.$container-max-width});

--- a/packages/web/src/scss/components/Container/_theme.scss
+++ b/packages/web/src/scss/components/Container/_theme.scss
@@ -1,5 +1,6 @@
 @use 'sass:map';
 @use '@tokens' as tokens;
+@use '../../settings/dictionaries';
 @use '../../tools/tokens' as tokens-tools;
 @use 'tools';
 
@@ -9,7 +10,8 @@ $container-max-width: tokens-tools.get-variable-if-exists('container-xlarge-max-
 $container-paddings: map.get(tokens.$containers, padding);
 $container-breakpoints: tokens.$breakpoints;
 
-$container-sizes: (
+$size-dictionary: dictionaries.$size-extended;
+$size-config: (
     xsmall: tools.get-size('xsmall', $container-max-width),
     small: tools.get-size('small', $container-max-width),
     medium: tools.get-size('medium', $container-max-width),

--- a/packages/web/src/scss/components/FileUploader/_FileUploaderAttachment.scss
+++ b/packages/web/src/scss/components/FileUploader/_FileUploaderAttachment.scss
@@ -1,4 +1,4 @@
-@use '../../theme/form-fields' as form-fields-theme;
+@use '../../settings/form-fields' as form-fields-settings;
 @use '../../tools/accessibility';
 @use '../../tools/reset';
 @use '../../tools/typography';
@@ -56,6 +56,6 @@
 
     &:focus-visible {
         outline: 0;
-        box-shadow: form-fields-theme.$input-focus-shadow;
+        box-shadow: form-fields-settings.$input-focus-shadow;
     }
 }

--- a/packages/web/src/scss/components/FileUploader/_FileUploaderInput.scss
+++ b/packages/web/src/scss/components/FileUploader/_FileUploaderInput.scss
@@ -3,7 +3,7 @@
 // 3. Increase specificity to make the disabled state override any other
 
 @use '../../settings/cursors';
-@use '../../theme/form-fields' as form-fields-theme;
+@use '../../settings/form-fields' as form-fields-settings;
 @use '../../tools/accessibility';
 @use '../../tools/form-fields' as form-fields-tools;
 @use '../../tools/links';
@@ -36,7 +36,7 @@ $_field-name: 'FileUploaderInput';
 }
 
 .FileUploaderInput__input:focus-visible ~ .FileUploaderInput__dropZone {
-    box-shadow: form-fields-theme.$input-focus-shadow;
+    box-shadow: form-fields-settings.$input-focus-shadow;
 }
 
 .FileUploaderInput__dropZone > svg {
@@ -123,7 +123,7 @@ $_field-name: 'FileUploaderInput';
     ~ .FileUploaderInput__dropZone
     > .FileUploaderInput__dropZoneLabel
     > .FileUploaderInput__link {
-    color: form-fields-theme.$input-color-state-disabled;
+    color: form-fields-settings.$input-color-state-disabled;
 }
 
 .FileUploaderInput
@@ -136,8 +136,8 @@ $_field-name: 'FileUploaderInput';
 // stylelint-enable selector-max-compound-selectors, selector-max-specificity
 
 .FileUploaderInput > .FileUploaderInput__input:disabled ~ .FileUploaderInput__dropZone {
-    border-color: form-fields-theme.$input-border-color-state-disabled;
-    background-color: form-fields-theme.$input-background-color-state-disabled;
+    border-color: form-fields-settings.$input-border-color-state-disabled;
+    background-color: form-fields-settings.$input-background-color-state-disabled;
 }
 // stylelint-enable selector-max-class
 

--- a/packages/web/src/scss/components/PartnerLogo/_PartnerLogo.scss
+++ b/packages/web/src/scss/components/PartnerLogo/_PartnerLogo.scss
@@ -19,7 +19,11 @@
     height: var(--#{tokens.$css-variable-prefix}partner-logo-image-height);
 }
 
-@include dictionaries.generate-sizes($class-name: 'PartnerLogo', $sizes: theme.$sizes);
+@include dictionaries.generate-sizes(
+    $class-name: 'PartnerLogo',
+    $dictionary-values: theme.$size-dictionary,
+    $config: theme.$size-config
+);
 
 .PartnerLogo--fluid {
     display: flex;

--- a/packages/web/src/scss/components/PartnerLogo/_theme.scss
+++ b/packages/web/src/scss/components/PartnerLogo/_theme.scss
@@ -1,8 +1,10 @@
 @use '@tokens' as tokens;
+@use '../../settings/dictionaries';
 
 $background-color: tokens.$background-primary;
 $border-radius: tokens.$radius-200;
-$sizes: (
+$size-dictionary: dictionaries.$size;
+$size-config: (
     small: (
         image-height: 32px,
         padding: tokens.$space-500,

--- a/packages/web/src/scss/components/Pill/_Pill.scss
+++ b/packages/web/src/scss/components/Pill/_Pill.scss
@@ -19,10 +19,10 @@
 @include dictionaries.generate-colors(
     $class-name: 'Pill',
     $dictionary-values: theme.$color-dictionary,
-    $config: theme.$color-dictionary-config
+    $config: theme.$color-config
 );
 @include dictionaries.generate-colors(
     $class-name: 'Pill',
     $dictionary-values: theme.$color-selected-dictionary,
-    $config: theme.$color-selected-dictionary-config
+    $config: theme.$color-selected-config
 );

--- a/packages/web/src/scss/components/Pill/_theme.scss
+++ b/packages/web/src/scss/components/Pill/_theme.scss
@@ -13,7 +13,7 @@ $color-dictionary: (
     neutral: neutral,
 );
 
-$color-dictionary-config: (
+$color-config: (
     color: 'content-subtle',
     background-color: 'background-basic',
 );
@@ -22,7 +22,7 @@ $color-selected-dictionary: (
     selected: selected,
 );
 
-$color-selected-dictionary-config: (
+$color-selected-config: (
     color: 'content-subtle',
     background-color: 'state-default',
 );

--- a/packages/web/src/scss/components/Radio/_Radio.scss
+++ b/packages/web/src/scss/components/Radio/_Radio.scss
@@ -3,7 +3,7 @@
 // 2. Make the text selectable and allow links to be clickable in the helper text.
 
 @use 'sass:map';
-@use '../../theme/form-fields' as form-fields-theme;
+@use '../../settings/form-fields' as form-fields-settings;
 @use '../../tools/form-fields' as form-fields-tools;
 @use 'theme';
 
@@ -26,10 +26,10 @@ $_field-name: 'Radio';
     margin: theme.$input-margin;
     font: inherit;
     border-radius: theme.$input-border-radius;
-    background-color: form-fields-theme.$input-background-color;
+    background-color: form-fields-settings.$input-background-color;
 
     &:checked {
-        border-color: form-fields-theme.$inline-field-input-border-color-checked;
+        border-color: form-fields-settings.$inline-field-input-border-color-checked;
     }
 
     &::before {
@@ -54,7 +54,7 @@ $_field-name: 'Radio';
 
     position: relative; // 2.
     z-index: 1; // 2.
-    margin-left: form-fields-theme.$inline-field-gap;
+    margin-left: form-fields-settings.$inline-field-gap;
 }
 
 @include form-fields-tools.input-field-validation-states($_field-name);
@@ -63,7 +63,7 @@ $_field-name: 'Radio';
     @include form-fields-tools.inline-field-label();
     @include form-fields-tools.stretch();
 
-    margin-left: form-fields-theme.$inline-field-gap;
+    margin-left: form-fields-settings.$inline-field-gap;
 }
 
 .Radio__label--hidden {
@@ -112,11 +112,11 @@ $_field-name: 'Radio';
 .Radio > .Radio__input:disabled {
     @include form-fields-tools.input-disabled();
 
-    border-color: form-fields-theme.$input-border-color-state-disabled;
-    background-color: form-fields-theme.$input-background-color-state-disabled;
+    border-color: form-fields-settings.$input-border-color-state-disabled;
+    background-color: form-fields-settings.$input-background-color-state-disabled;
 
     &:checked {
-        border-color: form-fields-theme.$input-border-color-state-disabled;
+        border-color: form-fields-settings.$input-border-color-state-disabled;
     }
 
     &::before {
@@ -126,5 +126,5 @@ $_field-name: 'Radio';
 
 // stylelint-disable-next-line selector-max-specificity -- 1.
 .Radio--item:not(.Radio--disabled, .Radio.is-disabled) .Radio__input:is(:hover, :active):not(:checked, :disabled) {
-    background-color: form-fields-theme.$input-background-color;
+    background-color: form-fields-settings.$input-background-color;
 }

--- a/packages/web/src/scss/components/Radio/_theme.scss
+++ b/packages/web/src/scss/components/Radio/_theme.scss
@@ -1,13 +1,13 @@
 @use '@tokens' as tokens;
+@use '../../settings/form-fields' as form-fields-settings;
 @use '../../settings/transitions';
-@use '../../theme/form-fields' as form-fields-theme;
 
 $input-border-radius: tokens.$radius-full;
 $input-size: 20px;
 $input-margin: tokens.$space-200;
 $input-inner-dot-size: 10px;
-$input-background-color: form-fields-theme.$inline-field-input-background-color-checked;
-$input-background-color-state-disabled: form-fields-theme.$input-color-state-disabled;
+$input-background-color: form-fields-settings.$inline-field-input-background-color-checked;
+$input-background-color-state-disabled: form-fields-settings.$input-color-state-disabled;
 $input-transition-duration: transitions.$duration-100;
 $input-transition-timing: transitions.$timing-eased-in-out;
 $input-focus-shadow: tokens.$focus-ring;

--- a/packages/web/src/scss/components/Select/_Select.scss
+++ b/packages/web/src/scss/components/Select/_Select.scss
@@ -1,10 +1,12 @@
 // 1. Calculate select end padding to cover the space occupied by the icon.
 
 @use 'sass:map';
+@use '@tokens' as tokens;
 @use '../../settings/cursors';
-@use '../../theme/form-fields' as form-fields-theme;
+@use '../../settings/form-fields' as form-fields-settings;
 @use '../../tools/form-fields' as form-fields-tools;
 @use '../../tools/reset';
+@use '../../tools/string' as spirit-string;
 
 $_field-name: 'Select';
 
@@ -38,20 +40,24 @@ $_field-name: 'Select';
     align-items: center;
     justify-content: center;
     aspect-ratio: 1;
-    color: form-fields-theme.$box-field-input-color-state-default;
+    color: form-fields-settings.$box-field-input-color-state-default;
     pointer-events: none;
 }
 
 .Select__input {
-    @include form-fields-tools.box-field-input();
+    @include form-fields-tools.box-field-input($_field-name);
 
     appearance: none;
+    height: var(
+        --#{tokens.$css-variable-prefix}#{spirit-string.convert-pascal-case-to-kebab-case($_field-name)}-input-height
+    );
 
     // 1.
     padding-inline-end: calc(
-        #{map.get(form-fields-theme.$input-typography, mobile, font-size) *
-            map.get(form-fields-theme.$input-typography, mobile, line-height)} +
-            (2 * #{form-fields-theme.$box-field-input-padding-y}) + #{form-fields-theme.$box-field-input-padding-x}
+        #{map.get(form-fields-settings.$input-typography, mobile, font-size) *
+            map.get(form-fields-settings.$input-typography, mobile, line-height)} +
+            (2 * #{form-fields-settings.$box-field-input-padding-y}) +
+            #{form-fields-settings.$box-field-input-padding-x}
     );
 
     &::-ms-expand {
@@ -88,7 +94,7 @@ $_field-name: 'Select';
 }
 
 :is(.Select--disabled, .Select.is-disabled) .Select__icon {
-    color: form-fields-theme.$input-color-state-disabled;
+    color: form-fields-settings.$input-color-state-disabled;
 }
 
 :is(.Select--disabled, .Select.is-disabled) > :is(.Select__validationText, [data-spirit-element='validation_text']) {

--- a/packages/web/src/scss/components/Tag/_Tag.scss
+++ b/packages/web/src/scss/components/Tag/_Tag.scss
@@ -5,6 +5,8 @@
 @use 'theme';
 
 .Tag {
+    @include typography.from-css-variables($infix: 'tag');
+
     display: inline-block;
     padding-inline: var(--#{tokens.$css-variable-prefix}tag-padding-x);
     padding-block: var(--#{tokens.$css-variable-prefix}tag-padding-y);
@@ -26,9 +28,13 @@
 @include dictionaries.generate-colors(
     $class-name: 'Tag',
     $dictionary-values: theme.$color-dictionary,
-    $config: theme.$color-dictionary-config
+    $config: theme.$color-config
 );
-@include dictionaries.generate-sizes('Tag', theme.$sizes);
+@include dictionaries.generate-sizes(
+    $class-name: 'Tag',
+    $dictionary-values: theme.$size-dictionary,
+    $config: theme.$size-config
+);
 
 .Tag--subtle.Tag--xsmall {
     border-color: transparent;

--- a/packages/web/src/scss/components/Tag/_theme.scss
+++ b/packages/web/src/scss/components/Tag/_theme.scss
@@ -10,8 +10,7 @@ $color-dictionary: (
     emotion: dictionaries.$emotion-colors,
     neutral: neutral,
 );
-
-$color-dictionary-config: (
+$color-config: (
     color: 'content-subtle',
     border-color: 'border-basic',
     background-color: 'background-basic',
@@ -20,7 +19,8 @@ $color-dictionary-config: (
     subtle-background-color: 'background-subtle',
 );
 
-$sizes: (
+$size-dictionary: dictionaries.$size-extended;
+$size-config: (
     xsmall: (
         padding-x: tokens.$space-500,
         padding-y: tokens.$space-200,

--- a/packages/web/src/scss/components/TextArea/_TextArea.scss
+++ b/packages/web/src/scss/components/TextArea/_TextArea.scss
@@ -1,6 +1,7 @@
 @use 'sass:map';
-@use '../../theme/form-fields' as form-fields-theme;
+@use '@tokens' as tokens;
 @use '../../tools/form-fields' as form-fields-tools;
+@use '../../tools/string' as spirit-string;
 @use 'theme';
 
 $_field-name: 'TextArea';
@@ -22,11 +23,11 @@ $_field-name: 'TextArea';
 }
 
 .TextArea__input {
-    @include form-fields-tools.box-field-input();
+    @include form-fields-tools.box-field-input($_field-name);
 
-    min-height: calc(
-        #{theme.$input-min-height} + 2 * #{form-fields-theme.$box-field-input-padding-x} + 2 *
-            #{form-fields-theme.$box-field-input-border-width}
+    min-height: var(
+        --#{tokens.$css-variable-prefix}#{spirit-string.convert-pascal-case-to-kebab-case($_field-name)}-input-height,
+        map.get(theme.$input-size-config, medium, height)
     );
     resize: vertical;
 }

--- a/packages/web/src/scss/components/TextArea/_theme.scss
+++ b/packages/web/src/scss/components/TextArea/_theme.scss
@@ -1,1 +1,17 @@
-$input-min-height: 3.375rem;
+@use 'sass:map';
+@use '../../settings/form-fields' as form-fields-settings;
+
+$input-size-config: map.deep-merge(
+    form-fields-settings.$box-field-size-config,
+    (
+        small: (
+            height: 64px,
+        ),
+        medium: (
+            height: 80px,
+        ),
+        large: (
+            height: 96px,
+        ),
+    )
+);

--- a/packages/web/src/scss/components/TextField/_TextField.scss
+++ b/packages/web/src/scss/components/TextField/_TextField.scss
@@ -15,10 +15,12 @@
 //       3. validation text.
 //     Also, high-specificity selectors are necessary to achieve the desired result.
 
+@use '@tokens' as tokens;
 @use '../../settings/cursors';
-@use '../../theme/form-fields' as form-fields-theme;
+@use '../../settings/form-fields' as form-fields-settings;
 @use '../../tools/form-fields' as form-fields-tools;
 @use '../../tools/reset';
+@use '../../tools/string' as spirit-string;
 @use 'theme';
 
 $_field-name: 'TextField';
@@ -40,7 +42,11 @@ $_field-name: 'TextField';
 }
 
 .TextField__input {
-    @include form-fields-tools.box-field-input();
+    @include form-fields-tools.box-field-input($_field-name);
+
+    height: var(
+        --#{tokens.$css-variable-prefix}#{spirit-string.convert-pascal-case-to-kebab-case($_field-name)}-input-height
+    );
 
     &[type='email'],
     &[type='number'],
@@ -60,8 +66,8 @@ $_field-name: 'TextField';
     // 2.
     &[size] {
         width: calc(
-            var(--text-field-input-width) + 2 * #{form-fields-theme.$box-field-input-padding-x} + 2 *
-                #{form-fields-theme.$box-field-input-border-width} + var(--text-field-arrows-width, 0px)
+            var(--text-field-input-width) + 2 * #{form-fields-settings.$box-field-input-padding-x} + 2 *
+                #{form-fields-settings.$box-field-input-border-width} + var(--text-field-arrows-width, 0px)
         );
     }
 
@@ -98,18 +104,19 @@ $_field-name: 'TextField';
     align-items: center;
     justify-content: center;
     padding-inline: theme.$input-password-toggle-padding-x;
-    color: form-fields-theme.$box-field-input-color-state-default;
-    border-radius: 0 form-fields-theme.$box-field-input-border-radius form-fields-theme.$box-field-input-border-radius 0;
-    background-color: form-fields-theme.$input-background-color;
+    color: form-fields-settings.$box-field-input-color-state-default;
+    border-radius: 0 form-fields-settings.$box-field-input-border-radius
+        form-fields-settings.$box-field-input-border-radius 0;
+    background-color: form-fields-settings.$input-background-color;
 
     // 5.
     &::before {
         content: '';
         position: absolute;
         inset: 0;
-        border: form-fields-theme.$box-field-input-border-width form-fields-theme.$box-field-input-border-style
-            form-fields-theme.$input-border-color;
-        border-radius: form-fields-theme.$box-field-input-border-radius;
+        border: form-fields-settings.$box-field-input-border-width form-fields-settings.$box-field-input-border-style
+            form-fields-settings.$input-border-color;
+        border-radius: form-fields-settings.$box-field-input-border-radius;
         pointer-events: none;
     }
 }
@@ -121,12 +128,12 @@ $_field-name: 'TextField';
 }
 
 .TextField__input:hover + .TextField__passwordToggle__button {
-    background-color: form-fields-theme.$input-background-color-state-hover;
+    background-color: form-fields-settings.$input-background-color-state-hover;
 }
 
 .TextField__input:active + .TextField__passwordToggle__button,
 .TextField__input:focus-within + .TextField__passwordToggle__button {
-    background-color: form-fields-theme.$input-background-color-state-active;
+    background-color: form-fields-settings.$input-background-color-state-active;
 }
 
 .TextField__passwordToggle__icon {
@@ -161,8 +168,8 @@ $_field-name: 'TextField';
     z-index: 1;
     width: (2 * theme.$input-password-toggle-padding-x) + theme.$input-password-toggle-icon-size;
     height: 100%;
-    border-radius: form-fields-theme.$box-field-input-border-radius;
-    box-shadow: form-fields-theme.$input-focus-shadow;
+    border-radius: form-fields-settings.$box-field-input-border-radius;
+    box-shadow: form-fields-settings.$input-focus-shadow;
 }
 
 .TextField__validationText,
@@ -197,14 +204,14 @@ $_field-name: 'TextField';
 :is(.TextField--disabled, .TextField.is-disabled)
     .TextField__passwordToggle
     .TextField__passwordToggle__button::before {
-    border-color: form-fields-theme.$input-border-color-state-disabled;
+    border-color: form-fields-settings.$input-border-color-state-disabled;
 }
 
 .TextField .TextField__input:disabled ~ .TextField__passwordToggle__button,
 :is(.TextField--disabled, .TextField.is-disabled) .TextField__passwordToggle__button {
     @include form-fields-tools.input-disabled();
 
-    background-color: form-fields-theme.$input-background-color-state-disabled;
+    background-color: form-fields-settings.$input-background-color-state-disabled;
     pointer-events: none;
     cursor: cursors.$disabled;
 }

--- a/packages/web/src/scss/components/Toast/_ToastBar.scss
+++ b/packages/web/src/scss/components/Toast/_ToastBar.scss
@@ -101,7 +101,7 @@
 @include dictionaries.generate-colors(
     $class-name: 'ToastBar',
     $dictionary-values: theme.$color-dictionary,
-    $config: theme.$color-dictionary-config,
+    $config: theme.$color-config,
     $generate-data-attribute: true
 );
 

--- a/packages/web/src/scss/components/Toast/_theme.scss
+++ b/packages/web/src/scss/components/Toast/_theme.scss
@@ -19,7 +19,7 @@ $color-dictionary: (
     neutral: neutral,
 );
 
-$color-dictionary-config: (
+$color-config: (
     color: 'content-subtle',
     background-color: 'background-basic',
 );

--- a/packages/web/src/scss/components/Toggle/_Toggle.scss
+++ b/packages/web/src/scss/components/Toggle/_Toggle.scss
@@ -1,6 +1,6 @@
 @use 'theme';
 @use '../../settings/cursors';
-@use '../../theme/form-fields' as form-fields-theme;
+@use '../../settings/form-fields' as form-fields-settings;
 @use '../../tools/form-fields' as form-fields-tools;
 @use '../../tools/reset';
 
@@ -12,7 +12,7 @@ $_field-name: 'Toggle';
     align-items: start;
     justify-content: space-between;
     max-width: theme.$max-width;
-    margin-block: form-fields-theme.$inline-field-margin-y;
+    margin-block: form-fields-settings.$inline-field-margin-y;
 }
 
 .Toggle--fluid {
@@ -21,7 +21,7 @@ $_field-name: 'Toggle';
 
 .Toggle__text {
     flex: 1;
-    margin-right: form-fields-theme.$inline-field-gap;
+    margin-right: form-fields-settings.$inline-field-gap;
 }
 
 .Toggle__label {

--- a/packages/web/src/scss/settings/_form-fields.scss
+++ b/packages/web/src/scss/settings/_form-fields.scss
@@ -1,4 +1,5 @@
 @use '@tokens' as tokens;
+@use 'dictionaries';
 
 // Common for all form components
 $input-typography: tokens.$body-medium-regular;
@@ -53,6 +54,22 @@ $box-field-input-padding-y: calc(#{tokens.$space-500} - #{tokens.$border-width-1
 $box-field-input-width: 18rem;
 $box-field-label-typography: tokens.$body-small-semibold;
 $box-field-label-margin-bottom: tokens.$space-400;
+
+$box-field-size-dictionary: dictionaries.$size;
+$box-field-size-config: (
+    small: (
+        height: 32px,
+        typography: tokens.$body-small-regular,
+    ),
+    medium: (
+        height: 40px,
+        typography: tokens.$body-medium-regular,
+    ),
+    large: (
+        height: 48px,
+        typography: tokens.$body-medium-regular,
+    ),
+);
 
 $validation-states: (
     success: (

--- a/packages/web/src/scss/tools/__tests__/_dictionaries.test.scss
+++ b/packages/web/src/scss/tools/__tests__/_dictionaries.test.scss
@@ -401,9 +401,12 @@
         @include test.assert() {
             @include test.output() {
                 @include dictionaries.generate-variants(
-                    'TestFill',
-                    (fill, outline),
-                    (
+                    $class-name: 'TestFill',
+                    $dictionary-values: (
+                        'fill',
+                        'outline',
+                    ),
+                    $config: (
                         fill: (
                             margin-bottom: 0,
                             border-radius: 5px,
@@ -434,9 +437,12 @@
         @include test.assert() {
             @include test.output() {
                 @include dictionaries.generate-variants(
-                    'TestFill',
-                    (fill, outline),
-                    (
+                    $class-name: 'TestFill',
+                    $dictionary-values: (
+                        'fill',
+                        'outline',
+                    ),
+                    $config: (
                         fill: (
                             margin-bottom: 0,
                             border-radius: 5px,
@@ -446,7 +452,7 @@
                             border-radius: 15px,
                         ),
                     ),
-                    'custom'
+                    $custom-component-infix: 'custom'
                 );
             }
 
@@ -470,8 +476,11 @@
         @include test.assert() {
             @include test.output() {
                 @include dictionaries.generate-sizes(
-                    'TestSize',
-                    (
+                    $class-name: 'TestSize',
+                    $dictionary-values: (
+                        'large',
+                    ),
+                    $config: (
                         large: (
                             width: 100px,
                             height: 200px,
@@ -488,6 +497,37 @@
                     --spirit-test-size-height: 200px;
                     --spirit-test-size-padding-y: 12px;
                     --spirit-test-size-padding-x: 16px;
+                }
+            }
+        }
+    }
+
+    @include test.it('should generate correct size classes based on a config and infix') {
+        @include test.assert() {
+            @include test.output() {
+                @include dictionaries.generate-sizes(
+                    $class-name: 'TestSize',
+                    $dictionary-values: (
+                        'large',
+                    ),
+                    $config: (
+                        large: (
+                            width: 100px,
+                            height: 200px,
+                            padding-y: 12px,
+                            padding-x: 16px,
+                        ),
+                    ),
+                    $infix: 'infix'
+                );
+            }
+
+            @include test.expect() {
+                .TestSize--large {
+                    --spirit-test-size-infix-width: 100px;
+                    --spirit-test-size-infix-height: 200px;
+                    --spirit-test-size-infix-padding-y: 12px;
+                    --spirit-test-size-infix-padding-x: 16px;
                 }
             }
         }

--- a/packages/web/src/scss/tools/__tests__/_form-fields.test.scss
+++ b/packages/web/src/scss/tools/__tests__/_form-fields.test.scss
@@ -1,6 +1,6 @@
 @use 'true' as test;
 @use '../../settings/cursors';
-@use '../../theme/form-fields' as form-fields-theme;
+@use '../../settings/form-fields' as form-fields-settings;
 @use '../form-fields';
 
 @include test.describe('form-fields mixins') {
@@ -14,10 +14,10 @@
 
             @include test.expect() {
                 .label-disabled-test {
-                    color: form-fields-theme.$label-color-state-disabled;
+                    color: form-fields-settings.$label-color-state-disabled;
 
                     &::after {
-                        color: form-fields-theme.$label-color-state-disabled;
+                        color: form-fields-settings.$label-color-state-disabled;
                     }
                 }
             }
@@ -34,7 +34,7 @@
 
             @include test.expect() {
                 .input-disabled-test {
-                    color: form-fields-theme.$input-color-state-disabled;
+                    color: form-fields-settings.$input-color-state-disabled;
                     cursor: cursors.$disabled;
                 }
             }

--- a/packages/web/src/scss/tools/__tests__/_typography.test.scss
+++ b/packages/web/src/scss/tools/__tests__/_typography.test.scss
@@ -1,7 +1,7 @@
 @use 'sass:map';
 @use 'true' as test;
-@use '../typography';
 @use '@tokens' as tokens;
+@use '../typography';
 
 @include test.describe('generate mixin') {
     @include test.it('should generate typography styles for a given token and breakpoint') {
@@ -11,11 +11,7 @@
                 'font-size': 16px,
                 'font-style': italic,
                 'font-weight': 700,
-                'text-indent': 2em,
-                'text-transform': uppercase,
-                'text-decoration': underline,
                 'line-height': 1.5,
-                'letter-spacing': 0.05em,
             ),
         );
 
@@ -28,19 +24,99 @@
 
             @include test.expect() {
                 @media (width >= #{map.get(tokens.$breakpoints, 'tablet')}) {
-                    // stylelint-disable order/properties-order -- Disabling rule due to conditional rendering affecting property order
                     .typography-test {
                         font-style: italic;
                         font-weight: 700;
                         font-size: 16px;
                         line-height: 1.5;
                         font-family: Arial, sans-serif;
-                        letter-spacing: 0.05em;
-                        text-decoration: underline;
-                        text-transform: uppercase;
-                        text-indent: 2em;
                     }
-                    // stylelint-enable order/properties-order
+                }
+            }
+        }
+    }
+
+    @include test.it('should generate typography styles for a given token and breakpoint as custom properties') {
+        $sample-token: (
+            'tablet': (
+                'font-family': 'arial, sans-serif',
+                'font-size': 16px,
+                'font-style': italic,
+                'font-weight': 700,
+                'line-height': 1.5,
+            ),
+        );
+
+        @include test.assert() {
+            @include test.output() {
+                .typography-test {
+                    @include typography.generate(
+                        $token: $sample-token,
+                        $as-css-variables: true,
+                        $css-variable-infix: 'my-component'
+                    );
+                }
+            }
+
+            @include test.expect() {
+                @media (width >= #{map.get(tokens.$breakpoints, 'tablet')}) {
+                    .typography-test {
+                        --spirit-my-component-font-style: italic;
+                        --spirit-my-component-font-weight: 700;
+                        --spirit-my-component-font-size: 16px;
+                        --spirit-my-component-line-height: 1.5;
+                        --spirit-my-component-font-family: arial, sans-serif;
+                    }
+                }
+            }
+        }
+    }
+}
+
+@include test.describe('from-css-variables mixin') {
+    @include test.it('should read typography properties from custom properties') {
+        @include test.assert() {
+            @include test.output() {
+                .typography-test {
+                    @include typography.from-css-variables($infix: 'my-component');
+                }
+            }
+
+            @include test.expect() {
+                .typography-test {
+                    font-style: var(--spirit-my-component-font-style);
+                    font-weight: var(--spirit-my-component-font-weight);
+                    font-size: var(--spirit-my-component-font-size);
+                    line-height: var(--spirit-my-component-line-height);
+                    font-family: var(--spirit-my-component-font-family);
+                }
+            }
+        }
+    }
+
+    @include test.it('should read typography properties from custom properties with fallback') {
+        $sample-fallback: (
+            'font-family': 'arial, sans-serif',
+            'font-size': 16px,
+            'font-style': italic,
+            'font-weight': 700,
+            'line-height': 1.5,
+        );
+
+        @include test.assert() {
+            @include test.output() {
+                .typography-test {
+                    @include typography.from-css-variables($infix: 'my-component', $fallback-config: $sample-fallback);
+                }
+            }
+
+            @include test.expect() {
+                .typography-test {
+                    font-style: var(--spirit-my-component-font-style, italic);
+                    font-weight: var(--spirit-my-component-font-weight, 700);
+                    font-size: var(--spirit-my-component-font-size, 16px);
+                    line-height: var(--spirit-my-component-line-height, 1.5);
+                    font-family: var(--spirit-my-component-font-family, arial, sans-serif);
                 }
             }
         }

--- a/packages/web/src/scss/tools/_dictionaries.scss
+++ b/packages/web/src/scss/tools/_dictionaries.scss
@@ -3,13 +3,13 @@
 @use 'sass:meta';
 @use 'sass:string';
 @use '@tokens' as tokens;
-@use './alignment';
-@use './links';
-@use './list' as spirit-list;
-@use './placement';
-@use './reset';
-@use './string' as spirit-string;
-@use './typography';
+@use 'alignment';
+@use 'links';
+@use 'list' as spirit-list;
+@use 'placement';
+@use 'reset';
+@use 'string' as spirit-string;
+@use 'typography';
 
 // Function to validate presence of a given value in a dictionary
 // Parameters are:
@@ -197,20 +197,31 @@
 // Mixin to generate size classes based on a config
 // Parameters are:
 // * $class-name: the name of the component class to generate
-// * $dictionary-values: list of the dictionary values to generate
-// * $sizes: map of the size variables to generate
-@mixin generate-sizes($class-name, $sizes) {
-    @each $size, $variables in $sizes {
-        .#{$class-name}--#{$size} {
-            $component-infix: spirit-string.convert-pascal-case-to-kebab-case(
-                spirit-string.remove-prefix($class-name, 'UNSTABLE_')
-            );
+// * $dictionary-values: list of the dictionary values to validate the $config keys against
+// * $config: map of the properties to generate, their value is the suffix of the token variable
+// * $infix: infix to use for custom properties (e.g. 'input' for input fields)
+@mixin generate-sizes($class-name, $dictionary-values, $config, $infix: '') {
+    $custom-property-infix: spirit-string.convert-pascal-case-to-kebab-case(
+        spirit-string.remove-prefix($class-name, 'UNSTABLE_')
+    );
 
-            @each $variable-key, $variable-value in $variables {
-                @if $variable-key == 'typography' {
-                    @include typography.generate($variable-value);
-                } @else {
-                    --#{tokens.$css-variable-prefix}#{$component-infix}-#{$variable-key}: #{$variable-value};
+    @if $infix != '' {
+        $custom-property-infix: '#{$custom-property-infix}-#{spirit-string.convert-pascal-case-to-kebab-case($infix)}';
+    }
+
+    @each $key, $variables in $config {
+        @if validate-dictionary-value($dictionary-values, $key) {
+            .#{$class-name}--#{$key} {
+                @each $property-name, $property-value in $variables {
+                    @if $property-name == 'typography' {
+                        @include typography.generate(
+                            $property-value,
+                            $as-css-variables: true,
+                            $css-variable-infix: $custom-property-infix
+                        );
+                    } @else {
+                        --#{tokens.$css-variable-prefix}#{$custom-property-infix}-#{$property-name}: #{$property-value};
+                    }
                 }
             }
         }

--- a/packages/web/src/scss/tools/_form-fields.scss
+++ b/packages/web/src/scss/tools/_form-fields.scss
@@ -2,17 +2,20 @@
 // 2. Put the input above the stretched label.
 
 @use 'sass:map';
+@use 'sass:string';
+@use '@tokens' as tokens;
 @use '../settings/cursors';
-@use '../theme/form-fields' as form-fields-theme;
+@use '../settings/form-fields' as form-fields-settings;
 @use 'accessibility';
 @use 'reset';
+@use 'string' as spirit-string;
 @use 'typography';
 
 @mixin label-disabled() {
-    color: form-fields-theme.$label-color-state-disabled;
+    color: form-fields-settings.$label-color-state-disabled;
 
     &::after {
-        color: form-fields-theme.$label-color-state-disabled;
+        color: form-fields-settings.$label-color-state-disabled;
     }
 }
 
@@ -21,23 +24,23 @@
 }
 
 @mixin label-required() {
-    @include typography.generate(form-fields-theme.$label-required-typography);
+    @include typography.generate(form-fields-settings.$label-required-typography);
 
     content: '*';
-    margin-left: form-fields-theme.$label-required-margin-left;
-    color: form-fields-theme.$label-required-color;
+    margin-left: form-fields-settings.$label-required-margin-left;
+    color: form-fields-settings.$label-required-color;
 }
 
 @mixin input-disabled() {
-    color: form-fields-theme.$input-color-state-disabled;
+    color: form-fields-settings.$input-color-state-disabled;
     cursor: cursors.$disabled;
 }
 
 @mixin validation-text() {
-    @include typography.generate(form-fields-theme.$validation-text-typography);
+    @include typography.generate(form-fields-settings.$validation-text-typography);
 
     display: block;
-    margin-top: form-fields-theme.$validation-text-margin-top;
+    margin-top: form-fields-settings.$validation-text-margin-top;
 
     & > ul {
         @include reset.list();
@@ -49,17 +52,17 @@
 
     &:has(> svg:first-child:not(:only-child)) {
         display: flex;
-        column-gap: form-fields-theme.$validation-text-icon-gap;
+        column-gap: form-fields-settings.$validation-text-icon-gap;
     }
 }
 
 @mixin validation-text-disabled() {
-    color: form-fields-theme.$validation-text-color-state-disabled;
+    color: form-fields-settings.$validation-text-color-state-disabled;
 }
 
 @mixin inline-field-root() {
     display: inline-flex;
-    margin-block: form-fields-theme.$inline-field-margin-y;
+    margin-block: form-fields-settings.$inline-field-margin-y;
 }
 
 @mixin inline-field-root-disabled() {
@@ -68,14 +71,14 @@
 
 @mixin box-field-root() {
     display: inline-block;
-    width: form-fields-theme.$box-field-input-width;
+    width: form-fields-settings.$box-field-input-width;
 }
 
 @mixin inline-field-label() {
-    @include typography.generate(form-fields-theme.$input-typography);
+    @include typography.generate(form-fields-settings.$input-typography);
 
     display: block;
-    color: form-fields-theme.$label-color-state-default;
+    color: form-fields-settings.$label-color-state-default;
     cursor: cursors.$form-fields;
 }
 
@@ -86,68 +89,74 @@
 }
 
 @mixin box-field-label() {
-    @include typography.generate(form-fields-theme.$box-field-label-typography);
+    @include typography.generate(form-fields-settings.$box-field-label-typography);
 
     display: block;
-    margin-bottom: form-fields-theme.$box-field-label-margin-bottom;
-    color: form-fields-theme.$label-color-state-default;
+    margin-bottom: form-fields-settings.$box-field-label-margin-bottom;
+    color: form-fields-settings.$label-color-state-default;
 }
 
 @mixin inline-field-input() {
     z-index: 1; // 2.
     appearance: none;
-    border: form-fields-theme.$inline-field-input-border-width solid form-fields-theme.$input-border-color;
-    background-color: form-fields-theme.$input-background-color;
+    border: form-fields-settings.$inline-field-input-border-width solid form-fields-settings.$input-border-color;
+    background-color: form-fields-settings.$input-background-color;
     cursor: cursors.$form-fields;
     print-color-adjust: exact; // 1.
 
     &:focus-visible {
         outline: 0;
-        box-shadow: form-fields-theme.$input-focus-shadow;
+        box-shadow: form-fields-settings.$input-focus-shadow;
     }
 
     @media (hover: hover) {
         &:hover {
-            background-color: form-fields-theme.$input-background-color-state-hover;
+            background-color: form-fields-settings.$input-background-color-state-hover;
         }
     }
 
     &:active {
-        background-color: form-fields-theme.$input-background-color-state-active;
+        background-color: form-fields-settings.$input-background-color-state-active;
     }
 }
 
-@mixin box-field-input() {
-    @include typography.generate(form-fields-theme.$input-typography);
+@mixin box-field-input($field-name) {
+    // @deprecated Remove typography fallback when form field sizes are mandatory.
+    // Migration: delete the `$fallback-config` parameter.
+    // https://jira.almacareer.tech/browse/DS-1884 — Remove deprecated typography mixin from form fields
+    @include typography.from-css-variables(
+        $infix: #{spirit-string.convert-pascal-case-to-kebab-case($field-name)}-input,
+        $fallback-config: map.get(form-fields-settings.$box-field-size-config, medium, typography, mobile)
+    );
 
     display: block;
     width: 100%;
-    padding: form-fields-theme.$box-field-input-padding-y form-fields-theme.$box-field-input-padding-x;
-    color: form-fields-theme.$box-field-input-color-state-default;
-    border: form-fields-theme.$box-field-input-border-width form-fields-theme.$box-field-input-border-style
-        form-fields-theme.$input-border-color;
-    border-radius: form-fields-theme.$box-field-input-border-radius;
-    background: form-fields-theme.$input-background-color;
+    padding: form-fields-settings.$box-field-input-padding-y form-fields-settings.$box-field-input-padding-x;
+    color: form-fields-settings.$box-field-input-color-state-default;
+    border: form-fields-settings.$box-field-input-border-width form-fields-settings.$box-field-input-border-style
+        form-fields-settings.$input-border-color;
+    border-radius: form-fields-settings.$box-field-input-border-radius;
+    background: form-fields-settings.$input-background-color;
 
     &::placeholder {
-        color: form-fields-theme.$box-field-input-placeholder-color-state-default;
+        color: form-fields-settings.$box-field-input-placeholder-color-state-default;
         opacity: 1;
     }
 
     @media (hover: hover) {
         &:hover {
-            background-color: form-fields-theme.$input-background-color-state-hover;
+            background-color: form-fields-settings.$input-background-color-state-hover;
         }
     }
 
     &:active,
     &:focus-within {
-        background-color: form-fields-theme.$input-background-color-state-active;
+        background-color: form-fields-settings.$input-background-color-state-active;
     }
 }
 
 @mixin input-field-validation-states($field-name) {
-    @each $validation-state-name, $validation-state-value in form-fields-theme.$validation-states {
+    @each $validation-state-name, $validation-state-value in form-fields-settings.$validation-states {
         @if $field-name == 'FileUploaderInput' {
             :is(.#{$field-name}--#{$validation-state-name}, .#{$field-name}.has-#{$validation-state-name})
                 > .#{$field-name}__input
@@ -209,69 +218,69 @@
 }
 
 @mixin box-field-focus-visible() {
-    border-color: form-fields-theme.$box-field-input-border-color-focus;
+    border-color: form-fields-settings.$box-field-input-border-color-focus;
     outline: 0;
-    box-shadow: form-fields-theme.$input-focus-shadow;
+    box-shadow: form-fields-settings.$input-focus-shadow;
 }
 
 @mixin box-field-disabled-input() {
     @include input-disabled();
 
-    border-color: form-fields-theme.$input-border-color-state-disabled;
-    background-color: form-fields-theme.$input-background-color-state-disabled;
+    border-color: form-fields-settings.$input-border-color-state-disabled;
+    background-color: form-fields-settings.$input-background-color-state-disabled;
 
     &::placeholder {
-        color: form-fields-theme.$box-field-input-placeholder-color-state-disabled;
+        color: form-fields-settings.$box-field-input-placeholder-color-state-disabled;
     }
 }
 
 @mixin item() {
     align-items: center;
     width: 100%;
-    padding: form-fields-theme.$item-padding-y form-fields-theme.$item-padding-x;
+    padding: form-fields-settings.$item-padding-y form-fields-settings.$item-padding-x;
     margin-block: 0;
-    border-radius: form-fields-theme.$item-border-radius;
-    background-color: form-fields-theme.$item-background-color-state-default;
+    border-radius: form-fields-settings.$item-border-radius;
+    background-color: form-fields-settings.$item-background-color-state-default;
 
     @media (hover: hover) {
         &:hover {
-            background-color: form-fields-theme.$item-background-color-state-hover;
+            background-color: form-fields-settings.$item-background-color-state-hover;
         }
     }
 
     &:active {
-        background-color: form-fields-theme.$item-background-color-state-active;
+        background-color: form-fields-settings.$item-background-color-state-active;
     }
 }
 
 @mixin item-disabled() {
-    background-color: form-fields-theme.$item-background-color-state-default;
+    background-color: form-fields-settings.$item-background-color-state-default;
 }
 
 @mixin item-validation-text() {
-    @include typography.generate(form-fields-theme.$item-validation-text-typography);
+    @include typography.generate(form-fields-settings.$item-validation-text-typography);
 }
 
 @mixin item-label() {
-    @include typography.generate(form-fields-theme.$item-label-typography);
+    @include typography.generate(form-fields-settings.$item-label-typography);
 
-    color: form-fields-theme.$label-color-state-default;
+    color: form-fields-settings.$label-color-state-default;
 }
 
 @mixin helper-text() {
-    @include typography.generate(form-fields-theme.$helper-text-typography);
+    @include typography.generate(form-fields-settings.$helper-text-typography);
 
     display: block;
-    margin-top: form-fields-theme.$helper-text-margin-top;
-    color: form-fields-theme.$helper-text-color-state-default;
+    margin-top: form-fields-settings.$helper-text-margin-top;
+    color: form-fields-settings.$helper-text-color-state-default;
 }
 
 @mixin helper-text-disabled() {
-    color: form-fields-theme.$helper-text-color-state-disabled;
+    color: form-fields-settings.$helper-text-color-state-disabled;
 }
 
 @mixin item-helper-text() {
-    @include typography.generate(form-fields-theme.$item-helper-text-typography);
+    @include typography.generate(form-fields-settings.$item-helper-text-typography);
 }
 
 @mixin stretch($pseudo-element: before) {

--- a/packages/web/src/scss/tools/_typography.scss
+++ b/packages/web/src/scss/tools/_typography.scss
@@ -1,46 +1,62 @@
 @use 'sass:map';
+@use 'sass:meta';
 @use 'sass:string';
 @use 'breakpoint';
 @use '@tokens' as tokens;
 
-@mixin generate($token) {
+// Typography properties supported by mixins in this file.
+// Matches `TypographyShape` in Spirit Tokens Exporter.
+$_properties: (font-style, font-weight, font-size, line-height, font-family);
+
+// Mixin to generate typography styles
+// Parameters are:
+// * $token: the composite token to generate styles from
+// * $as-css-variables: if true, generates CSS custom properties (variables) instead of CSS properties
+// * $css-variable-infix: infix to use for CSS custom properties (e.g. 'input' for input fields)
+@mixin generate($token, $as-css-variables: false, $css-variable-infix: '') {
+    $custom-property-prefix: '';
+
+    @if $as-css-variables {
+        @if $css-variable-infix == '' {
+            @error 'Infix is required when $as-css-variables is true.';
+        }
+
+        $custom-property-prefix: '--#{tokens.$css-variable-prefix}#{$css-variable-infix}-';
+    }
+
     @each $breakpoint-name, $breakpoint-value in tokens.$breakpoints {
         @include breakpoint.up($breakpoint-value) {
-            @if map.has-key($token, $breakpoint-name, font-style) {
-                font-style: map.get($token, $breakpoint-name, font-style);
+            @each $property in $_properties {
+                @if map.has-key($token, $breakpoint-name, $property) {
+                    @if meta.type-of(map.get($token, $breakpoint-name, $property)) == 'string' {
+                        #{$custom-property-prefix}#{$property}: string.unquote(
+                            map.get($token, $breakpoint-name, $property)
+                        );
+                    } @else {
+                        #{$custom-property-prefix}#{$property}: map.get($token, $breakpoint-name, $property);
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Mixin to read typography properties from CSS custom properties
+// Parameters are:
+// * $infix: infix to use for CSS custom properties (variables) (e.g. 'input' for input fields)
+// * $fallback-config: optional fallback config to use if variables are not set
+@mixin from-css-variables($infix, $fallback-config: null) {
+    @each $property in $_properties {
+        @if $fallback-config {
+            $fallback: map.get($fallback-config, $property);
+
+            @if meta.type-of($fallback) == 'string' {
+                $fallback: string.unquote($fallback);
             }
 
-            @if map.has-key($token, $breakpoint-name, font-weight) {
-                font-weight: map.get($token, $breakpoint-name, font-weight);
-            }
-
-            @if map.has-key($token, $breakpoint-name, font-size) {
-                font-size: map.get($token, $breakpoint-name, font-size);
-            }
-
-            @if map.has-key($token, $breakpoint-name, line-height) {
-                line-height: map.get($token, $breakpoint-name, line-height);
-            }
-
-            @if map.has-key($token, $breakpoint-name, font-family) {
-                font-family: string.unquote(map.get($token, $breakpoint-name, font-family));
-            }
-
-            @if map.has-key($token, $breakpoint-name, letter-spacing) {
-                letter-spacing: map.get($token, $breakpoint-name, letter-spacing);
-            }
-
-            @if map.has-key($token, $breakpoint-name, text-decoration) {
-                text-decoration: map.get($token, $breakpoint-name, text-decoration);
-            }
-
-            @if map.has-key($token, $breakpoint-name, text-transform) {
-                text-transform: map.get($token, $breakpoint-name, text-transform);
-            }
-
-            @if map.has-key($token, $breakpoint-name, text-indent) {
-                text-indent: map.get($token, $breakpoint-name, text-indent);
-            }
+            #{$property}: var(--#{tokens.$css-variable-prefix}#{$infix}-#{$property}, #{$fallback});
+        } @else {
+            #{$property}: var(--#{tokens.$css-variable-prefix}#{$infix}-#{$property});
         }
     }
 }


### PR DESCRIPTION
Now we can grab the generated custom properties and use them anywhere in the component, not only where the `typography.generate()` mixin is called. **This is a required step before the introduction of generated form field sizes.**

Form field size configurations are already introduced so we can use the `medium` size as a fallback.

https://jira.almacareer.tech/browse/DS-1689

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
