### PR TITLE
Fix(web-react): ElementType fix in Accordion #DS-2181

### DIFF
--- a/packages/web-react/src/components/Accordion/Accordion.tsx
+++ b/packages/web-react/src/components/Accordion/Accordion.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import React from 'react';
+import React, { type ElementType } from 'react';
 import { useStyleProps } from '../../hooks';
-import { type AccordionProps } from '../../types';
+import { type SpiritAccordionProps } from '../../types';
 import { mergeStyleProps } from '../../utils';
 import { AccordionProvider } from './AccordionContext';
 import { useAccordionStyleProps } from './useAccordionStyleProps';
 
-const Accordion = (props: AccordionProps) => {
+const Accordion = <T extends ElementType = 'section'>(props: SpiritAccordionProps<T>) => {
   const { children, elementType: ElementTag = 'section', open, toggle, ...restProps } = props;
 
   const { classProps } = useAccordionStyleProps();
@@ -27,5 +27,7 @@ const Accordion = (props: AccordionProps) => {
 };
 
 Accordion.spiritComponent = 'Accordion';
+Accordion.spiritDefaultElement = 'section' as const;
+Accordion.spiritDefaultProps = null as unknown as SpiritAccordionProps<'section'>;
 
 export default Accordion;

--- a/packages/web-react/src/components/Accordion/AccordionHeader.tsx
+++ b/packages/web-react/src/components/Accordion/AccordionHeader.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import classNames from 'classnames';
-import React from 'react';
+import React, { type ElementType } from 'react';
 import { useStyleProps } from '../../hooks';
-import { type AccordionHeaderProps } from '../../types';
+import { type SpiritAccordionHeaderProps } from '../../types';
+import { mergeStyleProps } from '../../utils';
 import { Icon } from '../Icon';
 import { useAccordionContext } from './AccordionContext';
 import { useAccordionItemContext } from './AccordionItemContext';
@@ -11,13 +11,23 @@ import { useAccordionAriaProps } from './useAccordionAriaProps';
 import { useAccordionStyleProps } from './useAccordionStyleProps';
 import { useOpenItem } from './useOpenItem';
 
-const AccordionHeader = ({ children, slot, ...restProps }: AccordionHeaderProps) => {
+const defaultProps: Partial<SpiritAccordionHeaderProps> = {
+  elementType: 'h3',
+};
+
+const AccordionHeader = <T extends ElementType = 'h3'>(props: SpiritAccordionHeaderProps<T>) => {
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const { elementType: ElementTag = 'h3', children, slot, ...restProps } = propsWithDefaults;
   const { classProps } = useAccordionStyleProps();
   const { toggle } = useAccordionContext();
   const { id } = useAccordionItemContext();
   const { styleProps, props: transferProps } = useStyleProps(restProps);
   const { isOpen } = useOpenItem(id);
   const { triggerProps, headerProps } = useAccordionAriaProps({ id, isOpen });
+  const mergedStyleProps = mergeStyleProps(ElementTag, {
+    classProps: classProps.header,
+    styleProps,
+  });
 
   const itemToggle = () => {
     if (toggle && id) {
@@ -26,12 +36,7 @@ const AccordionHeader = ({ children, slot, ...restProps }: AccordionHeaderProps)
   };
 
   return (
-    <h3
-      {...transferProps}
-      {...styleProps}
-      {...headerProps}
-      className={classNames(classProps.header, styleProps.className)}
-    >
+    <ElementTag {...transferProps} {...mergedStyleProps} {...headerProps}>
       <button type="button" className={classProps.toggle} onClick={itemToggle} {...triggerProps}>
         {children}
       </button>
@@ -41,10 +46,12 @@ const AccordionHeader = ({ children, slot, ...restProps }: AccordionHeaderProps)
           <Icon name="chevron-down" />
         </span>
       </span>
-    </h3>
+    </ElementTag>
   );
 };
 
 AccordionHeader.spiritComponent = 'AccordionHeader';
+AccordionHeader.spiritDefaultElement = 'h3' as const;
+AccordionHeader.spiritDefaultProps = null as unknown as SpiritAccordionHeaderProps<'h3'>;
 
 export default AccordionHeader;

--- a/packages/web-react/src/components/Accordion/AccordionItem.tsx
+++ b/packages/web-react/src/components/Accordion/AccordionItem.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import React from 'react';
+import React, { type ElementType } from 'react';
 import { useStyleProps } from '../../hooks';
-import { type AccordionItemProps } from '../../types';
+import { type SpiritAccordionItemProps } from '../../types';
 import { mergeStyleProps } from '../../utils';
 import { AccordionItemProvider } from './AccordionItemContext';
 import { useAccordionStyleProps } from './useAccordionStyleProps';
 
-const AccordionItem = (props: AccordionItemProps) => {
+const AccordionItem = <T extends ElementType = 'article'>(props: SpiritAccordionItemProps<T>) => {
   const { children, elementType: ElementTag = 'article', id, ...restProps } = props;
 
   const { classProps } = useAccordionStyleProps();
@@ -24,5 +24,7 @@ const AccordionItem = (props: AccordionItemProps) => {
 };
 
 AccordionItem.spiritComponent = 'AccordionItem';
+AccordionItem.spiritDefaultElement = 'article' as const;
+AccordionItem.spiritDefaultProps = null as unknown as SpiritAccordionItemProps<'article'>;
 
 export default AccordionItem;

--- a/packages/web-react/src/components/Accordion/README.md
+++ b/packages/web-react/src/components/Accordion/README.md
@@ -131,12 +131,12 @@ import { AccordionOpenStateType } from '@alma-oss/spirit-web-react/types';
 
 ## Accordion Props
 
-| Name          | Type                               | Default   | Required | Description                                      |
-| ------------- | ---------------------------------- | --------- | -------- | ------------------------------------------------ |
-| `children`    | `ReactNode`                        | —         | ✓        | Accordion children's nodes                       |
-| `elementType` | \[`section` \| `article` \| `div`] | `section` | ✕        | Type of element used as wrapper                  |
-| `open`        | \[`string` \| `string[]`]          | —         | ✕        | Open item or list of open items \*               |
-| `toggle`      | `(id: string) => void`             | —         | ✕        | A generic handler for a single **AccordionItem** |
+| Name          | Type                      | Default   | Required | Description                                      |
+| ------------- | ------------------------- | --------- | -------- | ------------------------------------------------ |
+| `children`    | `ReactNode`               | —         | ✓        | Accordion children's nodes                       |
+| `elementType` | `ElementType`             | `section` | ✕        | Type of element used as wrapper                  |
+| `open`        | \[`string` \| `string[]`] | —         | ✕        | Open item or list of open items \*               |
+| `toggle`      | `(id: string) => void`    | —         | ✕        | A generic handler for a single **AccordionItem** |
 
 (\*) Depending on the type of default value, what is set as the default will affect whether one or more will be open at the same time.
 
@@ -146,12 +146,12 @@ and [escape hatches][readme-escape-hatches].
 
 ## Uncontrolled Accordion Props
 
-| Name          | Type                               | Default   | Required | Description                                    |
-| ------------- | ---------------------------------- | --------- | -------- | ---------------------------------------------- |
-| `children`    | `ReactNode`                        | —         | ✓        | Accordion children's nodes                     |
-| `defaultOpen` | \[`string` \| `string[]`]          | —         | ✕        | Default open item(s) \*                        |
-| `elementType` | \[`section` \| `article` \| `div`] | `section` | ✕        | Type of element used as wrapper                |
-| `stayOpen`    | `bool`                             | —         | ✕        | Item stay open when another one is also opened |
+| Name          | Type                      | Default   | Required | Description                                    |
+| ------------- | ------------------------- | --------- | -------- | ---------------------------------------------- |
+| `children`    | `ReactNode`               | —         | ✓        | Accordion children's nodes                     |
+| `defaultOpen` | \[`string` \| `string[]`] | —         | ✕        | Default open item(s) \*                        |
+| `elementType` | `ElementType`             | `section` | ✕        | Type of element used as wrapper                |
+| `stayOpen`    | `bool`                    | —         | ✕        | Item stay open when another one is also opened |
 
 (\*) If this attribute is an array, then the `stayOpen` parameter should also be set.
 
@@ -161,11 +161,11 @@ and [escape hatches][readme-escape-hatches].
 
 ## AccordionItem Props
 
-| Name          | Type                               | Default   | Required | Description                                     |
-| ------------- | ---------------------------------- | --------- | -------- | ----------------------------------------------- |
-| `children`    | `ReactNode`                        | —         | ✓        | Item children node                              |
-| `elementType` | \[`article` \| `section` \| `div`] | `article` | ✕        | Type of element used as wrapper for single item |
-| `id`          | `string`                           | —         | ✓        | Item id                                         |
+| Name          | Type          | Default   | Required | Description                                     |
+| ------------- | ------------- | --------- | -------- | ----------------------------------------------- |
+| `children`    | `ReactNode`   | —         | ✓        | Item children node                              |
+| `elementType` | `ElementType` | `article` | ✕        | Type of element used as wrapper for single item |
+| `id`          | `string`      | —         | ✓        | Item id                                         |
 
 On top of the API options, the components accept [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]
@@ -173,11 +173,11 @@ and [escape hatches][readme-escape-hatches].
 
 ## AccordionHeader Props
 
-| Name          | Type          | Default | Required | Description             |
-| ------------- | ------------- | ------- | -------- | ----------------------- |
-| `children`    | `ReactNode`   | —       | ✓        | Header children node    |
-| `elementType` | `ElementType` | `h3`    | ✕        | Type of element         |
-| `slot`        | `ReactNode`   | —       | ✕        | Side slot in the header |
+| Name          | Type          | Default | Required | Description                     |
+| ------------- | ------------- | ------- | -------- | ------------------------------- |
+| `children`    | `ReactNode`   | —       | ✓        | Header children node            |
+| `elementType` | `ElementType` | `h3`    | ✕        | Type of element used as wrapper |
+| `slot`        | `ReactNode`   | —       | ✕        | Side slot in the header         |
 
 On top of the API options, the components accept [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]

--- a/packages/web-react/src/components/Accordion/UncontrolledAccordion.tsx
+++ b/packages/web-react/src/components/Accordion/UncontrolledAccordion.tsx
@@ -1,18 +1,20 @@
 'use client';
 
-import React from 'react';
-import { type UncontrolledAccordionProps } from '../../types';
+import React, { type ElementType } from 'react';
+import { type SpiritAccordionProps, type SpiritUncontrolledAccordionProps } from '../../types';
 import Accordion from './Accordion';
 import { useAccordion } from './useAccordion';
 
-const UncontrolledAccordion = (props: UncontrolledAccordionProps) => {
+const UncontrolledAccordion = <T extends ElementType = 'section'>(props: SpiritUncontrolledAccordionProps<T>) => {
   const { defaultOpen, stayOpen, ...restProps } = props;
 
   const { open, toggle } = useAccordion({ defaultOpen, stayOpen });
 
-  return <Accordion open={open} toggle={toggle} {...restProps} />;
+  return <Accordion {...(restProps as SpiritAccordionProps<T>)} open={open} toggle={toggle} />;
 };
 
 UncontrolledAccordion.spiritComponent = 'UncontrolledAccordion';
+UncontrolledAccordion.spiritDefaultElement = 'section' as const;
+UncontrolledAccordion.spiritDefaultProps = null as unknown as SpiritUncontrolledAccordionProps<'section'>;
 
 export default UncontrolledAccordion;

--- a/packages/web-react/src/components/Accordion/__tests__/AccordionHeader.test.tsx
+++ b/packages/web-react/src/components/Accordion/__tests__/AccordionHeader.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {
   ariaAttributesTest,
   classNamePrefixProviderTest,
+  elementTypePropsTest,
   restPropsTest,
   stylePropsTest,
   validHtmlAttributesTest,
@@ -15,6 +16,8 @@ jest.mock('../../../hooks/useIcon');
 
 describe('AccordionHeader', () => {
   classNamePrefixProviderTest(AccordionHeader, 'Accordion__itemHeader');
+
+  elementTypePropsTest(AccordionHeader);
 
   stylePropsTest(
     (props: Record<string, unknown>) => (

--- a/packages/web-react/src/components/Accordion/stories/Accordion.stories.tsx
+++ b/packages/web-react/src/components/Accordion/stories/Accordion.stories.tsx
@@ -1,7 +1,7 @@
 import { Markdown } from '@storybook/addon-docs/blocks';
 import type { Meta, StoryObj } from '@storybook/react';
-import React, { useState } from 'react';
-import { type AccordionOpenStateType, type AccordionProps } from '../../../types';
+import React, { type ElementType, useState } from 'react';
+import { type AccordionOpenStateType, type SpiritAccordionProps } from '../../../types';
 import { Link } from '../../Link';
 import { Pill } from '../../Pill';
 import toggleValueByType from '../demo/toggleValueByType';
@@ -39,7 +39,7 @@ const meta: Meta<typeof Accordion> = {
 export default meta;
 type Story = StoryObj<typeof Accordion>;
 
-const AccordionWithHooks = (args: AccordionProps) => {
+const AccordionWithHooks = (args: SpiritAccordionProps<ElementType>) => {
   const [openState, setOpenState] = useState<AccordionOpenStateType>('accordion-item-example-1');
 
   const toggle = (id: string) => {

--- a/packages/web-react/src/components/Accordion/stories/AccordionHeader.stories.tsx
+++ b/packages/web-react/src/components/Accordion/stories/AccordionHeader.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import React, { useState } from 'react';
-import { type AccordionHeaderProps, type AccordionOpenStateType } from '../../../types';
+import React, { type ElementType, useState } from 'react';
+import { type AccordionOpenStateType, type SpiritAccordionHeaderProps } from '../../../types';
 import { Link } from '../../Link';
 import { Pill } from '../../Pill';
 import toggleValueByType from '../demo/toggleValueByType';
@@ -48,7 +48,7 @@ const meta: Meta<typeof AccordionHeader> = {
 export default meta;
 type Story = StoryObj<typeof AccordionHeader>;
 
-const AccordionWithHooks = (args: AccordionHeaderProps) => {
+const AccordionWithHooks = (args: SpiritAccordionHeaderProps<ElementType>) => {
   const [openState, setOpenState] = useState<AccordionOpenStateType>('accordion-item-example-1');
 
   const toggle = (id: string) => {

--- a/packages/web-react/src/components/Accordion/stories/AccordionItem.stories.tsx
+++ b/packages/web-react/src/components/Accordion/stories/AccordionItem.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import React, { useState } from 'react';
-import { type AccordionItemProps, type AccordionOpenStateType } from '../../../types';
+import React, { type ElementType, useState } from 'react';
+import { type AccordionOpenStateType, type SpiritAccordionItemProps } from '../../../types';
 import { Link } from '../../Link';
 import { Pill } from '../../Pill';
 import toggleValueByType from '../demo/toggleValueByType';
@@ -29,7 +29,7 @@ const meta: Meta<typeof AccordionItem> = {
 export default meta;
 type Story = StoryObj<typeof AccordionItem>;
 
-const AccordionWithHooks = (args: AccordionItemProps) => {
+const AccordionWithHooks = (args: SpiritAccordionItemProps<ElementType>) => {
   const [openState, setOpenState] = useState<AccordionOpenStateType>('accordion-item-example-1');
 
   const toggle = (id: string) => {

--- a/packages/web-react/src/components/Accordion/useAccordion.ts
+++ b/packages/web-react/src/components/Accordion/useAccordion.ts
@@ -1,9 +1,13 @@
 'use client';
 
 import { useState } from 'react';
-import { type AccordionHandlingProps, type AccordionOpenStateType, type UncontrolledAccordionProps } from '../../types';
+import {
+  type AccordionHandlingProps,
+  type AccordionOpenStateType,
+  type UncontrolledAccordionBaseProps,
+} from '../../types';
 
-export const useAccordion = ({ defaultOpen, stayOpen }: UncontrolledAccordionProps): AccordionHandlingProps => {
+export const useAccordion = ({ defaultOpen, stayOpen }: UncontrolledAccordionBaseProps): AccordionHandlingProps => {
   const [open, setOpen] = useState<AccordionOpenStateType>(defaultOpen);
 
   const toggle = (id: string) => {

--- a/packages/web-react/src/types/accordion.ts
+++ b/packages/web-react/src/types/accordion.ts
@@ -1,5 +1,10 @@
 import { type ElementType, type ReactNode } from 'react';
-import { type ChildrenProps, type ElementTypeProps, type StyleProps, type TransferProps } from './shared';
+import {
+  type ChildrenProps,
+  type ElementTypeProps,
+  type SpiritPolymorphicElementPropsWithRef,
+  type StyleProps,
+} from './shared';
 
 export type AccordionOpenStateType = string | string[] | undefined;
 
@@ -12,25 +17,37 @@ export interface AccordionItemContextProps {
   id: string;
 }
 
-export interface BaseAccordionProps extends ChildrenProps, StyleProps, TransferProps {}
+export interface BaseAccordionProps extends ChildrenProps, StyleProps {}
 
-export interface AccordionProps<T extends ElementType = 'section'>
-  extends BaseAccordionProps,
-    AccordionHandlingProps,
-    ElementTypeProps<T> {}
+export interface AccordionBaseProps extends BaseAccordionProps, AccordionHandlingProps {}
 
-export interface AccordionHeaderProps<T extends ElementType = 'h3'> extends BaseAccordionProps, ElementTypeProps<T> {
+export type AccordionProps<T extends ElementType> = ElementTypeProps<T> & AccordionBaseProps;
+
+export type SpiritAccordionProps<T extends ElementType = 'section'> = AccordionProps<T> &
+  SpiritPolymorphicElementPropsWithRef<T, AccordionProps<T>>;
+
+export type AccordionHeaderProps<T extends ElementType = 'h3'> = ElementTypeProps<T> & {
   slot?: ReactNode;
-}
+} & BaseAccordionProps;
 
-export interface AccordionItemProps<T extends ElementType = 'article'>
-  extends BaseAccordionProps,
-    AccordionItemContextProps,
-    ElementTypeProps<T> {}
+export type SpiritAccordionHeaderProps<T extends ElementType = 'h3'> = AccordionHeaderProps<T> &
+  SpiritPolymorphicElementPropsWithRef<T, AccordionHeaderProps<T>>;
+
+export interface AccordionItemBaseProps extends BaseAccordionProps, AccordionItemContextProps {}
+
+export type AccordionItemProps<T extends ElementType> = ElementTypeProps<T> & AccordionItemBaseProps;
+
+export type SpiritAccordionItemProps<T extends ElementType = 'article'> = AccordionItemProps<T> &
+  SpiritPolymorphicElementPropsWithRef<T, AccordionItemProps<T>>;
 
 export interface AccordionContentProps extends BaseAccordionProps {}
 
-export interface UncontrolledAccordionProps extends BaseAccordionProps {
+export interface UncontrolledAccordionBaseProps extends BaseAccordionProps {
   defaultOpen?: AccordionOpenStateType;
   stayOpen?: boolean;
 }
+
+export type UncontrolledAccordionProps<T extends ElementType> = ElementTypeProps<T> & UncontrolledAccordionBaseProps;
+
+export type SpiritUncontrolledAccordionProps<T extends ElementType = 'section'> = UncontrolledAccordionProps<T> &
+  SpiritPolymorphicElementPropsWithRef<T, UncontrolledAccordionProps<T>>;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

**Fixes:**
- `Accordion` now correctly supports `elementType` instead of being limited to default HTML tags.
- `AccordionHeader` no longer uses a hardcoded `<h3>`; it now respects the documented elementType prop.
-  Removed `TransferProps`

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

https://jira.almacareer.tech/browse/DS-2181

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
