### PR TITLE
Fix(web-react): Use `fixed` strategy for Tooltips inside PricingPlan #DS-2037

### DIFF
--- a/packages/web-react/src/components/PricingPlan/PricingPlanFeatureTitle.tsx
+++ b/packages/web-react/src/components/PricingPlan/PricingPlanFeatureTitle.tsx
@@ -28,6 +28,7 @@ const PricingPlanFeatureTitle = ({
       isOpen={isTooltipOpen}
       onToggle={toggleTooltip}
       placement="top"
+      positionStrategy="fixed"
       trigger={['click']}
       UNSAFE_className={classProps.body.featureTitle}
     >


### PR DESCRIPTION
We do this to avoid unwanted scrollbar in ScrollView for PricingPlans which are out of viewport.

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
