### PR TITLE
Fix(web): Do not export `border-focus` as utility class

### DIFF
--- a/packages/web/src/scss/settings/_utilities.scss
+++ b/packages/web/src/scss/settings/_utilities.scss
@@ -43,7 +43,6 @@ $utilities: (
                 ),
                 (
                     basic: tokens.$border-basic,
-                    focus: tokens.$border-focus,
                 )
             ),
     ),


### PR DESCRIPTION
## Description

### Additional context

`$border-focus` token is for private usage only and should only be used within the focus state