### PR TITLE
Feat(web): Introduce new responsive border radii for form fields #DS-…

### DIFF
--- a/packages/web/src/scss/components/Select/README.md
+++ b/packages/web/src/scss/components/Select/README.md
@@ -341,5 +341,7 @@ JS interaction class when controlled by JavaScript:
 </div>
 ```
 
+👉 Please note that responsive border radius is defined by design specifications.
+
 [prefixed]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/README.md#prefixing-css-class-names
 [dictionary-validation]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation

--- a/packages/web/src/scss/components/Select/_Select.scss
+++ b/packages/web/src/scss/components/Select/_Select.scss
@@ -14,6 +14,7 @@ $_field-name: 'Select';
 
 .Select {
     @include form-fields-tools.box-field-root();
+    @include form-fields-tools.box-field-root-responsive-border-radius($_field-name);
 }
 
 .Select__label {

--- a/packages/web/src/scss/components/Stack/index.html
+++ b/packages/web/src/scss/components/Stack/index.html
@@ -15,7 +15,7 @@
           <label for="textfield-stack-1" class="TextField__label TextField__label--required">Label</label>
           <input type="text" id="textfield-stack-1" class="TextField__input" placeholder="Placeholder" />
         </div>
-        <div class="StackItem TextField">
+        <div class="TextField TextField--medium">
           <label for="textfield-stack-2" class="TextField__label TextField__label--required">Label</label>
           <input type="text" id="textfield-stack-2" class="TextField__input" placeholder="Placeholder" />
         </div>

--- a/packages/web/src/scss/components/TextArea/README.md
+++ b/packages/web/src/scss/components/TextArea/README.md
@@ -207,6 +207,8 @@ Filled</textarea
 </div>
 ```
 
+👉 Please note that responsive border radius is defined by design specifications.
+
 [web-readme]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/README.md
 [prefixed]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/README.md#prefixing-css-class-names
 [dictionary-validation]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation

