### PR TITLE
Chore(ci): Enable trusted publishing using GitHub Actions and npm

### DIFF
--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -11,5 +11,6 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
+        registry-url: 'https://registry.npmjs.org'
         cache: 'yarn'
         cache-dependency-path: yarn.lock

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
 jobs:
   has-tags:
     name: 🏷️ Analyze Tags
@@ -42,16 +46,17 @@ jobs:
       - name: Build
         run: yarn build
 
-      - name: Authenticate npm
-        run: ./bin/ci/npm-auth.sh
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # TODO: Remove after Trusted Publishers are working
+      # - name: Authenticate npm
+      #   run: ./bin/ci/npm-auth.sh
+      #   env:
+      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish
         run: make publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Post Changelog
         run: yarn post-changelog


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

NPM has introduced Trusted Publishing using OICD, so there will be no need for a long-term token on the GitHub Actions side. The manual publishing using the tokens should still work; however, this should be a safer way.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

https://docs.npmjs.com/trusted-publishers

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
