### PR TITLE
Fix(web,web-react): Close HTML dialog after all Modal or Drawer transitions are done #DS-2050

### DIFF
--- a/packages/web-react/src/components/Dialog/useDialog.ts
+++ b/packages/web-react/src/components/Dialog/useDialog.ts
@@ -1,5 +1,6 @@
 import { useEffect, MutableRefObject } from 'react';
 import { useScrollControl } from '../../hooks';
+import { waitForTransitionEnd } from '../../utils';
 
 export const useDialog = (ref: MutableRefObject<HTMLDialogElement | null>, isOpen: boolean) => {
   useEffect(() => {
@@ -8,8 +9,16 @@ export const useDialog = (ref: MutableRefObject<HTMLDialogElement | null>, isOpe
     if (dialogNode) {
       if (isOpen && dialogNode.showModal) {
         dialogNode.showModal();
+        // Add visual state class after showing dialog
+        dialogNode.classList.add('is-open');
       } else if (dialogNode.close) {
-        dialogNode.close();
+        // Remove visual state class first to trigger transition
+        dialogNode.classList.remove('is-open');
+
+        // Wait for transition to complete before closing
+        waitForTransitionEnd(dialogNode).then(() => {
+          dialogNode.close();
+        });
       }
     }
   }, [isOpen, ref]);
@@ -19,12 +28,20 @@ export const useDialog = (ref: MutableRefObject<HTMLDialogElement | null>, isOpe
   const openDialog = () => {
     if (ref?.current) {
       ref.current.showModal();
+      ref.current.classList.add('is-open');
     }
   };
 
   const closeDialog = () => {
-    if (ref?.current) {
-      ref.current.close();
+    const dialogNode = ref?.current;
+    if (dialogNode && dialogNode.open) {
+      // Remove visual state class first to trigger transition
+      dialogNode.classList.remove('is-open');
+
+      // Wait for transition to complete before closing
+      waitForTransitionEnd(dialogNode).then(() => {
+        dialogNode.close();
+      });
     }
   };
 

--- a/packages/web-react/src/components/PricingPlan/__tests__/PricingPlanFeatureTitle.test.tsx
+++ b/packages/web-react/src/components/PricingPlan/__tests__/PricingPlanFeatureTitle.test.tsx
@@ -125,7 +125,7 @@ describe('PricingPlanFeatureTitle', () => {
       ).toBeInTheDocument();
     });
 
-    it('should close modal when clicking close button', () => {
+    it('should close modal when clicking close button', async () => {
       const trigger = screen.getByRole('button', { name: 'Feature with Modal' });
 
       fireEvent.click(trigger);
@@ -133,6 +133,13 @@ describe('PricingPlanFeatureTitle', () => {
 
       const closeButton = screen.getByRole('button', { name: 'Close' });
       fireEvent.click(closeButton);
+
+      // Wait for the transition to complete
+      await new Promise<void>((resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, 100);
+      });
 
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });

--- a/packages/web-react/src/utils/__tests__/transitions.test.ts
+++ b/packages/web-react/src/utils/__tests__/transitions.test.ts
@@ -1,0 +1,167 @@
+import { waitForTransitionEnd } from '../transitions';
+
+describe('waitForTransitionEnd', () => {
+  let mockElement: HTMLElement;
+  let mockGetComputedStyle: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockElement = document.createElement('div');
+    mockGetComputedStyle = jest.spyOn(window, 'getComputedStyle');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should resolve immediately when element has no transition', async () => {
+    const mockStyle = {
+      transitionDuration: '0s',
+      transitionDelay: '0s',
+    };
+    mockGetComputedStyle.mockReturnValue(mockStyle as CSSStyleDeclaration);
+
+    const startTime = Date.now();
+    await waitForTransitionEnd(mockElement);
+    const endTime = Date.now();
+
+    // Should resolve almost immediately (within 10ms)
+    expect(endTime - startTime).toBeLessThan(10);
+  });
+
+  it('should resolve when transitionend event fires', async () => {
+    const mockStyle = {
+      transitionDuration: '0.3s',
+      transitionDelay: '0.1s',
+    };
+    mockGetComputedStyle.mockReturnValue(mockStyle as CSSStyleDeclaration);
+
+    const promise = waitForTransitionEnd(mockElement);
+
+    // Simulate transitionend event
+    setTimeout(() => {
+      mockElement.dispatchEvent(new Event('transitionend'));
+    }, 10);
+
+    await promise;
+  });
+
+  it('should resolve via fallback timeout if transitionend never fires', async () => {
+    const mockStyle = {
+      transitionDuration: '0.1s',
+      transitionDelay: '0.05s',
+    };
+    mockGetComputedStyle.mockReturnValue(mockStyle as CSSStyleDeclaration);
+
+    const startTime = Date.now();
+    await waitForTransitionEnd(mockElement);
+    const endTime = Date.now();
+
+    // Should resolve after the calculated timeout (150ms + 50ms buffer = 200ms)
+    // Allow some tolerance for test execution time
+    expect(endTime - startTime).toBeGreaterThanOrEqual(150);
+    expect(endTime - startTime).toBeLessThan(300);
+  });
+
+  it('should handle elements with only transition duration', async () => {
+    const mockStyle = {
+      transitionDuration: '0.2s',
+      transitionDelay: '0s',
+    };
+    mockGetComputedStyle.mockReturnValue(mockStyle as CSSStyleDeclaration);
+
+    const promise = waitForTransitionEnd(mockElement);
+
+    setTimeout(() => {
+      mockElement.dispatchEvent(new Event('transitionend'));
+    }, 10);
+
+    await promise;
+  });
+
+  it('should handle elements with only transition delay', async () => {
+    const mockStyle = {
+      transitionDuration: '0s',
+      transitionDelay: '0.1s',
+    };
+    mockGetComputedStyle.mockReturnValue(mockStyle as CSSStyleDeclaration);
+
+    const promise = waitForTransitionEnd(mockElement);
+
+    setTimeout(() => {
+      mockElement.dispatchEvent(new Event('transitionend'));
+    }, 10);
+
+    await promise;
+  });
+
+  it('should handle invalid transition values gracefully', async () => {
+    const mockStyle = {
+      transitionDuration: 'invalid',
+      transitionDelay: 'also-invalid',
+    };
+    mockGetComputedStyle.mockReturnValue(mockStyle as CSSStyleDeclaration);
+
+    const startTime = Date.now();
+    await waitForTransitionEnd(mockElement);
+    const endTime = Date.now();
+
+    // Should resolve immediately when values are invalid
+    expect(endTime - startTime).toBeLessThan(10);
+  });
+
+  it('should remove event listener after transitionend fires', async () => {
+    const mockStyle = {
+      transitionDuration: '0.1s',
+      transitionDelay: '0s',
+    };
+    mockGetComputedStyle.mockReturnValue(mockStyle as CSSStyleDeclaration);
+
+    const removeEventListenerSpy = jest.spyOn(mockElement, 'removeEventListener');
+
+    const promise = waitForTransitionEnd(mockElement);
+
+    setTimeout(() => {
+      mockElement.dispatchEvent(new Event('transitionend'));
+    }, 10);
+
+    await promise;
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('transitionend', expect.any(Function));
+  });
+
+  it('should handle multiple rapid transitionend events', async () => {
+    const mockStyle = {
+      transitionDuration: '0.1s',
+      transitionDelay: '0s',
+    };
+    mockGetComputedStyle.mockReturnValue(mockStyle as CSSStyleDeclaration);
+
+    const promise = waitForTransitionEnd(mockElement);
+
+    // Fire multiple transitionend events
+    setTimeout(() => {
+      mockElement.dispatchEvent(new Event('transitionend'));
+      mockElement.dispatchEvent(new Event('transitionend'));
+      mockElement.dispatchEvent(new Event('transitionend'));
+    }, 10);
+
+    await promise;
+  });
+
+  it('should calculate timeout correctly for complex transitions', async () => {
+    const mockStyle = {
+      transitionDuration: '0.5s',
+      transitionDelay: '0.2s',
+    };
+    mockGetComputedStyle.mockReturnValue(mockStyle as CSSStyleDeclaration);
+
+    const startTime = Date.now();
+    await waitForTransitionEnd(mockElement);
+    const endTime = Date.now();
+
+    // Should resolve after (500ms + 200ms) * 1000 + 50ms = 700.05ms
+    // But since we're not firing transitionend, it should use the fallback
+    expect(endTime - startTime).toBeGreaterThanOrEqual(700);
+    expect(endTime - startTime).toBeLessThan(800);
+  });
+});

--- a/packages/web-react/src/utils/index.ts
+++ b/packages/web-react/src/utils/index.ts
@@ -10,3 +10,4 @@ export * from './ssr';
 export * from './string';
 export * from './stylePropsClassesGenerator';
 export * from './toPascalCase';
+export * from './transitions';

--- a/packages/web-react/src/utils/transitions.ts
+++ b/packages/web-react/src/utils/transitions.ts
@@ -1,0 +1,34 @@
+/**
+ * Wait for transitionend if there's a transition running.
+ * Otherwise resolve immediately.
+ *
+ * @param element - The HTML element to wait for transition end
+ * @returns {Promise<void>} Promise that resolves when the transition ends or immediately if no transition
+ */
+export function waitForTransitionEnd(element: HTMLElement): Promise<void> {
+  return new Promise((resolve) => {
+    const computedStyle = window.getComputedStyle(element);
+    const duration = parseFloat(computedStyle.transitionDuration || '0');
+    const delay = parseFloat(computedStyle.transitionDelay || '0');
+    const total = (duration + delay) * 1000;
+
+    if (total === 0) {
+      resolve(); // No transition
+
+      return;
+    }
+
+    const onEnd = () => {
+      element.removeEventListener('transitionend', onEnd);
+      resolve();
+    };
+
+    element.addEventListener('transitionend', onEnd);
+
+    // Fallback in case transitionend never fires
+    setTimeout(() => {
+      element.removeEventListener('transitionend', onEnd);
+      resolve();
+    }, total + 50);
+  });
+}

--- a/packages/web/src/js/Modal.ts
+++ b/packages/web/src/js/Modal.ts
@@ -3,7 +3,7 @@ import { warning } from './common/utilities';
 import { EVENT_KEY } from './constants';
 import EventHandler from './dom/EventHandler';
 import SelectorEngine from './dom/SelectorEngine';
-import { enableToggleTrigger, ScrollControl, SpiritConfig } from './utils';
+import { enableToggleTrigger, ScrollControl, SpiritConfig, executeAfterTransition } from './utils';
 import { type SpiritElement } from './types';
 
 // TODO: Remove `handleKeyDown` listener when Chrome fixes the bug,
@@ -122,7 +122,15 @@ class Modal extends BaseComponent {
 
     const toggleEl = SelectorEngine.findOne(MODAL_TOGGLE_SELECTOR, this.element);
     toggleEl?.setAttribute('aria-expanded', 'true');
+
+    // Close the dialog first if it's already open to prevent InvalidStateError
+    if (this.element?.open) {
+      this.element.close();
+    }
+
     this.element?.showModal();
+    // Add visual state class after showing modal
+    this.element?.classList.add('is-open');
 
     this.addEventListeners();
     this.isShown = true;
@@ -149,14 +157,24 @@ class Modal extends BaseComponent {
     const toggleEl = SelectorEngine.findOne(MODAL_TOGGLE_SELECTOR, this.element);
 
     if (typeof target.close === 'function') {
-      target.close();
+      // Remove visual state class first to trigger transition
+      target.classList.remove('is-open');
+
+      // Wait for transition to complete before closing
+      executeAfterTransition(target, () => {
+        target.close();
+        toggleEl?.setAttribute('aria-expanded', 'false');
+        this.removeEventListeners();
+        this.isShown = false;
+        this.scrollControl.enableScroll();
+      });
+    } else {
+      // If no close function, clean up immediately
+      toggleEl?.setAttribute('aria-expanded', 'false');
+      this.removeEventListeners();
+      this.isShown = false;
+      this.scrollControl.enableScroll();
     }
-    toggleEl?.setAttribute('aria-expanded', 'false');
-
-    this.removeEventListeners();
-    this.isShown = false;
-
-    this.scrollControl.enableScroll();
   }
 
   toggle(

--- a/packages/web/src/js/Offcanvas.ts
+++ b/packages/web/src/js/Offcanvas.ts
@@ -2,7 +2,13 @@ import { breakpoints } from '@lmc-eu/spirit-design-tokens';
 import BaseComponent from './BaseComponent';
 import { warning } from './common/utilities';
 import EventHandler from './dom/EventHandler';
-import { ScrollControl, SpiritConfig, enableDismissTrigger, enableToggleTrigger } from './utils';
+import {
+  ScrollControl,
+  SpiritConfig,
+  enableDismissTrigger,
+  enableToggleTrigger,
+  executeAfterTransition,
+} from './utils';
 import { SpiritElement } from './types';
 
 const NAME = 'offcanvas';
@@ -114,6 +120,11 @@ class Offcanvas extends BaseComponent {
       return;
     }
 
+    // Close the dialog first if it's already open to prevent InvalidStateError
+    if (this.element.open) {
+      this.element.close();
+    }
+
     this.element.classList.add(OPEN_CLASSNAME);
     this.element.showModal();
     relatedTarget.setAttribute('aria-expanded', 'true');
@@ -139,17 +150,22 @@ class Offcanvas extends BaseComponent {
       return;
     }
 
+    // Remove visual state class first to trigger transition
     this.element.classList.remove(OPEN_CLASSNAME);
-    this.element.close();
-    this.element.removeAttribute('aria-modal');
-    this.element.removeAttribute('role');
 
-    this.removeEventListeners();
-    this.isShown = false;
+    // Wait for transition to complete before closing
+    executeAfterTransition(this.element, () => {
+      this.element.close();
+      this.element.removeAttribute('aria-modal');
+      this.element.removeAttribute('role');
 
-    EventHandler.trigger(this.element, EVENT_HIDDEN);
+      this.removeEventListeners();
+      this.isShown = false;
 
-    this.scrollControl.enableScroll();
+      EventHandler.trigger(this.element, EVENT_HIDDEN);
+
+      this.scrollControl.enableScroll();
+    });
   }
 
   toggle(targetElement: HTMLElement | null) {

--- a/packages/web/src/js/__tests__/Modal.test.ts
+++ b/packages/web/src/js/__tests__/Modal.test.ts
@@ -2,16 +2,30 @@ import { clearFixture, getFixture } from '../../../tests/helpers/fixture';
 import EventHandler from '../dom/EventHandler';
 import Modal from '../Modal';
 
+// Mock the executeAfterTransition function
+jest.mock('../utils/Transitions', () => ({
+  executeAfterTransition: jest.fn((element, callback) => {
+    // Simulate immediate execution for tests
+    callback();
+  }),
+}));
+
 describe('Modal', () => {
   let fixtureEl: Element;
 
   beforeAll(() => {
     fixtureEl = getFixture();
+    // Dialog element do not work in Jest tests due to issue in jsdom
+    // `TypeError: this.element.showModal is not a function`
+    // @see: https://github.com/jsdom/jsdom/issues/3294
+    HTMLDialogElement.prototype.showModal = jest.fn();
+    HTMLDialogElement.prototype.close = jest.fn();
   });
 
   afterEach(() => {
     clearFixture();
     document.body.classList.remove('is-open');
+    jest.clearAllMocks();
   });
 
   describe('constructor', () => {
@@ -41,6 +55,18 @@ describe('Modal', () => {
 
       expect(spy).not.toHaveBeenCalled();
     });
+
+    it('should add is-open class after showing modal', () => {
+      fixtureEl.innerHTML = '<dialog class="Modal"><div class="Modal__content"></div></dialog>';
+
+      const modalEl = fixtureEl.querySelector('.Modal') as HTMLDialogElement;
+      const modal = new Modal(modalEl);
+
+      modal.show();
+
+      expect(modalEl.classList.contains('is-open')).toBe(true);
+      expect(modalEl.showModal).toHaveBeenCalled();
+    });
   });
 
   describe('hide', () => {
@@ -55,6 +81,44 @@ describe('Modal', () => {
       modal.hide(event);
 
       expect.anything();
+    });
+
+    it('should remove is-open class and wait for transition before closing', () => {
+      fixtureEl.innerHTML = '<dialog class="Modal"><div class="Modal__content"></div></dialog>';
+
+      const modalEl = fixtureEl.querySelector('.Modal') as HTMLDialogElement;
+      const modal = new Modal(modalEl);
+
+      // First show the modal
+      modal.show();
+      expect(modalEl.classList.contains('is-open')).toBe(true);
+
+      const event = new Event('click');
+      Object.defineProperty(event, 'target', { value: modalEl });
+
+      modal.hide(event);
+
+      // Should remove is-open class immediately
+      expect(modalEl.classList.contains('is-open')).toBe(false);
+
+      // Should close after transition (mocked to execute immediately)
+      expect(modalEl.close).toHaveBeenCalled();
+    });
+
+    it('should handle target without close function', () => {
+      fixtureEl.innerHTML = '<div class="Modal"><div class="Modal__content"></div></div>';
+
+      const modalEl = fixtureEl.querySelector('.Modal') as HTMLElement;
+      const modal = new Modal(modalEl);
+
+      const event = new Event('click');
+      Object.defineProperty(event, 'target', { value: modalEl });
+
+      modal.hide(event);
+
+      // Should not call executeAfterTransition for elements without close function
+      // Since it's a div, it won't have a close method
+      expect(modalEl).not.toHaveProperty('close');
     });
   });
 

--- a/packages/web/src/scss/components/Drawer/_Drawer.scss
+++ b/packages/web/src/scss/components/Drawer/_Drawer.scss
@@ -42,7 +42,7 @@
     justify-content: end;
 }
 
-.Drawer[open] {
+.Drawer.is-open {
     --#{tokens.$css-variable-prefix}drawer-translate-x: 0%;
 
     visibility: visible;

--- a/packages/web/src/scss/components/Modal/_Modal.scss
+++ b/packages/web/src/scss/components/Modal/_Modal.scss
@@ -62,7 +62,7 @@
     --modal-transform-origin: bottom center;
 }
 
-.Modal[open] {
+.Modal.is-open {
     --modal-scale: 1;
     --modal-translate-y: 0;
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
