### PR TITLE
Feat(web): Introduce sizes for `Select`, `TextArea`, and `TextField` #DS-1689

### DIFF
--- a/apps/demo/partials/themeSwitcher.hbs
+++ b/apps/demo/partials/themeSwitcher.hbs
@@ -1,4 +1,4 @@
-<div class="Select Select--fluid">
+<div class="Select Select--medium Select--fluid">
   <label for="{{id}}" class="Select__label {{#if isLabelHidden }}Select__label--hidden{{/if}}">Theme</label>
   <div class="Select__inputContainer">
     <select id="{{id}}" name="theme" class="Select__input" onchange="switchTheme(event)" autocomplete="off">

--- a/packages/web/DEPRECATIONS.md
+++ b/packages/web/DEPRECATIONS.md
@@ -23,6 +23,16 @@ The direction values `row` and `column` were removed, please use `horizontal` an
 - `<div class="Flex Flex--row" />` → `<div class="Flex Flex--horizontal" />`
 - `<div class="Flex Flex--column" />` → `<div class="Flex Flex--vertical" />`
 
+### Form Fields
+
+Form fields now support the `size` property. Ensure that a size is set for all form fields. The default size is `medium`.
+
+#### Migration Guide
+
+- `<div class="Select"><!-- … --></div>` → `<div class="Select Select--medium"><!-- … --></div>`
+- `<div class="TextArea"><!-- … --></div>` → `<div class="TextArea TextArea--medium"><!-- … --></div>`
+- `<div class="TextField"><!-- … --></div>` → `<div class="TextField TextField--medium"><!-- … --></div>`
+
 ### Header
 
 The `Header` component was removed, please use `UNSTABLE_Header` component instead.

