### PR TITLE
Test(web-react): Add accessibility tests for layout and semantic components #DS-2243

### DIFF
--- a/packages/web-react/src/components/Card/__tests__/Card.accessibility.test.tsx
+++ b/packages/web-react/src/components/Card/__tests__/Card.accessibility.test.tsx
@@ -1,0 +1,52 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { accessibilityTest, guardMissingSelector, runAxe } from '@local/tests';
+import Card from '../Card';
+import CardBody from '../CardBody';
+import CardTitle from '../CardTitle';
+
+jest.mock('../../../hooks/useIcon');
+
+describe('Card accessibility', () => {
+  const cardContent = (
+    <CardBody>
+      <CardTitle isHeading>Card Title</CardTitle>
+      <p>Card content goes here.</p>
+    </CardBody>
+  );
+
+  accessibilityTest((props) => <Card {...props}>{cardContent}</Card>, 'article');
+
+  it('should be accessible with custom element type', async () => {
+    const { container } = render(<Card elementType="section">{cardContent}</Card>);
+
+    const card = container.querySelector('section');
+    guardMissingSelector('section', card);
+
+    const results = await runAxe(card);
+
+    expect(results).toHaveNoAxeViolations();
+  });
+
+  it('should be accessible in horizontal layout', async () => {
+    const { container } = render(<Card direction="horizontal">{cardContent}</Card>);
+
+    const card = container.querySelector('article');
+    guardMissingSelector('article', card);
+
+    const results = await runAxe(card);
+
+    expect(results).toHaveNoAxeViolations();
+  });
+
+  it('should be accessible when boxed', async () => {
+    const { container } = render(<Card isBoxed>{cardContent}</Card>);
+
+    const card = container.querySelector('article');
+    guardMissingSelector('article', card);
+
+    const results = await runAxe(card);
+
+    expect(results).toHaveNoAxeViolations();
+  });
+});

--- a/packages/web-react/src/components/FieldGroup/__tests__/FieldGroup.accessibility.test.tsx
+++ b/packages/web-react/src/components/FieldGroup/__tests__/FieldGroup.accessibility.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { accessibilityDisabledTest, accessibilityTest, accessibilityValidationStateTest } from '@local/tests';
+import { Checkbox } from '../../Checkbox';
+import FieldGroup from '../FieldGroup';
+
+jest.mock('../../../hooks/useIcon');
+
+describe('FieldGroup accessibility', () => {
+  const fieldGroupContent = (
+    <>
+      <Checkbox id="checkbox-1" name="checkbox-1" label="Option 1" />
+      <Checkbox id="checkbox-2" name="checkbox-2" label="Option 2" />
+    </>
+  );
+
+  accessibilityTest(
+    (props) => (
+      <FieldGroup {...props} id="field-group-default" label="Label">
+        {fieldGroupContent}
+      </FieldGroup>
+    ),
+    'fieldset',
+  );
+
+  accessibilityDisabledTest(
+    (props) => (
+      <FieldGroup {...props} id="field-group-disabled" label="Label" isDisabled>
+        {fieldGroupContent}
+      </FieldGroup>
+    ),
+    'fieldset',
+  );
+
+  accessibilityValidationStateTest(
+    (props) => (
+      <FieldGroup {...props} id="field-group-validation" label="Label" validationText="Validation text">
+        {fieldGroupContent}
+      </FieldGroup>
+    ),
+    'fieldset',
+  );
+});

--- a/packages/web-react/src/components/Footer/__tests__/Footer.accessibility.test.tsx
+++ b/packages/web-react/src/components/Footer/__tests__/Footer.accessibility.test.tsx
@@ -1,0 +1,40 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { accessibilityTest, guardMissingSelector, runAxe } from '@local/tests';
+import Footer from '../Footer';
+
+describe('Footer accessibility', () => {
+  const footerContent = (
+    <>
+      <nav>
+        <a href="https://example.com">Link 1</a>
+        <a href="https://example.com">Link 2</a>
+      </nav>
+      <p>Copyright text</p>
+    </>
+  );
+
+  accessibilityTest((props) => <Footer {...props}>{footerContent}</Footer>, 'footer');
+
+  it('should be accessible with different background colors', async () => {
+    const { container } = render(<Footer backgroundColor="primary">{footerContent}</Footer>);
+
+    const footer = container.querySelector('footer');
+    guardMissingSelector('footer', footer);
+
+    const results = await runAxe(footer);
+
+    expect(results).toHaveNoAxeViolations();
+  });
+
+  it('should be accessible with text alignment', async () => {
+    const { container } = render(<Footer textAlignment="center">{footerContent}</Footer>);
+
+    const footer = container.querySelector('footer');
+    guardMissingSelector('footer', footer);
+
+    const results = await runAxe(footer);
+
+    expect(results).toHaveNoAxeViolations();
+  });
+});

