### PR TITLE
Feat(web-twig): Introduce sizes for `Select`, `TextArea`, and `TextField` #DS-1904

### DIFF
--- a/packages/web-twig/src/Resources/components/Select/README.md
+++ b/packages/web-twig/src/Resources/components/Select/README.md
@@ -16,6 +16,28 @@ Basic example usage:
 </Select>
 ```
 
+Sizes:
+
+```twig
+<Select id="select-size-small" label="Small" name="selectSizeSmall" size="small">
+  <option value="" selected>Placeholder</option>
+  <option value="1">Option 1</option>
+  <option value="2">Option 2</option>
+</Select>
+
+<Select id="select-size-medium" label="Medium (default)" name="selectSizeMedium">
+  <option value="" selected>Placeholder</option>
+  <option value="1">Option 1</option>
+  <option value="2">Option 2</option>
+</Select>
+
+<Select id="select-size-large" label="Large" name="selectSizeLarge" size="large">
+  <option value="" selected>Placeholder</option>
+  <option value="1">Option 1</option>
+  <option value="2">Option 2</option>
+</Select>
+```
+
 Usage with `isRequired` attribute:
 
 ```twig
@@ -64,23 +86,24 @@ Without lexer:
 
 ## API
 
-| Name                    | Type                                           | Default | Required | Description                                                |
-| ----------------------- | ---------------------------------------------- | ------- | -------- | ---------------------------------------------------------- |
-| `hasValidationIcon`     | `boolean`                                      | `false` | ✕        | Whether to show validation icon                            |
-| `helperText`            | `string`                                       | `null`  | ✕        | Custom helper text                                         |
-| `id`                    | `string`                                       | —       | ✓        | Select and label identification                            |
-| `inputProps`            | `string[]`                                     | `[]`    | ✕        | Pass additional attributes to the select element           |
-| `isDisabled`            | `bool`                                         | `false` | ✕        | If true, select is disabled                                |
-| `isFluid`               | `bool`                                         | `false` | ✕        | If true, the element spans to the full width of its parent |
-| `isLabelHidden`         | `bool`                                         | `false` | ✕        | If true, label is hidden                                   |
-| `isRequired`            | `bool`                                         | `false` | ✕        | If true, select is required                                |
-| `label`                 | `string`                                       | —       | ✓\*      | Label text                                                 |
-| `name`                  | `string`                                       | `null`  | ✕        | Select name                                                |
-| `UNSAFE_helperText`     | `string`                                       | `null`  | ✕        | Unescaped custom helper text                               |
-| `UNSAFE_label`          | `string`                                       | —       | ✓\*      | Unescaped label text                                       |
-| `UNSAFE_validationText` | \[`string` \| `string[]`]                      | `null`  | ✕        | Unescaped validation text                                  |
-| `validationState`       | [Validation dictionary][dictionary-validation] | `null`  | ✕        | Type of validation state.                                  |
-| `validationText`        | \[`string` \| `string[]`]                      | `null`  | ✕        | Validation text                                            |
+| Name                    | Type                                           | Default  | Required | Description                                                |
+| ----------------------- | ---------------------------------------------- | -------- | -------- | ---------------------------------------------------------- |
+| `hasValidationIcon`     | `boolean`                                      | `false`  | ✕        | Whether to show validation icon                            |
+| `helperText`            | `string`                                       | `null`   | ✕        | Custom helper text                                         |
+| `id`                    | `string`                                       | —        | ✓        | Select and label identification                            |
+| `inputProps`            | `string[]`                                     | `[]`     | ✕        | Pass additional attributes to the select element           |
+| `isDisabled`            | `bool`                                         | `false`  | ✕        | If true, select is disabled                                |
+| `isFluid`               | `bool`                                         | `false`  | ✕        | If true, the element spans to the full width of its parent |
+| `isLabelHidden`         | `bool`                                         | `false`  | ✕        | If true, label is hidden                                   |
+| `isRequired`            | `bool`                                         | `false`  | ✕        | If true, select is required                                |
+| `label`                 | `string`                                       | —        | ✓\*      | Label text                                                 |
+| `name`                  | `string`                                       | `null`   | ✕        | Select name                                                |
+| `size`                  | [Size dictionary][dictionary-size]             | `medium` | ✕        | Size variant                                               |
+| `UNSAFE_helperText`     | `string`                                       | `null`   | ✕        | Unescaped custom helper text                               |
+| `UNSAFE_label`          | `string`                                       | —        | ✓\*      | Unescaped label text                                       |
+| `UNSAFE_validationText` | \[`string` \| `string[]`]                      | `null`   | ✕        | Unescaped validation text                                  |
+| `validationState`       | [Validation dictionary][dictionary-validation] | `null`   | ✕        | Type of validation state.                                  |
+| `validationText`        | \[`string` \| `string[]`]                      | `null`   | ✕        | Validation text                                            |
 
 (\*) The label is required for this component. Use `label` or `UNSAFE_label` to set the label.
 
