### PR TITLE
Fix(scripts): Force fetching the tags and rewrite local ones

### DIFF
--- a/scripts/post-changelog/post-changelog.ts
+++ b/scripts/post-changelog/post-changelog.ts
@@ -282,7 +282,7 @@ async function configureWebhookURL() {
 async function publishChangelog(npmPackage: string) {
   try {
     const diff = await executeGitOperationWithRetry(async () => {
-      await simpleGit().fetch(['origin', 'main', '--tags']);
+      await simpleGit().fetch(['origin', '--tags', '--force']);
       const tags = await simpleGit().tags({ '--sort': '-taggerdate' });
       const diff = await getDiff(
         argv.dry ? '@lmc-eu/spirit-web-react@3.1.0' : (tags.latest ?? ''),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

  * when a tag like 0.0.1 already exists locally but the remote reference differs
  * git fails with "reference already exists"

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

- https://github.com/lmc-eu/spirit-design-system/actions/runs/20071890884/job/57576022177

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
