### PR TITLE
Test(web-react): Add accessibility tests for important accessibility components #DS-2243

### DIFF
--- a/packages/web-react/src/components/Alert/__tests__/Alert.accessibility.test.tsx
+++ b/packages/web-react/src/components/Alert/__tests__/Alert.accessibility.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { accessibilityTest } from '@local/tests';
+import { type SpiritAlertProps } from '../../../types';
+import Alert from '../Alert';
+
+jest.mock('../../../hooks/useIcon');
+
+describe('Alert accessibility', () => {
+  const AlertTest = (props: SpiritAlertProps) => <Alert {...props}>Alert content</Alert>;
+
+  accessibilityTest(AlertTest, 'div');
+});

--- a/packages/web-react/src/components/Dialog/__tests__/Dialog.accessibility.test.tsx
+++ b/packages/web-react/src/components/Dialog/__tests__/Dialog.accessibility.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { runAxe } from '@local/tests/testUtils/runAxe';
+import Dialog from '../Dialog';
+
+describe('Dialog accessibility', () => {
+  it('should be accessible when open', async () => {
+    render(
+      <Dialog id="dialog-example" isOpen onClose={() => {}}>
+        <div>Dialog content</div>
+      </Dialog>,
+    );
+
+    const element = screen.getByRole('dialog');
+    const results = await runAxe(element);
+
+    expect(results).toHaveNoAxeViolations();
+  });
+});

--- a/packages/web-react/src/components/SkipLink/__tests__/SkipLink.accessibility.test.tsx
+++ b/packages/web-react/src/components/SkipLink/__tests__/SkipLink.accessibility.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { accessibilityTest } from '@local/tests';
+import { type SpiritSkipLinkProps } from '../../../types';
+import SkipLink from '../SkipLink';
+
+describe('SkipLink accessibility', () => {
+  const SkipLinkTest = (props: SpiritSkipLinkProps) => (
+    <SkipLink {...props} href="#main-content">
+      Skip to main content
+    </SkipLink>
+  );
+
+  accessibilityTest(SkipLinkTest, 'a');
+});


### PR DESCRIPTION
## Description

> [!NOTE]
> **Part 6** - more accessibility tests will come in another PRs

Add accessibility tests for Alert, Dialog, and SkipLink components.

- Add Alert.accessibility.test.tsx with tests for default state
- Add Dialog.accessibility.test.tsx with tests for open state using act and waitFor
- Add SkipLink.accessibility.test.tsx with tests for default state

### Additional context

- Alert test uses `accessibilityTest` helper for default state
- Alert test includes mock for `useIcon` hook to suppress warnings about missing icons
- Dialog test uses `act` and `waitFor` for asynchronous rendering of the native `<dialog>` element
- Dialog test uses `screen.getByRole('dialog')` to target the dialog element
- SkipLink test uses `accessibilityTest` helper for default state

#### How to test

`yarn workspace @lmc-eu/spirit-web-react test:unit --testPathPatterns="accessibility" --testNamePattern="Alert|Dialog|SkipLink"`

### Issue reference

[Accessibility testing for the remaining components](https://jira.almacareer.tech/browse/DS-2243)