@@ -88,6 +111,7 @@ On top of the API options, the components accept [additional attributes][readme-
 If you need more control over the styling of a component, you can use [style props][readme-style-props]
 and [escape hatches][readme-escape-hatches].
 
+[dictionary-size]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#size
 [dictionary-validation]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation
 [readme-additional-attributes]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/README.md#additional-attributes
 [readme-escape-hatches]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/README.md#escape-hatches

--- a/packages/web-twig/src/Resources/components/Select/Select.stories.twig
+++ b/packages/web-twig/src/Resources/components/Select/Select.stories.twig
@@ -9,6 +9,10 @@
         {% include '@components/Select/stories/SelectDefault.twig' %}
     </DocsSection>
 
+    <DocsSection title="Sizes">
+        {% include '@components/Select/stories/SelectSizes.twig' %}
+    </DocsSection>
+
     <DocsSection title="Required with Placeholder">
         {% include '@components/Select/stories/SelectRequiredWithPlaceholder.twig' %}
     </DocsSection>

--- a/packages/web-twig/src/Resources/components/Select/Select.twig
+++ b/packages/web-twig/src/Resources/components/Select/Select.twig
@@ -10,6 +10,7 @@
 {%- set _isRequired = props.isRequired | default(false) -%}
 {%- set _label = props.label | default(null) -%}
 {%- set _name = props.name | default(null) -%}
+{%- set _size = props.size | default('medium') -%}
 {%- set _unsafeHelperText = props.UNSAFE_helperText | default(null) -%}
 {%- set _unsafeLabel = props.UNSAFE_label | default(null) -%}
 {%- set _unsafeValidationText = props.UNSAFE_validationText | default(null) -%}
@@ -18,6 +19,7 @@
 
 {# Class names #}
 {%- set _rootClassName = _spiritClassPrefix ~ 'Select' -%}
+{%- set _rootSizeClassName = _spiritClassPrefix ~ 'Select--' ~ _size -%}
 {%- set _rootFluidClassName = _isFluid ? _spiritClassPrefix ~ 'Select--fluid' : null -%}
 {%- set _rootDisabledClassName = _isDisabled ? _spiritClassPrefix ~ 'Select--disabled' : null -%}
 {%- set _rootValidationStateClassName = _validationState ? _spiritClassPrefix ~ 'Select--' ~ _validationState : null -%}
@@ -32,8 +34,9 @@
 
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
-{%- set _classNames = [ _rootClassName, _rootFluidClassName, _rootDisabledClassName, _rootValidationStateClassName, _styleProps.className ] -%}
+{%- set _classNames = [ _rootClassName, _rootSizeClassName, _rootFluidClassName, _rootDisabledClassName, _rootValidationStateClassName, _styleProps.className ] -%}
 {%- set _helperTextId = _helperText or _unsafeHelperText ? _id ~ '-helper-text' : null -%}
+{%- set _iconSize = (_size == 'small') ? '16' : '20' -%}
 {%- set _labelClassNames = [ _labelClassName, _labelHiddenClassName, _labelRequiredClassName ] -%}
 {%- set _mainPropsWithoutId = props | filter((value, prop) => prop is not same as('id')) -%}
 {%- set _validationTextId = _validationText or _unsafeValidationText ? _id ~ '-validation-text' : null -%}
@@ -60,7 +63,7 @@
             {%- block content %}{% endblock -%}
         </select>
         <div class="{{ _iconClassName }}">
-            <Icon name="chevron-down" />
+            <Icon name="chevron-down" boxSize="{{ _iconSize }}" />
         </div>
     </div>
     <HelperText

--- a/packages/web-twig/src/Resources/components/Select/__tests__/__fixtures__/selectSize.twig
+++ b/packages/web-twig/src/Resources/components/Select/__tests__/__fixtures__/selectSize.twig
@@ -1,0 +1,7 @@
+{% set inputProps = { "data-validate": "true" } %}
+
+<Select id="example" name="example" label="Label" inputProps={ inputProps } size="large">
+    <option value="" selected>Placeholder</option>
+    <option value="1">Option 1</option>
+    <option value="2">Option 2</option>
+</Select>

--- a/packages/web-twig/src/Resources/components/Select/__tests__/__snapshots__/selectDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Select/__tests__/__snapshots__/selectDefault.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="Select">
+    <div class="Select Select--medium">
       <label for="example" class="Select__label">Label</label>
       <div class="Select__inputContainer">
         <select data-validate="true" id="example" name="example" class="Select__input">
@@ -20,7 +20,7 @@
           </option>
         </select>
         <div class="Select__icon">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" id="svg_558248b5050467b27d20185b3d536bbb" class="Icon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewbox="0 0 24 24" fill="none" id="svg_1832e28de2fce140dddc6fa8ecff0657" class="Icon" aria-hidden="true">
           <path d="M15.88 9.63472L12 13.5147L8.11998 9.63472C7.72998 9.24472 7.09998 9.24472 6.70998 9.63472C6.31998 10.0247 6.31998 10.6547 6.70998 11.0447L11.3 15.6347C11.69 16.0247 12.32 16.0247 12.71 15.6347L17.3 11.0447C17.69 10.6547 17.69 10.0247 17.3 9.63472C16.91 9.25472 16.27 9.24472 15.88 9.63472Z" fill="currentColor">
           </path></svg>
         </div>

--- a/packages/web-twig/src/Resources/components/Select/__tests__/__snapshots__/selectDisabled.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Select/__tests__/__snapshots__/selectDisabled.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="Select Select--disabled">
+    <div class="Select Select--medium Select--disabled">
       <label for="example" class="Select__label">Label</label>
       <div class="Select__inputContainer">
         <select id="example" name="example" class="Select__input" disabled>
@@ -20,7 +20,7 @@
           </option>
         </select>
         <div class="Select__icon">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" id="svg_558248b5050467b27d20185b3d536bbb" class="Icon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewbox="0 0 24 24" fill="none" id="svg_1832e28de2fce140dddc6fa8ecff0657" class="Icon" aria-hidden="true">
           <path d="M15.88 9.63472L12 13.5147L8.11998 9.63472C7.72998 9.24472 7.09998 9.24472 6.70998 9.63472C6.31998 10.0247 6.31998 10.6547 6.70998 11.0447L11.3 15.6347C11.69 16.0247 12.32 16.0247 12.71 15.6347L17.3 11.0447C17.69 10.6547 17.69 10.0247 17.3 9.63472C16.91 9.25472 16.27 9.24472 15.88 9.63472Z" fill="currentColor">
           </path></svg>
         </div>

--- a/packages/web-twig/src/Resources/components/Select/__tests__/__snapshots__/selectHelperText.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Select/__tests__/__snapshots__/selectHelperText.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="Select">
+    <div class="Select Select--medium">
       <label for="example" class="Select__label">Label</label>
       <div class="Select__inputContainer">
         <select id="example" name="example" class="Select__input" aria-describedby="example-helper-text">
@@ -20,7 +20,7 @@
           </option>
         </select>
         <div class="Select__icon">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" id="svg_558248b5050467b27d20185b3d536bbb" class="Icon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewbox="0 0 24 24" fill="none" id="svg_1832e28de2fce140dddc6fa8ecff0657" class="Icon" aria-hidden="true">
           <path d="M15.88 9.63472L12 13.5147L8.11998 9.63472C7.72998 9.24472 7.09998 9.24472 6.70998 9.63472C6.31998 10.0247 6.31998 10.6547 6.70998 11.0447L11.3 15.6347C11.69 16.0247 12.32 16.0247 12.71 15.6347L17.3 11.0447C17.69 10.6547 17.69 10.0247 17.3 9.63472C16.91 9.25472 16.27 9.24472 15.88 9.63472Z" fill="currentColor">
           </path></svg>
         </div>

--- a/packages/web-twig/src/Resources/components/Select/__tests__/__snapshots__/selectLabelHidden.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Select/__tests__/__snapshots__/selectLabelHidden.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="Select">
+    <div class="Select Select--medium">
       <label for="example" class="Select__label Select__label--hidden">Label</label>
       <div class="Select__inputContainer">
         <select id="example" name="example" class="Select__input">
@@ -20,7 +20,7 @@
           </option>
         </select>
         <div class="Select__icon">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" id="svg_558248b5050467b27d20185b3d536bbb" class="Icon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewbox="0 0 24 24" fill="none" id="svg_1832e28de2fce140dddc6fa8ecff0657" class="Icon" aria-hidden="true">
           <path d="M15.88 9.63472L12 13.5147L8.11998 9.63472C7.72998 9.24472 7.09998 9.24472 6.70998 9.63472C6.31998 10.0247 6.31998 10.6547 6.70998 11.0447L11.3 15.6347C11.69 16.0247 12.32 16.0247 12.71 15.6347L17.3 11.0447C17.69 10.6547 17.69 10.0247 17.3 9.63472C16.91 9.25472 16.27 9.24472 15.88 9.63472Z" fill="currentColor">
           </path></svg>
         </div>

--- a/packages/web-twig/src/Resources/components/Select/__tests__/__snapshots__/selectSize.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Select/__tests__/__snapshots__/selectSize.twig.snap.html
@@ -5,10 +5,10 @@
     </title>
   </head>
   <body>
-    <div class="Select Select--medium Select--fluid">
+    <div class="Select Select--large">
       <label for="example" class="Select__label">Label</label>
       <div class="Select__inputContainer">
-        <select id="example" name="example" class="Select__input">
+        <select data-validate="true" id="example" name="example" class="Select__input">
           <option value="" selected>
             Placeholder
           </option>

--- a/packages/web-twig/src/Resources/components/Select/__tests__/__snapshots__/selectValidationState.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/Select/__tests__/__snapshots__/selectValidationState.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="Select Select--success">
+    <div class="Select Select--medium Select--success">
       <label for="select-success" class="Select__label Select__label--required">Validation success</label>
       <div class="Select__inputContainer">
         <select id="select-success" name="select-success" class="Select__input" required="" aria-describedby="select-success-validation-text">
@@ -20,7 +20,7 @@
           </option>
         </select>
         <div class="Select__icon">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" id="svg_558248b5050467b27d20185b3d536bbb" class="Icon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewbox="0 0 24 24" fill="none" id="svg_1832e28de2fce140dddc6fa8ecff0657" class="Icon" aria-hidden="true">
           <path d="M15.88 9.63472L12 13.5147L8.11998 9.63472C7.72998 9.24472 7.09998 9.24472 6.70998 9.63472C6.31998 10.0247 6.31998 10.6547 6.70998 11.0447L11.3 15.6347C11.69 16.0247 12.32 16.0247 12.71 15.6347L17.3 11.0447C17.69 10.6547 17.69 10.0247 17.3 9.63472C16.91 9.25472 16.27 9.24472 15.88 9.63472Z" fill="currentColor">
           </path></svg>
         </div>
@@ -31,7 +31,7 @@
       </div>
     </div>
 
-    <div class="Select Select--warning">
+    <div class="Select Select--medium Select--warning">
       <label for="select-warning" class="Select__label Select__label--required">Validation warning</label>
       <div class="Select__inputContainer">
         <select id="select-warning" name="select-warning" class="Select__input" required="" aria-describedby="select-warning-validation-text">
@@ -46,8 +46,8 @@
           </option>
         </select>
         <div class="Select__icon">
-          <svg width="24" height="24" fill="none" viewbox="0 0 24 24" class="Icon" aria-hidden="true">
-          <use href="#svg_558248b5050467b27d20185b3d536bbb">
+          <svg width="20" height="20" fill="none" viewbox="0 0 20 20" class="Icon" aria-hidden="true">
+          <use href="#svg_1832e28de2fce140dddc6fa8ecff0657">
           </use></svg>
         </div>
       </div>
@@ -57,7 +57,7 @@
       </div>
     </div>
 
-    <div class="Select Select--danger">
+    <div class="Select Select--medium Select--danger">
       <label for="select-danger" class="Select__label Select__label--required">Validation danger</label>
       <div class="Select__inputContainer">
         <select id="select-danger" name="select-danger" class="Select__input" required="" aria-describedby="select-danger-validation-text">
@@ -72,8 +72,8 @@
           </option>
         </select>
         <div class="Select__icon">
-          <svg width="24" height="24" fill="none" viewbox="0 0 24 24" class="Icon" aria-hidden="true">
-          <use href="#svg_558248b5050467b27d20185b3d536bbb">
+          <svg width="20" height="20" fill="none" viewbox="0 0 20 20" class="Icon" aria-hidden="true">
+          <use href="#svg_1832e28de2fce140dddc6fa8ecff0657">
           </use></svg>
         </div>
       </div>

--- a/packages/web-twig/src/Resources/components/Select/stories/SelectSizes.twig
+++ b/packages/web-twig/src/Resources/components/Select/stories/SelectSizes.twig
@@ -1,0 +1,21 @@
+<Grid cols="{{ { mobile: 1, desktop: 3 } }}">
+
+    <Select id="select-size-small" label="Small" name="selectSizeSmall" size="small" helperText="Helper text">
+        <option value="" selected>Placeholder</option>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+    </Select>
+
+    <Select id="select-size-medium" label="Medium (default)" name="selectSizeMedium" helperText="Helper text">
+        <option value="" selected>Placeholder</option>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+    </Select>
+
+    <Select id="select-size-large" label="Large" name="selectSizeLarge" size="large" helperText="Helper text">
+        <option value="" selected>Placeholder</option>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+    </Select>
+
+</Grid>

--- a/packages/web-twig/src/Resources/components/TextArea/README.md
+++ b/packages/web-twig/src/Resources/components/TextArea/README.md
@@ -27,6 +27,34 @@ Advanced example usage:
 />
 ```
 
+Sizes:
+
+```twig
+<TextArea
+    id="text-area-size-small"
+    label="Small"
+    name="textAreaSizeSmall"
+    placeholder="Placeholder"
+    size="small"
+    helperText="Helper text"
+/>
+<TextArea
+    id="text-area-size-medium"
+    label="Medium (default)"
+    name="textAreaSizeMedium"
+    placeholder="Placeholder"
+    helperText="Helper text"
+/>
+<TextArea
+    id="text-area-size-large"
+    label="Large"
+    name="textAreaSizeLarge"
+    placeholder="Placeholder"
+    size="large"
+    helperText="Helper text"
+/>
+```
+
 Without lexer:
 
 ```twig
@@ -47,29 +75,30 @@ Without lexer:
 
 ## API
 
-| Name                    | Type                                           | Default | Required | Description                                                                                                 |
-| ----------------------- | ---------------------------------------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `autocomplete`          | `string`                                       | `null`  | ✕        | [Automated assistance in filling][autocomplete-attr]                                                        |
-| `hasValidationIcon`     | `boolean`                                      | `false` | ✕        | Whether to show validation icon                                                                             |
-| `helperText`            | `string`                                       | `null`  | ✕        | Custom helper text                                                                                          |
-| `id`                    | `string`                                       | —       | ✓        | TextArea and label identification                                                                           |
-| `inputProps`            | `string[]`                                     | `[]`    | ✕        | Pass additional attributes to the textarea element                                                          |
-| `isAutoResizing`        | `bool`                                         | `false` | ✕        | If true, TextArea adjusts its height as user types, see [plugin info](#javascript-plugin-for-auto-resizing) |
-| `isDisabled`            | `bool`                                         | `false` | ✕        | If true, TextArea is disabled                                                                               |
-| `isFluid`               | `bool`                                         | `false` | ✕        | If true, the element spans to the full width of its parent                                                  |
-| `isLabelHidden`         | `bool`                                         | `false` | ✕        | If true, label is hidden                                                                                    |
-| `isRequired`            | `bool`                                         | `false` | ✕        | If true, TextArea is required                                                                               |
-| `label`                 | `string`                                       | —       | ✓\*      | Label text                                                                                                  |
-| `maxlength`             | `number`                                       | `null`  | ✕        | Maximum number of characters                                                                                |
-| `name`                  | `string`                                       | `null`  | ✕        | TextArea name                                                                                               |
-| `placeholder`           | `string`                                       | `null`  | ✕        | TextArea placeholder                                                                                        |
-| `rows`                  | `number`                                       | `null`  | ✕        | Number of visible rows                                                                                      |
-| `UNSAFE_helperText`     | `string`                                       | `null`  | ✕        | Unescaped custom helper text                                                                                |
-| `UNSAFE_label`          | `string`                                       | —       | ✓\*      | Unescaped label text                                                                                        |
-| `UNSAFE_validationText` | \[`string` \| `string[]`]                      | `null`  | ✕        | Unescaped custom validation text                                                                            |
-| `validationState`       | [Validation dictionary][dictionary-validation] | `null`  | ✕        | Type of validation state.                                                                                   |
-| `validationText`        | \[`string` \| `string[]`]                      | `null`  | ✕        | Validation text                                                                                             |
-| `value`                 | `string`                                       | `null`  | ✕        | TextArea value                                                                                              |
+| Name                    | Type                                           | Default  | Required | Description                                                                                                 |
+| ----------------------- | ---------------------------------------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `autocomplete`          | `string`                                       | `null`   | ✕        | [Automated assistance in filling][autocomplete-attr]                                                        |
+| `hasValidationIcon`     | `boolean`                                      | `false`  | ✕        | Whether to show validation icon                                                                             |
+| `helperText`            | `string`                                       | `null`   | ✕        | Custom helper text                                                                                          |
+| `id`                    | `string`                                       | —        | ✓        | TextArea and label identification                                                                           |
+| `inputProps`            | `string[]`                                     | `[]`     | ✕        | Pass additional attributes to the textarea element                                                          |
+| `isAutoResizing`        | `bool`                                         | `false`  | ✕        | If true, TextArea adjusts its height as user types, see [plugin info](#javascript-plugin-for-auto-resizing) |
+| `isDisabled`            | `bool`                                         | `false`  | ✕        | If true, TextArea is disabled                                                                               |
+| `isFluid`               | `bool`                                         | `false`  | ✕        | If true, the element spans to the full width of its parent                                                  |
+| `isLabelHidden`         | `bool`                                         | `false`  | ✕        | If true, label is hidden                                                                                    |
+| `isRequired`            | `bool`                                         | `false`  | ✕        | If true, TextArea is required                                                                               |
+| `label`                 | `string`                                       | —        | ✓\*      | Label text                                                                                                  |
+| `maxlength`             | `number`                                       | `null`   | ✕        | Maximum number of characters                                                                                |
+| `name`                  | `string`                                       | `null`   | ✕        | TextArea name                                                                                               |
+| `placeholder`           | `string`                                       | `null`   | ✕        | TextArea placeholder                                                                                        |
+| `rows`                  | `number`                                       | `null`   | ✕        | Number of visible rows                                                                                      |
+| `size`                  | [Size dictionary][dictionary-size]             | `medium` | ✕        | Size variant                                                                                                |
+| `UNSAFE_helperText`     | `string`                                       | `null`   | ✕        | Unescaped custom helper text                                                                                |
+| `UNSAFE_label`          | `string`                                       | —        | ✓\*      | Unescaped label text                                                                                        |
+| `UNSAFE_validationText` | \[`string` \| `string[]`]                      | `null`   | ✕        | Unescaped custom validation text                                                                            |
+| `validationState`       | [Validation dictionary][dictionary-validation] | `null`   | ✕        | Type of validation state.                                                                                   |
+| `validationText`        | \[`string` \| `string[]`]                      | `null`   | ✕        | Validation text                                                                                             |
+| `value`                 | `string`                                       | `null`   | ✕        | TextArea value                                                                                              |
 
 (\*) Label is required. You can use the `label` for simple text or `UNSAFE_label` for HTML content.
 
@@ -102,6 +131,7 @@ Then you need to add attribute `isAutoResizing` to the component.
 👉 Check the [component's docs in the web package][web-js-api] to see the full documentation and API of the plugin.
 
 [autocomplete-attr]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
+[dictionary-size]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#size
 [dictionary-validation]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation
 [readme-additional-attributes]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/README.md#additional-attributes
 [readme-escape-hatches]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/README.md#escape-hatches

--- a/packages/web-twig/src/Resources/components/TextArea/TextArea.stories.twig
+++ b/packages/web-twig/src/Resources/components/TextArea/TextArea.stories.twig
@@ -9,6 +9,10 @@
         {% include '@components/TextArea/stories/TextAreaDefault.twig' %}
     </DocsSection>
 
+    <DocsSection title="Sizes">
+        {% include '@components/TextArea/stories/TextAreaSizes.twig' %}
+    </DocsSection>
+
     <DocsSection title="Required">
         {% include '@components/TextArea/stories/TextAreaRequired.twig' %}
     </DocsSection>

--- a/packages/web-twig/src/Resources/components/TextArea/__tests__/__snapshots__/textAreaDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/TextArea/__tests__/__snapshots__/textAreaDefault.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="TextArea TextArea--danger">
+    <div class="TextArea TextArea--medium TextArea--danger">
       <label for="example" class="TextArea__label TextArea__label--required">TextArea</label> 
 
       <textarea minlength="6" maxlength="10" rows="10" data-validate="true" id="example" name="example" class="TextArea__input" required="" aria-describedby="example-validation-text">TextArea value</textarea>

--- a/packages/web-twig/src/Resources/components/TextArea/__tests__/__snapshots__/textAreaWithAutoResize.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/TextArea/__tests__/__snapshots__/textAreaWithAutoResize.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div data-test="test" class="TextArea TextArea--error" data-spirit-toggle="autoResize">
+    <div data-test="test" class="TextArea TextArea--medium TextArea--error" data-spirit-toggle="autoResize">
       <label for="example" class="TextArea__label TextArea__label--required">TextArea</label> 
 
       <textarea maxlength="10" minlength="6" rows="10" id="example" name="example" class="TextArea__input" required="" aria-describedby="example-validation-text">TextArea value</textarea>

--- a/packages/web-twig/src/Resources/components/TextArea/__tests__/__snapshots__/textAreaWithHelperText.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/TextArea/__tests__/__snapshots__/textAreaWithHelperText.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="TextArea">
+    <div class="TextArea TextArea--medium">
       <label for="example" class="TextArea__label">TextArea</label> 
 
       <textarea id="example" name="" class="TextArea__input" aria-describedby="example-helper-text"></textarea>

--- a/packages/web-twig/src/Resources/components/TextArea/__tests__/__snapshots__/textAreaWithMultilineMessage.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/TextArea/__tests__/__snapshots__/textAreaWithMultilineMessage.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="TextArea TextArea--danger">
+    <div class="TextArea TextArea--medium TextArea--danger">
       <label for="example" class="TextArea__label">TextArea</label> 
 
       <textarea id="example" name="" class="TextArea__input" aria-describedby="example-validation-text"></textarea>

--- a/packages/web-twig/src/Resources/components/TextArea/stories/TextAreaSizes.twig
+++ b/packages/web-twig/src/Resources/components/TextArea/stories/TextAreaSizes.twig
@@ -1,0 +1,27 @@
+<Grid cols="{{ { mobile: 1, desktop: 3 } }}">
+
+    <TextArea
+        id="text-area-size-small"
+        label="Small"
+        name="textAreaSizeSmall"
+        placeholder="Placeholder"
+        size="small"
+        helperText="Helper text"
+    />
+    <TextArea
+        id="text-area-size-medium"
+        label="Medium (default)"
+        name="textAreaSizeMedium"
+        placeholder="Placeholder"
+        helperText="Helper text"
+    />
+    <TextArea
+        id="text-area-size-large"
+        label="Large"
+        name="textAreaSizeLarge"
+        placeholder="Placeholder"
+        size="large"
+        helperText="Helper text"
+    />
+
+</Grid>

--- a/packages/web-twig/src/Resources/components/TextField/README.md
+++ b/packages/web-twig/src/Resources/components/TextField/README.md
@@ -10,8 +10,6 @@ Basic example usage:
 
 Advanced example usage:
 
-Default TextField:
-
 ```twig
 <TextField
   hasValidationIcon
@@ -24,6 +22,34 @@ Default TextField:
   type="text"
   validationState="danger"
   validationText="validation failed"
+/>
+```
+
+Sizes:
+
+```twig
+<TextField
+    id="text-field-size-small"
+    label="Small"
+    name="textFieldSizeSmall"
+    placeholder="Placeholder"
+    size="small"
+    helperText="Helper text"
+/>
+<TextField
+    id="text-field-size-medium"
+    label="Medium (default)"
+    name="textFieldSizeMedium"
+    placeholder="Placeholder"
+    helperText="Helper text"
+/>
+<TextField
+    id="text-field-size-large"
+    label="Large"
+    name="textFieldSizeLarge"
+    placeholder="Placeholder"
+    size="large"
+    helperText="Helper text"
 />
 ```
 
@@ -59,29 +85,30 @@ Without lexer:
 
 ## API
 
-| Name                    | Type                                                                         | Default | Required | Description                                                             |
-| ----------------------- | ---------------------------------------------------------------------------- | ------- | -------- | ----------------------------------------------------------------------- |
-| `autocomplete`          | `string`                                                                     | `null`  | ✕        | [Automated assistance in filling][autocomplete-attr]                    |
-| `hasValidationIcon`     | `boolean`                                                                    | `false` | ✕        | Whether to show validation icon                                         |
-| `hasPasswordToggle`     | `bool`                                                                       | `false` | ✕        | If true, the `type` is set to `password` and a password toggle is shown |
-| `helperText`            | `string`                                                                     | `null`  | ✕        | Custom helper text                                                      |
-| `id`                    | `string`                                                                     | —       | ✓        | Input and label identification                                          |
-| `inputProps`            | `string[]`                                                                   | `[]`    | ✕        | Pass additional attributes to the input element                         |
-| `inputWidth`            | `number`                                                                     | `null`  | ✕        | Input width                                                             |
-| `isDisabled`            | `bool`                                                                       | `false` | ✕        | If true, input is disabled                                              |
-| `isFluid`               | `bool`                                                                       | `false` | ✕        | If true, the element spans to the full width of its parent              |
-| `isLabelHidden`         | `bool`                                                                       | `false` | ✕        | If true, label is hidden                                                |
-| `isRequired`            | `bool`                                                                       | `false` | ✕        | If true, input is required                                              |
-| `label`                 | `string`                                                                     | —       | ✓\*      | Label text                                                              |
-| `name`                  | `string`                                                                     | `null`  | ✕        | Input name                                                              |
-| `placeholder`           | `string`                                                                     | `null`  | ✕        | Input placeholder                                                       |
-| `type`                  | \[`email` \| `number` \| `password` \| `search` \| `tel` \| `text` \| `url`] | `text`  | ✕        | Input type                                                              |
-| `UNSAFE_helperText`     | `string`                                                                     | `null`  | ✕        | Unescaped custom helper text                                            |
-| `UNSAFE_label`          | `string`                                                                     | —       | ✓\*      | Unescaped label text                                                    |
-| `UNSAFE_validationText` | \[`string` \| `string[]`]                                                    | `null`  | ✕        | Unescaped validation text                                               |
-| `validationState`       | [Validation dictionary][dictionary-validation]                               | `null`  | ✕        | Type of validation state.                                               |
-| `validationText`        | \[`string` \| `string[]`]                                                    | `null`  | ✕        | Validation text                                                         |
-| `value`                 | `string`                                                                     | `null`  | ✕        | Input value                                                             |
+| Name                    | Type                                                                         | Default  | Required | Description                                                             |
+| ----------------------- | ---------------------------------------------------------------------------- | -------- | -------- | ----------------------------------------------------------------------- |
+| `autocomplete`          | `string`                                                                     | `null`   | ✕        | [Automated assistance in filling][autocomplete-attr]                    |
+| `hasValidationIcon`     | `boolean`                                                                    | `false`  | ✕        | Whether to show validation icon                                         |
+| `hasPasswordToggle`     | `bool`                                                                       | `false`  | ✕        | If true, the `type` is set to `password` and a password toggle is shown |
+| `helperText`            | `string`                                                                     | `null`   | ✕        | Custom helper text                                                      |
+| `id`                    | `string`                                                                     | —        | ✓        | Input and label identification                                          |
+| `inputProps`            | `string[]`                                                                   | `[]`     | ✕        | Pass additional attributes to the input element                         |
+| `inputWidth`            | `number`                                                                     | `null`   | ✕        | Input width                                                             |
+| `isDisabled`            | `bool`                                                                       | `false`  | ✕        | If true, input is disabled                                              |
+| `isFluid`               | `bool`                                                                       | `false`  | ✕        | If true, the element spans to the full width of its parent              |
+| `isLabelHidden`         | `bool`                                                                       | `false`  | ✕        | If true, label is hidden                                                |
+| `isRequired`            | `bool`                                                                       | `false`  | ✕        | If true, input is required                                              |
+| `label`                 | `string`                                                                     | —        | ✓\*      | Label text                                                              |
+| `name`                  | `string`                                                                     | `null`   | ✕        | Input name                                                              |
+| `placeholder`           | `string`                                                                     | `null`   | ✕        | Input placeholder                                                       |
+| `size`                  | [Size dictionary][dictionary-size]                                           | `medium` | ✕        | Size variant                                                            |
+| `type`                  | \[`email` \| `number` \| `password` \| `search` \| `tel` \| `text` \| `url`] | `text`   | ✕        | Input type                                                              |
+| `UNSAFE_helperText`     | `string`                                                                     | `null`   | ✕        | Unescaped custom helper text                                            |
+| `UNSAFE_label`          | `string`                                                                     | —        | ✓\*      | Unescaped label text                                                    |
+| `UNSAFE_validationText` | \[`string` \| `string[]`]                                                    | `null`   | ✕        | Unescaped validation text                                               |
+| `validationState`       | [Validation dictionary][dictionary-validation]                               | `null`   | ✕        | Type of validation state.                                               |
+| `validationText`        | \[`string` \| `string[]`]                                                    | `null`   | ✕        | Validation text                                                         |
+| `value`                 | `string`                                                                     | `null`   | ✕        | Input value                                                             |
 
 (\*) The label is required for this component. Use `label` or `UNSAFE_label` to set the label.
 
@@ -115,6 +142,7 @@ Then you need to add attribute `hasPasswordToggle` to the component.
 👉 Check the [component's docs in the web package][web-js-api] to see the full documentation and API of the plugin.
 
 [autocomplete-attr]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
+[dictionary-size]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#size
 [dictionary-validation]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation
 [readme-additional-attributes]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/README.md#additional-attributes
 [readme-escape-hatches]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/README.md#escape-hatches

--- a/packages/web-twig/src/Resources/components/TextField/TextField.stories.twig
+++ b/packages/web-twig/src/Resources/components/TextField/TextField.stories.twig
@@ -9,6 +9,14 @@
         {% include '@components/TextField/stories/TextFieldDefault.twig' %}
     </DocsSection>
 
+    <DocsSection title="Password Toggle">
+        {% include '@components/TextField/stories/TextFieldPasswordToggle.twig' %}
+    </DocsSection>
+
+    <DocsSection title="Sizes">
+        {% include '@components/TextField/stories/TextFieldSizes.twig' %}
+    </DocsSection>
+
     <DocsSection title="Required">
         {% include '@components/TextField/stories/TextFieldRequired.twig' %}
     </DocsSection>
@@ -37,16 +45,12 @@
         {% include '@components/TextField/stories/TextFieldFluid.twig' %}
     </DocsSection>
 
-    <DocsSection title="Size">
+    <DocsSection title="Input Size">
         {% include '@components/TextField/stories/TextFieldInputWidth.twig' %}
     </DocsSection>
 
     <DocsSection title="Inline" stackAlignment="stretch">
         {% include '@components/TextField/stories/TextFieldInline.twig' %}
-    </DocsSection>
-
-    <DocsSection title="Password Toggle">
-        {% include '@components/TextField/stories/TextFieldPasswordToggle.twig' %}
     </DocsSection>
 
 {% endblock %}

--- a/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/passwordFieldDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/passwordFieldDefault.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="TextField TextField--danger">
+    <div class="TextField TextField--medium TextField--danger">
       <label for="example-2" class="TextField__label TextField__label--required">Password field</label> <input type="password" id="example-2" name="example2" class="TextField__input" required="" aria-describedby="example-2-validation-text">
       <div class="TextField__validationText" id="example-2-validation-text">
         validation failed

--- a/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldDefault.twig.snap.html
@@ -5,14 +5,14 @@
     </title>
   </head>
   <body>
-    <div class="TextField TextField--danger">
+    <div class="TextField TextField--medium TextField--danger">
       <label for="example" class="TextField__label TextField__label--required">Text field</label> <input minlength="6" placeholder="Some long placeholder" value="Some long value" data-validate="true" type="text" id="example" name="example" class="TextField__input" required="" aria-describedby="example-validation-text">
       <div class="TextField__validationText" id="example-validation-text">
         validation failed
       </div>
     </div>
 
-    <div class="TextField TextField--disabled TextField--danger">
+    <div class="TextField TextField--medium TextField--disabled TextField--danger">
       <label for="example" class="TextField__label TextField__label--required">Text field</label> <input minlength="6" placeholder="Some long placeholder" value="Some long value" data-validate="true" type="text" id="example" name="example" class="TextField__input" disabled required="" aria-describedby="example-validation-text">
       <div class="TextField__validationText" id="example-validation-text">
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewbox="0 0 24 24" fill="none" id="svg_b9dd7d040cc17e885d046cf711e416db" class="Icon" aria-hidden="true">

--- a/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldDefaultPure.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldDefaultPure.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="TextField TextField--danger">
+    <div class="TextField TextField--medium TextField--danger">
       <input type="text" id="example" name="example" class="TextField__input" required="" aria-describedby="example-validation-text">
       <div class="TextField__validationText" id="example-validation-text">
         validation failed

--- a/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldNotRequired.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldNotRequired.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="TextField">
+    <div class="TextField TextField--medium">
       <label for="example" class="TextField__label">Text field</label> <input value="filled" type="text" id="example" name="example" class="TextField__input">
     </div>
   </body>

--- a/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldPasswordToggle.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldPasswordToggle.twig.snap.html
@@ -5,24 +5,24 @@
     </title>
   </head>
   <body>
-    <div class="TextField">
+    <div class="TextField TextField--medium">
       <label for="password-toggle" class="TextField__label">Text field with password toggle</label>
       <div class="TextField__passwordToggle">
-        <input type="password" id="password-toggle" name="passwordToggle" class="TextField__input"> <button type="button" class="TextField__passwordToggle__button" role="switch" aria-checked="false" aria-label="Show password" data-spirit-toggle="password"><span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--hidden"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" id="svg_3342f3cc3ee0fc688b23ac80282945dd" class="Icon" aria-hidden="true">
+        <input type="password" id="password-toggle" name="passwordToggle" class="TextField__input"> <button type="button" class="TextField__passwordToggle__button" role="switch" aria-checked="false" aria-label="Show password" data-spirit-toggle="password"><span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--hidden"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewbox="0 0 24 24" fill="none" id="svg_e192fce9cd625329592da544d6e61261" class="Icon" aria-hidden="true">
         <path d="M12 4.5C7 4.5 2.73 7.61 1 12C2.73 16.39 7 19.5 12 19.5C17 19.5 21.27 16.39 23 12C21.27 7.61 17 4.5 12 4.5ZM12 17C9.24 17 7 14.76 7 12C7 9.24 9.24 7 12 7C14.76 7 17 9.24 17 12C17 14.76 14.76 17 12 17ZM12 9C10.34 9 9 10.34 9 12C9 13.66 10.34 15 12 15C13.66 15 15 13.66 15 12C15 10.34 13.66 9 12 9Z" fill="currentColor">
-        </path></svg></span> <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--shown"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" id="svg_1e11ce96d8fc2b1eefab16215680b94a" class="Icon" aria-hidden="true">
+        </path></svg></span> <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--shown"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewbox="0 0 24 24" fill="none" id="svg_841f7617c322b9753b5af22d8ab486f4" class="Icon" aria-hidden="true">
         <path d="M12 7C14.76 7 17 9.24 17 12C17 12.65 16.87 13.26 16.64 13.83L19.56 16.75C21.07 15.49 22.26 13.86 22.99 12C21.26 7.61 16.99 4.5 11.99 4.5C10.59 4.5 9.25 4.75 8.01 5.2L10.17 7.36C10.74 7.13 11.35 7 12 7ZM2 4.27L4.28 6.55L4.74 7.01C3.08 8.3 1.78 10.02 1 12C2.73 16.39 7 19.5 12 19.5C13.55 19.5 15.03 19.2 16.38 18.66L16.8 19.08L19.73 22L21 20.73L3.27 3L2 4.27ZM7.53 9.8L9.08 11.35C9.03 11.56 9 11.78 9 12C9 13.66 10.34 15 12 15C12.22 15 12.44 14.97 12.65 14.92L14.2 16.47C13.53 16.8 12.79 17 12 17C9.24 17 7 14.76 7 12C7 11.21 7.2 10.47 7.53 9.8ZM11.84 9.02L14.99 12.17L15.01 12.01C15.01 10.35 13.67 9.01 12.01 9.01L11.84 9.02Z" fill="currentColor">
         </path></svg></span></button>
       </div>
     </div>
 
-    <div class="TextField TextField--disabled">
+    <div class="TextField TextField--medium TextField--disabled">
       <label for="password-toggle" class="TextField__label">Text field with password toggle</label>
       <div class="TextField__passwordToggle">
-        <input type="password" id="password-toggle" name="passwordToggle" class="TextField__input" disabled> <button type="button" class="TextField__passwordToggle__button" role="switch" aria-checked="false" aria-label="Show password" data-spirit-toggle="password" disabled><span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--hidden"><svg width="24" height="24" fill="none" viewbox="0 0 24 24" class="Icon" aria-hidden="true">
-        <use href="#svg_3342f3cc3ee0fc688b23ac80282945dd">
-        </use></svg></span> <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--shown"><svg width="24" height="24" fill="none" viewbox="0 0 24 24" class="Icon" aria-hidden="true">
-        <use href="#svg_1e11ce96d8fc2b1eefab16215680b94a">
+        <input type="password" id="password-toggle" name="passwordToggle" class="TextField__input" disabled> <button type="button" class="TextField__passwordToggle__button" role="switch" aria-checked="false" aria-label="Show password" data-spirit-toggle="password" disabled><span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--hidden"><svg width="20" height="20" fill="none" viewbox="0 0 20 20" class="Icon" aria-hidden="true">
+        <use href="#svg_e192fce9cd625329592da544d6e61261">
+        </use></svg></span> <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--shown"><svg width="20" height="20" fill="none" viewbox="0 0 20 20" class="Icon" aria-hidden="true">
+        <use href="#svg_841f7617c322b9753b5af22d8ab486f4">
         </use></svg></span></button>
       </div>
     </div>

--- a/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldWithHelperText.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldWithHelperText.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="TextField">
+    <div class="TextField TextField--medium">
       <label for="example" class="TextField__label">Text field</label> <input type="text" id="example" name="example" class="TextField__input" aria-describedby="example-helper-text">
       <div class="TextField__helperText" id="example-helper-text">
         This is helper text

--- a/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldWithInvisibleLabel.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldWithInvisibleLabel.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="TextField">
+    <div class="TextField TextField--medium">
       <input type="text" id="example" name="example" class="TextField__input" required="">
     </div>
   </body>

--- a/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldWithMultilineMessage.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldWithMultilineMessage.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="TextField TextField--danger">
+    <div class="TextField TextField--medium TextField--danger">
       <label for="example" class="TextField__label">Text field</label> <input type="text" id="example" name="example" class="TextField__input" aria-describedby="example-validation-text">
       <div class="TextField__validationText" id="example-validation-text">
         <ul>

--- a/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldWithUnsafe.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/TextField/__tests__/__snapshots__/textFieldWithUnsafe.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div class="TextField TextField--success">
+    <div class="TextField TextField--medium TextField--success">
       <label for="example" class="TextField__label">This is <strong>label</strong> text</label> <input type="text" id="example" name="example" class="TextField__input" aria-describedby="example-helper-text example-validation-text">
       <div class="TextField__helperText" id="example-helper-text">
         This is <strong>helper</strong> text

--- a/packages/web-twig/src/Resources/components/TextField/stories/TextFieldSizes.twig
+++ b/packages/web-twig/src/Resources/components/TextField/stories/TextFieldSizes.twig
@@ -1,0 +1,54 @@
+<Grid cols="{{ { mobile: 1, desktop: 3 } }}">
+
+    <TextField
+        id="text-field-size-small"
+        label="Small"
+        name="textFieldSizeSmall"
+        placeholder="Placeholder"
+        size="small"
+        helperText="Helper text"
+    />
+    <TextField
+        id="text-field-size-medium"
+        label="Medium (default)"
+        name="textFieldSizeMedium"
+        placeholder="Placeholder"
+        helperText="Helper text"
+    />
+    <TextField
+        id="text-field-size-large"
+        label="Large"
+        name="textFieldSizeLarge"
+        placeholder="Placeholder"
+        size="large"
+        helperText="Helper text"
+    />
+
+    <TextField
+        id="text-field-password-size-small"
+        label="Small"
+        name="textFieldPasswordSizeSmall"
+        value="password"
+        size="small"
+        helperText="Helper text"
+        hasPasswordToggle
+    />
+    <TextField
+        id="text-field-password-size-medium"
+        label="Medium (default)"
+        name="textFieldPasswordSizeMedium"
+        value="password"
+        helperText="Helper text"
+        hasPasswordToggle
+    />
+    <TextField
+        id="text-field-password-size-large"
+        label="Large"
+        name="textFieldPasswordSizeLarge"
+        value="password"
+        size="large"
+        helperText="Helper text"
+        hasPasswordToggle
+    />
+
+</Grid>

--- a/packages/web-twig/src/Resources/components/TextFieldBase/README.md
+++ b/packages/web-twig/src/Resources/components/TextFieldBase/README.md
@@ -10,8 +10,6 @@ Basic example usage:
 
 Advanced example usage:
 
-Default TextFieldBase:
-
 ```twig
 <TextFieldBase
   hasValidationIcon
@@ -24,6 +22,34 @@ Default TextFieldBase:
   type="text"
   validationState="danger"
   validationText="validation failed"
+/>
+```
+
+Sizes:
+
+```twig
+<TextFieldBase
+    id="text-field-base-size-small"
+    label="Small"
+    name="textFieldBaseSizeSmall"
+    placeholder="Placeholder"
+    size="small"
+    helperText="Helper text"
+/>
+<TextFieldBase
+    id="text-field-base-size-medium"
+    label="Medium (default)"
+    name="textFieldBaseSizeMedium"
+    placeholder="Placeholder"
+    helperText="Helper text"
+/>
+<TextFieldBase
+    id="text-field-base-size-large"
+    label="Large"
+    name="textFieldBaseSizeLarge"
+    placeholder="Placeholder"
+    size="large"
+    helperText="Helper text"
 />
 ```
 
@@ -59,31 +85,32 @@ Without lexer:
 
 ## API
 
-| Name                    | Type                                                                         | Default | Required | Description                                                             |
-| ----------------------- | ---------------------------------------------------------------------------- | ------- | -------- | ----------------------------------------------------------------------- |
-| `autocomplete`          | `string`                                                                     | `null`  | ✕        | [Automated assistance in filling][autocomplete-attr]                    |
-| `hasValidationIcon`     | `boolean`                                                                    | `false` | ✕        | Whether to show validation icon                                         |
-| `hasPasswordToggle`     | `bool`                                                                       | `false` | ✕        | If true, the `type` is set to `password` and a password toggle is shown |
-| `helperText`            | `string`                                                                     | `null`  | ✕        | Custom helper text                                                      |
-| `id`                    | `string`                                                                     | —       | ✓        | Input and label identification                                          |
-| `inputProps`            | `string[]`                                                                   | `[]`    | ✕        | Pass additional attributes to the input/textarea element                |
-| `isAutoResizing`        | `bool`                                                                       | `false` | ✕        | If true, TextArea adjusts its height as user types                      |
-| `isDisabled`            | `bool`                                                                       | `false` | ✕        | If true, input is disabled                                              |
-| `isFluid`               | `bool`                                                                       | `false` | ✕        | If true, the element spans to the full width of its parent              |
-| `isLabelHidden`         | `bool`                                                                       | `false` | ✕        | If true, label is hidden                                                |
-| `isMultiline`           | `bool`                                                                       | `false` | ✕        | If true, rendered DOM element is `textarea`                             |
-| `isRequired`            | `bool`                                                                       | `false` | ✕        | If true, input is required                                              |
-| `label`                 | `string`                                                                     | —       | ✓\*      | Label text                                                              |
-| `name`                  | `string`                                                                     | `null`  | ✕        | Input name                                                              |
-| `pattern`               | `string`                                                                     | `null`  | ✕        | Defines regular expressions for allowed value types                     |
-| `placeholder`           | `string`                                                                     | `null`  | ✕        | Input placeholder                                                       |
-| `type`                  | \[`email` \| `number` \| `password` \| `search` \| `tel` \| `text` \| `url`] | `text`  | ✕        | Input type                                                              |
-| `UNSAFE_helperText`     | `string`                                                                     | `null`  | ✕        | Unescaped custom helper text                                            |
-| `UNSAFE_label`          | `string`                                                                     | —       | ✓\*      | Unescaped label text                                                    |
-| `UNSAFE_validationText` | \[`string` \| `string[]`]                                                    | `null`  | ✕        | Unescaped validation text                                               |
-| `validationState`       | [Validation dictionary][dictionary-validation]                               | `null`  | ✕        | Type of validation state.                                               |
-| `validationText`        | \[`string` \| `string[]`]                                                    | `null`  | ✕        | Validation text                                                         |
-| `value`                 | `string`                                                                     | `null`  | ✕        | Input value                                                             |
+| Name                    | Type                                                                         | Default  | Required | Description                                                             |
+| ----------------------- | ---------------------------------------------------------------------------- | -------- | -------- | ----------------------------------------------------------------------- |
+| `autocomplete`          | `string`                                                                     | `null`   | ✕        | [Automated assistance in filling][autocomplete-attr]                    |
+| `hasValidationIcon`     | `boolean`                                                                    | `false`  | ✕        | Whether to show validation icon                                         |
+| `hasPasswordToggle`     | `bool`                                                                       | `false`  | ✕        | If true, the `type` is set to `password` and a password toggle is shown |
+| `helperText`            | `string`                                                                     | `null`   | ✕        | Custom helper text                                                      |
+| `id`                    | `string`                                                                     | —        | ✓        | Input and label identification                                          |
+| `inputProps`            | `string[]`                                                                   | `[]`     | ✕        | Pass additional attributes to the input/textarea element                |
+| `isAutoResizing`        | `bool`                                                                       | `false`  | ✕        | If true, TextFieldBase adjusts its height as user types                 |
+| `isDisabled`            | `bool`                                                                       | `false`  | ✕        | If true, input is disabled                                              |
+| `isFluid`               | `bool`                                                                       | `false`  | ✕        | If true, the element spans to the full width of its parent              |
+| `isLabelHidden`         | `bool`                                                                       | `false`  | ✕        | If true, label is hidden                                                |
+| `isMultiline`           | `bool`                                                                       | `false`  | ✕        | If true, rendered DOM element is `textarea`                             |
+| `isRequired`            | `bool`                                                                       | `false`  | ✕        | If true, input is required                                              |
+| `label`                 | `string`                                                                     | —        | ✓\*      | Label text                                                              |
+| `name`                  | `string`                                                                     | `null`   | ✕        | Input name                                                              |
+| `pattern`               | `string`                                                                     | `null`   | ✕        | Defines regular expressions for allowed value types                     |
+| `placeholder`           | `string`                                                                     | `null`   | ✕        | Input placeholder                                                       |
+| `size`                  | [Size dictionary][dictionary-size]                                           | `medium` | ✕        | Size variant                                                            |
+| `type`                  | \[`email` \| `number` \| `password` \| `search` \| `tel` \| `text` \| `url`] | `text`   | ✕        | Input type                                                              |
+| `UNSAFE_helperText`     | `string`                                                                     | `null`   | ✕        | Unescaped custom helper text                                            |
+| `UNSAFE_label`          | `string`                                                                     | —        | ✓\*      | Unescaped label text                                                    |
+| `UNSAFE_validationText` | \[`string` \| `string[]`]                                                    | `null`   | ✕        | Unescaped validation text                                               |
+| `validationState`       | [Validation dictionary][dictionary-validation]                               | `null`   | ✕        | Type of validation state.                                               |
+| `validationText`        | \[`string` \| `string[]`]                                                    | `null`   | ✕        | Validation text                                                         |
+| `value`                 | `string`                                                                     | `null`   | ✕        | Input value                                                             |
 
 (\*) The label is required for this component. Use `label` or `UNSAFE_label` to set the label.
 
@@ -92,6 +119,7 @@ If you need more control over the styling of a component, you can use [style pro
 and [escape hatches][readme-escape-hatches].
 
 [autocomplete-attr]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
+[dictionary-size]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#size
 [dictionary-validation]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation
 [readme-additional-attributes]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/README.md#additional-attributes
 [readme-escape-hatches]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/README.md#escape-hatches

--- a/packages/web-twig/src/Resources/components/TextFieldBase/TextFieldBase.twig
+++ b/packages/web-twig/src/Resources/components/TextFieldBase/TextFieldBase.twig
@@ -11,6 +11,7 @@
 {%- set _isRequired = props.isRequired | default(false) -%}
 {%- set _label = props.label | default(null) -%}
 {%- set _name = props.name | default(null) -%}
+{%- set _size = props.size | default('medium') -%}
 {%- set _type = props.type | default('text') -%}
 {%- set _unsafeHelperText = props.UNSAFE_helperText | default(null) -%}
 {%- set _unsafeLabel = props.UNSAFE_label | default(null) -%}
@@ -28,6 +29,7 @@
 
 {# Class names #}
 {%- set _rootClassName = _spiritClassPrefix ~ _isMultiline ? 'TextArea' : 'TextField' -%}
+{%- set _rootSizeClassName = _spiritClassPrefix ~ _rootClassName ~ '--' ~ _size -%}
 {%- set _inputClassName = _rootClassName ~ '__input' -%}
 {%- set _labelClassName = _rootClassName ~ '__label' -%}
 {%- set _labelHiddenClassName = _isLabelHidden ? _rootClassName ~ '__label--hidden' : null -%}
@@ -45,8 +47,9 @@
 
 {# Miscellaneous #}
 {%- set _styleProps = useStyleProps(props) -%}
-{%- set _rootClassNames = [ _rootClassName, _rootDisabledClassName, _rootFluidClassName, _rootValidationStateClassName, _styleProps.className ] -%}
+{%- set _rootClassNames = [ _rootClassName, _rootSizeClassName, _rootDisabledClassName, _rootFluidClassName, _rootValidationStateClassName, _styleProps.className ] -%}
 {%- set _helperTextId = _helperText or _unsafeHelperText ? _id ~ '-helper-text' : null -%}
+{%- set _iconSize = (_size == 'small') ? '16' : '20' -%}
 {%- set _labelClassNames = [ _labelClassName, _labelHiddenClassName, _labelRequiredClassName ] -%}
 {%- set _allowedAttributes = [ 'autocomplete', 'placeholder'] -%}
 {%- set _textFieldAllowedAttributes = _allowedAttributes | merge([ 'value' ]) -%}
@@ -107,10 +110,10 @@
                     {{ _disabledAttr }}
                 >
                     <span class="{{ _passwordToggleIconClassName }} {{ _passwordToggleIconHiddenClassName }}">
-                        <Icon name="visibility-on" />
+                        <Icon name="visibility-on" boxSize="{{ _iconSize }}" />
                     </span>
                     <span class="{{ _passwordToggleIconClassName }} {{ _passwordToggleIconShownClassName }}">
-                        <Icon name="visibility-off" />
+                        <Icon name="visibility-off" boxSize="{{ _iconSize }}" />
                     </span>
                 </button>
             </div>

--- a/packages/web-twig/src/Resources/components/TextFieldBase/__tests__/__snapshots__/textFieldBaseDefault.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/TextFieldBase/__tests__/__snapshots__/textFieldBaseDefault.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div data-test="test" data-validate="1" data-spirit-validate="1" data-custom-validate="true" class="TextField TextField--danger">
+    <div data-test="test" data-validate="1" data-spirit-validate="1" data-custom-validate="true" class="TextField TextField--medium TextField--danger">
       <label for="example" class="TextField__label TextField__label--required">Text field</label> <input minlength="6" autocomplete="on" placeholder="Very long text" value="Some long value" data-validate="true" type="text" id="example" name="example" class="TextField__input" size="10" required="" aria-describedby="example-validation-text">
       <div class="TextField__validationText" id="example-validation-text">
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewbox="0 0 24 24" fill="none" id="svg_b9dd7d040cc17e885d046cf711e416db" class="Icon" aria-hidden="true">

--- a/packages/web-twig/src/Resources/components/TextFieldBase/__tests__/__snapshots__/textFieldBaseMultiline.twig.snap.html
+++ b/packages/web-twig/src/Resources/components/TextFieldBase/__tests__/__snapshots__/textFieldBaseMultiline.twig.snap.html
@@ -5,7 +5,7 @@
     </title>
   </head>
   <body>
-    <div data-test="test" class="TextArea TextArea--danger">
+    <div data-test="test" class="TextArea TextArea--medium TextArea--danger">
       <label for="example" class="TextArea__label TextArea__label--required">Textarea</label> 
 
       <textarea minlength="6" id="example" name="example" class="TextArea__input" required="" aria-describedby="example-validation-text"></textarea>


### PR DESCRIPTION
New sizes introduced according to our Size Dictionary:

- `<ComponentName>--small`
- `<ComponentName>--medium` (default)
- `<ComponentName>--large`

<!-- Thank you for contributing! -->

## Description

This is a follow-up of #2057.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

https://jira.almacareer.tech/browse/DS-1689

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
