### PR TITLE
Refactor(web): Hover background for a moment overlaps the active bg #DS-1902

### DIFF
--- a/packages/web/src/scss/components/SegmentedControl/_SegmentedControlItem.scss
+++ b/packages/web/src/scss/components/SegmentedControl/_SegmentedControlItem.scss
@@ -34,6 +34,7 @@
     @media (hover: hover) {
         :not(:checked, :disabled) + &:hover {
             background-color: theme.$item-background-hover;
+            transition: theme.$transition-hover;
         }
     }
 

--- a/packages/web/src/scss/components/SegmentedControl/_theme.scss
+++ b/packages/web/src/scss/components/SegmentedControl/_theme.scss
@@ -11,12 +11,15 @@ $border-width: tokens.$border-width-100;
 $border-radius: tokens.$radius-full;
 $transition-radio:
     transform transitions.$duration-200 transitions.$timing-eased-in-out,
-    color transitions.$duration-100 transitions.$timing-eased-in-out,
-    background-color transitions.$duration-200 transitions.$timing-eased-in-out;
+    background-color transitions.$duration-100 transitions.$timing-eased-out,
+    color transitions.$duration-100 transitions.$timing-eased-in-out;
 $transition-checkbox:
+    background-color transitions.$duration-200 transitions.$timing-eased-out,
     color transitions.$duration-200 transitions.$timing-eased-in-out,
-    border-color transitions.$duration-200 transitions.$timing-eased-in-out,
-    background-color transitions.$duration-200 transitions.$timing-eased-in-out;
+    border-color transitions.$duration-200 transitions.$timing-eased-in-out;
+$transition-hover:
+    background-color transitions.$duration-200 transitions.$timing-eased-in-out,
+    color transitions.$duration-200 transitions.$timing-eased-in-out;
 $max-items: 10;
 $focus-ring: tokens.$focus-ring;
 $fill-variant-dictionary: dictionaries.$fill-variants;


### PR DESCRIPTION

## Description

When you click on some item, the active background that slides into position is below the hover background, so the hover background for a moment, overlaps the active background.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