--- a/packages/web-react/src/components/Header/__tests__/Header.accessibility.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/Header.accessibility.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { accessibilityTest, guardMissingSelector, runAxe } from '@local/tests';
+import Header from '../Header';
+
+describe('Header accessibility', () => {
+  const headerContent = (
+    <nav>
+      <a href="https://example.com">Link 1</a>
+      <a href="https://example.com">Link 2</a>
+    </nav>
+  );
+
+  accessibilityTest((props) => <Header {...props}>{headerContent}</Header>, 'header');
+
+  it('should be accessible in simple variant', async () => {
+    const { container } = render(<Header isSimple>{headerContent}</Header>);
+
+    const header = container.querySelector('header');
+    guardMissingSelector('header', header);
+
+    const results = await runAxe(header);
+
+    expect(results).toHaveNoAxeViolations();
+  });
+
+  it('should be accessible with different colors', async () => {
+    const { container } = render(<Header color="primary">{headerContent}</Header>);
+
+    const header = container.querySelector('header');
+    guardMissingSelector('header', header);
+
+    const results = await runAxe(header);
+
+    expect(results).toHaveNoAxeViolations();
+  });
+});

--- a/packages/web-react/src/components/ScrollView/__tests__/ScrollView.accessibility.test.tsx
+++ b/packages/web-react/src/components/ScrollView/__tests__/ScrollView.accessibility.test.tsx
@@ -1,0 +1,55 @@
+import { render } from '@testing-library/react';
+import React, { type ReactElement } from 'react';
+import { guardMissingSelector, runAxe } from '@local/tests';
+import ScrollView from '../ScrollView';
+
+jest.mock('../../../hooks/useIcon');
+
+describe('ScrollView accessibility', () => {
+  const contentItemStyle = { width: '200px', height: '100px' };
+
+  const scrollViewContent = (
+    <>
+      <div style={contentItemStyle}>Content item 1</div>
+      <div style={contentItemStyle}>Content item 2</div>
+      <div style={contentItemStyle}>Content item 3</div>
+    </>
+  );
+
+  const testScrollViewAccessibility = async (scrollView: ReactElement) => {
+    const { container } = render(scrollView);
+
+    const viewport = container.querySelector('[tabindex="0"]');
+    guardMissingSelector('[tabindex="0"]', viewport);
+
+    const element = viewport?.parentElement;
+    guardMissingSelector('parent of [tabindex="0"]', element);
+
+    const results = await runAxe(element);
+
+    expect(results).toHaveNoAxeViolations();
+  };
+
+  it('should be accessible in its default state', async () => {
+    const { container } = render(<ScrollView>{scrollViewContent}</ScrollView>);
+
+    const viewport = container.querySelector('[tabindex="0"]');
+    guardMissingSelector('[tabindex="0"]', viewport);
+
+    const results = await runAxe(viewport);
+
+    expect(results).toHaveNoAxeViolations();
+  });
+
+  it('should be accessible with arrows', async () => {
+    await testScrollViewAccessibility(
+      <ScrollView hasArrows ariaLabelArrows={{ start: 'Previous', end: 'Next' }}>
+        {scrollViewContent}
+      </ScrollView>,
+    );
+  });
+
+  it('should be accessible in vertical direction', async () => {
+    await testScrollViewAccessibility(<ScrollView direction="vertical">{scrollViewContent}</ScrollView>);
+  });
+});

