### PR TITLE
Chore(ci): Set GitHub Actions environment for npm publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,5 +1,9 @@
 name: 🚢 Publish
 
+concurrency:
+  group: npm-registry
+  cancel-in-progress: true
+
 on:
   push:
     branches:
@@ -35,6 +39,7 @@ jobs:
     needs: has-tags
     if: ${{ needs.has-tags.outputs.has-tag == 'true' }}
     runs-on: ubuntu-24.04
+    environment: npm-registry
 
     steps:
       - name: Clone repository

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -52,6 +52,7 @@ jobs:
         run: yarn build
 
       # TODO: Remove after Trusted Publishers are working
+      # Uncomment the following line if trusted publishing is not configured or if you encounter authentication errors.
       # - name: Authenticate npm
       #   run: ./bin/ci/npm-auth.sh
       #   env:
@@ -61,6 +62,7 @@ jobs:
         run: make publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Uncomment the following line if trusted publishing is not configured or if you encounter authentication errors.
           # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Post Changelog


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The `npm` environment has been set up to add an additional layer of protection for publishing our packages to npm repository. It means that every run of the `publish.yaml` action that will publish a package to npm must be authorized/approved by a second person (this setting can be discussed). 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

- https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments
- https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
