### PR TITLE
BREAKING CHANGE(web-twig): Remove `data-spirit-more` from Collapse trigger

### DIFF
--- a/packages/web-twig/docs/migrations/migration-v5.md
+++ b/packages/web-twig/docs/migrations/migration-v5.md
@@ -8,6 +8,7 @@ Introducing version 5 of the _spirit-web-twig_ package.
 
 - [Component Changes](#component-changes)
   - [Button and ButtonLink: `isBlock` Prop Removed](#button-and-buttonlink-isblock-prop-removed)
+  - [Collapse: Rename `data-spirit-more` to `data-spirit-is-disposable`](#collapse-rename-data-spirit-more-to-data-spirit-is-disposable)
 
 ## Component Changes
 
@@ -18,6 +19,14 @@ Button `isBlock` prop was removed. Use utility classes or the `Grid` component t
 #### Migration Guide
 
 See instructions how to make a fluid button in [`Button`][button-readme-fluid] or [`ButtonLink`][buttonlink-readme-fluid] README files.
+
+### Collapse: Rename `data-spirit-more` to `data-spirit-is-disposable`
+
+The `data-spirit-more` attribute was removed. Use `data-spirit-is-disposable` instead for hiding triggers on collapse.
+
+#### Migration Guide
+
+- `<Button {# … #} data-spirit-more>Collapse trigger</Button>` → `<Button {# … #} data-spirit-is-disposable>Collapse trigger</Button>`
 
 ---
 

--- a/packages/web-twig/src/Resources/components/Collapse/README.md
+++ b/packages/web-twig/src/Resources/components/Collapse/README.md
@@ -69,23 +69,16 @@ and [escape hatches][readme-escape-hatches].
 
 ## Trigger Attributes
 
-| Name                        | Type     | Default    | Required | Description                                                                                                         |
-| --------------------------- | -------- | ---------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
-| `aria-controls`             | `string` | —          | ✕        | Aria controls state (auto)                                                                                          |
-| `aria-expanded`             | `string` | —          | ✕        | Aria expanded state (auto)                                                                                          |
-| `data-spirit-is-disposable` | `bool`   | —          | ✕        | For hide on collapse as more trigger                                                                                |
-| `data-spirit-more`          | `bool`   | —          | ✕        | [**DEPRECATED**][readme-deprecations] in favor of `data-spirit-is-disposable`; For hide on collapse as more trigger |
-| `data-spirit-target`        | `string` | —          | ✓        | Target selector                                                                                                     |
-| `data-spirit-toggle`        | `string` | `collapse` | ✓        | Iterable selector                                                                                                   |
+| Name                        | Type     | Default    | Required | Description                          |
+| --------------------------- | -------- | ---------- | -------- | ------------------------------------ |
+| `aria-controls`             | `string` | —          | ✕        | Aria controls state (auto)           |
+| `aria-expanded`             | `string` | —          | ✕        | Aria expanded state (auto)           |
+| `data-spirit-is-disposable` | `bool`   | —          | ✕        | For hide on collapse as more trigger |
+| `data-spirit-target`        | `string` | —          | ✓        | Target selector                      |
+| `data-spirit-toggle`        | `string` | `collapse` | ✓        | Iterable selector                    |
 
 Other necessary attributes are toggled automatically, like `aria-controls` and `aria-expanded` when component is loaded
 or width of window is changed. There can be several triggers, the same rules apply to each.
-
-### ⚠️ DEPRECATION NOTICE
-
-Data attribute `data-spirit-more` is deprecated and will be removed in the next major release. Use `data-spirit-is-disposable` attribute instead.
-
-[What are deprecations?][readme-deprecations]
 
 ## JavaScript Plugin
 
@@ -103,7 +96,6 @@ Or, feel free to write the controlling script yourself.
 
 [collapse]: https://github.com/lmc-eu/spirit-design-system/tree/main/packages/web/src/scss/components/Collapse
 [readme-additional-attributes]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/README.md#additional-attributes
-[readme-deprecations]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/README.md#deprecations
 [readme-escape-hatches]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/README.md#escape-hatches
 [readme-style-props]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web-twig/README.md#style-props
 [web-js-api]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/scss/components/Collapse/README.md#javascript-plugin


### PR DESCRIPTION
The data-spirit-more attribute has been removed from Collapse trigger elements
in favor of data-spirit-is-disposable for better semantic naming and consistency.

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
