### PR TITLE
Fix(web-react): Remove `use client` directive from barrel files

### DIFF
--- a/packages/web-react/src/components/Accordion/index.ts
+++ b/packages/web-react/src/components/Accordion/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export * from './useAccordion';
 export * from './useAccordionAriaProps';
 export * from './useAccordionStyleProps';

--- a/packages/web-react/src/components/Accordion/useAccordion.ts
+++ b/packages/web-react/src/components/Accordion/useAccordion.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import { type AccordionHandlingProps, type AccordionOpenStateType, type UncontrolledAccordionProps } from '../../types';
 

--- a/packages/web-react/src/components/ActionGroup/index.ts
+++ b/packages/web-react/src/components/ActionGroup/index.ts
@@ -1,3 +1,1 @@
-'use client';
-
 export { default as ActionGroup } from './ActionGroup';

--- a/packages/web-react/src/components/Alert/index.ts
+++ b/packages/web-react/src/components/Alert/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export * from './useAlertStyleProps';
 export { default as Alert } from './Alert';

--- a/packages/web-react/src/components/Avatar/index.ts
+++ b/packages/web-react/src/components/Avatar/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Avatar } from './Avatar';
 export * from './useAvatarStyleProps';

--- a/packages/web-react/src/components/Box/index.ts
+++ b/packages/web-react/src/components/Box/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Box } from './Box';
 export * from './useBoxStyleProps';

--- a/packages/web-react/src/components/Breadcrumbs/index.ts
+++ b/packages/web-react/src/components/Breadcrumbs/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Breadcrumbs } from './Breadcrumbs';
 export { default as BreadcrumbsItem } from './BreadcrumbsItem';
 export * from './useBreadcrumbsStyleProps';

--- a/packages/web-react/src/components/Button/index.ts
+++ b/packages/web-react/src/components/Button/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export * from './useButtonProps';
 export * from './useButtonStyleProps';
 export { default as Button } from './Button';

--- a/packages/web-react/src/components/ButtonLink/index.ts
+++ b/packages/web-react/src/components/ButtonLink/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export * from './useButtonLinkProps';
 export * from './useButtonLinkStyleProps';
 export { default as ButtonLink } from './ButtonLink';

--- a/packages/web-react/src/components/Card/index.ts
+++ b/packages/web-react/src/components/Card/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Card } from './Card';
 export { default as CardArtwork } from './CardArtwork';
 export { default as CardBody } from './CardBody';

--- a/packages/web-react/src/components/Checkbox/index.ts
+++ b/packages/web-react/src/components/Checkbox/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Checkbox } from './Checkbox';
 export * from './useCheckboxStyleProps';

--- a/packages/web-react/src/components/Collapse/index.ts
+++ b/packages/web-react/src/components/Collapse/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Collapse } from './Collapse';
 export { default as UncontrolledCollapse } from './UncontrolledCollapse';
 export * from './useCollapse';

--- a/packages/web-react/src/components/Collapse/useCollapse.ts
+++ b/packages/web-react/src/components/Collapse/useCollapse.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import { type ClickEvent } from '../../types';
 

--- a/packages/web-react/src/components/Collapse/useResizeHeight.ts
+++ b/packages/web-react/src/components/Collapse/useResizeHeight.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { type RefObject, useState } from 'react';
 import { useResizeObserver } from '../../hooks/useResizeObserver';
 

--- a/packages/web-react/src/components/Container/index.ts
+++ b/packages/web-react/src/components/Container/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export * from './useContainerStyleProps';
 export { default as Container } from './Container';

--- a/packages/web-react/src/components/ControlButton/index.ts
+++ b/packages/web-react/src/components/ControlButton/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export * from './useControlButtonProps';
 export * from './useControlButtonStyleProps';
 export { default as ControlButton } from './ControlButton';

--- a/packages/web-react/src/components/Dialog/index.ts
+++ b/packages/web-react/src/components/Dialog/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Dialog } from './Dialog';
 export * from './useDialog';

--- a/packages/web-react/src/components/Dialog/useDialog.ts
+++ b/packages/web-react/src/components/Dialog/useDialog.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { type MutableRefObject, type TransitionEvent, useCallback, useEffect } from 'react';
 import { CLASS_NAME_OPEN } from '../../constants';
 import { useScrollControl } from '../../hooks';

--- a/packages/web-react/src/components/Divider/index.ts
+++ b/packages/web-react/src/components/Divider/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Divider } from './Divider';
 export * from './useDividerStyleProps';

