### PR TITLE
Chore(ci): Use the dependency cache when installing packages

### DIFF
--- a/.github/actions/setup-install/action.yaml
+++ b/.github/actions/setup-install/action.yaml
@@ -1,18 +1,24 @@
 name: 'setup and install'
 description: 'Setup Node and Install Dependencies'
+inputs:
+  node-version:
+    description: 'Node.js version to use. If not provided, version is read from .nvmrc file'
+    required: false
 runs:
   using: 'composite'
   steps:
     - name: Setup Node
       uses: ./.github/actions/setup-node
-
-    - name: Restore cached node_modules
-      uses: actions/cache@v4
       with:
-        path: '**/node_modules'
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        node-version: ${{ inputs.node-version }}
+
+    - name: Restore Cache
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ./.yarn/cache
+        key: ${{ runner.os }}-Yarn-main
         restore-keys: |
-          ${{ runner.os }}-yarn-
+          ${{ runner.os }}-Yarn-main-
 
     - name: Install dependencies
       uses: ./.github/actions/deps-install

--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -1,5 +1,9 @@
 name: 'setup node'
 description: 'Setup Node'
+inputs:
+  node-version:
+    description: 'Node.js version to use. If not provided, version is read from .nvmrc file'
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -10,7 +14,6 @@ runs:
     - name: Set up Node
       uses: actions/setup-node@v4
       with:
-        node-version-file: '.nvmrc'
+        node-version: ${{ inputs.node-version }}
+        node-version-file: ${{ inputs.node-version == '' && '.nvmrc' || '' }}
         registry-url: 'https://registry.npmjs.org'
-        cache: 'yarn'
-        cache-dependency-path: yarn.lock

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,17 +31,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Configure Node
-        uses: actions/setup-node@v4
+      - name: Setup and Install
+        uses: ./.github/actions/setup-install
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn --immutable --inline-builds
 
       - name: Build packages
         run: yarn build

--- a/.github/workflows/supernova.yaml
+++ b/.github/workflows/supernova.yaml
@@ -37,9 +37,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
+        uses: ././github/actions/setup-node
 
       - name: Publish Supernova Documentation
         run: npx @supernovaio/cli publish-documentation --apiKey="${{secrets.SUPERNOVA_TOKEN}}" --designSystemId="${{secrets.SUPERNOVA_DS_ID}}"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Use previously created dependency cache - https://github.com/lmc-eu/spirit-design-system/pull/2285

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

The runs of the GitHub Actions should be the same or slightly performant; however, the size of the stored cache should significantly decrease from almost 10 GB to max 1 GB at most.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
