### PR TITLE
Refactor(web): Remove a recent "fix" of `Matrix` rendering in Safari #DS-2051

### DIFF
--- a/packages/web-react/src/components/Matrix/README.md
+++ b/packages/web-react/src/components/Matrix/README.md
@@ -78,6 +78,10 @@ However, you can also explicitly set the `rows` prop if you want to control the 
 
 ⚠️ For multi-line Matrix layouts, the number of item rows `itemRows` must be set explicitly. This is required by the [`subgrid`][mdn-subgrid] feature.
 
+⚠️ Be careful when adding margin to Matrix items. It is a known issue that
+adding a top margin to an item causes a [rendering bug][jira-pricing-safari-bug]
+in Safari.
+
 ## Matrix Vs. Grid
 
 The key difference of [Grid][grid] and Matrix is that Matrix is capable of
@@ -118,6 +122,7 @@ If you need more control over the styling of a component, you can use [style pro
 and [escape hatches][readme-escape-hatches].
 
 [grid]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-react/src/components/Grid/README.md
+[jira-pricing-safari-bug]: https://jira.almacareer.tech/browse/DS-2051
 [mdn-grid]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout
 [mdn-subgrid]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid
 [readme-additional-attributes]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-react/README.md#additional-attributes

--- a/packages/web/src/scss/components/Matrix/README.md
+++ b/packages/web/src/scss/components/Matrix/README.md
@@ -185,6 +185,10 @@ for tablets and larger screens, with a single column of content on mobile:
 `--spirit-matrix-item-rows` must be set explicitly. This is required by the
 [`subgrid`][mdn-subgrid] feature.
 
+⚠️ Be careful when adding margin to Matrix items. It is a known issue that
+adding a top margin to an item causes a [rendering bug][jira-pricing-safari-bug]
+in Safari.
+
 ### Custom Vertical Spacing
 
 By default, Matrix creates a zero-row gap, which is probably what you want for
@@ -236,6 +240,7 @@ As of now, only **single-column components** are supported in Matrix.
 [pricing-plan]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/scss/components/PricingPlan/README.md
 [scroll-view]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/scss/components/ScrollView/README.md#horizontal-scrolling
 [stack]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/scss/components/Stack/README.md
+[jira-pricing-safari-bug]: https://jira.almacareer.tech/browse/DS-2051
 [mdn-grid]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout
 [mdn-grid-row]: https://developer.mozilla.org/en-US/docs/Glossary/Grid_Row
 [mdn-subgrid]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid

--- a/packages/web/src/scss/components/Matrix/_Matrix.scss
+++ b/packages/web/src/scss/components/Matrix/_Matrix.scss
@@ -11,32 +11,6 @@
 // 3. Force subgrid on direct descendants. Only effective when the descendant's `display` is set to `grid`.
 //
 // 4. Place the descendants in the Matrix layout and make them inherit its grid rows.
-//
-// 5. Trigger repaint to fix PricingPlan header rows randomly collapsing in a single-column Matrix in Safari.
-//    Source: https://www.flowradar.com/answer/causing-css-grid-elements-display-incorrectly-safari-fix-safari-desktop-ipad
-//
-//    Using `will-change: transform` value turned out to be a bug in combination with descendants
-//    with `position: fixed` and `transform` property (e.g. Modal component).
-//    The `will-change: contents` doesn't influence the visual appearance of elements, so it's preferable temporary solution.
-//
-//    ℹ️ Alternative solution:
-//    1. Detecting the number of columns with a style query.
-//    2. Turn off subgrid for Matrix children if the number of columns is 1.
-//
-//    Re: 1.
-//    Since the Matrix column count is controlled by custom properties, we could turn off subgrid for Matrix children
-//    based on a style query which is supported in Safari (but not in all baseline browsers) as of July 2025:
-//
-//    ```
-//    @container style(--spirit-matrix-columns-internal: 1) {
-//       .Matrix > * {
-//         grid-template-rows: <BUT WHAT NOW?> !important;
-//       }
-//    }
-//    ```
-//
-//    We don't use this approach because it would lead to mixing component styles: it either requires forcing a number
-//    of rows of Matrix children from outside, or reading a custom property of Matrix in the PricingPlan component.
 
 @use '@tokens' as tokens;
 @use '../../tools/reset';
@@ -85,7 +59,6 @@ $_default-rows: 100; // 1.
     display: grid;
     grid-template-columns: repeat(var(--#{tokens.$css-variable-prefix}matrix-columns-internal), 1fr); // 2.a
     grid-template-rows: repeat(var(--#{tokens.$css-variable-prefix}matrix-rows-internal), auto); // 2.a
-    will-change: contents; // 5.
 }
 
 // stylelint-disable-next-line selector-max-universal -- 3.

--- a/packages/web/src/scss/components/Matrix/_Matrix.scss
+++ b/packages/web/src/scss/components/Matrix/_Matrix.scss
@@ -59,6 +59,7 @@ $_default-rows: 100; // 1.
     display: grid;
     grid-template-columns: repeat(var(--#{tokens.$css-variable-prefix}matrix-columns-internal), 1fr); // 2.a
     grid-template-rows: repeat(var(--#{tokens.$css-variable-prefix}matrix-rows-internal), auto); // 2.a
+    width: 100%;
 }
 
 // stylelint-disable-next-line selector-max-universal -- 3.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

We found out the root of the issue was in the top margin of `Matrix` items.
Forcing the repaint actually did not fix the issue for us, so we can remove it.

Additionally, expand `Matrix` width to 100% of its container to match the behavior of `Grid`.

### Additional context

This change reverts the "fix" originally introduced in https://github.com/lmc-eu/spirit-design-system/pull/2134.

### Issue reference

https://jira.almacareer.tech/browse/DS-2051

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
