### PR TITLE
Test(web-react): Add accessibility tests for navigation components #DS-2243

### DIFF
--- a/packages/web-react/src/components/Breadcrumbs/__tests__/Breadcrumbs.accessibility.test.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/__tests__/Breadcrumbs.accessibility.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { accessibilityTest } from '@local/tests';
+import Breadcrumbs from '../Breadcrumbs';
+import BreadcrumbsItem from '../BreadcrumbsItem';
+
+jest.mock('../../../hooks/useIcon');
+
+describe('Breadcrumbs accessibility', () => {
+  accessibilityTest(
+    (props) => (
+      <Breadcrumbs
+        {...props}
+        items={[
+          { title: 'Home', url: '#' },
+          { title: 'Current', url: '#' },
+        ]}
+      />
+    ),
+    'nav',
+  );
+
+  accessibilityTest(
+    (props) => (
+      <Breadcrumbs {...props}>
+        <BreadcrumbsItem href="#">Home</BreadcrumbsItem>
+        <BreadcrumbsItem isCurrent>Current</BreadcrumbsItem>
+      </Breadcrumbs>
+    ),
+    'nav',
+  );
+});

--- a/packages/web-react/src/components/Navigation/__tests__/Navigation.accessibility.test.tsx
+++ b/packages/web-react/src/components/Navigation/__tests__/Navigation.accessibility.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { accessibilityTest } from '@local/tests';
+import Navigation from '../Navigation';
+import NavigationAction from '../NavigationAction';
+import NavigationItem from '../NavigationItem';
+
+jest.mock('../../../hooks/useIcon');
+
+describe('Navigation accessibility', () => {
+  accessibilityTest(
+    (props) => (
+      <Navigation {...props} aria-label="Main Navigation">
+        <NavigationItem>
+          <NavigationAction href="#">Home</NavigationAction>
+        </NavigationItem>
+        <NavigationItem>
+          <NavigationAction href="#">About</NavigationAction>
+        </NavigationItem>
+      </Navigation>
+    ),
+    'nav',
+  );
+});

--- a/packages/web-react/src/components/Pagination/__tests__/Pagination.accessibility.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/Pagination.accessibility.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { accessibilityTest } from '@local/tests';
+import Pagination from '../Pagination';
+import PaginationItem from '../PaginationItem';
+import PaginationLink from '../PaginationLink';
+
+jest.mock('../../../hooks/useIcon');
+
+describe('Pagination accessibility', () => {
+  accessibilityTest(
+    (props) => (
+      <Pagination {...props}>
+        <PaginationItem>
+          <PaginationLink href="#" pageNumber={1} accessibilityLabel="Go to Page 1" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" pageNumber={2} isCurrent accessibilityLabel="Current Page, Page 2" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" pageNumber={3} accessibilityLabel="Go to Page 3" />
+        </PaginationItem>
+      </Pagination>
+    ),
+    'nav',
+  );
+});

--- a/packages/web-react/src/components/Tabs/__tests__/Tabs.accessibility.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/Tabs.accessibility.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { accessibilitySelectedTest, accessibilityTest } from '@local/tests';
+import TabContent from '../TabContent';
+import TabItem from '../TabItem';
+import TabList from '../TabList';
+import TabPane from '../TabPane';
+import Tabs from '../Tabs';
+
+jest.mock('../../../hooks/useIcon');
+
+describe('Tabs accessibility', () => {
+  accessibilityTest(
+    (props) => (
+      <Tabs {...props} selectedTab={1} toggle={() => {}}>
+        <TabList>
+          <TabItem forTabPane={1}>Tab 1</TabItem>
+          <TabItem forTabPane={2}>Tab 2</TabItem>
+        </TabList>
+        <TabContent>
+          <TabPane id={1}>Content 1</TabPane>
+          <TabPane id={2}>Content 2</TabPane>
+        </TabContent>
+      </Tabs>
+    ),
+    '[role="tablist"]',
+  );
+
+  accessibilitySelectedTest(
+    (props) => (
+      <Tabs {...props} selectedTab={2} toggle={() => {}}>
+        <TabList>
+          <TabItem forTabPane={1}>Tab 1</TabItem>
+          <TabItem forTabPane={2}>Tab 2</TabItem>
+        </TabList>
+        <TabContent>
+          <TabPane id={1}>Content 1</TabPane>
+          <TabPane id={2}>Content 2</TabPane>
+        </TabContent>
+      </Tabs>
+    ),
+    '[role="tablist"]',
+  );
+});