--- a/packages/web-react/src/components/Drawer/index.ts
+++ b/packages/web-react/src/components/Drawer/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Drawer } from './Drawer';
 export { default as DrawerCloseButton } from './DrawerCloseButton';
 export { default as DrawerPanel } from './DrawerPanel';

--- a/packages/web-react/src/components/Dropdown/index.ts
+++ b/packages/web-react/src/components/Dropdown/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Dropdown } from './Dropdown';
 export { default as DropdownTrigger } from './DropdownTrigger';
 export { default as DropdownPopover } from './DropdownPopover';

--- a/packages/web-react/src/components/Dropdown/useDropdown.ts
+++ b/packages/web-react/src/components/Dropdown/useDropdown.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { type MutableRefObject, useState } from 'react';
 import { useClickOutside } from '../../hooks';
 import { type ClickEvent } from '../../types';

--- a/packages/web-react/src/components/EmptyState/index.ts
+++ b/packages/web-react/src/components/EmptyState/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as EmptyState } from './EmptyState';
 export { default as EmptyStateSection } from './EmptyStateSection';
 export * from './useEmptyStateStyleProps';

--- a/packages/web-react/src/components/Field/index.ts
+++ b/packages/web-react/src/components/Field/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as HelperText } from './HelperText';
 export { default as Label } from './Label';
 export { default as useAriaIds } from './useAriaIds';

--- a/packages/web-react/src/components/Field/useAriaIds.tsx
+++ b/packages/web-react/src/components/Field/useAriaIds.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback, useState } from 'react';
 
 export type RegisterParams = { add?: string; remove?: string };

--- a/packages/web-react/src/components/Field/useValidationTextRole.tsx
+++ b/packages/web-react/src/components/Field/useValidationTextRole.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useRef, useState } from 'react';
 import { type ValidationState, type ValidationTextType } from '../../types/shared';
 import { A11Y_ALERT_ROLE } from './constants';

--- a/packages/web-react/src/components/FieldGroup/index.ts
+++ b/packages/web-react/src/components/FieldGroup/index.ts
@@ -1,3 +1,1 @@
-'use client';
-
 export { default as FieldGroup } from './FieldGroup';

--- a/packages/web-react/src/components/FileUploader/index.ts
+++ b/packages/web-react/src/components/FileUploader/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as FileUploader } from './FileUploader';
 export { default as FileUploaderInput } from './FileUploaderInput';
 export { default as FileUploaderList } from './FileUploaderList';

--- a/packages/web-react/src/components/FileUploader/useFileQueue.ts
+++ b/packages/web-react/src/components/FileUploader/useFileQueue.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import { type FileMetadata, type FileQueueValueType, type FileUploaderHandlingProps } from '../../types';
 

--- a/packages/web-react/src/components/FileUploader/useFileUploaderInput.ts
+++ b/packages/web-react/src/components/FileUploader/useFileUploaderInput.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { type ChangeEvent, type DragEvent, useEffect, useState } from 'react';
 import { warning } from '../../common/utilities';
 import { useDragAndDrop } from '../../hooks';

--- a/packages/web-react/src/components/Flex/index.ts
+++ b/packages/web-react/src/components/Flex/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Flex } from './Flex';
 export * from './useFlexStyleProps';

--- a/packages/web-react/src/components/Footer/index.ts
+++ b/packages/web-react/src/components/Footer/index.ts
@@ -1,3 +1,1 @@
-'use client';
-
 export { default as Footer } from './Footer';

--- a/packages/web-react/src/components/Grid/index.ts
+++ b/packages/web-react/src/components/Grid/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Grid } from './Grid';
 export { default as GridItem } from './GridItem';
 export * from './useGridStyleProps';

--- a/packages/web-react/src/components/Header/index.ts
+++ b/packages/web-react/src/components/Header/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Header } from './Header';
 export { default as HeaderButton } from './HeaderButton';
 export { default as HeaderDesktopActions } from './HeaderDesktopActions';

--- a/packages/web-react/src/components/Heading/index.ts
+++ b/packages/web-react/src/components/Heading/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Heading } from './Heading';
 export * from './useHeadingStyleProps';

--- a/packages/web-react/src/components/Icon/index.ts
+++ b/packages/web-react/src/components/Icon/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Icon } from './Icon';
 export * from './useIconStyleProps';

