### PR TITLE
Fix(web-react): Fixed type in `PaginationLink` component

### DIFF
--- a/packages/web-react/src/components/Pagination/PaginationLink.tsx
+++ b/packages/web-react/src/components/Pagination/PaginationLink.tsx
@@ -24,7 +24,7 @@ const _PaginationLink = <E extends ElementType = 'a'>(props: SpiritPaginationLin
   );
 };
 
-const PaginationLink = forwardRef<HTMLAnchorElement, SpiritPaginationLinkProps>(_PaginationLink);
+const PaginationLink = forwardRef<HTMLAnchorElement, SpiritPaginationLinkProps<ElementType>>(_PaginationLink);
 
 PaginationLink.spiritComponent = 'PaginationLink';
 

--- a/packages/web/src/scss/settings/_utilities.scss
+++ b/packages/web/src/scss/settings/_utilities.scss
@@ -279,7 +279,7 @@ $utilities: (
             anywhere: break-all,
         ),
     ),
-    'text-word-break-with-overflow-wrwap': (
+    'text-word-break-with-overflow-wrap': (
         responsive: false,
         // 1.
         property: overflow-wrap,


### PR DESCRIPTION
## Description
- `PaginationLink` was not accepting any `elementType` other than 'a'
- Found typo in utility class name

### Additional context
- When consulting some stuff with Search team, found this bug in types and typo.
