### PR TITLE
Fix(web-react): Fix undefined `window` reference in server-side call #DS-2029

### DIFF
--- a/packages/web-react/src/components/ScrollView/useScrollPosition.ts
+++ b/packages/web-react/src/components/ScrollView/useScrollPosition.ts
@@ -1,5 +1,6 @@
-import { UIEvent, MutableRefObject, useState, useEffect } from 'react';
+import { UIEvent, MutableRefObject, useCallback, useState, useEffect } from 'react';
 import { Direction, Position } from '../../constants';
+import { useResizeObserver } from '../../hooks';
 import { PositionType, ScrollViewDirectionType } from '../../types';
 import { debounce } from '../../utils';
 import { EDGE_DETECTION_INACCURACY_PX, DEBOUNCE_DELAY } from './constants';
@@ -66,7 +67,12 @@ export const useScrollPosition = ({
     }
   };
 
-  window.addEventListener('resize', debounce(handleScrollViewState, DEBOUNCE_DELAY));
+  const debouncedHandler = useCallback(debounce(handleScrollViewState, DEBOUNCE_DELAY), [handleScrollViewState]);
+
+  useResizeObserver({
+    ref: viewportReference,
+    onResize: debouncedHandler,
+  });
 
   /* We want to call this hook only once */
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/web-react/src/hooks/index.ts
+++ b/packages/web-react/src/hooks/index.ts
@@ -12,6 +12,7 @@ export * from './useIcon';
 export * from './useIconName';
 export * from './useIsomorphicLayoutEffect';
 export * from './useLastActiveFocus';
+export * from './useResizeObserver';
 export * from './useScrollControl';
 export * from './useSpacingStyle';
 export * from './useToggle';


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description
fixes an undefined `window` error in cyborg

```
Import trace for requested module:
../../libs/design-system/index.ts
 ⨯ ReferenceError: window is not defined
    at useScrollPosition (../../../src/components/ScrollView/useScrollPosition.ts:69:2)
    at ScrollView (../../../src/components/ScrollView/ScrollView.tsx:23:77) {
  digest: '1603275361'
}
```

### Additional context


### Issue reference

https://jira.almacareer.tech/browse/DS-2029

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