--- a/packages/web-react/src/components/IconBox/index.ts
+++ b/packages/web-react/src/components/IconBox/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as IconBox } from './IconBox';
 export * from './useIconBoxColors';
 export * from './useIconBoxStyleProps';

--- a/packages/web-react/src/components/Item/index.ts
+++ b/packages/web-react/src/components/Item/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Item } from './Item';
 export * from './useItemStyleProps';

--- a/packages/web-react/src/components/Link/index.ts
+++ b/packages/web-react/src/components/Link/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Link } from './Link';
 export * from './useLinkStyleProps';

--- a/packages/web-react/src/components/Matrix/index.ts
+++ b/packages/web-react/src/components/Matrix/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Matrix } from './Matrix';
 export * from './Matrix';
 export * from './useMatrixStyleProps';

--- a/packages/web-react/src/components/Modal/index.ts
+++ b/packages/web-react/src/components/Modal/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Modal } from './Modal';
 export { default as ModalBody } from './ModalBody';
 export { default as ModalCloseButton } from './ModalCloseButton';

--- a/packages/web-react/src/components/Navigation/index.ts
+++ b/packages/web-react/src/components/Navigation/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Navigation } from './Navigation';
 export { default as NavigationAction } from './NavigationAction';
 export { default as NavigationAvatar } from './NavigationAvatar';

--- a/packages/web-react/src/components/NoSsr/index.ts
+++ b/packages/web-react/src/components/NoSsr/index.ts
@@ -1,3 +1,1 @@
-'use client';
-
 export { default as NoSsr } from './NoSsr';

--- a/packages/web-react/src/components/Pagination/index.ts
+++ b/packages/web-react/src/components/Pagination/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Pagination } from './Pagination';
 export { default as PaginationButtonLink } from './PaginationButtonLink';
 export { default as PaginationItem } from './PaginationItem';

--- a/packages/web-react/src/components/Pagination/usePagination.tsx
+++ b/packages/web-react/src/components/Pagination/usePagination.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback, useMemo, useState } from 'react';
 import { type UsePaginationProps } from '../../types/pagination';
 

--- a/packages/web-react/src/components/PartnerLogo/index.ts
+++ b/packages/web-react/src/components/PartnerLogo/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export * from './PartnerLogo';
 export * from './usePartnerLogoStyleProps';
 export { default as PartnerLogo } from './PartnerLogo';

--- a/packages/web-react/src/components/Pill/index.ts
+++ b/packages/web-react/src/components/Pill/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Pill } from './Pill';
 export * from './constants';
 export * from './usePillStyleProps';

--- a/packages/web-react/src/components/PricingPlan/index.ts
+++ b/packages/web-react/src/components/PricingPlan/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as PricingPlan } from './PricingPlan';
 export { default as PricingPlanHeader } from './PricingPlanHeader';
 export { default as PricingPlanBody } from './PricingPlanBody';

--- a/packages/web-react/src/components/ProductLogo/index.ts
+++ b/packages/web-react/src/components/ProductLogo/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export * from './ProductLogo';
 export { default as ProductLogo } from './ProductLogo';

--- a/packages/web-react/src/components/Radio/index.ts
+++ b/packages/web-react/src/components/Radio/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Radio } from './Radio';
 export * from './useRadioStyleProps';

--- a/packages/web-react/src/components/ScrollView/index.ts
+++ b/packages/web-react/src/components/ScrollView/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as ScrollView } from './ScrollView';
 export { default as ScrollViewArrows } from './ScrollViewArrows';
 export * from './constants';

--- a/packages/web-react/src/components/ScrollView/useScrollPosition.ts
+++ b/packages/web-react/src/components/ScrollView/useScrollPosition.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { type MutableRefObject, type UIEvent, useCallback, useEffect, useState } from 'react';
 import { Position, isDirectionHorizontal } from '../../constants';
 import { useResizeObserver } from '../../hooks';

--- a/packages/web-react/src/components/Section/index.ts
+++ b/packages/web-react/src/components/Section/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Section } from './Section';
 export * from './useSectionSizeProps';
 export * from './useSectionStyleProps';

--- a/packages/web-react/src/components/SegmentedControl/index.ts
+++ b/packages/web-react/src/components/SegmentedControl/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as SegmentedControl } from './SegmentedControl';
 export { default as SegmentedControlItem } from './SegmentedControlItem';
 export * from './useSegmentedControl';

--- a/packages/web-react/src/components/Select/index.ts
+++ b/packages/web-react/src/components/Select/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Select } from './Select';
 export * from './useSelectStyleProps';

