### PR TITLE
Test(web-react): Add accessibility tests for interactive components #DS-2243

### DIFF
--- a/packages/web-react/src/components/Accordion/__tests__/Accordion.accessibility.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/Accordion.accessibility.test.tsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { guardMissingSelector } from '@local/tests/testUtils/guardMissingSelector';
+import { runAxe } from '@local/tests/testUtils/runAxe';
+import Accordion from '../Accordion';
+import AccordionContent from '../AccordionContent';
+import AccordionHeader from '../AccordionHeader';
+import AccordionItem from '../AccordionItem';
+
+jest.mock('../../../hooks/useIcon');
+
+describe('Accordion accessibility', () => {
+  it('should be accessible when open', async () => {
+    const { container } = render(
+      <Accordion open="accordion-item-1" toggle={() => {}}>
+        <AccordionItem id="accordion-item-1">
+          <AccordionHeader>Accordion Header</AccordionHeader>
+          <AccordionContent>Accordion Content</AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    const element = container.querySelector('#accordion-item-1');
+
+    guardMissingSelector('#accordion-item-1', element);
+
+    const results = await runAxe(element);
+
+    expect(results).toHaveNoAxeViolations();
+  });
+});

--- a/packages/web-react/src/components/Collapse/__tests__/Collapse.accessibility.test.tsx
+++ b/packages/web-react/src/components/Collapse/__tests__/Collapse.accessibility.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { accessibilityOpenTest, accessibilityTest } from '@local/tests';
+import { type SpiritCollapseProps } from '../../../types';
+import { Button } from '../../Button';
+import Collapse from '../Collapse';
+
+const CollapseTest = ({ isOpen = false, ...props }: SpiritCollapseProps & { isOpen?: boolean }) => (
+  <>
+    <Button type="button" aria-expanded={isOpen} aria-controls="collapse-example" onClick={() => {}}>
+      Toggle Collapse
+    </Button>
+    <Collapse {...props} id="collapse-example" isOpen={isOpen}>
+      Collapse content
+    </Collapse>
+  </>
+);
+
+describe('Collapse accessibility', () => {
+  accessibilityTest(CollapseTest, '#collapse-example');
+
+  accessibilityOpenTest(CollapseTest, '#collapse-example');
+});

--- a/packages/web-react/src/components/Item/__tests__/Item.accessibility.test.tsx
+++ b/packages/web-react/src/components/Item/__tests__/Item.accessibility.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { accessibilityDisabledTest, accessibilityTest } from '@local/tests';
+import { type SpiritItemProps } from '../../../types';
+import Item from '../Item';
+
+jest.mock('../../../hooks/useIcon');
+
+describe('Item accessibility', () => {
+  const ItemTest = (props: SpiritItemProps) => <Item {...props} label="Item label" />;
+
+  accessibilityTest(ItemTest, 'button');
+
+  accessibilityDisabledTest(ItemTest, 'button');
+});

--- a/packages/web-react/src/components/SegmentedControl/__tests__/SegmentedControl.accessibility.test.tsx
+++ b/packages/web-react/src/components/SegmentedControl/__tests__/SegmentedControl.accessibility.test.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { accessibilityTest } from '@local/tests';
+import { type SpiritSegmentedControlProps } from '../../../types';
+import SegmentedControl from '../SegmentedControl';
+import SegmentedControlItem from '../SegmentedControlItem';
+
+describe('SegmentedControl accessibility', () => {
+  const SegmentedControlTest = (props: SpiritSegmentedControlProps) => {
+    const [selectedValue, setSelectedValue] = useState<string | string[]>('1');
+
+    return (
+      <SegmentedControl
+        {...props}
+        name="test-control"
+        label="Test label"
+        selectedValue={selectedValue}
+        setSelectedValue={setSelectedValue}
+        onSelectionChange={() => {}}
+      >
+        <SegmentedControlItem id="option-1" value="1">
+          Item 1
+        </SegmentedControlItem>
+        <SegmentedControlItem id="option-2" value="2">
+          Item 2
+        </SegmentedControlItem>
+      </SegmentedControl>
+    );
+  };
+
+  accessibilityTest(SegmentedControlTest, 'fieldset');
+});

--- a/packages/web-react/src/types/index.ts
+++ b/packages/web-react/src/types/index.ts
@@ -36,6 +36,7 @@ export * from './productLogo';
 export * from './radio';
 export * from './scrollView';
 export * from './section';
+export * from './segmentedControl';
 export * from './select';
 export * from './shared';
 export * from './skeleton';


### PR DESCRIPTION
## Description

> [!NOTE]
> **Part 5** - more accessibility tests will come in another PRs

Add accessibility tests for interactive components (Item, SegmentedControl, Accordion, and Collapse) to ensure they meet WCAG accessibility standards. These tests use `axe-core` and `jest-axe` to automatically detect accessibility violations.

The following accessibility test files were added:

- `Item.accessibility.test.tsx` - tests for default and disabled states
- `SegmentedControl.accessibility.test.tsx` - tests for default state
- `Accordion.accessibility.test.tsx` - tests for open state
- `Collapse.accessibility.test.tsx` - tests for default state

All tests use existing helper functions (`accessibilityTest`, `accessibilityDisabledTest`, `accessibilityOpenTest`) from `@local/tests` to ensure consistent test coverage across components.

### Additional context

- Item component is tested as a button element (default elementType) with default and disabled states
- Item test includes mock for `useIcon` hook to suppress warnings about missing icons
- SegmentedControl component is tested as a fieldset element with SegmentedControlItem children
- Accordion component uses custom implementation for open state test (uses `open` prop instead of `isOpen`)
- Accordion test includes mock for `useIcon` hook and uses `waitFor` to handle asynchronous rendering
- Collapse component is tested in default (closed) state using `accessibilityTest` helper

#### How to test

`yarn workspace @lmc-eu/spirit-web-react test:unit --testPathPatterns="accessibility" --testNamePattern="Item|SegmentedControl|Accordion|Collapse"`

### Issue reference

[Accessibility testing for the remaining components](https://jira.almacareer.tech/browse/DS-2243)