--- a/packages/web/src/scss/components/TextArea/_TextArea.scss
+++ b/packages/web/src/scss/components/TextArea/_TextArea.scss
@@ -10,6 +10,7 @@ $_field-name: 'TextArea';
 
 .TextArea {
     @include form-fields-tools.box-field-root();
+    @include form-fields-tools.box-field-root-responsive-border-radius($_field-name);
 }
 
 .TextArea__label {

--- a/packages/web/src/scss/components/TextField/README.md
+++ b/packages/web/src/scss/components/TextField/README.md
@@ -331,6 +331,8 @@ JS interaction class when controlled by JavaScript:
 </div>
 ```
 
+👉 Please note that responsive border radius is defined by design specifications.
+
 [prefixed]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/README.md#prefixing-css-class-names
 [dictionary-validation]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation
 [web-readme]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/README.md

--- a/packages/web/src/scss/components/TextField/_TextField.scss
+++ b/packages/web/src/scss/components/TextField/_TextField.scss
@@ -28,6 +28,7 @@ $_field-name: 'TextField';
 
 .TextField {
     @include form-fields-tools.box-field-root();
+    @include form-fields-tools.box-field-root-responsive-border-radius($_field-name);
 }
 
 .TextField__label {
@@ -106,8 +107,8 @@ $_field-name: 'TextField';
     justify-content: center;
     padding-inline: theme.$input-password-toggle-padding-x;
     color: form-fields-settings.$box-field-input-color-state-default;
-    border-radius: 0 form-fields-settings.$box-field-input-border-radius
-        form-fields-settings.$box-field-input-border-radius 0;
+    border-radius: 0 var(--#{tokens.$css-variable-prefix}form-fields-border-radius)
+        var(--#{tokens.$css-variable-prefix}form-fields-border-radius) 0;
     background-color: form-fields-settings.$input-background-color;
 
     // 5.
@@ -117,7 +118,7 @@ $_field-name: 'TextField';
         inset: 0;
         border: form-fields-settings.$box-field-input-border-width form-fields-settings.$box-field-input-border-style
             form-fields-settings.$input-border-color;
-        border-radius: form-fields-settings.$box-field-input-border-radius;
+        border-radius: var(--#{tokens.$css-variable-prefix}form-fields-border-radius);
         pointer-events: none;
     }
 }
@@ -169,7 +170,7 @@ $_field-name: 'TextField';
     z-index: 1;
     width: (2 * theme.$input-password-toggle-padding-x) + theme.$input-password-toggle-icon-size;
     height: 100%;
-    border-radius: form-fields-settings.$box-field-input-border-radius;
+    border-radius: var(--#{tokens.$css-variable-prefix}form-fields-border-radius);
     box-shadow: form-fields-settings.$input-focus-shadow;
 }
 

--- a/packages/web/src/scss/settings/_form-fields.scss
+++ b/packages/web/src/scss/settings/_form-fields.scss
@@ -1,4 +1,6 @@
+@use 'sass:map';
 @use '@tokens' as tokens;
+@use '../tools/tokens' as tokens-tools;
 @use 'dictionaries';
 
 // Common for all form components
@@ -62,18 +64,45 @@ $box-field-label-margin-bottom: tokens.$space-400;
 
 $box-field-size-dictionary: dictionaries.$size;
 $box-field-size-config: (
-    small: (
-        height: 32px,
-        typography: tokens.$body-small-regular,
-    ),
-    medium: (
-        height: 40px,
-        typography: tokens.$body-medium-regular,
-    ),
-    large: (
-        height: 48px,
-        typography: tokens.$body-medium-regular,
-    ),
+    small: map.merge(
+            (
+                height: 32px,
+                typography: tokens.$body-small-regular,
+            ),
+            tokens-tools.generate-responsive-map(
+                $property: 'border-radius',
+                $size: 'small',
+                $variable-prefix: 'form-field',
+                $token-name: 'radius',
+                $fallback: $box-field-input-border-radius,
+            )
+        ),
+    medium: map.merge(
+            (
+                height: 40px,
+                typography: tokens.$body-medium-regular,
+            ),
+            tokens-tools.generate-responsive-map(
+                $property: 'border-radius',
+                $size: 'medium',
+                $variable-prefix: 'form-field',
+                $token-name: 'radius',
+                $fallback: $box-field-input-border-radius,
+            )
+        ),
+    large: map.merge(
+            (
+                height: 48px,
+                typography: tokens.$body-medium-regular,
+            ),
+            tokens-tools.generate-responsive-map(
+                $property: 'border-radius',
+                $size: 'large',
+                $variable-prefix: 'form-field',
+                $token-name: 'radius',
+                $fallback: $box-field-input-border-radius,
+            )
+        ),
 );
 
 $validation-states: (

--- a/packages/web/src/scss/tools/__tests__/_tokens.test.scss
+++ b/packages/web/src/scss/tools/__tests__/_tokens.test.scss
@@ -30,6 +30,7 @@ $test-theme: (
 
 @include test.describe('get-variable-if-exists function') {
     @include test.it('should return the variable that exists in the tokens') {
+        // ⚠️ External dependency: touches actual design token values.
         @include test.assert-equal(
             tokens-tools.get-variable-if-exists('container-small-max-width', tokens.$container-max-width),
             tokens.$container-small-max-width
@@ -38,5 +39,44 @@ $test-theme: (
 
     @include test.it('should return the fallback variable') {
         @include test.assert-equal(tokens-tools.get-variable-if-exists('new-variable', '0px'), '0px');
+    }
+}
+
+@include test.describe('generate-responsive-map function') {
+    // ⚠️ External dependency: outputs actual design token values.
+    @include test.it('should return a map with responsive values for given arguments') {
+        $result: tokens-tools.generate-responsive-map(
+            $property: 'border-radius',
+            $size: 'medium',
+            $variable-prefix: 'form-field',
+            $token-name: 'radius',
+            $fallback: 4px,
+        );
+
+        $expected: (
+            'border-radius-mobile': 8px,
+            'border-radius-tablet': 8px,
+            'border-radius-desktop': 8px,
+        );
+
+        @include test.assert-equal($result, $expected);
+    }
+
+    @include test.it('should return a map with fallback values for given arguments') {
+        $result: tokens-tools.generate-responsive-map(
+            $property: 'border-radius',
+            $size: 'medium',
+            $variable-prefix: 'form-field',
+            $token-name: 'TEST',
+            $fallback: 4px,
+        );
+
+        $expected: (
+            'border-radius-mobile': 4px,
+            'border-radius-tablet': 4px,
+            'border-radius-desktop': 4px,
+        );
+
+        @include test.assert-equal($result, $expected);
     }
 }

--- a/packages/web/src/scss/tools/_form-fields.scss
+++ b/packages/web/src/scss/tools/_form-fields.scss
@@ -6,6 +6,7 @@
 @use '@tokens' as tokens;
 @use '../settings/cursors';
 @use '../settings/form-fields' as form-fields-settings;
+@use '../tools/breakpoint';
 @use 'accessibility';
 @use 'reset';
 @use 'string' as spirit-string;
@@ -74,6 +75,18 @@
     width: form-fields-settings.$box-field-input-width;
 }
 
+@mixin box-field-root-responsive-border-radius($field-name) {
+    @each $breakpoint-name, $breakpoint-value in tokens.$breakpoints {
+        @include breakpoint.up($breakpoint-value) {
+            --#{tokens.$css-variable-prefix}form-fields-border-radius: var(
+                --#{tokens.$css-variable-prefix}#{spirit-string.convert-pascal-case-to-kebab-case(
+                        $field-name
+                    )}-input-border-radius-#{$breakpoint-name}
+            );
+        }
+    }
+}
+
 @mixin inline-field-label() {
     @include typography.generate(form-fields-settings.$inline-field-label-typography);
 
@@ -135,7 +148,7 @@
     color: form-fields-settings.$box-field-input-color-state-default;
     border: form-fields-settings.$box-field-input-border-width form-fields-settings.$box-field-input-border-style
         form-fields-settings.$input-border-color;
-    border-radius: form-fields-settings.$box-field-input-border-radius;
+    border-radius: var(--#{tokens.$css-variable-prefix}form-fields-border-radius);
     background: form-fields-settings.$input-background-color;
 
     &::placeholder {

--- a/packages/web/src/scss/tools/_tokens.scss
+++ b/packages/web/src/scss/tools/_tokens.scss
@@ -21,3 +21,38 @@
         @return $fallback-value;
     }
 }
+
+// Function to generate a map of responsive values for a given property, size, and token prefix.
+//
+// Example:
+// generate-responsive-map($property: 'border-radius', $token-name: 'radius',  $size: 'small', $variable-prefix: 'form-field', $fallback: 2px) will return:
+// (
+//   'border-radius-mobile': 4px,
+//   'border-radius-tablet': 6px,
+//   'border-radius-desktop': 8px,
+// )
+//
+// Parameters are:
+// * $property: the base CSS property name (e.g. 'border-radius')
+// * $token-name: token name (e.g. 'radius')
+// * $size: the size variant (e.g. 'small', 'medium')
+// * $variable-prefix: prefix used for the token variable names (e.g. 'form-field')
+// * $fallback: value to use if token is not found
+@function generate-responsive-map($property, $token-name, $size, $variable-prefix, $fallback) {
+    $result: ();
+
+    @each $breakpoint-name, $breakpoint-value in tokens.$breakpoints {
+        $key: '#{$property}-#{$breakpoint-name}';
+        $variable-name: '#{$variable-prefix}-#{$size}-#{$token-name}-#{$breakpoint-name}';
+        $value: get-variable-if-exists($variable-name, $fallback);
+
+        $result: map.merge(
+            $result,
+            (
+                $key: $value,
+            )
+        );
+    }
+
+    @return $result;
+}


### PR DESCRIPTION
## Description
Adding responsive border radius to `Select`, `TextField` and `TextArea`.

### Additional context

### Issue reference

[Form | Radius | Use new tokens in components](https://jira.almacareer.tech/browse/DS-1875)