--- a/packages/web-react/src/components/Skeleton/index.ts
+++ b/packages/web-react/src/components/Skeleton/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export * from './useSkeletonStyleProps';
 export { default as SkeletonText } from './SkeletonText';
 export { default as SkeletonHeading } from './SkeletonHeading';

--- a/packages/web-react/src/components/SkipLink/index.ts
+++ b/packages/web-react/src/components/SkipLink/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as SkipLink } from './SkipLink';
 export * from './useSkipLinkStyleProps';

--- a/packages/web-react/src/components/Slider/index.ts
+++ b/packages/web-react/src/components/Slider/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Slider } from './Slider';
 export * from './useSliderStyleProps';

--- a/packages/web-react/src/components/Slider/useSlider.ts
+++ b/packages/web-react/src/components/Slider/useSlider.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { type ChangeEvent, useState } from 'react';
 
 export interface UseSliderReturn {

--- a/packages/web-react/src/components/Spinner/index.ts
+++ b/packages/web-react/src/components/Spinner/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Spinner } from './Spinner';
 export * from './useSpinnerStyleProps';

--- a/packages/web-react/src/components/SplitButton/UncontrolledSplitButton.tsx
+++ b/packages/web-react/src/components/SplitButton/UncontrolledSplitButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState } from 'react';
 import { type UncontrolledSplitButtonProps } from '../../types';
 import { Button } from '../Button';

--- a/packages/web-react/src/components/SplitButton/index.ts
+++ b/packages/web-react/src/components/SplitButton/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as SplitButton } from './SplitButton';
 export { default as UncontrolledSplitButton } from './UncontrolledSplitButton';
 export * from './useSplitButtonStyleProps';

--- a/packages/web-react/src/components/Stack/index.ts
+++ b/packages/web-react/src/components/Stack/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Stack } from './Stack';
 export { default as StackItem } from './StackItem';

--- a/packages/web-react/src/components/Tabs/index.ts
+++ b/packages/web-react/src/components/Tabs/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as TabContent } from './TabContent';
 export { default as TabContext } from './TabContext';
 export { default as TabItem } from './TabItem';

--- a/packages/web-react/src/components/Tabs/useTabs.ts
+++ b/packages/web-react/src/components/Tabs/useTabs.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback, useState } from 'react';
 import { type TabId } from '../../types';
 

--- a/packages/web-react/src/components/Tag/index.ts
+++ b/packages/web-react/src/components/Tag/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Tag } from './Tag';
 export * from './constants';
 export * from './useTagStyleProps';

--- a/packages/web-react/src/components/Text/index.ts
+++ b/packages/web-react/src/components/Text/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Text } from './Text';
 export * from './useTextStyleProps';

--- a/packages/web-react/src/components/TextArea/index.ts
+++ b/packages/web-react/src/components/TextArea/index.ts
@@ -1,3 +1,1 @@
-'use client';
-
 export { default as TextArea } from './TextArea';

--- a/packages/web-react/src/components/TextArea/useAdjustHeight.ts
+++ b/packages/web-react/src/components/TextArea/useAdjustHeight.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { type FormEvent, type FormEventHandler, type ForwardedRef, type MutableRefObject, useEffect } from 'react';
 
 export interface UseAdjustHeightProps {

--- a/packages/web-react/src/components/TextField/index.ts
+++ b/packages/web-react/src/components/TextField/index.ts
@@ -1,3 +1,1 @@
-'use client';
-
 export { default as TextField } from './TextField';

--- a/packages/web-react/src/components/TextFieldBase/index.ts
+++ b/packages/web-react/src/components/TextFieldBase/index.ts
@@ -1,3 +1,1 @@
-'use client';
-
 export { default as TextFieldBase } from './TextFieldBase';

--- a/packages/web-react/src/components/TextFieldBase/usePasswordToggle.ts
+++ b/packages/web-react/src/components/TextFieldBase/usePasswordToggle.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 
 export const usePasswordToggle = () => {

--- a/packages/web-react/src/components/Timeline/index.ts
+++ b/packages/web-react/src/components/Timeline/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Timeline } from './Timeline';
 export { default as TimelineContent } from './TimelineContent';
 export { default as TimelineHeading } from './TimelineHeading';

--- a/packages/web-react/src/components/Toast/index.ts
+++ b/packages/web-react/src/components/Toast/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Toast } from './Toast';
 export { default as ToastBar } from './ToastBar';
 export { default as ToastBarMessage } from './ToastBarMessage';

