### PR TITLE
Chore(ci): Reuse setup-node action in setup-install so the registry is correctly set

### DIFF
--- a/.github/actions/setup-install/action.yaml
+++ b/.github/actions/setup-install/action.yaml
@@ -3,16 +3,8 @@ description: 'Setup Node and Install Dependencies'
 runs:
   using: 'composite'
   steps:
-    - name: Enable Corepack
-      shell: bash
-      run: corepack enable
-
-    - name: Set up Node
-      uses: actions/setup-node@v4
-      with:
-        node-version-file: '.nvmrc'
-        cache: 'yarn'
-        cache-dependency-path: yarn.lock
+    - name: Setup Node
+      uses: ./.github/actions/setup-node
 
     - name: Restore cached node_modules
       uses: actions/cache@v4


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