--- a/packages/web-react/src/components/Timeline/__tests__/Timeline.accessibility.test.tsx
+++ b/packages/web-react/src/components/Timeline/__tests__/Timeline.accessibility.test.tsx
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { accessibilityTest, guardMissingSelector, runAxe } from '@local/tests';
+import Timeline from '../Timeline';
+import TimelineContent from '../TimelineContent';
+import TimelineHeading from '../TimelineHeading';
+import TimelineMarker from '../TimelineMarker';
+import TimelineStep from '../TimelineStep';
+
+jest.mock('../../../hooks/useIcon');
+
+describe('Timeline accessibility', () => {
+  const timelineStepContent = (stepNumber: number) => (
+    <>
+      <TimelineHeading>
+        <h3>Step {stepNumber}</h3>
+      </TimelineHeading>
+      <TimelineContent>
+        <p>Step {stepNumber} content</p>
+      </TimelineContent>
+    </>
+  );
+
+  const timelineStepWithNumber = (stepNumber: number) => (
+    <TimelineStep>
+      <TimelineMarker variant="number">{stepNumber}</TimelineMarker>
+      {timelineStepContent(stepNumber)}
+    </TimelineStep>
+  );
+
+  const timelineStepWithDot = (
+    <TimelineStep>
+      <TimelineMarker variant="dot" />
+      {timelineStepContent(1)}
+    </TimelineStep>
+  );
+
+  const timelineContent = (
+    <>
+      {timelineStepWithNumber(1)}
+      {timelineStepWithNumber(2)}
+    </>
+  );
+
+  accessibilityTest((props) => <Timeline {...props}>{timelineContent}</Timeline>, 'ol');
+
+  it('should be accessible with custom element type', async () => {
+    const { container } = render(<Timeline elementType="ul">{timelineStepWithDot}</Timeline>);
+
+    const timeline = container.querySelector('ul');
+    guardMissingSelector('ul', timeline);
+
+    const results = await runAxe(timeline);
+
+    expect(results).toHaveNoAxeViolations();
+  });
+
+  it('should be accessible with dot markers', async () => {
+    const { container } = render(<Timeline>{timelineStepWithDot}</Timeline>);
+
+    const timeline = container.querySelector('ol');
+    guardMissingSelector('ol', timeline);
+
+    const results = await runAxe(timeline);
+
+    expect(results).toHaveNoAxeViolations();
+  });
+});


### PR DESCRIPTION
## Description

> [!NOTE]
> One more PR for the accessibility tests 😅
> 
> **Part 7** - more accessibility tests will come in another PRs

Add accessibility tests for FieldGroup, ScrollView, Card, Timeline, Header, and Footer components.

* Add FieldGroup.accessibility.test.tsx with tests for default, disabled, and validation states
* Add ScrollView.accessibility.test.tsx with tests for default state, arrows, and vertical direction
* Add Card.accessibility.test.tsx with tests for default state, custom element type, horizontal layout, and boxed variant
* Add Timeline.accessibility.test.tsx with tests for default state, custom element type, and dot markers
* Add Header.accessibility.test.tsx with tests for default state, simple variant, and different colors
* Add Footer.accessibility.test.tsx with tests for default state, different background colors, and text alignment

### Additional context

* FieldGroup test uses `accessibilityTest`, `accessibilityDisabledTest`, and `accessibilityValidationStateTest` helpers
* FieldGroup test includes mock for `useIcon` hook to suppress warnings about missing icons
* ScrollView test uses custom helper function `testScrollViewAccessibility` for DRY code and tests viewport accessibility
* ScrollView test uses `guardMissingSelector` for safe element selection
* Card test uses `accessibilityTest` helper for default state and custom tests for variants
* Card test includes mock for `useIcon` hook
* Timeline test uses helper functions for DRY code (`timelineStepContent`, `timelineStepWithNumber`, `timelineStepWithDot`)
* Timeline test includes mock for `useIcon` hook
* Header and Footer tests use `accessibilityTest` helper and custom tests for variants
* All tests use `guardMissingSelector` for safe element selection with `querySelector`
* All tests follow DRY principles with reusable content constants

#### How to test

`yarn workspace @lmc-eu/spirit-web-react test:unit --testPathPatterns="accessibility" --testNamePattern="FieldGroup|ScrollView|Card|Timeline|Header|Footer"`

### Issue reference

[Accessibility testing for the remaining components](https://jira.almacareer.tech/browse/DS-2243)