--- a/packages/web-react/src/components/Toast/useToast.ts
+++ b/packages/web-react/src/components/Toast/useToast.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useContext } from 'react';
 import { ToastContext } from './ToastContext';
 

--- a/packages/web-react/src/components/Toggle/index.ts
+++ b/packages/web-react/src/components/Toggle/index.ts
@@ -1,4 +1,2 @@
-'use client';
-
 export { default as Toggle } from './Toggle';
 export * from './useToggleStyleProps';

--- a/packages/web-react/src/components/Tooltip/index.ts
+++ b/packages/web-react/src/components/Tooltip/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Tooltip } from './Tooltip';
 export { default as TooltipCloseButton } from './TooltipCloseButton';
 export { default as TooltipPopover } from './TooltipPopover';

--- a/packages/web-react/src/components/Tooltip/useFloating.ts
+++ b/packages/web-react/src/components/Tooltip/useFloating.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   type Placement,
   type Strategy,

--- a/packages/web-react/src/components/Tooltip/useTooltip.ts
+++ b/packages/web-react/src/components/Tooltip/useTooltip.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 
 export interface UseTooltipReturn {

--- a/packages/web-react/src/components/Tooltip/useTooltipStyleProps.ts
+++ b/packages/web-react/src/components/Tooltip/useTooltipStyleProps.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import classNames from 'classnames';
 import { type ElementType, useMemo } from 'react';
 import { useClassNamePrefix } from '../../hooks';

--- a/packages/web-react/src/components/Truncate/index.ts
+++ b/packages/web-react/src/components/Truncate/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as Truncate } from './Truncate';
 export * from './useTruncatedText';
 export * from './useTruncateStyleProps';

--- a/packages/web-react/src/components/Truncate/useTruncatedText.ts
+++ b/packages/web-react/src/components/Truncate/useTruncatedText.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { type ReactNode, useMemo } from 'react';
 import { type TruncateMode, TruncateModes } from '../../types';
 

--- a/packages/web-react/src/components/UNSTABLE_Header/demo/HeaderWithNavigation/index.ts
+++ b/packages/web-react/src/components/UNSTABLE_Header/demo/HeaderWithNavigation/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as MainNavigation } from './MainNavigation';
 export { default as ProfileNavigation } from './ProfileNavigation';
 export { default as SecondaryHorizontalNavigation } from './SecondaryHorizontalNavigation';

--- a/packages/web-react/src/components/UNSTABLE_Header/demo/HeaderWithNavigationAndNestedItems/index.ts
+++ b/packages/web-react/src/components/UNSTABLE_Header/demo/HeaderWithNavigationAndNestedItems/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as CollapseNavigation } from './CollapseNavigation';
 export { default as MainHorizontalNavigation } from './MainHorizontalNavigation';
 export { default as MainNavigationDropdown } from './MainHorizontalNavigationDropdown';

--- a/packages/web-react/src/components/UNSTABLE_Header/index.ts
+++ b/packages/web-react/src/components/UNSTABLE_Header/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export { default as UNSTABLE_Header } from './UNSTABLE_Header';
 export { default as UNSTABLE_HeaderLogo } from './UNSTABLE_HeaderLogo';
 export * as useUnstableHeaderStyleProps from './useUnstableHeaderStyleProps';

--- a/packages/web-react/src/components/VisuallyHidden/index.ts
+++ b/packages/web-react/src/components/VisuallyHidden/index.ts
@@ -1,3 +1,1 @@
-'use client';
-
 export { default as VisuallyHidden } from './VisuallyHidden';

--- a/packages/web-react/src/components/index.ts
+++ b/packages/web-react/src/components/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export * from './Accordion';
 export * from './ActionGroup';
 export * from './Alert';

--- a/packages/web-react/src/context/index.ts
+++ b/packages/web-react/src/context/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export * from './ClassNamePrefixContext';
 export * from './IconsContext';
 export * from './PropsContext';

--- a/packages/web-react/src/hooks/styleProps.ts
+++ b/packages/web-react/src/hooks/styleProps.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import classNames from 'classnames';
 import { type CSSProperties, type HTMLAttributes, useContext } from 'react';
 import { warning } from '../common/utilities';

