### PR TITLE
Chore(ci): Automate Storybook deploys to Chromatic #DS-2250

### DIFF
--- a/.github/workflows/storybook-deployment.yaml
+++ b/.github/workflows/storybook-deployment.yaml
@@ -1,0 +1,61 @@
+name: 🎨 Storybook on Chromatic
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths: &storybook-paths
+      - 'apps/storybook/**'
+      - 'packages/icons/**'
+      - 'packages/web-react/**'
+      - 'packages/design-tokens/**'
+  push:
+    branches:
+      - main
+    paths: *storybook-paths
+
+concurrency:
+  group: chromatic-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chromatic:
+    name: Deploy Storybook to Chromatic
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Node and Install Dependencies
+        uses: ./.github/actions/setup-install
+
+      - name: Build Design Tokens
+        run: yarn workspace @alma-oss/spirit-design-tokens build
+
+      - name: Build Design Icons
+        run: yarn workspace @alma-oss/spirit-icons build
+
+      - name: Publish to Chromatic
+        id: chromatic
+        uses: chromaui/action@c93e0bc3a63aa176e14a75b61a31847cbfdd341c # v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: apps/storybook
+          buildScriptName: build
+
+      - name: Post Storybook Link Comment
+        if: github.event_name == 'pull_request'
+        uses: dannyhw/storybook-chromatic-link-comment@f44e4cd606de2de337afec3b7ddb6996ee8dfaf4 # v0.11
+        with:
+          github-token: ${{ github.token }}
+          review-url: ${{ steps.chromatic.outputs.url }}
+          build-url: ${{ steps.chromatic.outputs.buildUrl }}
+          storybook-url: ${{ steps.chromatic.outputs.storybookUrl }}


### PR DESCRIPTION
- add workflow to deploy Storybook to Chromatic
- add comment with link to Storybook in PR

- [x] ❗️Remove testing change in button (needed for triggering storybook build)

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
