### PR TITLE
Feat(web-react): Add ReactNode type to PricingPlanFeature description

### DIFF
--- a/packages/web-react/src/components/PricingPlan/README.md
+++ b/packages/web-react/src/components/PricingPlan/README.md
@@ -131,11 +131,11 @@ import { PricingPlanBody } from '@lmc-eu/spirit-web-react';
 
 ### API
 
-| Name          | Type                                                                            | Default | Required | Description                                                                                 |
-| ------------- | ------------------------------------------------------------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------- |
-| `description` | `string`                                                                        | -       | ✕        | Optional introductory text                                                                  |
-| `elementType` | `ElementType`                                                                   | `div`   | ✕        | Type of element                                                                             |
-| `features`    | `{ title: string; description: string, tooltipContent?: string \| ReactNode}[]` | `[]`    | ✕        | List of features, each with a title and description. Optionally you can set tooltipContent. |
+| Name          | Type                                                                                         | Default | Required | Description                                                                                 |
+| ------------- | -------------------------------------------------------------------------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------- |
+| `description` | `string`                                                                                     | -       | ✕        | Optional introductory text                                                                  |
+| `elementType` | `ElementType`                                                                                | `div`   | ✕        | Type of element                                                                             |
+| `features`    | `{ title: string; description: string \| ReactNode, tooltipContent?: string \| ReactNode}[]` | `[]`    | ✕        | List of features, each with a title and description. Optionally you can set tooltipContent. |
 
 ## PricingPlanFooter
 

--- a/packages/web-react/src/components/PricingPlan/stories/PricingPlanBody.stories.tsx
+++ b/packages/web-react/src/components/PricingPlan/stories/PricingPlanBody.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta<typeof PricingPlanBody> = {
     features: {
       control: 'object',
       table: {
-        type: { summary: '{ title: string; description: string. tooltipContent?: string | ReactNode }[]' },
+        type: { summary: '{ title: string; description: string | ReactNode; tooltipContent?: string | ReactNode }[]' },
       },
     },
     description: {
@@ -38,7 +38,11 @@ const meta: Meta<typeof PricingPlanBody> = {
       },
       {
         title: 'Feature name with Tooltip',
-        description: 'This is a description for the feature. Please click the title to see the tooltip.',
+        description: (
+          <>
+            This is a <strong>description</strong> for the feature. Please click the title to see the tooltip.
+          </>
+        ),
         tooltipContent: 'This is a tooltip text',
       },
     ],

--- a/packages/web-react/src/types/pricingPlan.ts
+++ b/packages/web-react/src/types/pricingPlan.ts
@@ -27,7 +27,7 @@ export interface PricingPlanHeaderBaseProps extends StyleProps {
 
 export type PricingPlanFeature = {
   title: string;
-  description?: string;
+  description?: string | ReactNode;
   tooltipContent?: string | ReactNode;
 };
 


### PR DESCRIPTION
## Description

Add ReactNode type to PricingPlanFeature description

### Additional context

<img width="671" height="521" alt="Figma 2025-07-10 13 20 55" src="https://github.com/user-attachments/assets/80a5d2f4-6311-4f8d-8a9c-fea4d6593c8c" />

### Issue reference


