### PR TITLE
Fix(web-react): getElement second argument is now optional

### DIFF
--- a/packages/web-react/tests/testUtils/getElement.ts
+++ b/packages/web-react/tests/testUtils/getElement.ts
@@ -1,6 +1,6 @@
 import { RenderResult } from '@testing-library/react';
 
-const getElement = (dom: RenderResult, testId: string | undefined) =>
+const getElement = (dom: RenderResult, testId?: string) =>
   testId ? (dom.getByTestId(testId) as HTMLElement) : (dom.container.firstChild as HTMLElement);
 
 export default getElement;


### PR DESCRIPTION
- `testId` argument now does not need to be provided when calling `getElement` function

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
