### PR TITLE
Test(web-react): Add accessibility tests for button and link components #DS-2243

### DIFF
--- a/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.accessibility.test.tsx
+++ b/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.accessibility.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { accessibilityDisabledTest, accessibilityLoadingTest, accessibilityTest } from '@local/tests';
+import { type SpiritButtonLinkProps } from '../../../types';
+import ButtonLink from '../ButtonLink';
+
+jest.mock('../../../hooks/useIcon');
+
+describe('ButtonLink accessibility', () => {
+  const ButtonLinkTest = ({ children, ...props }: SpiritButtonLinkProps) => (
+    <ButtonLink {...props} href="#">
+      {children || 'Click me'}
+    </ButtonLink>
+  );
+
+  accessibilityTest(ButtonLinkTest, 'a');
+
+  accessibilityDisabledTest(ButtonLinkTest, 'a');
+
+  accessibilityLoadingTest((props) => <ButtonLinkTest {...props}>Loading</ButtonLinkTest>, 'a');
+});

--- a/packages/web-react/src/components/ControlButton/__tests__/ControlButton.accessibility.test.tsx
+++ b/packages/web-react/src/components/ControlButton/__tests__/ControlButton.accessibility.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { accessibilityDisabledTest, accessibilityTest } from '@local/tests';
+import { type SpiritControlButtonProps } from '../../../types';
+import { Icon } from '../../Icon';
+import ControlButton from '../ControlButton';
+
+jest.mock('../../../hooks/useIcon');
+
+describe('ControlButton accessibility', () => {
+  const ControlButtonTest = (props: SpiritControlButtonProps) => (
+    <ControlButton {...props} aria-label="Action">
+      <Icon name="close" />
+    </ControlButton>
+  );
+
+  accessibilityTest(ControlButtonTest, 'button');
+
+  accessibilityDisabledTest(ControlButtonTest, 'button');
+});

--- a/packages/web-react/src/components/SplitButton/__tests__/SplitButton.accessibility.test.tsx
+++ b/packages/web-react/src/components/SplitButton/__tests__/SplitButton.accessibility.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { accessibilityDisabledTest, accessibilityTest } from '@local/tests';
+import { type SpiritSplitButtonProps } from '../../../types';
+import { Button } from '../../Button';
+import SplitButton from '../SplitButton';
+
+jest.mock('../../../hooks/useIcon');
+
+describe('SplitButton accessibility', () => {
+  const SplitButtonTest = (props: SpiritSplitButtonProps) => (
+    <SplitButton {...props}>
+      <Button>Button 1</Button>
+      <Button>Button 2</Button>
+    </SplitButton>
+  );
+
+  accessibilityTest(SplitButtonTest, 'button');
+
+  accessibilityDisabledTest(SplitButtonTest, 'button');
+});


### PR DESCRIPTION
## Description

> [!NOTE]
> **Part 2** - more accessibility tests will come in another PRs

Add accessibility tests for button and link components (ButtonLink, SplitButton, and ControlButton) to ensure they meet WCAG accessibility standards. These tests use `axe-core` and `jest-axe` to automatically detect accessibility violations.

The following accessibility test files were added:

- `ButtonLink.accessibility.test.tsx` - tests for default, disabled, and loading states
- `SplitButton.accessibility.test.tsx` - tests for default and disabled states
- `ControlButton.accessibility.test.tsx` - tests for default and disabled states

All tests use existing helper functions (`accessibilityTest`, `accessibilityDisabledTest`, `accessibilityLoadingTest`) from `@local/tests` to ensure consistent test coverage across components.

### Additional context

- ButtonLink component is tested as an anchor element (`<a>`) since it renders as a link by default
- SplitButton component is tested by checking the Button components inside it, as SplitButton is a wrapper component that provides context to its children
- ControlButton test includes an Icon component to match typical usage patterns (icon-only buttons)
- All components follow the same accessibility testing pattern as existing Button component tests

#### How to test

`yarn workspace @lmc-eu/spirit-web-react test:unit --testPathPatterns="ButtonLink|SplitButton|ControlButton" --testPathPatterns="accessibility"`

### Issue reference

[Accessibility testing for the remaining components](https://jira.almacareer.tech/browse/DS-2243)