--- a/packages/web-react/src/hooks/useAriaDescribedBy.ts
+++ b/packages/web-react/src/hooks/useAriaDescribedBy.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useMemo } from 'react';
 
 export const useAriaDescribedBy = (ids: string[]) =>

--- a/packages/web-react/src/hooks/useCancelEvent.ts
+++ b/packages/web-react/src/hooks/useCancelEvent.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { type MutableRefObject, useCallback } from 'react';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 

--- a/packages/web-react/src/hooks/useClassNamePrefix.ts
+++ b/packages/web-react/src/hooks/useClassNamePrefix.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useContext } from 'react';
 import ClassNamePrefixContext from '../context/ClassNamePrefixContext';
 import { applyClassNamePrefix } from '../utils/classname';

--- a/packages/web-react/src/hooks/useClick.ts
+++ b/packages/web-react/src/hooks/useClick.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback } from 'react';
 import { type ClickEvent } from '../types';
 

--- a/packages/web-react/src/hooks/useClickOutside.ts
+++ b/packages/web-react/src/hooks/useClickOutside.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { type MutableRefObject, useCallback, useRef } from 'react';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 

--- a/packages/web-react/src/hooks/useDeprecationMessage.ts
+++ b/packages/web-react/src/hooks/useDeprecationMessage.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect } from 'react';
 import { warning } from '../common/utilities';
 

--- a/packages/web-react/src/hooks/useDragAndDrop.ts
+++ b/packages/web-react/src/hooks/useDragAndDrop.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { type DragEvent, useState } from 'react';
 import { type DragAndDropHandlingProps } from '../types';
 

--- a/packages/web-react/src/hooks/useIcon.ts
+++ b/packages/web-react/src/hooks/useIcon.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useContext } from 'react';
 import warning from '../common/utilities/warning';
 import IconsContext from '../context/IconsContext';

--- a/packages/web-react/src/hooks/useIsMounted.ts
+++ b/packages/web-react/src/hooks/useIsMounted.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * This implementation is a modified copy of the `usehooks-ts` library
  *

--- a/packages/web-react/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/packages/web-react/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * This file fixes the problem of using useLayoutEffect hook on the server side.
  *

--- a/packages/web-react/src/hooks/useLastActiveFocus.ts
+++ b/packages/web-react/src/hooks/useLastActiveFocus.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { type MutableRefObject, useEffect, useRef } from 'react';
 
 export const useLastActiveFocus = (isOpen: boolean) => {

--- a/packages/web-react/src/hooks/useResizeObserver.ts
+++ b/packages/web-react/src/hooks/useResizeObserver.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * This implementation is a modified copy of the `usehooks-ts` library
  *

--- a/packages/web-react/src/hooks/useScrollControl.ts
+++ b/packages/web-react/src/hooks/useScrollControl.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { type MutableRefObject, useEffect } from 'react';
 
 const CLASSNAME_SCROLLING_DISABLED = 'is-scrolling-disabled';

--- a/packages/web-react/src/hooks/useToggle.ts
+++ b/packages/web-react/src/hooks/useToggle.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback, useState } from 'react';
 
 export const useToggle = (initialState = false): [boolean, () => void] => {

--- a/packages/web-react/src/index.ts
+++ b/packages/web-react/src/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export * from './components';
 export * from './constants';
 export * from './context';

--- a/packages/web-react/tests/testUtils/renderWithHeaderContext.tsx
+++ b/packages/web-react/tests/testUtils/renderWithHeaderContext.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { render } from '@testing-library/react';
 import React, { type ElementType } from 'react';
 import { type HeaderDialogContextProps, HeaderDialogProvider } from '../../src';

--- a/packages/web-react/tests/testUtils/withTabsContext.tsx
+++ b/packages/web-react/tests/testUtils/withTabsContext.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React, { type ElementType } from 'react';
 import { type TabsContextType, TabsProvider } from '../../src';
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

  * Next.js error
  * unsupported to use "export *" in a client boundary
  * `export *` is too dynamic for Next.js because it must guarantee:
    * no srver-only functions leak into the client bundle
    * no forbidden server dependencies get pulled in
    * bundling stays deterministic
  * the component where are used must determine if it is client/server

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

- https://nextjs.org/docs/app/getting-started/server-and-client-components
- https://github.com/wevm/wagmi/discussions/3207
- https://github.com/heroui-inc/heroui/issues/2749
- https://www.zaynelovecraft.com/articles/understanding-client-components-and-client-boundaries

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

https://jira.almacareer.tech/browse/DS-2293

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