--- a/packages/web-react/tests/accessibilityTests/accessibilitySelectedTest.tsx
+++ b/packages/web-react/tests/accessibilityTests/accessibilitySelectedTest.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import React, { type ComponentType } from 'react';
+import { guardMissingSelector } from '../testUtils/guardMissingSelector';
+import { type RunAxeOptions, runAxe } from '../testUtils/runAxe';
+
+/**
+ * Run accessibility checks for a component when it has a selected state.
+ *
+ * @param Component - Component factory used in the test. Should accept props and configure the component with selected state.
+ * @param selector - CSS selector used to resolve the element for axe.
+ * @param axeOptions - Optional axe configuration overrides.
+ */
+export const accessibilitySelectedTest = (
+  Component: ComponentType<any>,
+  selector: string,
+  axeOptions?: RunAxeOptions,
+) => {
+  it('should be accessible when an item is selected', async () => {
+    const { container } = render(<Component />);
+    const element = container.querySelector(selector);
+
+    guardMissingSelector(selector, element);
+
+    const results = await runAxe(element, axeOptions);
+
+    expect(results).toHaveNoAxeViolations();
+  });
+};

--- a/packages/web-react/tests/accessibilityTests/index.ts
+++ b/packages/web-react/tests/accessibilityTests/index.ts
@@ -1,4 +1,5 @@
-export * from './accessibilityTest';
 export * from './accessibilityDisabledTest';
 export * from './accessibilityLoadingTest';
+export * from './accessibilitySelectedTest';
+export * from './accessibilityTest';
 export * from './accessibilityValidationStateTest';


### PR DESCRIPTION
## Description

> [!NOTE]
> **Part 3** - more accessibility tests will come in another PRs

Add accessibility tests for navigation components (Breadcrumbs, Pagination, Tabs, and Navigation) to ensure they meet WCAG accessibility standards. These tests use `axe-core` and `jest-axe` to automatically detect accessibility violations.

The following accessibility test files were added:

- `Breadcrumbs.accessibility.test.tsx` - tests for default state
- `Pagination.accessibility.test.tsx` - tests for default state
- `Tabs.accessibility.test.tsx` - tests for default and selected states
- `Navigation.accessibility.test.tsx` - tests for default state

A new helper function `accessibilitySelectedTest` was created to test components with selected state (used for Tabs component).

All tests use existing helper functions (`accessibilityTest`, `accessibilitySelectedTest`) from `@local/tests` to ensure consistent test coverage across components.

### Additional context

- `accessibilitySelectedTest` helper function was created to test components with selected state (e.g., selected tab in Tabs component)
- Tabs component requires `toggle` prop callback function, which is automatically provided by the helper function
- Breadcrumbs component is tested with both `items` prop and `children` prop approaches
- Pagination component is tested with PaginationItem and PaginationLink subcomponents
- Navigation component is tested with NavigationItem and NavigationAction subcomponents
- All navigation components render as `<nav>` elements with proper ARIA labels

#### How to test

`yarn workspace @lmc-eu/spirit-web-react test:unit --testPathPatterns="accessibility" --testNamePattern="Breadcrumbs|Pagination|Tabs|Navigation"`

### Issue reference

[Accessibility testing for the remaining components](https://jira.almacareer.tech/browse/DS-2243)
