### PR TITLE
Fix(web-react): Missing `id` attribute in UNSAFE_Header props typings

### DIFF
--- a/packages/web-react/src/types/unstableHeader.ts
+++ b/packages/web-react/src/types/unstableHeader.ts
@@ -2,6 +2,7 @@ import { type ElementType } from 'react';
 import { type LinkTarget } from './link';
 import {
   type ChildrenProps,
+  type SpiritElementProps,
   type SpiritPolymorphicElementPropsWithRef,
   type StyleProps,
   type TransferProps,
@@ -23,7 +24,7 @@ export type HeaderLogoProps<E extends ElementType> = {
   elementType?: E;
 } & HeaderLogoBaseProps;
 
-export interface SpiritHeaderProps extends StyleProps, ChildrenProps {
+export interface SpiritHeaderProps extends SpiritElementProps, ChildrenProps {
   hasBottomDivider?: boolean;
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
