### PR TITLE
Fix(web-react): Use aria-label on buttons instead of ariaLabel prop #DS-1879

### DIFF
--- a/packages/web-react/src/components/Accordion/__tests__/Accordion.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/Accordion.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -24,6 +25,8 @@ describe('Accordion', () => {
   restPropsTest(Accordion, '.Accordion');
 
   validHtmlAttributesTest(Accordion);
+
+  ariaAttributesTest(Accordion);
 
   it('should render text children', () => {
     const toggle = () => null;

--- a/packages/web-react/src/components/Accordion/__tests__/AccordionContent.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/AccordionContent.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
+import { ariaAttributesTest, classNamePrefixProviderTest, restPropsTest, stylePropsTest } from '@local/tests';
 import AccordionContent from '../AccordionContent';
 import AccordionItem from '../AccordionItem';
 
@@ -18,6 +18,8 @@ describe('AccordionContent', () => {
   );
 
   restPropsTest(AccordionContent, '.Accordion__content');
+
+  ariaAttributesTest(AccordionContent);
 
   it('should render text children', () => {
     const dom = render(<AccordionContent>Hello World</AccordionContent>);

--- a/packages/web-react/src/components/Accordion/__tests__/AccordionHeader.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/AccordionHeader.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import AccordionHeader from '../AccordionHeader';
 import AccordionItem from '../AccordionItem';
 
@@ -22,6 +28,8 @@ describe('AccordionHeader', () => {
   restPropsTest(AccordionHeader, '.Accordion__itemHeader');
 
   validHtmlAttributesTest(AccordionHeader);
+
+  ariaAttributesTest(AccordionHeader);
 
   it('should render text children', () => {
     const dom = render(<AccordionHeader>Hello World</AccordionHeader>);

--- a/packages/web-react/src/components/Accordion/__tests__/AccordionItem.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/AccordionItem.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -30,6 +31,8 @@ describe('AccordionItem', () => {
   restPropsTest(AccordionItem, '.Accordion__item');
 
   validHtmlAttributesTest(AccordionItem);
+
+  ariaAttributesTest(AccordionItem);
 
   it('should render text children', () => {
     const dom = render(<AccordionItem id="accordion-item-example">Hello World</AccordionItem>);

--- a/packages/web-react/src/components/Accordion/__tests__/UncontrolledAccordion.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/UncontrolledAccordion.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -30,6 +31,8 @@ describe('UncontrolledAccordion', () => {
   restPropsTest(UncontrolledAccordion, '.Accordion');
 
   validHtmlAttributesTest(UncontrolledAccordion);
+
+  ariaAttributesTest(UncontrolledAccordion);
 
   it('should render text children', () => {
     const dom = render(<UncontrolledAccordion>Hello World</UncontrolledAccordion>);

--- a/packages/web-react/src/components/ActionGroup/__tests__/ActionGroup.test.tsx
+++ b/packages/web-react/src/components/ActionGroup/__tests__/ActionGroup.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { elementTypePropsTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  elementTypePropsTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import ActionGroup from '../ActionGroup';
 
 describe('ActionGroup', () => {
@@ -13,6 +19,8 @@ describe('ActionGroup', () => {
   restPropsTest(ActionGroup, 'div');
 
   validHtmlAttributesTest(ActionGroup);
+
+  ariaAttributesTest(ActionGroup);
 
   elementTypePropsTest(ActionGroup);
 

--- a/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
+++ b/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   emotionColorPropsTest,
@@ -23,6 +24,8 @@ describe('Alert', () => {
   restPropsTest(Alert, 'div');
 
   validHtmlAttributesTest(Alert);
+
+  ariaAttributesTest(Alert);
 
   elementTypePropsTest(Alert);
 

--- a/packages/web-react/src/components/Avatar/__tests__/Avatar.test.tsx
+++ b/packages/web-react/src/components/Avatar/__tests__/Avatar.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   sizeExtendedPropsTest,
   restPropsTest,
@@ -24,6 +25,8 @@ describe('Avatar', () => {
   restPropsTest(Avatar, 'div');
 
   validHtmlAttributesTest(Avatar);
+
+  ariaAttributesTest(Avatar);
 
   elementTypePropsTest(Avatar);
 

--- a/packages/web-react/src/components/Box/__tests__/Box.test.tsx
+++ b/packages/web-react/src/components/Box/__tests__/Box.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -90,6 +91,8 @@ describe('Box', () => {
   restPropsTest(Box, 'div');
 
   validHtmlAttributesTest(Box);
+
+  ariaAttributesTest(Box);
 
   elementTypePropsTest(Box);
 

--- a/packages/web-react/src/components/Breadcrumbs/__tests__/BreadcrumbsItem.test.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/__tests__/BreadcrumbsItem.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import BreadcrumbsItem from '../BreadcrumbsItem';
 
 jest.mock('../../../hooks/useIcon');
@@ -15,6 +21,8 @@ describe('BreadcrumbsItem', () => {
   restPropsTest(BreadcrumbsItem, 'li');
 
   validHtmlAttributesTest(BreadcrumbsItem);
+
+  ariaAttributesTest(BreadcrumbsItem);
 
   describe('BreadcrumbsItem with go back title', () => {
     const BreadcrumbsItemGoBack = () => (

--- a/packages/web-react/src/components/Button/Button.tsx
+++ b/packages/web-react/src/components/Button/Button.tsx
@@ -6,7 +6,7 @@ import { useStyleProps } from '../../hooks';
 import { SpiritButtonProps } from '../../types';
 import { mergeStyleProps } from '../../utils';
 import { Spinner } from '../Spinner';
-import { useButtonAriaProps } from './useButtonAriaProps';
+import { useButtonProps } from './useButtonProps';
 import { useButtonStyleProps } from './useButtonStyleProps';
 
 const defaultProps: Partial<SpiritButtonProps> = {
@@ -34,7 +34,7 @@ const _Button = <T extends ElementType = 'button', C = void, S = void>(
     ...restProps
   } = propsWithDefaults;
 
-  const { buttonProps } = useButtonAriaProps(restProps);
+  const { buttonProps } = useButtonProps(restProps);
   const { classProps, props: modifiedProps } = useButtonStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
   const mergedStyleProps = mergeStyleProps(ElementTag, { classProps, styleProps, otherProps });

--- a/packages/web-react/src/components/Button/__tests__/Button.test.tsx
+++ b/packages/web-react/src/components/Button/__tests__/Button.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   componentButtonColorPropsTest,
   emotionColorPropsTest,
@@ -32,6 +33,8 @@ describe('Button', () => {
   restPropsTest(Button, 'button');
 
   validHtmlAttributesTest(Button);
+
+  ariaAttributesTest(Button);
 
   elementTypePropsTest(Button);
 

--- a/packages/web-react/src/components/Button/index.ts
+++ b/packages/web-react/src/components/Button/index.ts
@@ -1,6 +1,6 @@
 'use client';
 
-export * from './useButtonAriaProps';
+export * from './useButtonProps';
 export * from './useButtonStyleProps';
 export { default as Button } from './Button';
 
@@ -8,6 +8,6 @@ export { default as Button } from './Button';
 // ButtonLink is NOT exported from packages/web-react/src/components/index.ts
 // ButtonLink will be removed in a future release and Button should be used instead
 // [web-react: Polymorfní Button](https://jira.lmc.cz/browse/DS-978)
-export * from '../ButtonLink/useButtonLinkAriaProps';
+export * from '../ButtonLink/useButtonLinkProps';
 export * from '../ButtonLink/useButtonLinkStyleProps';
 export { default as ButtonLink } from '../ButtonLink/ButtonLink';

--- a/packages/web-react/src/components/Button/useButtonProps.ts
+++ b/packages/web-react/src/components/Button/useButtonProps.ts
@@ -12,13 +12,13 @@ const handleClick = (event: ClickEvent, isDisabled?: boolean, onClick?: (event: 
   }
 };
 
-export type UseButtonAriaProps = Partial<SpiritButtonProps>;
-export type UseButtonAriaReturn = {
-  buttonProps: UseButtonAriaProps;
+export type UseButtonProps = Partial<SpiritButtonProps>;
+export type UseButtonReturn = {
+  buttonProps: UseButtonProps;
 };
 
-export const useButtonAriaProps = (props: UseButtonAriaProps): UseButtonAriaReturn => {
-  const { isDisabled, isLoading, onClick, type = 'button', ariaLabel } = props;
+export const useButtonProps = (props: UseButtonProps): UseButtonReturn => {
+  const { isDisabled, isLoading, onClick, type = 'button' } = props;
 
   const additionalProps = {
     type,
@@ -29,7 +29,6 @@ export const useButtonAriaProps = (props: UseButtonAriaProps): UseButtonAriaRetu
     buttonProps: {
       ...additionalProps,
       onClick: (event) => handleClick(event as ClickEvent, isDisabled, onClick),
-      'aria-label': ariaLabel || undefined,
     },
   };
 };

--- a/packages/web-react/src/components/ButtonLink/ButtonLink.tsx
+++ b/packages/web-react/src/components/ButtonLink/ButtonLink.tsx
@@ -5,7 +5,7 @@ import { useStyleProps } from '../../hooks';
 import { SpiritButtonLinkProps } from '../../types';
 import { mergeStyleProps } from '../../utils';
 import { Spinner } from '../Spinner';
-import { useButtonLinkAriaProps } from './useButtonLinkAriaProps';
+import { useButtonLinkProps } from './useButtonLinkProps';
 import { useButtonLinkStyleProps } from './useButtonLinkStyleProps';
 
 const defaultProps: Partial<SpiritButtonLinkProps> = {
@@ -31,7 +31,7 @@ const _ButtonLink = <T extends ElementType = 'a', C = void, S = void>(
     ...restProps
   } = propsWithDefaults;
 
-  const { buttonLinkProps } = useButtonLinkAriaProps(propsWithDefaults);
+  const { buttonLinkProps } = useButtonLinkProps(propsWithDefaults);
   const { classProps, props: modifiedProps } = useButtonLinkStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
   const mergedStyleProps = mergeStyleProps(ElementTag, { classProps, styleProps, otherProps });

--- a/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
+++ b/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   componentButtonColorPropsTest,
   emotionColorPropsTest,
@@ -32,6 +33,8 @@ describe('ButtonLink', () => {
   restPropsTest(ButtonLink, 'a');
 
   validHtmlAttributesTest(ButtonLink);
+
+  ariaAttributesTest(ButtonLink);
 
   elementTypePropsTest(ButtonLink);
 

--- a/packages/web-react/src/components/ButtonLink/__tests__/useButtonLinkProps.test.ts
+++ b/packages/web-react/src/components/ButtonLink/__tests__/useButtonLinkProps.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { UseButtonLinkAriaProps, useButtonLinkAriaProps } from '../useButtonLinkAriaProps';
+import { UseButtonLinkProps, useButtonLinkProps } from '../useButtonLinkProps';
 
 describe('useButtonAriaProps', () => {
   it('should return aria props for anchor tag', () => {
@@ -9,8 +9,8 @@ describe('useButtonAriaProps', () => {
       isDisabled: false,
       target: '_blank',
       rel: 'noopener',
-    } as UseButtonLinkAriaProps;
-    const { result } = renderHook(() => useButtonLinkAriaProps(props));
+    } as UseButtonLinkProps;
+    const { result } = renderHook(() => useButtonLinkProps(props));
 
     expect(result.current.buttonLinkProps).toEqual({
       'aria-label': undefined,
@@ -30,8 +30,8 @@ describe('useButtonAriaProps', () => {
       isDisabled: true,
       target: '_blank',
       rel: 'noopener',
-    } as UseButtonLinkAriaProps;
-    const { result } = renderHook(() => useButtonLinkAriaProps(props));
+    } as UseButtonLinkProps;
+    const { result } = renderHook(() => useButtonLinkProps(props));
 
     expect(result.current.buttonLinkProps).toEqual({
       'aria-label': undefined,
@@ -48,8 +48,8 @@ describe('useButtonAriaProps', () => {
     const props = {
       elementType: 'button',
       isDisabled: false,
-    } as unknown as UseButtonLinkAriaProps;
-    const { result } = renderHook(() => useButtonLinkAriaProps(props));
+    } as unknown as UseButtonLinkProps;
+    const { result } = renderHook(() => useButtonLinkProps(props));
 
     expect(result.current.buttonLinkProps).toEqual({
       'aria-label': undefined,
@@ -65,8 +65,8 @@ describe('useButtonAriaProps', () => {
     const props = {
       elementType: 'button',
       isDisabled: true,
-    } as unknown as UseButtonLinkAriaProps;
-    const { result } = renderHook(() => useButtonLinkAriaProps(props));
+    } as unknown as UseButtonLinkProps;
+    const { result } = renderHook(() => useButtonLinkProps(props));
 
     expect(result.current.buttonLinkProps).toEqual({
       'aria-label': undefined,

--- a/packages/web-react/src/components/ButtonLink/index.ts
+++ b/packages/web-react/src/components/ButtonLink/index.ts
@@ -1,5 +1,5 @@
 'use client';
 
-export * from './useButtonLinkAriaProps';
+export * from './useButtonLinkProps';
 export * from './useButtonLinkStyleProps';
 export { default as ButtonLink } from './ButtonLink';

--- a/packages/web-react/src/components/ButtonLink/useButtonLinkProps.ts
+++ b/packages/web-react/src/components/ButtonLink/useButtonLinkProps.ts
@@ -12,13 +12,13 @@ const handleClick = (event: ClickEvent, isDisabled?: boolean, onClick?: (event: 
   }
 };
 
-export type UseButtonLinkAriaProps = Partial<SpiritButtonLinkProps>;
-export type UseButtonLinkAriaReturn = {
-  buttonLinkProps: UseButtonLinkAriaProps;
+export type UseButtonLinkProps = Partial<SpiritButtonLinkProps>;
+export type UseButtonLinkReturn = {
+  buttonLinkProps: UseButtonLinkProps;
 };
 
-export const useButtonLinkAriaProps = (props: UseButtonLinkAriaProps): UseButtonLinkAriaReturn => {
-  const { elementType, isDisabled, isLoading, onClick, href, target, rel, ariaLabel } = props;
+export const useButtonLinkProps = (props: UseButtonLinkProps): UseButtonLinkReturn => {
+  const { elementType, isDisabled, isLoading, onClick, href, target, rel } = props;
 
   const additionalProps = {
     role: 'button',
@@ -32,7 +32,6 @@ export const useButtonLinkAriaProps = (props: UseButtonLinkAriaProps): UseButton
     buttonLinkProps: {
       ...additionalProps,
       onClick: (event) => handleClick(event as ClickEvent, isDisabled, onClick),
-      'aria-label': ariaLabel || undefined,
     },
   };
 };

--- a/packages/web-react/src/components/Card/__tests__/Card.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/Card.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('Card', () => {
   restPropsTest(Card, 'article');
 
   validHtmlAttributesTest(Card);
+
+  ariaAttributesTest(Card);
 
   elementTypePropsTest(Card);
 

--- a/packages/web-react/src/components/Card/__tests__/CardArtwork.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardArtwork.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   alignmentXPropsTest,
   restPropsTest,
@@ -20,6 +21,8 @@ describe('CardArtwork', () => {
   alignmentXPropsTest(CardArtwork, 'CardArtwork');
 
   validHtmlAttributesTest(CardArtwork);
+
+  ariaAttributesTest(CardArtwork);
 
   it('should render artwork card component and have default class name', () => {
     render(<CardArtwork data-testid="test" />);

--- a/packages/web-react/src/components/Card/__tests__/CardBody.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardBody.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import CardBody from '../CardBody';
 
 describe('CardBody', () => {
@@ -12,6 +18,8 @@ describe('CardBody', () => {
   restPropsTest(CardBody, '.CardBody');
 
   validHtmlAttributesTest(CardBody);
+
+  ariaAttributesTest(CardBody);
 
   it('should render body card component and have default class name', () => {
     render(<CardBody data-testid="test" />);

--- a/packages/web-react/src/components/Card/__tests__/CardEyebrow.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardEyebrow.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import CardEyebrow from '../CardEyebrow';
 
 describe('CardEyebrow', () => {
@@ -12,6 +18,8 @@ describe('CardEyebrow', () => {
   restPropsTest(CardEyebrow, '.CardEyebrow');
 
   validHtmlAttributesTest(CardEyebrow);
+
+  ariaAttributesTest(CardEyebrow);
 
   it('should render eyebrow card component and have default class name', () => {
     render(<CardEyebrow data-testid="test" />);

--- a/packages/web-react/src/components/Card/__tests__/CardFooter.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardFooter.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   alignmentXPropsTest,
   restPropsTest,
@@ -20,6 +21,8 @@ describe('CardFooter', () => {
   alignmentXPropsTest(CardFooter, 'CardFooter');
 
   validHtmlAttributesTest(CardFooter);
+
+  ariaAttributesTest(CardFooter);
 
   it('should render footer card component and have default class names', () => {
     render(<CardFooter />);

--- a/packages/web-react/src/components/Card/__tests__/CardLink.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardLink.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('CardLink', () => {
   restPropsTest(CardLink, '.CardLink');
 
   validHtmlAttributesTest(CardLink);
+
+  ariaAttributesTest(CardLink);
 
   elementTypePropsTest(CardLink);
 

--- a/packages/web-react/src/components/Card/__tests__/CardLogo.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardLogo.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import CardLogo from '../CardLogo';
 
 describe('CardLogo', () => {
@@ -12,6 +18,8 @@ describe('CardLogo', () => {
   restPropsTest(CardLogo, '.CardLogo');
 
   validHtmlAttributesTest(CardLogo);
+
+  ariaAttributesTest(CardLogo);
 
   it('should render logo card component and have default class name', () => {
     render(<CardLogo data-testid="test" />);

--- a/packages/web-react/src/components/Card/__tests__/CardMedia.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardMedia.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   sizePropsTest,
   restPropsTest,
@@ -20,6 +21,8 @@ describe('CardMedia', () => {
   sizePropsTest(CardMedia);
 
   validHtmlAttributesTest(CardMedia);
+
+  ariaAttributesTest(CardMedia);
 
   it('should render media card media component and have default class names', () => {
     render(<CardMedia data-testid="test" />);

--- a/packages/web-react/src/components/Card/__tests__/CardTitle.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/CardTitle.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('CardTitle', () => {
   restPropsTest(CardTitle, '.CardTitle');
 
   validHtmlAttributesTest(CardTitle);
+
+  ariaAttributesTest(CardTitle);
 
   elementTypePropsTest(CardTitle);
 

--- a/packages/web-react/src/components/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/web-react/src/components/Checkbox/__tests__/Checkbox.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   validationStatePropsTest,
   itemPropsTest,
@@ -29,6 +30,8 @@ describe('Checkbox', () => {
   requiredPropsTest(Checkbox, 'checkbox', 'id', 'test-checkbox');
 
   validHtmlAttributesTest(Checkbox);
+
+  ariaAttributesTest(Checkbox);
 
   it('should have text classname', () => {
     render(<Checkbox id="checkbox" label="Label" />);

--- a/packages/web-react/src/components/Collapse/__tests__/Collapse.test.tsx
+++ b/packages/web-react/src/components/Collapse/__tests__/Collapse.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React, { useState } from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -21,6 +22,8 @@ describe('Collapse', () => {
   restPropsTest(Collapse, 'div');
 
   validHtmlAttributesTest(Collapse);
+
+  ariaAttributesTest(Collapse);
 
   elementTypePropsTest(Collapse);
 

--- a/packages/web-react/src/components/Collapse/__tests__/UncontrolledCollapse.test.tsx
+++ b/packages/web-react/src/components/Collapse/__tests__/UncontrolledCollapse.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -19,6 +20,8 @@ describe('UncontrolledCollapse', () => {
   restPropsTest(UncontrolledCollapse, 'div');
 
   validHtmlAttributesTest(UncontrolledCollapse);
+
+  ariaAttributesTest(UncontrolledCollapse);
 
   elementTypePropsTest(UncontrolledCollapse);
 

--- a/packages/web-react/src/components/Container/__tests__/Container.test.tsx
+++ b/packages/web-react/src/components/Container/__tests__/Container.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   restPropsTest,
   stylePropsTest,
@@ -26,6 +27,8 @@ describe('Container', () => {
   textAlignmentPropsTest(Container);
 
   validHtmlAttributesTest(Container);
+
+  ariaAttributesTest(Container);
 
   it('should render', () => {
     render(<Container data-testid={testId}>{text}</Container>);

--- a/packages/web-react/src/components/Divider/__tests__/Divider.test.tsx
+++ b/packages/web-react/src/components/Divider/__tests__/Divider.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import Divider from '../Divider';
 
 describe('Divider', () => {
@@ -12,6 +18,8 @@ describe('Divider', () => {
   restPropsTest(Divider, 'hr');
 
   validHtmlAttributesTest(Divider);
+
+  ariaAttributesTest(Divider);
 
   it('should have default classname', () => {
     render(<Divider />);

--- a/packages/web-react/src/components/Drawer/__tests__/Drawer.test.tsx
+++ b/packages/web-react/src/components/Drawer/__tests__/Drawer.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import { SpiritDrawerProps } from '../../../types';
 import Drawer from '../Drawer';
 
@@ -21,6 +27,8 @@ describe('Drawer', () => {
   restPropsTest(DrawerTest, 'dialog');
 
   validHtmlAttributesTest(DrawerTest);
+
+  ariaAttributesTest(DrawerTest);
 
   it('should not close drawer', () => {
     render(

--- a/packages/web-react/src/components/Drawer/__tests__/DrawerCloseButton.test.tsx
+++ b/packages/web-react/src/components/Drawer/__tests__/DrawerCloseButton.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   componentButtonColorPropsTest,
   emotionColorPropsTest,
@@ -23,6 +24,8 @@ describe('DrawerCloseButton', () => {
   emotionColorPropsTest(DrawerCloseButton, 'Button--');
 
   validHtmlAttributesTest(DrawerCloseButton);
+
+  ariaAttributesTest(DrawerCloseButton);
 
   it('should render drawer close button', () => {
     render(<DrawerCloseButton />);

--- a/packages/web-react/src/components/Drawer/__tests__/DrawerPanel.test.tsx
+++ b/packages/web-react/src/components/Drawer/__tests__/DrawerPanel.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('DrawerPanel', () => {
   restPropsTest(DrawerPanel, 'div');
 
   validHtmlAttributesTest(DrawerPanel);
+
+  ariaAttributesTest(DrawerPanel);
 
   elementTypePropsTest(DrawerPanel);
 

--- a/packages/web-react/src/components/Dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/web-react/src/components/Dropdown/__tests__/Dropdown.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import { DropdownAlignmentXType, DropdownAlignmentYType } from '../../../types';
 import Dropdown from '../Dropdown';
 import DropdownPopover from '../DropdownPopover';
@@ -20,6 +26,8 @@ describe('Dropdown', () => {
   restPropsTest(Dropdown, '.Dropdown');
 
   validHtmlAttributesTest(Dropdown);
+
+  ariaAttributesTest(Dropdown);
 
   it('should render text children', () => {
     render(

--- a/packages/web-react/src/components/Dropdown/__tests__/DropdownPopover.test.tsx
+++ b/packages/web-react/src/components/Dropdown/__tests__/DropdownPopover.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import DropdownPopover from '../DropdownPopover';
 
 describe('DropdownPopover', () => {
@@ -12,6 +18,8 @@ describe('DropdownPopover', () => {
   restPropsTest(DropdownPopover, '.DropdownPopover');
 
   validHtmlAttributesTest(DropdownPopover);
+
+  ariaAttributesTest(DropdownPopover);
 
   it('should have children', () => {
     const dom = render(<DropdownPopover>Popover</DropdownPopover>);

--- a/packages/web-react/src/components/EmptyState/__tests__/EmptyState.test.tsx
+++ b/packages/web-react/src/components/EmptyState/__tests__/EmptyState.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('EmptyState', () => {
   restPropsTest(EmptyState, 'div');
 
   validHtmlAttributesTest(EmptyState);
+
+  ariaAttributesTest(EmptyState);
 
   elementTypePropsTest(EmptyState);
 

--- a/packages/web-react/src/components/EmptyState/__tests__/EmptyStateSection.test.tsx
+++ b/packages/web-react/src/components/EmptyState/__tests__/EmptyStateSection.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('EmptyStateSection', () => {
   restPropsTest(EmptyStateSection, 'div');
 
   validHtmlAttributesTest(EmptyStateSection);
+
+  ariaAttributesTest(EmptyStateSection);
 
   elementTypePropsTest(EmptyStateSection);
 

--- a/packages/web-react/src/components/Field/__tests__/Label.test.tsx
+++ b/packages/web-react/src/components/Field/__tests__/Label.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { elementTypePropsTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  elementTypePropsTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import Label from '../Label';
 
 describe('Label', () => {
@@ -10,6 +16,8 @@ describe('Label', () => {
   restPropsTest(Label, 'label');
 
   validHtmlAttributesTest(Label);
+
+  ariaAttributesTest(Label);
 
   elementTypePropsTest(Label);
 

--- a/packages/web-react/src/components/FieldGroup/__tests__/FieldGroup.test.tsx
+++ b/packages/web-react/src/components/FieldGroup/__tests__/FieldGroup.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   validationStatePropsTest,
   restPropsTest,
@@ -34,6 +35,8 @@ describe('FieldGroup', () => {
   restPropsTest((props) => <FieldGroup {...props} label="Label" />, 'fieldset');
 
   validHtmlAttributesTest(FieldGroup);
+
+  ariaAttributesTest(FieldGroup);
 
   it('should render items as children', () => {
     render(

--- a/packages/web-react/src/components/FileUploader/__tests__/FileUploader.test.tsx
+++ b/packages/web-react/src/components/FileUploader/__tests__/FileUploader.test.tsx
@@ -1,6 +1,12 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import FileUploader from '../FileUploader';
 
 jest.mock('../../../hooks/useIcon');
@@ -13,4 +19,6 @@ describe('FileUploader', () => {
   restPropsTest(FileUploader, 'div');
 
   validHtmlAttributesTest(FileUploader);
+
+  ariaAttributesTest(FileUploader);
 });

--- a/packages/web-react/src/components/Flex/__tests__/Flex.test.tsx
+++ b/packages/web-react/src/components/Flex/__tests__/Flex.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -21,6 +22,8 @@ describe('Flex', () => {
   restPropsTest(Flex, 'div');
 
   validHtmlAttributesTest(Flex);
+
+  ariaAttributesTest(Flex);
 
   elementTypePropsTest(Flex);
 

--- a/packages/web-react/src/components/Footer/__tests__/Footer.test.tsx
+++ b/packages/web-react/src/components/Footer/__tests__/Footer.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   restPropsTest,
   stylePropsTest,
@@ -21,6 +22,8 @@ describe('Footer', () => {
   textAlignmentPropsTest(Footer);
 
   validHtmlAttributesTest(Footer);
+
+  ariaAttributesTest(Footer);
 
   it('should render text children', () => {
     render(<Footer>Hello World</Footer>);

--- a/packages/web-react/src/components/Grid/__tests__/Grid.test.tsx
+++ b/packages/web-react/src/components/Grid/__tests__/Grid.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -21,6 +22,8 @@ describe('Grid', () => {
   restPropsTest(Grid, 'div');
 
   validHtmlAttributesTest(Grid);
+
+  ariaAttributesTest(Grid);
 
   elementTypePropsTest(Grid);
 

--- a/packages/web-react/src/components/Grid/__tests__/GridItem.test.tsx
+++ b/packages/web-react/src/components/Grid/__tests__/GridItem.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,9 @@ describe('Grid', () => {
   restPropsTest(GridItem, 'div');
 
   validHtmlAttributesTest(GridItem);
+
+  ariaAttributesTest(GridItem);
+
   elementTypePropsTest(GridItem);
 
   it('should render text children', () => {

--- a/packages/web-react/src/components/Header/__tests__/Header.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/Header.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import Header from '../Header';
 
 describe('Header', () => {
@@ -12,6 +18,8 @@ describe('Header', () => {
   restPropsTest((props) => <Header {...props} />, 'header');
 
   validHtmlAttributesTest(Header);
+
+  ariaAttributesTest(Header);
 
   it('should render text children', () => {
     const dom = render(<Header id="test">Hello World</Header>);

--- a/packages/web-react/src/components/Header/__tests__/HeaderButton.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderButton.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import HeaderButton from '../HeaderButton';
 
 describe('HeaderButton', () => {
@@ -12,6 +18,8 @@ describe('HeaderButton', () => {
   restPropsTest((props) => <HeaderButton {...props} />, 'button');
 
   validHtmlAttributesTest(HeaderButton);
+
+  ariaAttributesTest(HeaderButton);
 
   it('should render text children', () => {
     const dom = render(<HeaderButton id="test">Hello World</HeaderButton>);

--- a/packages/web-react/src/components/Header/__tests__/HeaderDesktopActions.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDesktopActions.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import HeaderDesktopActions from '../HeaderDesktopActions';
 
 describe('HeaderDesktopActions', () => {
@@ -15,6 +21,8 @@ describe('HeaderDesktopActions', () => {
   restPropsTest((props) => <HeaderDesktopActions {...props} />, 'nav');
 
   validHtmlAttributesTest(HeaderDesktopActions);
+
+  ariaAttributesTest(HeaderDesktopActions);
 
   it('should render text children', () => {
     render(<HeaderDesktopActions id="test">Hello World</HeaderDesktopActions>);

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialog.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialog.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import HeaderDialog from '../HeaderDialog';
 
 describe('HeaderDialog', () => {
@@ -12,6 +18,8 @@ describe('HeaderDialog', () => {
   restPropsTest((props) => <HeaderDialog {...props} />, 'dialog');
 
   validHtmlAttributesTest(HeaderDialog);
+
+  ariaAttributesTest(HeaderDialog);
 
   it('should render text children', () => {
     const dom = render(

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogActions.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogActions.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import HeaderDialogActions from '../HeaderDialogActions';
 
 describe('HeaderDialogActions', () => {
@@ -15,6 +21,8 @@ describe('HeaderDialogActions', () => {
   restPropsTest((props) => <HeaderDialogActions {...props} />, 'nav');
 
   validHtmlAttributesTest(HeaderDialogActions);
+
+  ariaAttributesTest(HeaderDialogActions);
 
   it('should render text children', () => {
     const dom = render(<HeaderDialogActions id="test">Hello World</HeaderDialogActions>);

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogButton.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogButton.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import HeaderDialogButton from '../HeaderDialogButton';
 
 describe('HeaderDialogButton', () => {
@@ -15,6 +21,8 @@ describe('HeaderDialogButton', () => {
   restPropsTest((props) => <HeaderDialogButton {...props} />, 'button');
 
   validHtmlAttributesTest(HeaderDialogButton);
+
+  ariaAttributesTest(HeaderDialogButton);
 
   it('should render text children', () => {
     const dom = render(<HeaderDialogButton id="test">Hello World</HeaderDialogButton>);

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogCloseButton.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogCloseButton.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import HeaderDialogCloseButton from '../HeaderDialogCloseButton';
 
 jest.mock('../../../hooks/useIcon');
@@ -17,6 +23,8 @@ describe('HeaderDialogCloseButton', () => {
   restPropsTest((props) => <HeaderDialogCloseButton {...props} />, 'button');
 
   validHtmlAttributesTest(HeaderDialogCloseButton);
+
+  ariaAttributesTest(HeaderDialogCloseButton);
 
   it('should render text label', () => {
     const dom = render(<HeaderDialogCloseButton id="test" label="Hello World" />);

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogLink.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogLink.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -21,6 +22,8 @@ describe('HeaderDialogLink', () => {
   restPropsTest((props) => <HeaderDialogLink {...props} />, 'a');
 
   validHtmlAttributesTest(HeaderDialogLink);
+
+  ariaAttributesTest(HeaderDialogLink);
 
   elementTypePropsTest(HeaderDialogLink);
 

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogNav.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogNav.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import HeaderDialogNav from '../HeaderDialogNav';
 
 describe('HeaderDialogNav', () => {
@@ -15,6 +21,8 @@ describe('HeaderDialogNav', () => {
   restPropsTest((props) => <HeaderDialogNav {...props} />, 'ul');
 
   validHtmlAttributesTest(HeaderDialogNav);
+
+  ariaAttributesTest(HeaderDialogNav);
 
   it('should render text children', () => {
     const dom = render(<HeaderDialogNav id="test">Hello World</HeaderDialogNav>);

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogNavItem.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogNavItem.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import HeaderDialogNavItem from '../HeaderDialogNavItem';
 
 describe('HeaderDialogNavItem', () => {
@@ -15,6 +21,8 @@ describe('HeaderDialogNavItem', () => {
   restPropsTest((props) => <HeaderDialogNavItem {...props} />, 'li');
 
   validHtmlAttributesTest(HeaderDialogNavItem);
+
+  ariaAttributesTest(HeaderDialogNavItem);
 
   it('should render text children', () => {
     const dom = render(<HeaderDialogNavItem id="test">Hello World</HeaderDialogNavItem>);

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogText.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogText.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import HeaderDialogText from '../HeaderDialogText';
 
 describe('HeaderDialogText', () => {
@@ -15,6 +21,8 @@ describe('HeaderDialogText', () => {
   restPropsTest((props) => <HeaderDialogText {...props} />, 'span');
 
   validHtmlAttributesTest(HeaderDialogText);
+
+  ariaAttributesTest(HeaderDialogText);
 
   it('should render text children', () => {
     const dom = render(<HeaderDialogText id="test">Hello World</HeaderDialogText>);

--- a/packages/web-react/src/components/Header/__tests__/HeaderLink.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderLink.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('HeaderLink', () => {
   restPropsTest((props) => <HeaderLink {...props} />, 'a');
 
   validHtmlAttributesTest(HeaderLink);
+
+  ariaAttributesTest(HeaderLink);
 
   elementTypePropsTest(HeaderLink);
 

--- a/packages/web-react/src/components/Header/__tests__/HeaderMobileActions.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderMobileActions.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import { HEADER_MENU_TOGGLE_LABEL_DEFAULT } from '../constants';
 import HeaderMobileActions from '../HeaderMobileActions';
 
@@ -18,6 +24,8 @@ describe('HeaderMobileActions', () => {
   restPropsTest((props) => <HeaderMobileActions {...props} />, 'div');
 
   validHtmlAttributesTest(HeaderMobileActions);
+
+  ariaAttributesTest(HeaderMobileActions);
 
   it('should render text children', () => {
     const dom = render(

--- a/packages/web-react/src/components/Header/__tests__/HeaderNav.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderNav.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import HeaderNav from '../HeaderNav';
 
 describe('HeaderNav', () => {
@@ -12,6 +18,8 @@ describe('HeaderNav', () => {
   restPropsTest((props) => <HeaderNav {...props} />, 'ul');
 
   validHtmlAttributesTest(HeaderNav);
+
+  ariaAttributesTest(HeaderNav);
 
   it('should render text children', () => {
     const dom = render(<HeaderNav id="test">Hello World</HeaderNav>);

--- a/packages/web-react/src/components/Header/__tests__/HeaderNavItem.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderNavItem.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import HeaderNavItem from '../HeaderNavItem';
 
 describe('HeaderNavItem', () => {
@@ -12,6 +18,8 @@ describe('HeaderNavItem', () => {
   restPropsTest((props) => <HeaderNavItem {...props} />, 'li');
 
   validHtmlAttributesTest(HeaderNavItem);
+
+  ariaAttributesTest(HeaderNavItem);
 
   it('should render text children', () => {
     const dom = render(<HeaderNavItem id="test">Hello World</HeaderNavItem>);

--- a/packages/web-react/src/components/Heading/__tests__/Heading.test.tsx
+++ b/packages/web-react/src/components/Heading/__tests__/Heading.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   sizeExtendedPropsTest,
   sizePropsTest,
@@ -41,6 +42,8 @@ describe('Heading', () => {
   restPropsTest((props) => <Heading elementType="h1" {...props} />, 'h1');
 
   validHtmlAttributesTest((props) => <Heading elementType="h1" {...props} />);
+
+  ariaAttributesTest((props) => <Heading elementType="h1" {...props} />);
 
   elementTypePropsTest(Heading);
 

--- a/packages/web-react/src/components/Icon/__tests__/Icon.test.tsx
+++ b/packages/web-react/src/components/Icon/__tests__/Icon.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import { ariaAttributesTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
 import { toBeInDocumentProviderTest } from '@local/tests/providerTests/toBeInDocumentProviderTest';
 import { SpiritIconProps } from '../../../types';
 import Icon from '../Icon';
@@ -20,6 +20,8 @@ describe('Icon', () => {
   toBeInDocumentProviderTest(AddIcon, 'title');
 
   validHtmlAttributesTest(AddIcon);
+
+  ariaAttributesTest(AddIcon);
 
   describe('default props', () => {
     beforeEach(() => {

--- a/packages/web-react/src/components/Item/__tests__/Item.test.tsx
+++ b/packages/web-react/src/components/Item/__tests__/Item.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -21,6 +22,8 @@ describe('Item', () => {
   restPropsTest((props: SpiritItemProps) => <Item {...props} />, 'button');
 
   validHtmlAttributesTest(Item);
+
+  ariaAttributesTest(Item);
 
   elementTypePropsTest(Item);
 

--- a/packages/web-react/src/components/Link/__tests__/Link.test.tsx
+++ b/packages/web-react/src/components/Link/__tests__/Link.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   actionLinkColorPropsTest,
   restPropsTest,
@@ -23,6 +24,8 @@ describe('Link', () => {
   restPropsTest(Link, 'a');
 
   validHtmlAttributesTest(Link);
+
+  ariaAttributesTest(Link);
 
   elementTypePropsTest(Link);
 

--- a/packages/web-react/src/components/Modal/__tests__/Modal.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/Modal.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import { SpiritModalProps } from '../../../types';
 import Modal from '../Modal';
 
@@ -19,6 +25,8 @@ describe('Modal', () => {
   restPropsTest(ModalTest, 'dialog');
 
   validHtmlAttributesTest(ModalTest);
+
+  ariaAttributesTest(ModalTest);
 
   it('should not close modal dialog', () => {
     const mockedOnClose = jest.fn();

--- a/packages/web-react/src/components/Modal/__tests__/ModalBody.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/ModalBody.test.tsx
@@ -1,5 +1,11 @@
 import '@testing-library/jest-dom';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import ModalBody from '../ModalBody';
 
 describe('ModalBody', () => {
@@ -10,4 +16,6 @@ describe('ModalBody', () => {
   restPropsTest(ModalBody, 'div');
 
   validHtmlAttributesTest(ModalBody);
+
+  ariaAttributesTest(ModalBody);
 });

--- a/packages/web-react/src/components/Modal/__tests__/ModalCloseButton.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/ModalCloseButton.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import ModalCloseButton from '../ModalCloseButton';
 
 jest.mock('../../../hooks/useIcon');
@@ -14,6 +20,8 @@ describe('ModalCloseButton', () => {
   restPropsTest(ModalCloseButton, 'button');
 
   validHtmlAttributesTest(ModalCloseButton);
+
+  ariaAttributesTest(ModalCloseButton);
 
   it('should have icon', () => {
     render(<ModalCloseButton label="close" id="test" isOpen onClose={() => {}} />);

--- a/packages/web-react/src/components/Modal/__tests__/ModalDialog.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/ModalDialog.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('ModalDialog', () => {
   restPropsTest(ModalDialog, 'article');
 
   validHtmlAttributesTest(ModalDialog);
+
+  ariaAttributesTest(ModalDialog);
 
   elementTypePropsTest(ModalDialog);
 

--- a/packages/web-react/src/components/Modal/__tests__/ModalFooter.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/ModalFooter.test.tsx
@@ -1,5 +1,11 @@
 import '@testing-library/jest-dom';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import ModalFooter from '../ModalFooter';
 
 describe('ModalFooter', () => {
@@ -10,4 +16,6 @@ describe('ModalFooter', () => {
   restPropsTest(ModalFooter, 'footer');
 
   validHtmlAttributesTest(ModalFooter);
+
+  ariaAttributesTest(ModalFooter);
 });

--- a/packages/web-react/src/components/Modal/__tests__/ModalHeader.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/ModalHeader.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import ModalHeader from '../ModalHeader';
 
 jest.mock('../../../hooks/useIcon');
@@ -14,6 +20,8 @@ describe('ModalHeader', () => {
   restPropsTest(ModalHeader, 'header');
 
   validHtmlAttributesTest(ModalHeader);
+
+  ariaAttributesTest(ModalHeader);
 
   it('should have close button', () => {
     render(<ModalHeader>Modal Title</ModalHeader>);

--- a/packages/web-react/src/components/Navigation/__tests__/Navigation.test.tsx
+++ b/packages/web-react/src/components/Navigation/__tests__/Navigation.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import { Direction } from '../../../constants';
 import Navigation from '../Navigation';
 
@@ -28,6 +34,8 @@ describe('Navigation', () => {
   restPropsTest(Navigation, 'nav');
 
   validHtmlAttributesTest(Navigation);
+
+  ariaAttributesTest(Navigation);
 
   describe.each(dataProvider)('when direction is $direction', ({ direction, directionClassName }) => {
     beforeEach(() => {

--- a/packages/web-react/src/components/Navigation/__tests__/NavigationAction.test.tsx
+++ b/packages/web-react/src/components/Navigation/__tests__/NavigationAction.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('NavigationAction', () => {
   restPropsTest(NavigationAction, 'a');
 
   validHtmlAttributesTest(NavigationAction);
+
+  ariaAttributesTest(NavigationAction);
 
   elementTypePropsTest(NavigationAction);
 

--- a/packages/web-react/src/components/Navigation/__tests__/NavigationAvatar.test.tsx
+++ b/packages/web-react/src/components/Navigation/__tests__/NavigationAvatar.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -21,6 +22,8 @@ describe('NavigationAvatar', () => {
   restPropsTest(NavigationAvatar, 'a');
 
   validHtmlAttributesTest(NavigationAvatar);
+
+  ariaAttributesTest(NavigationAvatar);
 
   elementTypePropsTest(NavigationAvatar);
 

--- a/packages/web-react/src/components/Navigation/__tests__/NavigationItem.test.tsx
+++ b/packages/web-react/src/components/Navigation/__tests__/NavigationItem.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import NavigationItem from '../NavigationItem';
 
 describe('NavigationItem', () => {
@@ -12,6 +18,8 @@ describe('NavigationItem', () => {
   restPropsTest(NavigationItem, 'li');
 
   validHtmlAttributesTest(NavigationItem);
+
+  ariaAttributesTest(NavigationItem);
 
   it('should have default classname', () => {
     render(<NavigationItem>Content</NavigationItem>);

--- a/packages/web-react/src/components/Pagination/__tests__/Pagination.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/Pagination.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import Pagination from '../Pagination';
 
 describe('Pagination', () => {
@@ -19,6 +25,8 @@ describe('Pagination', () => {
   restPropsTest(Pagination, 'nav');
 
   validHtmlAttributesTest(Pagination);
+
+  ariaAttributesTest(Pagination);
 
   it('should render text children', () => {
     const dom = render(<Pagination>Hello World</Pagination>);

--- a/packages/web-react/src/components/Pagination/__tests__/PaginationButtonLink.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/PaginationButtonLink.test.tsx
@@ -1,5 +1,11 @@
 import '@testing-library/jest-dom';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import PaginationButtonLink from '../PaginationButtonLink';
 
 jest.mock('../../../hooks/useIcon');
@@ -12,4 +18,6 @@ describe('PaginationButtonLink', () => {
   restPropsTest(PaginationButtonLink, 'a');
 
   validHtmlAttributesTest(PaginationButtonLink);
+
+  ariaAttributesTest(PaginationButtonLink);
 });

--- a/packages/web-react/src/components/Pagination/__tests__/PaginationItem.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/PaginationItem.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import PaginationItem from '../PaginationItem';
 
 describe('PaginationItem', () => {
@@ -12,6 +18,8 @@ describe('PaginationItem', () => {
   restPropsTest(PaginationItem, 'li');
 
   validHtmlAttributesTest(PaginationItem);
+
+  ariaAttributesTest(PaginationItem);
 
   it('should render text children', () => {
     const dom = render(<PaginationItem>Hello World</PaginationItem>);

--- a/packages/web-react/src/components/Pagination/__tests__/PaginationLink.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/PaginationLink.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('PaginationLink', () => {
   restPropsTest(PaginationLink, 'a');
 
   validHtmlAttributesTest(PaginationLink);
+
+  ariaAttributesTest(PaginationLink);
 
   elementTypePropsTest(PaginationLink);
 

--- a/packages/web-react/src/components/Pagination/__tests__/PaginationLinkNext.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/PaginationLinkNext.test.tsx
@@ -1,5 +1,11 @@
 import '@testing-library/jest-dom';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import PaginationLinkNext from '../PaginationLinkNext';
 
 jest.mock('../../../hooks/useIcon');
@@ -12,4 +18,6 @@ describe('PaginationLinkNext', () => {
   restPropsTest(PaginationLinkNext, 'a');
 
   validHtmlAttributesTest(PaginationLinkNext);
+
+  ariaAttributesTest(PaginationLinkNext);
 });

--- a/packages/web-react/src/components/Pagination/__tests__/PaginationLinkPrevious.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/PaginationLinkPrevious.test.tsx
@@ -1,5 +1,11 @@
 import '@testing-library/jest-dom';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import PaginationLinkPrevious from '../PaginationLinkPrevious';
 
 jest.mock('../../../hooks/useIcon');
@@ -12,4 +18,6 @@ describe('PaginationLinkPrevious', () => {
   restPropsTest(PaginationLinkPrevious, 'a');
 
   validHtmlAttributesTest(PaginationLinkPrevious);
+
+  ariaAttributesTest(PaginationLinkPrevious);
 });

--- a/packages/web-react/src/components/PartnerLogo/__tests__/PartnerLogo.test.tsx
+++ b/packages/web-react/src/components/PartnerLogo/__tests__/PartnerLogo.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import { Sizes } from '../../../constants';
 import PartnerLogo from '../PartnerLogo';
 
@@ -13,6 +19,8 @@ describe('PartnerLogo', () => {
   restPropsTest(PartnerLogo, 'div');
 
   validHtmlAttributesTest(PartnerLogo);
+
+  ariaAttributesTest(PartnerLogo);
 
   it('should render children', () => {
     render(<PartnerLogo>Content</PartnerLogo>);

--- a/packages/web-react/src/components/Pill/__tests__/Pill.test.tsx
+++ b/packages/web-react/src/components/Pill/__tests__/Pill.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   emotionColorPropsTest,
@@ -21,6 +22,8 @@ describe('Pill', () => {
   restPropsTest(Pill, 'span');
 
   validHtmlAttributesTest(Pill);
+
+  ariaAttributesTest(Pill);
 
   elementTypePropsTest(Pill, 'div');
 

--- a/packages/web-react/src/components/ProductLogo/__tests__/ProductLogo.test.tsx
+++ b/packages/web-react/src/components/ProductLogo/__tests__/ProductLogo.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import ProductLogo from '../ProductLogo';
 
 describe('ProductLogo', () => {
@@ -12,6 +18,8 @@ describe('ProductLogo', () => {
   restPropsTest(ProductLogo, 'div');
 
   validHtmlAttributesTest(ProductLogo);
+
+  ariaAttributesTest(ProductLogo);
 
   it('should render children', () => {
     render(<ProductLogo>Content</ProductLogo>);

--- a/packages/web-react/src/components/Radio/__tests__/Radio.test.tsx
+++ b/packages/web-react/src/components/Radio/__tests__/Radio.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   validationStatePropsTest,
   itemPropsTest,
@@ -26,6 +27,8 @@ describe('Radio', () => {
   requiredPropsTest(Radio, 'radio', 'id', 'example-id');
 
   validHtmlAttributesTest(Radio);
+
+  ariaAttributesTest(Radio);
 
   it('should have label classname', () => {
     render(<Radio id="radio" label="label" />);

--- a/packages/web-react/src/components/ScrollView/__tests__/ScrollView.test.tsx
+++ b/packages/web-react/src/components/ScrollView/__tests__/ScrollView.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import { ScrollViewDirectionType, ScrollViewOverflowDecoratorsType } from '../../../types';
 import ScrollView from '../ScrollView';
 
@@ -13,6 +19,8 @@ describe('ScrollView', () => {
   restPropsTest(ScrollView, 'div');
 
   validHtmlAttributesTest(ScrollView);
+
+  ariaAttributesTest(ScrollView);
 
   it('should render children', () => {
     render(<ScrollView>Content</ScrollView>);

--- a/packages/web-react/src/components/Section/__tests__/Section.test.tsx
+++ b/packages/web-react/src/components/Section/__tests__/Section.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -34,6 +35,8 @@ describe('Section', () => {
   textAlignmentPropsTest(Section);
 
   validHtmlAttributesTest(Section);
+
+  ariaAttributesTest(Section);
 
   elementTypePropsTest(Section);
 

--- a/packages/web-react/src/components/Select/__tests__/Select.test.tsx
+++ b/packages/web-react/src/components/Select/__tests__/Select.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   validationStatePropsTest,
   requiredPropsTest,
@@ -28,6 +29,8 @@ describe('Select', () => {
   requiredPropsTest(Select, 'combobox', 'id', 'test-select');
 
   validHtmlAttributesTest(Select);
+
+  ariaAttributesTest(Select);
 
   it('should have label classname', () => {
     render(

--- a/packages/web-react/src/components/Skeleton/__tests__/SkeletonHeading.test.tsx
+++ b/packages/web-react/src/components/Skeleton/__tests__/SkeletonHeading.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { screen, render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('SkeletonHeading', () => {
   restPropsTest(SkeletonHeading, 'div');
 
   validHtmlAttributesTest(SkeletonHeading);
+
+  ariaAttributesTest(SkeletonHeading);
 
   elementTypePropsTest(SkeletonHeading);
 

--- a/packages/web-react/src/components/Skeleton/__tests__/SkeletonShape.test.tsx
+++ b/packages/web-react/src/components/Skeleton/__tests__/SkeletonShape.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, renderHook, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -20,6 +21,8 @@ describe('SkeletonShape', () => {
   restPropsTest(SkeletonShape, 'div');
 
   validHtmlAttributesTest(SkeletonShape);
+
+  ariaAttributesTest(SkeletonShape);
 
   elementTypePropsTest(SkeletonShape);
 

--- a/packages/web-react/src/components/Skeleton/__tests__/SkeletonText.test.tsx
+++ b/packages/web-react/src/components/Skeleton/__tests__/SkeletonText.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { screen, render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('SkeletonText', () => {
   restPropsTest(SkeletonText, 'div');
 
   validHtmlAttributesTest(SkeletonText);
+
+  ariaAttributesTest(SkeletonText);
 
   elementTypePropsTest(SkeletonText);
 

--- a/packages/web-react/src/components/Slider/__tests__/Slider.test.tsx
+++ b/packages/web-react/src/components/Slider/__tests__/Slider.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import Slider from '../Slider';
 
 describe('Slider', () => {
@@ -20,6 +26,8 @@ describe('Slider', () => {
   restPropsTest((props) => <Slider id={defaultProps.id} {...props} />, 'div');
 
   validHtmlAttributesTest((props) => <Slider id={defaultProps.id} {...props} />);
+
+  ariaAttributesTest((props) => <Slider id={defaultProps.id} {...props} />);
 
   it('should render slider', () => {
     render(<Slider {...defaultProps} />);

--- a/packages/web-react/src/components/Slider/__tests__/UncontrolledSlider.tsx
+++ b/packages/web-react/src/components/Slider/__tests__/UncontrolledSlider.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import { ariaAttributesTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
 import UncontrolledSlider from '../UncontrolledSlider';
 
 describe('Slider', () => {
@@ -18,6 +18,8 @@ describe('Slider', () => {
   restPropsTest((props) => <UncontrolledSlider id={defaultProps.id} {...props} />, 'div');
 
   validHtmlAttributesTest((props) => <UncontrolledSlider id={defaultProps.id} {...props} />);
+
+  ariaAttributesTest((props) => <UncontrolledSlider id={defaultProps.id} {...props} />);
 
   it('should render slider', () => {
     render(<UncontrolledSlider {...defaultProps} />);

--- a/packages/web-react/src/components/Spinner/__tests__/Spinner.test.tsx
+++ b/packages/web-react/src/components/Spinner/__tests__/Spinner.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import { TextColors } from '../../../constants';
 import { TextColorsDictionaryType } from '../../../types';
 import Spinner from '../Spinner';
@@ -16,6 +22,8 @@ describe('Spinner', () => {
   restPropsTest(Spinner, 'svg');
 
   validHtmlAttributesTest(Spinner);
+
+  ariaAttributesTest(Spinner);
 
   it('should have correct classes', () => {
     render(<Spinner data-testid="Spinner" />);

--- a/packages/web-react/src/components/SplitButton/__tests__/SplitButton.test.tsx
+++ b/packages/web-react/src/components/SplitButton/__tests__/SplitButton.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   restPropsTest,
   sizePropsTest,
@@ -25,6 +26,8 @@ describe('SplitButton', () => {
   restPropsTest(SplitButton, 'div');
 
   validHtmlAttributesTest(SplitButton);
+
+  ariaAttributesTest(SplitButton);
 
   sizePropsTest(
     (props) => (

--- a/packages/web-react/src/components/SplitButton/__tests__/UncontrolledSplitButton.test.tsx
+++ b/packages/web-react/src/components/SplitButton/__tests__/UncontrolledSplitButton.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import { ComponentButtonColors, Sizes } from '../../../constants';
 import { SplitButtonColorType } from '../../../types';
 import UncontrolledSplitButton from '../UncontrolledSplitButton';
@@ -20,6 +26,8 @@ describe('SplitButton', () => {
   restPropsTest(UncontrolledSplitButton, 'div');
 
   validHtmlAttributesTest(UncontrolledSplitButton);
+
+  ariaAttributesTest(UncontrolledSplitButton);
 
   it('should have default classname', () => {
     render(

--- a/packages/web-react/src/components/Stack/__tests__/Stack.test.tsx
+++ b/packages/web-react/src/components/Stack/__tests__/Stack.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('Stack', () => {
   restPropsTest(Stack, 'div');
 
   validHtmlAttributesTest(Stack);
+
+  ariaAttributesTest(Stack);
 
   elementTypePropsTest(Stack);
 

--- a/packages/web-react/src/components/Stack/__tests__/StackItem.test.tsx
+++ b/packages/web-react/src/components/Stack/__tests__/StackItem.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('StackItem', () => {
   restPropsTest(StackItem, 'div');
 
   validHtmlAttributesTest(StackItem);
+
+  ariaAttributesTest(StackItem);
 
   elementTypePropsTest(StackItem);
 

--- a/packages/web-react/src/components/Tabs/__tests__/TabItem.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabItem.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   restPropsTest,
   stylePropsTest,
@@ -18,6 +19,8 @@ describe('TabItem', () => {
   restPropsTest((props) => <TabItem forTabPane={0} {...props} />, 'button');
 
   validHtmlAttributesTest(TabItem, { forTabPane: 0 });
+
+  ariaAttributesTest(TabItem, { forTabPane: 0 });
 
   it('should render list item', () => {
     render(<TabItem forTabPane={0} />);

--- a/packages/web-react/src/components/Tabs/__tests__/TabLink.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabLink.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   stylePropsTest,
@@ -15,6 +16,8 @@ describe('TabLink', () => {
   classNamePrefixProviderTest(TabLink, 'Tabs__item');
 
   validHtmlAttributesTest(TabLink);
+
+  ariaAttributesTest(TabLink);
 
   elementTypePropsTest(TabLink);
 

--- a/packages/web-react/src/components/Tabs/__tests__/TabList.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabList.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import { ariaAttributesTest, classNamePrefixProviderTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
 import TabList from '../TabList';
 import Tabs from '../Tabs';
 
@@ -11,6 +11,8 @@ describe('TabList', () => {
   classNamePrefixProviderTest(TabList, 'Tabs');
 
   validHtmlAttributesTest(TabList);
+
+  ariaAttributesTest(TabList);
 
   it('should render with custom spacing for each breakpoint', () => {
     render(

--- a/packages/web-react/src/components/Tag/__tests__/Tag.test.tsx
+++ b/packages/web-react/src/components/Tag/__tests__/Tag.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   emotionColorPropsTest,
   sizeExtendedPropsTest,
@@ -24,6 +25,8 @@ describe('Tag', () => {
   restPropsTest(Tag, 'span');
 
   validHtmlAttributesTest(Tag);
+
+  ariaAttributesTest(Tag);
 
   elementTypePropsTest(Tag);
 

--- a/packages/web-react/src/components/Text/__tests__/Text.test.tsx
+++ b/packages/web-react/src/components/Text/__tests__/Text.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   sizeExtendedPropsTest,
   sizePropsTest,
@@ -32,6 +33,8 @@ describe('Text', () => {
   restPropsTest(Text, 'p');
 
   validHtmlAttributesTest(Text);
+
+  ariaAttributesTest(Text);
 
   elementTypePropsTest(Text);
 

--- a/packages/web-react/src/components/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/web-react/src/components/TextArea/__tests__/TextArea.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   validationStatePropsTest,
   requiredPropsTest,
@@ -26,6 +27,8 @@ describe('TextArea', () => {
   validationTextPropsTest(TextArea, '.TextArea__validationText');
 
   validHtmlAttributesTest(TextArea);
+
+  ariaAttributesTest(TextArea);
 
   it('should have label classname', () => {
     render(<TextArea id="textarea" label="Label" />);

--- a/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
+++ b/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   validationStatePropsTest,
   restPropsTest,
@@ -27,6 +28,8 @@ describe('TextField', () => {
     validationTextPropsTest(TextField, '.TextField__validationText', type as TextFieldType);
 
     validHtmlAttributesTest(TextField);
+
+    ariaAttributesTest(TextField);
 
     it('should have label classname', () => {
       render(<TextField id="textfield" label="Label" type={type as TextFieldType} />);

--- a/packages/web-react/src/components/TextFieldBase/__tests__/TextFieldBase.test.tsx
+++ b/packages/web-react/src/components/TextFieldBase/__tests__/TextFieldBase.test.tsx
@@ -1,7 +1,12 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, requiredPropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  requiredPropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import { TextFieldType } from '../../../types';
 import TextFieldBase from '../TextFieldBase';
 
@@ -11,6 +16,8 @@ describe('TextFieldBase', () => {
   requiredPropsTest(TextFieldBase, 'textbox', 'id', 'textfieldbase');
 
   validHtmlAttributesTest(TextFieldBase);
+
+  ariaAttributesTest(TextFieldBase);
 
   describe.each(['text', 'password', 'email'])('input type %s', (type) => {
     it('should have connected label and input', () => {

--- a/packages/web-react/src/components/Toast/__tests__/Toast.test.tsx
+++ b/packages/web-react/src/components/Toast/__tests__/Toast.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import Toast from '../Toast';
 
 describe('Toast', () => {
@@ -12,6 +18,8 @@ describe('Toast', () => {
   restPropsTest(Toast, 'div');
 
   validHtmlAttributesTest(Toast);
+
+  ariaAttributesTest(Toast);
 
   it('should render with default alignments', () => {
     const dom = render(<Toast />);

--- a/packages/web-react/src/components/Toast/__tests__/ToastBar.test.tsx
+++ b/packages/web-react/src/components/Toast/__tests__/ToastBar.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import ToastBar from '../ToastBar';
 
 jest.mock('../../../hooks/useIcon');
@@ -14,6 +20,8 @@ describe('ToastBar', () => {
   restPropsTest((props) => <ToastBar {...props} id="test" />, 'div');
 
   validHtmlAttributesTest(ToastBar);
+
+  ariaAttributesTest(ToastBar);
 
   it('should not render', () => {
     const dom = render(<ToastBar isOpen={false} id="test" />);

--- a/packages/web-react/src/components/Toast/__tests__/ToastBarLink.test.tsx
+++ b/packages/web-react/src/components/Toast/__tests__/ToastBarLink.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { elementTypePropsTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  elementTypePropsTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import ToastBarLink from '../ToastBarLink';
 
 describe('ToastBarLink', () => {
@@ -10,6 +16,8 @@ describe('ToastBarLink', () => {
   restPropsTest(ToastBarLink, 'a');
 
   validHtmlAttributesTest(ToastBarLink);
+
+  ariaAttributesTest(ToastBarLink);
 
   elementTypePropsTest(ToastBarLink);
 

--- a/packages/web-react/src/components/Toast/__tests__/ToastBarMessage.test.tsx
+++ b/packages/web-react/src/components/Toast/__tests__/ToastBarMessage.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import { ariaAttributesTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
 import ToastBarMessage from '../ToastBarMessage';
 
 describe('ToastBarMessage', () => {
@@ -10,6 +10,8 @@ describe('ToastBarMessage', () => {
   restPropsTest(ToastBarMessage, 'div');
 
   validHtmlAttributesTest(ToastBarMessage);
+
+  ariaAttributesTest(ToastBarMessage);
 
   beforeEach(() => {
     render(<ToastBarMessage>Example children</ToastBarMessage>);

--- a/packages/web-react/src/components/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/web-react/src/components/Toggle/__tests__/Toggle.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   validationStatePropsTest,
   requiredPropsTest,
@@ -23,6 +24,8 @@ describe('Toggle', () => {
   requiredPropsTest(Toggle, 'checkbox', 'id', 'example-id');
 
   validHtmlAttributesTest(Toggle);
+
+  ariaAttributesTest(Toggle);
 
   it('should have correct className', () => {
     render(<Toggle id="test-toggle" label="Toggle Label" />);

--- a/packages/web-react/src/components/Tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/web-react/src/components/Tooltip/__tests__/Tooltip.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import { Button } from '../../Button';
 import { Tooltip, TooltipPopover, TooltipTrigger } from '..';
 
@@ -17,6 +23,8 @@ describe('Tooltip', () => {
   restPropsTest((props) => <Tooltip id={id} {...props} />, 'div');
 
   validHtmlAttributesTest(Tooltip);
+
+  ariaAttributesTest(Tooltip);
 
   it('should render tooltip', () => {
     const onToggle = () => null;

--- a/packages/web-react/src/components/Tooltip/__tests__/TooltipPopover.test.tsx
+++ b/packages/web-react/src/components/Tooltip/__tests__/TooltipPopover.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import { TooltipPopover } from '..';
 
 describe('TooltipPopover', () => {
@@ -12,6 +18,8 @@ describe('TooltipPopover', () => {
   restPropsTest((props) => <TooltipPopover {...props} />, 'div');
 
   validHtmlAttributesTest(TooltipPopover);
+
+  ariaAttributesTest(TooltipPopover);
 
   it('should render tooltip popover', () => {
     const popoverText = 'TooltipPopover';

--- a/packages/web-react/src/components/Tooltip/__tests__/TooltipTrigger.test.tsx
+++ b/packages/web-react/src/components/Tooltip/__tests__/TooltipTrigger.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { elementTypePropsTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  elementTypePropsTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import { Button } from '../../Button';
 import { TooltipTrigger } from '..';
 
@@ -11,6 +17,8 @@ describe('TooltipTrigger', () => {
   restPropsTest((props) => <TooltipTrigger elementType={Button} {...props} />, 'button');
 
   validHtmlAttributesTest(TooltipTrigger);
+
+  ariaAttributesTest(TooltipTrigger);
 
   elementTypePropsTest(TooltipTrigger);
 

--- a/packages/web-react/src/components/UNSTABLE_Header/__tests__/UNSTABLE_Header.test.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Header/__tests__/UNSTABLE_Header.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { classNamePrefixProviderTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import UNSTABLE_Header from '../UNSTABLE_Header';
 
 describe('UNSTABLE_Header', () => {
@@ -12,6 +18,8 @@ describe('UNSTABLE_Header', () => {
   restPropsTest(UNSTABLE_Header, 'header');
 
   validHtmlAttributesTest(UNSTABLE_Header);
+
+  ariaAttributesTest(UNSTABLE_Header);
 
   it('should have default classname', () => {
     render(<UNSTABLE_Header>Content</UNSTABLE_Header>);

--- a/packages/web-react/src/components/UNSTABLE_Header/__tests__/UNSTABLE_HeaderLogo.test.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Header/__tests__/UNSTABLE_HeaderLogo.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('UNSTABLE_HeaderLogo', () => {
   restPropsTest(UNSTABLE_HeaderLogo, 'a');
 
   validHtmlAttributesTest(UNSTABLE_HeaderLogo);
+
+  ariaAttributesTest(UNSTABLE_HeaderLogo);
 
   elementTypePropsTest(UNSTABLE_HeaderLogo);
 

--- a/packages/web-react/src/components/UNSTABLE_Truncate/__tests__/UNSTABLE_Truncate.test.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Truncate/__tests__/UNSTABLE_Truncate.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('UNSTABLE_Truncate', () => {
   restPropsTest(UNSTABLE_Truncate, 'span');
 
   validHtmlAttributesTest(UNSTABLE_Truncate);
+
+  ariaAttributesTest(UNSTABLE_Truncate);
 
   elementTypePropsTest(UNSTABLE_Truncate, 'div');
 

--- a/packages/web-react/src/components/VisuallyHidden/__tests__/VisuallyHidden.test.tsx
+++ b/packages/web-react/src/components/VisuallyHidden/__tests__/VisuallyHidden.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import {
+  ariaAttributesTest,
   classNamePrefixProviderTest,
   elementTypePropsTest,
   restPropsTest,
@@ -18,6 +19,8 @@ describe('Visually Hidden', () => {
   restPropsTest(VisuallyHidden, 'span');
 
   validHtmlAttributesTest(VisuallyHidden);
+
+  ariaAttributesTest(VisuallyHidden);
 
   elementTypePropsTest(VisuallyHidden, 'div');
 

--- a/packages/web-react/src/types/button.ts
+++ b/packages/web-react/src/types/button.ts
@@ -1,7 +1,6 @@
 import { ComponentPropsWithRef, ElementType } from 'react';
 import {
   ComponentButtonColorsDictionaryType,
-  AriaLabelingProps,
   ChildrenProps,
   ClickEvents,
   EmotionColorsDictionaryType,
@@ -13,7 +12,7 @@ export type ButtonColor<C> = ComponentButtonColorsDictionaryType | EmotionColors
 export type ButtonSize<S> = SizesDictionaryType | S;
 export type ButtonType = 'button' | 'submit' | 'reset';
 
-export interface ButtonBaseProps<C = void, S = void> extends ChildrenProps, StyleProps, AriaLabelingProps, ClickEvents {
+export interface ButtonBaseProps<C = void, S = void> extends ChildrenProps, StyleProps, ClickEvents {
   /** The color of the button. */
   color?: ButtonColor<C>;
   /** Whether the button is disabled. */

--- a/packages/web-react/src/types/navigation.ts
+++ b/packages/web-react/src/types/navigation.ts
@@ -3,7 +3,6 @@ import { NavigationItem } from '../components';
 import { LinkTarget } from './link';
 import {
   AlignmentYExtendedDictionaryType,
-  AriaLabelingProps,
   ChildrenProps,
   DirectionDictionaryType,
   ShapeVariantDictionaryType,
@@ -16,7 +15,7 @@ type NonNullableShapeVariant = NonNullable<ShapeVariantDictionaryType>;
 
 export type NavigationActionVariantsType = NonNullableShapeVariant | Record<string, NonNullableShapeVariant>;
 
-export interface NavigationActionBaseProps extends ChildrenProps, StyleProps, AriaLabelingProps, TransferProps {
+export interface NavigationActionBaseProps extends ChildrenProps, StyleProps, TransferProps {
   /** NavigationAction's href attribute */
   href?: string;
   /** Whether is the NavigationAction disabled */
@@ -29,7 +28,7 @@ export interface NavigationActionBaseProps extends ChildrenProps, StyleProps, Ar
   variant?: NavigationActionVariantsType;
 }
 
-export interface NavigationAvatarBaseProps extends ChildrenProps, StyleProps, AriaLabelingProps, TransferProps {
+export interface NavigationAvatarBaseProps extends ChildrenProps, StyleProps, TransferProps {
   /** Content of the avatar, such as an image, icon, or text. */
   avatarContent: ReactElement | ReactNode;
   /** NavigationAvatar's href attribute */
@@ -70,7 +69,7 @@ export type SpiritNavigationActionProps<E extends ElementType = 'a'> = Navigatio
 export type SpiritNavigationAvatarProps<E extends ElementType = 'a'> = NavigationAvatarProps<E> &
   SpiritPolymorphicElementPropsWithRef<E, NavigationAvatarProps<E>>;
 
-export interface SpiritNavigationProps extends StyleProps, AriaLabelingProps {
+export interface SpiritNavigationProps extends StyleProps {
   children:
     | ReactElement<HTMLLIElement>
     | ReactElement<typeof NavigationItem>

--- a/packages/web-react/src/types/shared/dom.ts
+++ b/packages/web-react/src/types/shared/dom.ts
@@ -1,6 +1,0 @@
-export interface AriaLabelingProps {
-  /**
-   * Defines a string value that labels the current element.
-   */
-  ariaLabel?: string;
-}

--- a/packages/web-react/src/types/shared/index.ts
+++ b/packages/web-react/src/types/shared/index.ts
@@ -4,7 +4,6 @@ export * from './adornments';
 export * from './dialogs';
 export * from './dictionaries';
 export * from './directions';
-export * from './dom';
 export * from './dragAndDrop';
 export * from './element';
 export * from './events';

--- a/packages/web-react/tests/providerTests/ariaAttributesTest.tsx
+++ b/packages/web-react/tests/providerTests/ariaAttributesTest.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import React, { ComponentType } from 'react';
+import { getComponentName } from '../testUtils/getComponentName';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const ariaAttributesTest = (Component: ComponentType<any>, props: object = {}) => {
+  const componentName = getComponentName(Component);
+
+  test(`should render aria-label attribute for ${componentName}`, () => {
+    render(<Component {...props} aria-label="Aria Label" />);
+    const component = screen.getByLabelText('Aria Label');
+
+    expect(component).toBeInTheDocument();
+  });
+};

--- a/packages/web-react/tests/providerTests/index.ts
+++ b/packages/web-react/tests/providerTests/index.ts
@@ -1,3 +1,4 @@
+export * from './ariaAttributesTest';
 export * from './classNamePrefixProviderTest';
 export * from './dictionaryPropsTest';
 export * from './elementTypePropsTest';

--- a/packages/web-react/tests/providerTests/validHtmlAttributesTest.tsx
+++ b/packages/web-react/tests/providerTests/validHtmlAttributesTest.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import { htmlElementAttributes } from 'html-element-attributes';
 import React, { ComponentType } from 'react';
+import { getComponentName } from '../testUtils/getComponentName';
 
 const globalAttributes = [...htmlElementAttributes['*'], 'role'];
 
@@ -34,7 +35,7 @@ const validateHTMLForComponent = (container: HTMLElement) => {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const validHtmlAttributesTest = (Component: ComponentType<any>, props: object = {}) => {
-  const componentName = Component.displayName || Component.name || Component.spiritComponent || 'UnknownComponent';
+  const componentName = getComponentName(Component);
 
   test(`should render valid HTML for ${componentName}`, () => {
     const { container } = render(<Component {...props} />);

--- a/packages/web-react/tests/testUtils/getComponentName.ts
+++ b/packages/web-react/tests/testUtils/getComponentName.ts
@@ -1,0 +1,8 @@
+import { ComponentType } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const getComponentName = (Component: ComponentType<any>): string => {
+  const componentName = Component.displayName || Component.name || Component.spiritComponent || 'UnknownComponent';
+
+  return componentName;
+};

--- a/packages/web-react/tests/testUtils/index.ts
+++ b/packages/web-react/tests/testUtils/index.ts
@@ -1,3 +1,4 @@
+export * from './getComponentName';
 export * from './renderWithHeaderContext';
 export * from './withHeaderContext';
 export * from './withHeader';


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

https://jira.almacareer.tech/browse/DS-1879
<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
