### PR TITLE
Fix(web): Check if utility values list is not empty before generating

### DIFF
--- a/packages/web/src/scss/tools/__tests__/_utilities.test.scss
+++ b/packages/web/src/scss/tools/__tests__/_utilities.test.scss
@@ -96,4 +96,20 @@
             }
         }
     }
+
+    @include test.it('should not fail if values are empty') {
+        $sample-utility: (
+            property: display,
+            class: d,
+            values: (),
+        );
+
+        @include test.assert() {
+            @include test.output() {
+                @include utilities.generate($sample-utility, '');
+            }
+
+            @include test.expect();
+        }
+    }
 }

--- a/packages/web/src/scss/tools/_utilities.scss
+++ b/packages/web/src/scss/tools/_utilities.scss
@@ -57,7 +57,10 @@
 @mixin generate($utility, $infix) {
     $values: map.get($utility, values);
 
-    @if meta.type-of($values) == 'string' or meta.type-of(list.nth($values, 1)) != 'list' {
+    @if meta.type-of($values) ==
+        'string' or
+        (meta.type-of($values) == 'list' and list.length($values) > 0 and meta.type-of(list.nth($values, 1)) != 'list')
+    {
         $values: list.zip($values, $values);
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

It was failing when adopters didn't have the new gradient tokens.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
