### PR TITLE
Fix(web-react): Set default height of opened Collapse to undefined #DS-2048

### DIFF
--- a/packages/web-react/src/components/Collapse/useResizeHeight.ts
+++ b/packages/web-react/src/components/Collapse/useResizeHeight.ts
@@ -5,8 +5,8 @@ type Size = {
   height: number | undefined;
 };
 
-export const useResizeHeight = (ref: RefObject<HTMLElement>): string => {
-  const [height, setHeight] = useState<string>('0px');
+export const useResizeHeight = (ref: RefObject<HTMLElement>): string | undefined => {
+  const [height, setHeight] = useState<string | undefined>(undefined);
 
   const onResize = (size: Size) => {
     const currentHeight = size.height;


### PR DESCRIPTION
## Description

- Content is now not rendered under the Collapse on initial load
- Undefined height prevents the content below the opened Collapse from being pushed down when the height is calculated

### Additional context

Fix for Cyborg/Prace.cz (localhost:3000/nabidky)

### Issue reference

[Collapse has 0px height on page load](https://jira.almacareer.tech/browse/DS-2048)