--- a/packages/web/src/js/__tests__/AutoResize.test.ts
+++ b/packages/web/src/js/__tests__/AutoResize.test.ts
@@ -14,7 +14,7 @@ describe('AutoResize', () => {
 
   beforeEach(() => {
     fixtureEl.innerHTML = `
-      <div class="TextArea" data-spirit-toggle="autoResize">
+      <div class="TextArea TextArea--medium" data-spirit-toggle="autoResize">
         <label for="textarea" class="TextArea__label">Label</label>
         <textarea id="textarea" class="TextArea__input">Test content</textarea>
       </div>

--- a/packages/web/src/scss/components/Drawer/index.html
+++ b/packages/web/src/scss/components/Drawer/index.html
@@ -110,7 +110,7 @@
                 </label>
               </div>
             </div>
-            <div class="TextArea">
+            <div class="TextArea TextArea--medium">
               <label for="drawer-content" class="TextArea__label">Drawer content</label>
               <textarea name="content" class="TextArea__input" id="drawer-content">This is a Drawer content.</textarea>
             </div>

--- a/packages/web/src/scss/components/FieldGroup/README.md
+++ b/packages/web/src/scss/components/FieldGroup/README.md
@@ -119,7 +119,7 @@ disabled styling on all elements.
   <legend class="accessibility-hidden">Label</legend>
   <div class="FieldGroup__label" aria-hidden="true">Label</div>
   <div class="FieldGroup__fields">
-    <div class="TextField TextField--disabled">
+    <div class="TextField TextField--medium TextField--disabled">
       <label for="text-field" class="TextField__label">Label</label>
       <input type="text" id="text-field" class="TextField__input" name="textField" placeholder="Placeholder" disabled />
     </div>

--- a/packages/web/src/scss/components/Footer/README.md
+++ b/packages/web/src/scss/components/Footer/README.md
@@ -221,7 +221,7 @@ Responsive values can be defined using the `tablet` and `desktop` infixes.
       </ul>
       <!-- Language switch -->
       <div class="text-desktop-right">
-        <div class="Select">
+        <div class="Select Select--medium">
           <label for="select-language" class="Select__label Select__label--hidden">Language</label>
           <div class="Select__inputContainer">
             <select id="select-language" name="language" class="Select__input">

--- a/packages/web/src/scss/components/Footer/index.html
+++ b/packages/web/src/scss/components/Footer/index.html
@@ -227,7 +227,7 @@
 
           <!-- Language switch -->
           <div class="text-desktop-right">
-            <div class="Select">
+            <div class="Select Select--medium">
               <label for="select-language" class="Select__label Select__label--hidden">Language</label>
               <div class="Select__inputContainer">
                 <select id="select-language" name="language" class="Select__input">
@@ -555,7 +555,7 @@
 
           <!-- Language switch -->
           <div class="GridItem text-desktop-right" style="--grid-item-column-start-desktop: 11; --grid-item-column-end-desktop: 13;">
-            <div class="Select Select--fluid">
+            <div class="Select Select--medium Select--fluid">
               <label for="select-language-minimalistic" class="Select__label Select__label--hidden">Language</label>
               <div class="Select__inputContainer">
                 <select id="select-language-minimalistic" name="language" class="Select__input">

--- a/packages/web/src/scss/components/Modal/index.html
+++ b/packages/web/src/scss/components/Modal/index.html
@@ -239,9 +239,9 @@
           <!-- ModalBody: start -->
           <div class="ModalBody">
             <!-- Content: start -->
-            <div class="TextField mb-400">
+            <div class="TextField TextField--medium mb-400">
               <label for="text-field" class="TextField__label">Label</label>
-              <input type="text" id="text-field" class="TextField__input" placeholder="TextField" />
+              <input type="text" id="text-field" class="TextField__input" placeholder="TextField TextField--medium" />
             </div>
             <p>
               The primary action is a button with <code>type="submit"</code> and closes the dialog on submission.

--- a/packages/web/src/scss/components/Select/README.md
+++ b/packages/web/src/scss/components/Select/README.md
@@ -3,7 +3,7 @@
 Basic usage:
 
 ```html
-<div class="Select">
+<div class="Select Select--medium">
   <label for="select-simple" class="Select__label">Label</label>
   <div class="Select__inputContainer">
     <select id="select-simple" name="simple" class="Select__input">
@@ -19,10 +19,59 @@ Basic usage:
 </div>
 ```
 
+Sizes:
+
+```html
+<div class="Select Select--small">
+  <label for="select-size-small" class="Select__label">Small</label>
+  <div class="Select__inputContainer">
+    <select id="select-size-small" name="size-small" class="Select__input">
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+    </select>
+    <div class="Select__icon">
+      <svg width="24" height="24" aria-hidden="true">
+        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+      </svg>
+    </div>
+  </div>
+</div>
+
+<div class="Select Select--medium">
+  <label for="select-size-medium" class="Select__label">Medium (default)</label>
+  <div class="Select__inputContainer">
+    <select id="select-size-medium" name="size-medium" class="Select__input">
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+    </select>
+    <div class="Select__icon">
+      <svg width="24" height="24" aria-hidden="true">
+        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+      </svg>
+    </div>
+  </div>
+</div>
+
+<div class="Select Select--large">
+  <label for="select-size-large" class="Select__label">Large</label>
+  <div class="Select__inputContainer">
+    <select id="select-size-large" name="size-large" class="Select__input">
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+    </select>
+    <div class="Select__icon">
+      <svg width="24" height="24" aria-hidden="true">
+        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+      </svg>
+    </div>
+  </div>
+</div>
+```
+
 Required select (requires a placeholder option):
 
 ```html
-<div class="Select">
+<div class="Select Select--medium">
   <label for="select-simple" class="Select__label Select__label--required">Label</label>
   <div class="Select__inputContainer">
     <select id="select-simple" name="simple" class="Select__input" required>
@@ -42,7 +91,7 @@ Required select (requires a placeholder option):
 Hidden label:
 
 ```html
-<div class="Select">
+<div class="Select Select--medium">
   <label for="select-hidden-label" class="Select__label Select__label--hidden">Label</label>
   <div class="Select__inputContainer">
     <select id="select-hidden-label" name="hiddenLabel" class="Select__input">
@@ -69,7 +118,7 @@ until the user picks a real option, not the placeholder. This makes
 sure users give all needed details before sending the form.
 
 ```html
-<div class="Select">
+<div class="Select Select--medium">
   <label for="select-placeholder" class="Select__label">Label</label>
   <div class="Select__inputContainer">
     <select id="select-placeholder" name="placeholder" class="Select__input">
@@ -85,7 +134,7 @@ sure users give all needed details before sending the form.
   </div>
 </div>
 
-<div class="Select">
+<div class="Select Select--medium">
   <label for="select-placeholder-disabled" class="Select__label Select__label--required">Label</label>
   <div class="Select__inputContainer">
     <select id="select-placeholder-disabled" name="placeholderDisabled" class="Select__input" required>
@@ -105,7 +154,7 @@ sure users give all needed details before sending the form.
 Fluid width:
 
 ```html
-<div class="Select Select--fluid">
+<div class="Select Select--medium Select--fluid">
   <label for="select-fluid" class="Select__label">Label</label>
   <div class="Select__inputContainer">
     <select id="select-fluid" name="fluid" class="Select__input">
@@ -124,7 +173,7 @@ Fluid width:
 Usage with helper text:
 
 ```html
-<div class="Select">
+<div class="Select Select--medium">
   <label for="select-helper-text" class="Select__label">Label</label>
   <div class="Select__inputContainer">
     <select id="select-helper-text" name="helperText" class="Select__input">
@@ -152,7 +201,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
 - To render validation text with an icon, add `<svg>` icon inside of `.Select__validationText`.
 
 ```html
-<div class="Select Select--success">
+<div class="Select Select--medium Select--success">
   <label for="select-success" class="Select__label">Label</label>
   <div class="Select__inputContainer">
     <select id="select-success" name="success" class="Select__input">
@@ -167,7 +216,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
   </div>
 </div>
 
-<div class="Select Select--warning">
+<div class="Select Select--medium Select--warning">
   <label for="select-warning" class="Select__label">Label</label>
   <div class="Select__inputContainer">
     <select id="select-warning" name="warning" class="Select__input">
@@ -183,7 +232,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
   <div class="Select__validationText">Validation text</div>
 </div>
 
-<div class="Select Select--danger">
+<div class="Select Select--medium Select--danger">
   <label for="select-danger" class="Select__label">Label</label>
   <div class="Select__inputContainer">
     <select id="select-danger" name="danger" class="Select__input">
@@ -204,7 +253,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
   </div>
 </div>
 
-<div class="Select Select--warning">
+<div class="Select Select--medium Select--warning">
   <label for="select-warning" class="Select__label">Label</label>
   <div class="Select__inputContainer">
     <select id="select-warning" name="warning" class="Select__input">
@@ -238,7 +287,7 @@ attribute. This way your JS remains disconnected from CSS that may or may not be
 components mix CSS with JS by design and handle prefixes their own way.**
 
 ```html
-<div class="Select has-danger">
+<div class="Select Select--medium has-danger">
   <label for="select-js-validation" class="Select__label">Label</label>
   <div class="Select__inputContainer">
     <select id="select-js-validation" name="jsValidation" class="Select__input">
@@ -262,7 +311,7 @@ be marked by adding `Select--disabled` modifier class, or with `is-disabled`
 JS interaction class when controlled by JavaScript:
 
 ```html
-<div class="Select Select--disabled">
+<div class="Select Select--medium Select--disabled">
   <label for="select-disabled" class="Select__label">Label</label>
   <div class="Select__inputContainer">
     <select id="select-disabled" name="disabled" class="Select__input" disabled>
@@ -276,7 +325,7 @@ JS interaction class when controlled by JavaScript:
     </div>
   </div>
 </div>
-<div class="Select is-disabled">
+<div class="Select Select--medium is-disabled">
   <label for="select-is-disabled" class="Select__label">Label</label>
   <div class="Select__inputContainer">
     <select id="select-is-disabled" name="isDisabled" class="Select__input" disabled>

--- a/packages/web/src/scss/components/Select/_Select.scss
+++ b/packages/web/src/scss/components/Select/_Select.scss
@@ -1,9 +1,11 @@
 // 1. Calculate select end padding to cover the space occupied by the icon.
+// 2. Tweak the input line height of `small` Select size to align the text vertically within the input.
 
 @use 'sass:map';
 @use '@tokens' as tokens;
 @use '../../settings/cursors';
 @use '../../settings/form-fields' as form-fields-settings;
+@use '../../tools/dictionaries';
 @use '../../tools/form-fields' as form-fields-tools;
 @use '../../tools/reset';
 @use '../../tools/string' as spirit-string;
@@ -54,8 +56,18 @@ $_field-name: 'Select';
 
     // 1.
     padding-inline-end: calc(
-        #{map.get(form-fields-settings.$input-typography, mobile, font-size) *
-            map.get(form-fields-settings.$input-typography, mobile, line-height)} +
+        var(
+                --#{tokens.$css-variable-prefix}#{spirit-string.convert-pascal-case-to-kebab-case(
+                        $_field-name
+                    )}-input-font-size,
+                map.get(form-fields-settings.$box-field-input-fallback-typography, mobile, font-size)
+            ) *
+            var(
+                --#{tokens.$css-variable-prefix}#{spirit-string.convert-pascal-case-to-kebab-case(
+                        $_field-name
+                    )}-input-line-height,
+                map.get(form-fields-settings.$box-field-input-fallback-typography, mobile, line-height)
+            ) +
             (2 * #{form-fields-settings.$box-field-input-padding-y}) +
             #{form-fields-settings.$box-field-input-padding-x}
     );
@@ -82,7 +94,18 @@ $_field-name: 'Select';
     @include form-fields-tools.helper-text();
 }
 
+@include dictionaries.generate-sizes(
+    $class-name: $_field-name,
+    $dictionary-values: form-fields-settings.$box-field-size-dictionary,
+    $config: form-fields-settings.$box-field-size-config,
+    $infix: 'input'
+);
 @include form-fields-tools.input-field-validation-states($_field-name);
+
+// 2.
+.Select--small {
+    --#{tokens.$css-variable-prefix}select-input-line-height: 1.3;
+}
 
 .Select--disabled > .Select__label {
     @include form-fields-tools.label-disabled();

--- a/packages/web/src/scss/components/Select/index.html
+++ b/packages/web/src/scss/components/Select/index.html
@@ -8,7 +8,7 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="Select">
+      <div class="Select Select--medium">
         <label for="select-simple" class="Select__label">Label</label>
         <div class="Select__inputContainer">
           <select id="select-simple" name="default" class="Select__input">
@@ -33,11 +33,75 @@
 
   <div class="Container">
 
+    <h2 class="docs-Heading">Sizes</h2>
+
+    <div class="docs-Stack docs-Stack--stretch">
+      <div class="Grid Grid--cols-1 Grid--desktop--cols-3">
+
+        <div class="Select Select--small">
+          <label for="select-size-small" class="Select__label">Small</label>
+          <div class="Select__inputContainer">
+            <select id="select-size-small" name="size-small" class="Select__input">
+              <option value="1">Option 1</option>
+              <option value="2">Option 2</option>
+            </select>
+            <div class="Select__icon">
+              <svg width="24" height="24" aria-hidden="true">
+                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+              </svg>
+            </div>
+          </div>
+          <div class="Select__helperText">Helper text</div>
+        </div>
+
+        <div class="Select Select--medium">
+          <label for="select-size-medium" class="Select__label">Medium (default)</label>
+          <div class="Select__inputContainer">
+            <select id="select-size-medium" name="size-medium" class="Select__input">
+              <option value="1">Option 1</option>
+              <option value="2">Option 2</option>
+            </select>
+            <div class="Select__icon">
+              <svg width="24" height="24" aria-hidden="true">
+                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+              </svg>
+            </div>
+          </div>
+          <div class="Select__helperText">Helper text</div>
+        </div>
+
+        <div class="Select Select--large">
+          <label for="select-size-large" class="Select__label">Large</label>
+          <div class="Select__inputContainer">
+            <select id="select-size-large" name="size-large" class="Select__input">
+              <option value="1">Option 1</option>
+              <option value="2">Option 2</option>
+            </select>
+            <div class="Select__icon">
+              <svg width="24" height="24" aria-hidden="true">
+                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+              </svg>
+            </div>
+          </div>
+          <div class="Select__helperText">Helper text</div>
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+
+</section>
+
+<section class="py-900 py-tablet-1000">
+
+  <div class="Container">
+
     <h2 class="docs-Heading">Required with Placeholder</h2>
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="Select">
+      <div class="Select Select--medium">
         <label for="select-required" class="Select__label Select__label--required">Label</label>
         <div class="Select__inputContainer">
           <select id="select-required" name="required" class="Select__input" required>
@@ -67,7 +131,7 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="Select">
+      <div class="Select Select--medium">
         <label for="select-hidden-label" class="Select__label Select__label--hidden">Label</label>
         <div class="Select__inputContainer">
           <select id="select-hidden-label" name="hiddenLabel" class="Select__input">
@@ -96,7 +160,7 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="Select">
+      <div class="Select Select--medium">
         <label for="select-placeholder" class="Select__label">Label</label>
         <div class="Select__inputContainer">
           <select id="select-placeholder" name="placeholder" class="Select__input">
@@ -112,7 +176,7 @@
         </div>
       </div>
 
-      <div class="Select">
+      <div class="Select Select--medium">
         <label for="select-placeholder-disabled" class="Select__label Select__label--required">Label</label>
         <div class="Select__inputContainer">
           <select id="select-placeholder-disabled" name="placeholderDisabled" class="Select__input" required>
@@ -142,7 +206,7 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="Select">
+      <div class="Select Select--medium">
         <label for="select-helper-text" class="Select__label">Label</label>
         <div class="Select__inputContainer">
           <select id="select-helper-text" name="helperText" class="Select__input">
@@ -172,7 +236,7 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="Select Select--disabled">
+      <div class="Select Select--medium Select--disabled">
         <label for="select-disabled" class="Select__label">Label</label>
         <div class="Select__inputContainer">
           <select id="select-disabled" name="disabled" class="Select__input" disabled>
@@ -201,7 +265,7 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="Select Select--success">
+      <div class="Select Select--medium Select--success">
         <label for="select-success" class="Select__label">Label</label>
         <div class="Select__inputContainer">
           <select id="select-success" name="success" class="Select__input">
@@ -216,7 +280,7 @@
         </div>
       </div>
 
-      <div class="Select Select--warning">
+      <div class="Select Select--medium Select--warning">
         <label for="select-warning" class="Select__label">Label</label>
         <div class="Select__inputContainer">
           <select id="select-warning" name="warning" class="Select__input">
@@ -232,7 +296,7 @@
         <div class="Select__validationText">Validation text</div>
       </div>
 
-      <div class="Select Select--danger">
+      <div class="Select Select--medium Select--danger">
         <label for="select-danger" class="Select__label">Label</label>
         <div class="Select__inputContainer">
           <select id="select-danger" name="danger" class="Select__input">
@@ -267,7 +331,7 @@
       {{setVar "states" "success" "warning" "danger" }}
       {{#each @root.states as |state|}}
 
-      <div class="Select Select--{{state}}">
+      <div class="Select Select--medium Select--{{state}}">
         <label for="select-{{state}}-icon" class="Select__label">Label</label>
         <div class="Select__inputContainer">
           <select id="select-{{state}}-icon" name="danger" class="Select__input">
@@ -306,7 +370,7 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="Select Select--fluid">
+      <div class="Select Select--medium Select--fluid">
         <label for="select-fluid" class="Select__label">Label</label>
         <div class="Select__inputContainer">
           <select id="select-fluid" name="default" class="Select__input">

--- a/packages/web/src/scss/components/Stack/README.md
+++ b/packages/web/src/scss/components/Stack/README.md
@@ -10,11 +10,11 @@ Usage with form fields:
 
 ```html
 <div class="Stack Stack--hasSpacing">
-  <div class="TextField">
+  <div class="TextField TextField--medium">
     <label for="textfield-stack-1" class="TextField__label TextField__label--required">Label</label>
     <input type="text" id="textfield-stack-1" class="TextField__input" placeholder="Placeholder" />
   </div>
-  <div class="TextField">
+  <div class="TextField TextField--medium">
     <label for="textfield-stack-2" class="TextField__label TextField__label--required">Label</label>
     <input type="text" id="textfield-stack-2" class="TextField__input" placeholder="Placeholder" />
   </div>

--- a/packages/web/src/scss/components/Stack/index.html
+++ b/packages/web/src/scss/components/Stack/index.html
@@ -11,7 +11,7 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <div class="Stack Stack--hasSpacing">
-        <div class="TextField">
+        <div class="TextField TextField--medium">
           <label for="textfield-stack-1" class="TextField__label TextField__label--required">Label</label>
           <input type="text" id="textfield-stack-1" class="TextField__input" placeholder="Placeholder" />
         </div>

--- a/packages/web/src/scss/components/TextArea/README.md
+++ b/packages/web/src/scss/components/TextArea/README.md
@@ -3,16 +3,35 @@
 Basic usage:
 
 ```html
-<div class="TextArea">
+<div class="TextArea TextArea--medium">
   <label for="text-area-default" class="TextArea__label">Label</label>
   <textarea id="text-area-default" class="TextArea__input" name="default" placeholder="Placeholder"></textarea>
+</div>
+```
+
+Sizes:
+
+```html
+<div class="TextArea TextArea--small">
+  <label for="text-area-size-small" class="TextArea__label">Small</label>
+  <textarea id="text-area-size-small" class="TextArea__input" name="size-small" placeholder="Placeholder"></textarea>
+</div>
+
+<div class="TextArea TextArea--medium">
+  <label for="text-area-size-medium" class="TextArea__label">Medium (default)</label>
+  <textarea id="text-area-size-medium" class="TextArea__input" name="size-medium" placeholder="Placeholder"></textarea>
+</div>
+
+<div class="TextArea TextArea--large">
+  <label for="text-area-size-large" class="TextArea__label">Large</label>
+  <textarea id="text-area-size-large" class="TextArea__input" name="size-large" placeholder="Placeholder"></textarea>
 </div>
 ```
 
 Required textarea:
 
 ```html
-<div class="TextArea">
+<div class="TextArea TextArea--medium">
   <label for="text-area-required" class="TextArea__label TextArea__label--required">Label</label>
   <textarea id="text-area-required" class="TextArea__input" name="required" placeholder="Placeholder"></textarea>
 </div>
@@ -21,7 +40,7 @@ Required textarea:
 Hidden label:
 
 ```html
-<div class="TextArea">
+<div class="TextArea TextArea--medium">
   <label for="text-area-hidden-label" class="TextArea__label TextArea__label--hidden">Hidden Label</label>
   <textarea id="text-area-hidden-label" class="TextArea__input" name="hiddenLabel" placeholder="Placeholder">
 Filled</textarea
@@ -32,7 +51,7 @@ Filled</textarea
 Fluid width:
 
 ```html
-<div class="TextArea TextArea--fluid">
+<div class="TextArea TextArea--medium TextArea--fluid">
   <label for="text-area-fluid" class="TextArea__label">Label</label>
   <textarea id="text-area-fluid" class="TextArea__input" name="fluid" placeholder="Placeholder"></textarea>
 </div>
@@ -41,7 +60,7 @@ Fluid width:
 Helper text:
 
 ```html
-<div class="TextArea">
+<div class="TextArea TextArea--medium">
   <label for="text-area-helper-text" class="TextArea__label">Label</label>
   <textarea id="text-area-helper-text" class="TextArea__input" name="helperText" placeholder="Placeholder"></textarea>
   <div class="TextArea__helperText">Helper text</div>
@@ -57,7 +76,7 @@ There are several ways to adjust the textarea width:
 The number of visible text lines for the control. Supported values are positive integers from `3` up.
 
 ```html
-<div class="TextArea">
+<div class="TextArea TextArea--medium">
   <label for="text-area-rows" class="TextArea__label">Label</label>
   <textarea id="text-area-rows" class="TextArea__input" rows="3" name="rows"></textarea>
 </div>
@@ -84,7 +103,7 @@ plugins.
 Then you need to add data attribute `data-spirit-toggle="autoResize"` to the component.
 
 ```html
-<div class="TextArea" data-spirit-toggle="autoResize">
+<div class="TextArea TextArea--medium" data-spirit-toggle="autoResize">
   <label for="text-area-auto-resize" class="TextArea__label">Label of auto-resizing TextArea</label>
   <textarea id="text-area-auto-resize" class="TextArea__input" name="autoResize"></textarea>
 </div>
@@ -101,13 +120,13 @@ a JS interaction class when controlled by JavaScript (`has-success`,
 - To render validation text with an icon, add `<svg>` icon inside of `.TextArea__validationText`.
 
 ```html
-<div class="TextArea TextArea--danger">
+<div class="TextArea TextArea--medium TextArea--danger">
   <label for="text-area-danger" class="TextArea__label">Label</label>
   <textarea id="text-area-danger" class="TextArea__input" name="danger" placeholder="Placeholder">Filled</textarea>
   <div class="TextArea__validationText">Danger validation text</div>
 </div>
 
-<div class="TextArea has-danger">
+<div class="TextArea TextArea--medium has-danger">
   <label for="text-area-danger-has-danger" class="TextArea__label">Label</label>
   <textarea id="text-area-danger-has-danger" class="TextArea__input" name="hasDanger" placeholder="Placeholder">
     Filled
@@ -122,7 +141,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
   </ul>
 </div>
 
-<div class="TextArea has-warning">
+<div class="TextArea TextArea--medium has-warning">
   <label for="text-area-danger-has-warning" class="TextArea__label">Label</label>
   <textarea id="text-area-danger-has-warning" class="TextArea__input" name="hasDanger" placeholder="Placeholder">
     Filled
@@ -148,7 +167,7 @@ attribute. This way your JS remains disconnected from CSS that may or may not be
 components mix CSS with JS by design and handle prefixes their own way.**
 
 ```html
-<div class="TextArea has-danger">
+<div class="TextArea TextArea--medium has-danger">
   <label for="text-area-js-validation" class="TextArea__label">Label</label>
   <textarea id="text-area-js-validation" class="TextArea__input" name="jsValidation" placeholder="Placeholder">
 Filled</textarea
@@ -164,7 +183,7 @@ be marked by adding `TextArea--disabled` modifier class, or with `is-disabled`
 JS interaction class when controlled by JavaScript:
 
 ```html
-<div class="TextArea TextArea--disabled">
+<div class="TextArea TextArea--medium TextArea--disabled">
   <label for="text-area-disabled" class="TextArea__label">Label</label>
   <textarea
     id="text-area-disabled"
@@ -174,7 +193,7 @@ JS interaction class when controlled by JavaScript:
     disabled
   ></textarea>
 </div>
-<div class="TextArea TextArea--disabled">
+<div class="TextArea TextArea--medium TextArea--disabled">
   <label for="text-area-disabled-filled" class="TextArea__label">Label</label>
   <textarea
     id="text-area-disabled-filled"

--- a/packages/web/src/scss/components/TextArea/_TextArea.scss
+++ b/packages/web/src/scss/components/TextArea/_TextArea.scss
@@ -1,5 +1,7 @@
 @use 'sass:map';
 @use '@tokens' as tokens;
+@use '../../settings/form-fields' as form-fields-settings;
+@use '../../tools/dictionaries';
 @use '../../tools/form-fields' as form-fields-tools;
 @use '../../tools/string' as spirit-string;
 @use 'theme';
@@ -49,6 +51,12 @@ $_field-name: 'TextArea';
     @include form-fields-tools.helper-text();
 }
 
+@include dictionaries.generate-sizes(
+    $class-name: $_field-name,
+    $dictionary-values: form-fields-settings.$box-field-size-dictionary,
+    $config: theme.$input-size-config,
+    $infix: 'input'
+);
 @include form-fields-tools.input-field-validation-states($_field-name);
 
 .TextArea--disabled > .TextArea__label {

--- a/packages/web/src/scss/components/TextArea/index.html
+++ b/packages/web/src/scss/components/TextArea/index.html
@@ -8,12 +8,12 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextArea">
+      <div class="TextArea TextArea--medium">
         <label for="text-area-default" class="TextArea__label">Label</label>
         <textarea id="text-area-default" class="TextArea__input" name="default" placeholder="Placeholder"></textarea>
       </div>
 
-      <div class="TextArea">
+      <div class="TextArea TextArea--medium">
         <label for="text-area-filled" class="TextArea__label">Label</label>
         <textarea id="text-area-filled" class="TextArea__input" name="defaultFilled" placeholder="Placeholder">Filled</textarea>
       </div>
@@ -28,11 +28,45 @@
 
   <div class="Container">
 
+    <h2 class="docs-Heading">Sizes</h2>
+
+    <div class="docs-Stack docs-Stack--stretch">
+      <div class="Grid Grid--cols-1 Grid--desktop--cols-3">
+
+        <div class="TextArea TextArea--small">
+          <label for="text-area-size-small" class="TextArea__label">Small</label>
+          <textarea id="text-area-size-small" class="TextArea__input" name="size-small" placeholder="Placeholder"></textarea>
+          <div class="TextArea__helperText">Helper text</div>
+        </div>
+
+        <div class="TextArea TextArea--medium">
+          <label for="text-area-size-medium" class="TextArea__label">Medium (default)</label>
+          <textarea id="text-area-size-medium" class="TextArea__input" name="size-medium" placeholder="Placeholder"></textarea>
+          <div class="TextArea__helperText">Helper text</div>
+        </div>
+
+        <div class="TextArea TextArea--large">
+          <label for="text-area-size-large" class="TextArea__label">Large</label>
+          <textarea id="text-area-size-large" class="TextArea__input" name="size-large" placeholder="Placeholder"></textarea>
+          <div class="TextArea__helperText">Helper text</div>
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+
+</section>
+
+<section class="py-900 py-tablet-1000">
+
+  <div class="Container">
+
     <h2 class="docs-Heading">Required</h2>
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextArea">
+      <div class="TextArea TextArea--medium">
         <label for="text-area-required" class="TextArea__label TextArea__label--required">Label</label>
         <textarea id="text-area-required" class="TextArea__input" name="required" placeholder="Placeholder" required></textarea>
       </div>
@@ -51,7 +85,7 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextArea">
+      <div class="TextArea TextArea--medium">
         <label for="text-area-hidden-label" class="TextArea__label TextArea__label--hidden">Hidden Label</label>
         <textarea id="text-area-hidden-label" class="TextArea__input" name="hiddenLabel" placeholder="Placeholder"></textarea>
       </div>
@@ -70,7 +104,7 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextArea">
+      <div class="TextArea TextArea--medium">
         <label for="text-area-helper-text" class="TextArea__label">Label</label>
         <textarea id="text-area-helper-text" class="TextArea__input" name="helperText" placeholder="Placeholder"></textarea>
         <div class="TextArea__helperText">Helper text</div>
@@ -90,12 +124,12 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextArea TextArea--disabled">
+      <div class="TextArea TextArea--medium TextArea--disabled">
         <label for="text-area-disabled" class="TextArea__label">Label</label>
         <textarea id="text-area-disabled" class="TextArea__input" name="disabled" placeholder="Placeholder" disabled></textarea>
       </div>
 
-      <div class="TextArea TextArea--disabled">
+      <div class="TextArea TextArea--medium TextArea--disabled">
         <label for="text-area-disabled-filled" class="TextArea__label TextArea__label--required">Label</label>
         <textarea id="text-area-disabled-filled" class="TextArea__input" name="disabledFilled" disabled required>Filled</textarea>
       </div>
@@ -114,18 +148,18 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextArea TextArea--success">
+      <div class="TextArea TextArea--medium TextArea--success">
         <label for="text-area-success" class="TextArea__label">Label</label>
         <textarea id="text-area-success" class="TextArea__input" name="success" placeholder="Placeholder">Filled</textarea>
       </div>
 
-      <div class="TextArea TextArea--warning">
+      <div class="TextArea TextArea--medium TextArea--warning">
         <label for="text-area-warning" class="TextArea__label">Label</label>
         <textarea id="text-area-warning" class="TextArea__input" name="warning" placeholder="Placeholder">Filled</textarea>
         <div class="TextArea__validationText">Validation text</div>
       </div>
 
-      <div class="TextArea TextArea--danger">
+      <div class="TextArea TextArea--medium TextArea--danger">
         <label for="text-area-danger" class="TextArea__label">Label</label>
         <textarea id="text-area-danger" class="TextArea__input" name="danger" placeholder="Placeholder">Filled</textarea>
         <div class="TextArea__validationText">
@@ -136,7 +170,7 @@
         </div>
       </div>
 
-      <div class="TextArea TextArea--danger">
+      <div class="TextArea TextArea--medium TextArea--danger">
         <label for="text-area-danger-with-helper-text" class="TextArea__label TextArea__label--required">Label</label>
         <textarea id="text-area-danger-with-helper-text" class="TextArea__input" placeholder="Placeholder" name="dangerWithHelperText" required>Filled</textarea>
         <div class="TextArea__helperText">This is helper text</div>
@@ -157,7 +191,7 @@
       {{setVar "states" "success" "warning" "danger" }}
       {{#each @root.states as |state|}}
 
-      <div class="TextArea TextArea--{{state}}">
+      <div class="TextArea TextArea--medium TextArea--{{state}}">
         <label for="text-area-{{state}}-with-icon"
                class="TextArea__label TextArea__label--required"
         >Label</label>
@@ -189,7 +223,7 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextArea TextArea--fluid">
+      <div class="TextArea TextArea--medium TextArea--fluid">
         <label for="text-area-fluid" class="TextArea__label">Label</label>
         <textarea id="text-area-fluid" class="TextArea__input" name="fluid" placeholder="Placeholder">Filled</textarea>
       </div>
@@ -209,7 +243,7 @@
     <div class="docs-Stack docs-Stack--start">
 
       <div style="display: flex; gap: 1rem; align-items: flex-start">
-        <div class="TextArea">
+        <div class="TextArea TextArea--medium">
           <label for="text-area-inline" class="TextArea__label TextArea__label--hidden">Hidden Label</label>
           <textarea id="text-area-inline" class="TextArea__input" name="inline" placeholder="Placeholder">Filled</textarea>
         </div>
@@ -230,7 +264,7 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextArea" data-spirit-toggle="autoResize">
+      <div class="TextArea TextArea--medium" data-spirit-toggle="autoResize">
         <label for="text-area-auto-resize" class="TextArea__label">Label</label>
         <textarea id="text-area-auto-resize" class="TextArea__input" name="autoResize"></textarea>
       </div>

--- a/packages/web/src/scss/components/TextField/README.md
+++ b/packages/web/src/scss/components/TextField/README.md
@@ -3,16 +3,41 @@
 Basic usage:
 
 ```html
-<div class="TextField">
+<div class="TextField TextField--medium">
   <label for="text-field-default" class="TextField__label">Label</label>
   <input type="text" id="text-field-default" class="TextField__input" name="default" placeholder="Placeholder" />
+</div>
+```
+
+Sizes:
+
+```html
+<div class="TextField TextField--small">
+  <label for="text-field-size-small" class="TextField__label">Small</label>
+  <input type="text" id="text-field-size-small" class="TextField__input" name="size-small" placeholder="Placeholder" />
+</div>
+
+<div class="TextField TextField--medium">
+  <label for="text-field-size-medium" class="TextField__label">Medium (default)</label>
+  <input
+    type="text"
+    id="text-field-size-medium"
+    class="TextField__input"
+    name="size-medium"
+    placeholder="Placeholder"
+  />
+</div>
+
+<div class="TextField TextField--large">
+  <label for="text-field-size-large" class="TextField__label">Large</label>
+  <input type="text" id="text-field-size-large" class="TextField__input" name="size-large" placeholder="Placeholder" />
 </div>
 ```
 
 Required input:
 
 ```html
-<div class="TextField">
+<div class="TextField TextField--medium">
   <label for="text-field-required" class="TextField__label TextField__label--required">Label</label>
   <input
     type="text"
@@ -28,7 +53,7 @@ Required input:
 Hidden label:
 
 ```html
-<div class="TextField">
+<div class="TextField TextField--medium">
   <label for="text-field-hidden-label" class="TextField__label TextField__label--hidden">Label</label>
   <input
     type="text"
@@ -43,7 +68,7 @@ Hidden label:
 Fluid width:
 
 ```html
-<div class="TextField TextField--fluid">
+<div class="TextField TextField--medium TextField--fluid">
   <label for="text-field-fluid" class="TextField__label">Label</label>
   <input
     type="text"
@@ -59,7 +84,7 @@ Fluid width:
 Helper Text:
 
 ```html
-<div class="TextField">
+<div class="TextField TextField--medium">
   <label for="text-field-helper-text" class="TextField__label">Label</label>
   <input type="text" id="text-field-helper-text" class="TextField__input" name="helperText" placeholder="Placeholder" />
   <div class="TextField__helperText">Helper text</div>
@@ -97,11 +122,11 @@ instead of default `ch`, define a `--text-field-input-width` CSS custom property
 element:
 
 ```html
-<div class="TextField">
+<div class="TextField TextField--medium">
   <label for="text-field-size" class="TextField__label">4000 (in Roman numerals)</label>
   <input type="text" size="4" id="text-field-size" class="TextField__input" name="size" placeholder="Placeholder" />
 </div>
-<div class="TextField">
+<div class="TextField TextField--medium">
   <label for="text-field-size-em" class="TextField__label">4000 (in Roman numerals)</label>
   <input
     type="text"
@@ -140,7 +165,7 @@ plugins.
 Then you need to add data attribute `data-spirit-toggle="password"` to the input.
 
 ```html
-<div class="TextField">
+<div class="TextField TextField--medium">
   <label for="text-field-password-toggle" class="TextField__label">Password Toggle</label>
   <div class="TextField__passwordToggle">
     <input
@@ -184,7 +209,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
 - To render validation text with an icon, add `<svg>` icon inside of `.TextField__validationText`.
 
 ```html
-<div class="TextField TextField--success">
+<div class="TextField TextField--medium TextField--success">
   <label for="text-field-success" class="TextField__label">Label</label>
   <input
     type="text"
@@ -196,7 +221,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
   />
 </div>
 
-<div class="TextField TextField--warning">
+<div class="TextField TextField--medium TextField--warning">
   <label for="text-field-warning" class="TextField__label">Label</label>
   <input
     type="text"
@@ -209,7 +234,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
   <div class="TextField__validationText">Validation text</div>
 </div>
 
-<div class="TextField TextField--danger">
+<div class="TextField TextField--medium TextField--danger">
   <label for="text-field-danger" class="TextField__label">Label</label>
   <input
     type="text"
@@ -227,7 +252,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
   </div>
 </div>
 
-<div class="TextField TextField--warning">
+<div class="TextField TextField--medium TextField--warning">
   <label for="text-field-warning-validation-icon" class="TextField__label">Label</label>
   <input
     type="text"
@@ -258,7 +283,7 @@ attribute. This way your JS remains disconnected from CSS that may or may not be
 components mix CSS with JS by design and handle prefixes their own way.**
 
 ```html
-<div class="TextField has-danger">
+<div class="TextField TextField--medium has-danger">
   <label for="text-field-has-danger" class="TextField__label">Label</label>
   <input
     type="text"
@@ -279,7 +304,7 @@ be marked by adding `TextField--disabled` modifier class, or with `is-disabled`
 JS interaction class when controlled by JavaScript:
 
 ```html
-<div class="TextField TextField--disabled">
+<div class="TextField TextField--medium TextField--disabled">
   <label for="text-field-disabled" class="TextField__label">Label</label>
   <input
     type="text"
@@ -291,7 +316,7 @@ JS interaction class when controlled by JavaScript:
   />
 </div>
 
-<div class="TextField TextField--disabled">
+<div class="TextField TextField--medium TextField--disabled">
   <label for="text-field-disabled-filled" class="TextField__label TextField__label--required">Label</label>
   <input
     type="text"

--- a/packages/web/src/scss/components/TextField/_TextField.scss
+++ b/packages/web/src/scss/components/TextField/_TextField.scss
@@ -18,6 +18,7 @@
 @use '@tokens' as tokens;
 @use '../../settings/cursors';
 @use '../../settings/form-fields' as form-fields-settings;
+@use '../../tools/dictionaries';
 @use '../../tools/form-fields' as form-fields-tools;
 @use '../../tools/reset';
 @use '../../tools/string' as spirit-string;
@@ -181,6 +182,12 @@ $_field-name: 'TextField';
     @include form-fields-tools.helper-text();
 }
 
+@include dictionaries.generate-sizes(
+    $class-name: $_field-name,
+    $dictionary-values: form-fields-settings.$box-field-size-dictionary,
+    $config: form-fields-settings.$box-field-size-config,
+    $infix: 'input'
+);
 @include form-fields-tools.input-field-validation-states($_field-name);
 
 .TextField--disabled > .TextField__label {

--- a/packages/web/src/scss/components/TextField/index.html
+++ b/packages/web/src/scss/components/TextField/index.html
@@ -8,17 +8,17 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextField">
+      <div class="TextField TextField--medium">
         <label for="text-field-default" class="TextField__label">Label</label>
         <input type="text" id="text-field-default" class="TextField__input" name="default" placeholder="Placeholder" />
       </div>
 
-      <div class="TextField">
+      <div class="TextField TextField--medium">
         <label for="text-field-filled" class="TextField__label">Label</label>
         <input type="text" id="text-field-filled" class="TextField__input" name="filled" placeholder="Placeholder" value="Filled" />
       </div>
 
-      <div class="TextField">
+      <div class="TextField TextField--medium">
         <label for="text-field-password" class="TextField__label">Label</label>
         <input type="password" id="text-field-password" class="TextField__input" name="password" placeholder="Placeholder" value="Filled" />
       </div>
@@ -33,11 +33,45 @@
 
   <div class="Container">
 
+    <h2 class="docs-Heading">Sizes</h2>
+
+    <div class="docs-Stack docs-Stack--stretch">
+      <div class="Grid Grid--cols-1 Grid--desktop--cols-3">
+
+        <div class="TextField TextField--small">
+          <label for="text-field-size-small" class="TextField__label">Small</label>
+          <input type="text" id="text-field-size-small" class="TextField__input" name="size-small" placeholder="Placeholder" />
+          <div class="TextField__helperText">Helper text</div>
+        </div>
+
+        <div class="TextField TextField--medium">
+          <label for="text-field-size-medium" class="TextField__label">Medium (default)</label>
+          <input type="text" id="text-field-size-medium" class="TextField__input" name="size-medium" placeholder="Placeholder" />
+          <div class="TextField__helperText">Helper text</div>
+        </div>
+
+        <div class="TextField TextField--large">
+          <label for="text-field-size-large" class="TextField__label">Large</label>
+          <input type="text" id="text-field-size-large" class="TextField__input" name="size-large" placeholder="Placeholder" />
+          <div class="TextField__helperText">Helper text</div>
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+
+</section>
+
+<section class="py-900 py-tablet-1000">
+
+  <div class="Container">
+
     <h2 class="docs-Heading">Required</h2>
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextField">
+      <div class="TextField TextField--medium">
         <label for="text-field-required" class="TextField__label TextField__label--required">Label</label>
         <input type="text" id="text-field-required" class="TextField__input" name="required" placeholder="Placeholder" required />
       </div>
@@ -56,7 +90,7 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextField">
+      <div class="TextField TextField--medium">
         <label for="text-field-hidden-label" class="TextField__label TextField__label--hidden">Label</label>
         <input type="text" id="text-field-hidden-label" class="TextField__input" name="hiddenLabel" placeholder="Placeholder" />
       </div>
@@ -74,7 +108,7 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextField">
+      <div class="TextField TextField--medium">
         <label for="text-field-helper-text" class="TextField__label">Label</label>
         <input type="text" id="text-field-helper-text" class="TextField__input" name="helperText" placeholder="Placeholder" />
         <div class="TextField__helperText">Helper text</div>
@@ -94,12 +128,12 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextField TextField--disabled">
+      <div class="TextField TextField--medium TextField--disabled">
         <label for="text-field-disabled" class="TextField__label">Label</label>
         <input type="text" id="text-field-disabled" class="TextField__input" name="disabled" placeholder="Placeholder" disabled />
       </div>
 
-      <div class="TextField TextField--disabled">
+      <div class="TextField TextField--medium TextField--disabled">
         <label for="text-field-disabled-filled" class="TextField__label TextField__label--required">Label</label>
         <input
           type="text"
@@ -127,18 +161,18 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextField TextField--success">
+      <div class="TextField TextField--medium TextField--success">
         <label for="text-field-success" class="TextField__label">Label</label>
         <input type="text" id="text-field-success" class="TextField__input" name="success" placeholder="Placeholder" value="Filled" />
       </div>
 
-      <div class="TextField TextField--warning">
+      <div class="TextField TextField--medium TextField--warning">
         <label for="text-field-warning" class="TextField__label">Label</label>
         <input type="text" id="text-field-warning" class="TextField__input" name="warning" placeholder="Placeholder" value="Filled" />
         <div class="TextField__validationText">Validation text</div>
       </div>
 
-      <div class="TextField TextField--danger">
+      <div class="TextField TextField--medium TextField--danger">
         <label for="text-field-danger" class="TextField__label">Label</label>
         <input type="text" id="text-field-danger" class="TextField__input" name="danger" placeholder="Placeholder" value="Filled" />
         <div class="TextField__validationText">
@@ -149,7 +183,7 @@
         </div>
       </div>
 
-      <div class="TextField TextField--danger">
+      <div class="TextField TextField--medium TextField--danger">
         <label
           for="text-field-danger-with-helper-text"
           class="TextField__label TextField__label--required"
@@ -181,7 +215,7 @@
       {{setVar "states" "success" "warning" "danger" }}
       {{#each @root.states as |state|}}
 
-      <div class="TextField TextField--{{state}}">
+      <div class="TextField TextField--medium TextField--{{state}}">
         <label
           for="text-field-{{state}}-with-icon"
           class="TextField__label TextField__label--required"
@@ -224,7 +258,7 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextField TextField--fluid">
+      <div class="TextField TextField--medium TextField--fluid">
         <label for="text-field-fluid" class="TextField__label">Label</label>
         <input type="text" id="text-field-fluid" class="TextField__input" name="fluid" placeholder="Placeholder" value="Filled" />
       </div>
@@ -239,11 +273,11 @@
 
   <div class="Container">
 
-    <h2 class="docs-Heading">Size</h2>
+    <h2 class="docs-Heading">Input Size</h2>
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextField">
+      <div class="TextField TextField--medium">
         <label for="text-field-size" class="TextField__label">4000 (in Roman numerals)</label>
         <input type="text" size="4" id="text-field-size" class="TextField__input" name="size" placeholder="Placeholder" />
       </div>
@@ -262,7 +296,7 @@
     <div class="docs-Stack docs-Stack--start">
 
       <div style="display: flex; gap: 1rem; align-items: flex-start; max-width: 320px;">
-        <div class="TextField">
+        <div class="TextField TextField--medium">
           <label for="text-field-inline" class="TextField__label TextField__label--hidden">Hidden Label</label>
           <input type="text" id="text-field-inline" class="TextField__input" name="inline" placeholder="Placeholder" value="Filled" />
         </div>
@@ -270,11 +304,11 @@
       </div>
 
       <div style="display: flex; gap: 1rem; align-items: flex-start; max-width: 320px;">
-        <div class="TextField">
+        <div class="TextField TextField--medium">
           <label for="text-field-inline-first" class="TextField__label TextField__label--hidden">Hidden Label</label>
           <input type="text" id="text-field-inline-first" class="TextField__input" name="inlineFirst" placeholder="Placeholder" value="Filled" />
         </div>
-        <div class="TextField TextField--danger">
+        <div class="TextField TextField--medium TextField--danger">
           <label for="text-field-inline-password" class="TextField__label TextField__label--hidden">Hidden Label</label>
           <div class="TextField__passwordToggle">
             <input type="password" id="text-field-inline-password" class="TextField__input" name="inlinePassword" value="1234" />
@@ -317,7 +351,7 @@
 
     <div class="docs-Stack docs-Stack--start">
 
-      <div class="TextField">
+      <div class="TextField TextField--medium">
         <label for="text-field-password-toggle" class="TextField__label">Password Toggle</label>
         <div class="TextField__passwordToggle">
           <input
@@ -349,7 +383,7 @@
         </div>
       </div>
 
-      <div class="TextField TextField--disabled">
+      <div class="TextField TextField--medium TextField--disabled">
         <label for="text-field-password-toggle-disabled" class="TextField__label">Password Toggle</label>
         <div class="TextField__passwordToggle">
           <input

--- a/packages/web/src/scss/components/Toast/index.html
+++ b/packages/web/src/scss/components/Toast/index.html
@@ -180,7 +180,7 @@
         <fieldset style="border: 0;">
           <legend class="mb-500">New Toast:</legend>
           <div class="Stack Stack--hasSpacing">
-            <div class="Select">
+            <div class="Select Select--medium">
               <label for="toast-color" class="Select__label">Color</label>
               <div class="Select__inputContainer">
                 <select id="toast-color" name="color" class="Select__input" autocomplete="off">
@@ -218,12 +218,12 @@
                 <label class="Checkbox__label" for="toast-enable-auto-close">Enable AutoClose</label>
               </div>
             </div>
-            <div class="TextField">
+            <div class="TextField TextField--medium">
               <label for="toast-auto-close-interval" class="TextField__label">AutoClose interval (ms)</label>
               <input type="number" min="0" max="60000" step="500" value="3000" id="toast-auto-close-interval"
                      name="auto-close-interval" class="TextField__input"/>
             </div>
-            <div class="TextArea">
+            <div class="TextArea TextArea--medium">
               <label for="toast-message" class="TextArea__label">Message</label>
               <textarea id="toast-message" class="TextArea__input"
                         autocomplete="off">This is a new toast message.</textarea>
@@ -236,7 +236,7 @@
                 <label class="Checkbox__label" for="toast-enable-link">Add link</label>
               </div>
             </div>
-            <div class="TextArea">
+            <div class="TextArea TextArea--medium">
               <label for="toast-link" class="TextArea__label">Link</label>
               <textarea id="toast-link" class="TextArea__input" autocomplete="off">This is a toast link.</textarea>
               <div class="TextArea__helperText">Can contain HTML.</div>
@@ -273,7 +273,7 @@
       <form>
         <fieldset style="border: 0;">
           <legend class="mb-500">Virtual keyboard interaction:</legend>
-          <div class="TextField">
+          <div class="TextField TextField--medium">
             <label for="text-field-for-focus" class="TextField__label">In Chrome on Android, tap into this text field to
               see how Toast position updates:</label>
             <input type="text" id="text-field-for-focus" class="TextField__input" name="default" placeholder="Tap here!"/>

--- a/packages/web/src/scss/components/Tooltip/index.html
+++ b/packages/web/src/scss/components/Tooltip/index.html
@@ -525,7 +525,7 @@
           </div>
         </div>
         <div class="Grid Grid--cols-1 Grid--tablet--cols-2 mb-700">
-          <div class="Select">
+          <div class="Select Select--medium">
             <label for="my-advanced-select" class="Select__label">Suggested placement</label>
             <div class="Select__inputContainer">
               <select id="my-advanced-select" name="advanced-placement" class="Select__input">
@@ -549,7 +549,7 @@
               </div>
             </div>
           </div>
-          <div class="Select">
+          <div class="Select Select--medium">
             <label for="my-advanced-select-fallback" class="Select__label">Suggested fallback placements</label>
             <div class="Select__inputContainer">
               <select id="my-advanced-select-fallback" name="advanced-placement-fallback" class="Select__input">

--- a/packages/web/src/scss/settings/_form-fields.scss
+++ b/packages/web/src/scss/settings/_form-fields.scss
@@ -2,7 +2,6 @@
 @use 'dictionaries';
 
 // Common for all form components
-$input-typography: tokens.$body-medium-regular;
 $input-color-state-disabled: tokens.$disabled-content;
 $input-background-color: tokens.$form-field-filled-background-state-default;
 $input-background-color-state-hover: tokens.$form-field-filled-background-state-hover;
@@ -32,6 +31,7 @@ $helper-text-color-state-default: tokens.$form-field-helper-text;
 $helper-text-color-state-disabled: tokens.$disabled-content;
 
 // Inline field form components – Checkbox, Radio, etc.
+$inline-field-label-typography: tokens.$body-medium-regular;
 $inline-field-gap: tokens.$space-500;
 $inline-field-margin-y: tokens.$space-500;
 $inline-field-input-border-color-checked: tokens.$form-field-filled-border-state-selected;
@@ -45,6 +45,11 @@ $box-field-input-border-width: tokens.$border-width-100;
 $box-field-input-border-style: solid;
 $box-field-input-border-color-focus: tokens.$border-focus;
 $box-field-input-focus-shadow: tokens.$focus-ring;
+
+// @deprecated Remove typography fallback when form field sizes are mandatory.
+// Migration: delete the `$box-field-input-fallback-typography` variable.
+// https://jira.almacareer.tech/browse/DS-1884 — Remove deprecated typography mixin from form fields
+$box-field-input-fallback-typography: tokens.$body-medium-regular;
 
 $box-field-input-border-radius: tokens.$radius-300;
 $box-field-input-placeholder-color-state-default: tokens.$form-field-filled-placeholder;

--- a/packages/web/src/scss/tools/_form-fields.scss
+++ b/packages/web/src/scss/tools/_form-fields.scss
@@ -75,7 +75,7 @@
 }
 
 @mixin inline-field-label() {
-    @include typography.generate(form-fields-settings.$input-typography);
+    @include typography.generate(form-fields-settings.$inline-field-label-typography);
 
     display: block;
     color: form-fields-settings.$label-color-state-default;


### PR DESCRIPTION
## Description

New sizes introduced according to our Size Dictionary:

- `<ComponentName>--small`
- `<ComponentName>--medium` (default)
- `<ComponentName>--large`

The `medium` size exactly matches current appearance (without `size`). The `*--medium` class name does not need to be present in HTML until the next major version of `spirit-web` is released.

### Additional context

![image](https://github.com/user-attachments/assets/5bb61918-bb87-444f-a86b-e7d8bced82fc)
![image](https://github.com/user-attachments/assets/c1f7bbfb-56a4-4c17-97c7-2a7198cbabcb)
![image](https://github.com/user-attachments/assets/3ab9b5b4-8a5e-4f39-8932-9972a7d117d4)


### Issue reference

https://jira.almacareer.tech/browse/DS-1689

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
