### PR TITLE
Feat(web): Introduce new helper classes to control visibility by `aria-checked` #DS-596

### DIFF
--- a/packages/web/DEPRECATIONS.md
+++ b/packages/web/DEPRECATIONS.md
@@ -6,6 +6,14 @@ This document lists all deprecations that will be removed in the next major vers
 
 ## Deprecations
 
+👉 [What are deprecations?][readme-deprecations]
+
+### Button
+
+The `Button--block` modifier will be removed in the next major version.
+
+For more information, see documentation of the [Button][button] component.
+
 ### Collapse `data-spirit-is-disposable`
 
 The `data-spirit-more` attribute was removed, please use `data-spirit-is-disposable` instead.
@@ -63,13 +71,27 @@ If you are using the `Stack` component with dividers, you must wrap each item in
 </div>
 ```
 
-### Button
+### TextField
 
-The `Button--block` modifier will be removed in the next major version.
+The `TextField__passwordToggle__icon--*` modifiers are deprecated in favor of new
+`accessibility-<checked | unchecked>` helpers.
 
-For more information, see documentation for [Button][button] component.
+For more information, see documentation of the [TextField][text-field] component.
 
-👉 [What are deprecations?][readme-deprecations]
+#### Migration Guide
+
+```html
+<span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--shown"><!-- … --></span>
+<span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--hidden"><!-- … --></span>
+```
+
+↓
+
+```html
+<span class="TextField__passwordToggle__icon accessibility-unchecked"><!-- … --></span>
+<span class="TextField__passwordToggle__icon accessibility-checked"><!-- … --></span>
+```
 
 [button]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/scss/components/Button/README.md
 [readme-deprecations]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/README.md#deprecations
+[text-field]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/scss/components/TextField/README.md

--- a/packages/web/src/scss/components/TextField/README.md
+++ b/packages/web/src/scss/components/TextField/README.md
@@ -183,14 +183,14 @@ Then you need to add data attribute `data-spirit-toggle="password"` to the input
       aria-label="Show password"
       data-spirit-toggle="password"
     >
-      <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--hidden">
-        <svg width="24" height="24" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#visibility-on" />
+      <span class="TextField__passwordToggle__icon accessibility-unchecked">
+        <svg width="20" height="20" aria-hidden="true">
+          <use xlink:href="/assets/icons/svg/sprite.svg#visibility-on" />
         </svg>
       </span>
-      <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--shown">
-        <svg width="24" height="24" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#visibility-off" />
+      <span class="TextField__passwordToggle__icon accessibility-checked">
+        <svg width="20" height="20" aria-hidden="true">
+          <use xlink:href="/assets/icons/svg/sprite.svg#visibility-off" />
         </svg>
       </span>
     </button>

--- a/packages/web/src/scss/components/TextField/_TextField.scss
+++ b/packages/web/src/scss/components/TextField/_TextField.scss
@@ -139,13 +139,17 @@ $_field-name: 'TextField';
 }
 
 .TextField__passwordToggle__icon {
+    display: inline-flex;
     pointer-events: none;
 }
 
+// @deprecated: The `TextField__passwordToggle__icon--*` modifiers are deprecated in favor of new
+// `accessibility-<checked | unchecked>` helpers. Does not affect the React implementation.
+// Migration: Delete the shown/hidden modifier classes.
 .TextField__passwordToggle__icon:not(.TextField__passwordToggle__icon--shown, .TextField__passwordToggle__icon--hidden),
 .TextField__passwordToggle__icon--hidden,
 .TextField__passwordToggle__button[aria-checked='true'] > .TextField__passwordToggle__icon--shown {
-    display: flex;
+    display: inline-flex;
 }
 
 // stylelint-disable-next-line no-descending-specificity -- 7.

--- a/packages/web/src/scss/components/TextField/index.html
+++ b/packages/web/src/scss/components/TextField/index.html
@@ -55,13 +55,13 @@
             aria-label="Show password"
             data-spirit-toggle="password"
           >
-            <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--hidden">
-              <svg width="20" height="20" aria-hidden="true">
+            <span class="TextField__passwordToggle__icon accessibility-unchecked">
+              <svg class="Icon" width="20" height="20" aria-hidden="true">
                 <use xlink:href="/assets/icons/svg/sprite.svg#visibility-on" />
               </svg>
             </span>
-              <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--shown">
-              <svg width="20" height="20" aria-hidden="true">
+            <span class="TextField__passwordToggle__icon accessibility-checked">
+              <svg class="Icon" width="20" height="20" aria-hidden="true">
                 <use xlink:href="/assets/icons/svg/sprite.svg#visibility-off" />
               </svg>
             </span>
@@ -89,16 +89,16 @@
             data-spirit-toggle="password"
             disabled
           >
-          <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--hidden">
-            <svg width="20" height="20" aria-hidden="true">
-              <use xlink:href="/assets/icons/svg/sprite.svg#visibility-on" />
-            </svg>
-          </span>
-            <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--shown">
-            <svg width="20" height="20" aria-hidden="true">
-              <use xlink:href="/assets/icons/svg/sprite.svg#visibility-off" />
-            </svg>
-          </span>
+            <span class="TextField__passwordToggle__icon accessibility-unchecked">
+              <svg class="Icon" width="20" height="20" aria-hidden="true">
+                <use xlink:href="/assets/icons/svg/sprite.svg#visibility-on" />
+              </svg>
+            </span>
+            <span class="TextField__passwordToggle__icon accessibility-checked">
+              <svg class="Icon" width="20" height="20" aria-hidden="true">
+                <use xlink:href="/assets/icons/svg/sprite.svg#visibility-off" />
+              </svg>
+            </span>
           </button>
         </div>
       </div>
@@ -148,13 +148,13 @@
               aria-label="Show password"
               data-spirit-toggle="password"
             >
-              <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--hidden">
-                <svg width="16" height="16" aria-hidden="true">
+              <span class="TextField__passwordToggle__icon accessibility-unchecked">
+                <svg class="Icon" width="16" height="16" aria-hidden="true">
                   <use xlink:href="/assets/icons/svg/sprite.svg#visibility-on" />
                 </svg>
               </span>
-                <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--shown">
-                <svg width="16" height="16" aria-hidden="true">
+              <span class="TextField__passwordToggle__icon accessibility-checked">
+                <svg class="Icon" width="16" height="16" aria-hidden="true">
                   <use xlink:href="/assets/icons/svg/sprite.svg#visibility-off" />
                 </svg>
               </span>
@@ -175,13 +175,13 @@
               aria-label="Show password"
               data-spirit-toggle="password"
             >
-              <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--hidden">
-                <svg width="20" height="20" aria-hidden="true">
+              <span class="TextField__passwordToggle__icon accessibility-unchecked">
+                <svg class="Icon" width="20" height="20" aria-hidden="true">
                   <use xlink:href="/assets/icons/svg/sprite.svg#visibility-on" />
                 </svg>
               </span>
-              <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--shown">
-                <svg width="20" height="20" aria-hidden="true">
+              <span class="TextField__passwordToggle__icon accessibility-checked">
+                <svg class="Icon" width="20" height="20" aria-hidden="true">
                   <use xlink:href="/assets/icons/svg/sprite.svg#visibility-off" />
                 </svg>
               </span>
@@ -202,13 +202,13 @@
               aria-label="Show password"
               data-spirit-toggle="password"
             >
-              <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--hidden">
-                <svg width="20" height="20" aria-hidden="true">
+              <span class="TextField__passwordToggle__icon accessibility-unchecked">
+                <svg class="Icon" width="20" height="20" aria-hidden="true">
                   <use xlink:href="/assets/icons/svg/sprite.svg#visibility-on" />
                 </svg>
               </span>
-              <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--shown">
-                <svg width="20" height="20" aria-hidden="true">
+              <span class="TextField__passwordToggle__icon accessibility-checked">
+                <svg class="Icon" width="20" height="20" aria-hidden="true">
                   <use xlink:href="/assets/icons/svg/sprite.svg#visibility-off" />
                 </svg>
               </span>
@@ -392,7 +392,7 @@
           required
         />
         <div class="TextField__validationText">
-          <svg width="20" height="20" aria-hidden="true">
+          <svg class="Icon" width="20" height="20" aria-hidden="true">
             {{#if (eq state "success")}}
             <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
             {{else}}
@@ -481,16 +481,16 @@
               aria-label="Show password"
               data-spirit-toggle="password"
             >
-            <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--hidden">
-              <svg width="20" height="20" aria-hidden="true">
-                <use xlink:href="/assets/icons/svg/sprite.svg#visibility-on" />
-              </svg>
-            </span>
-              <span class="TextField__passwordToggle__icon TextField__passwordToggle__icon--shown">
-              <svg width="20" height="20" aria-hidden="true">
-                <use xlink:href="/assets/icons/svg/sprite.svg#visibility-off" />
-              </svg>
-            </span>
+              <span class="TextField__passwordToggle__icon accessibility-unchecked">
+                <svg class="Icon" width="20" height="20" aria-hidden="true">
+                  <use xlink:href="/assets/icons/svg/sprite.svg#visibility-on" />
+                </svg>
+              </span>
+                <span class="TextField__passwordToggle__icon accessibility-checked">
+                <svg class="Icon" width="20" height="20" aria-hidden="true">
+                  <use xlink:href="/assets/icons/svg/sprite.svg#visibility-off" />
+                </svg>
+              </span>
             </button>
           </div>
           <div class="TextField__validationText">Too short</div>

--- a/packages/web/src/scss/helpers/accessibility/README.md
+++ b/packages/web/src/scss/helpers/accessibility/README.md
@@ -1,0 +1,63 @@
+# Accessibility
+
+Accessibility helpers are tiny CSS classes that make it easier to create accessible websites.
+
+## Visually Hidden
+
+A common helper for hiding content visually but keeping it [accessible to screen readers][wcag-hiding-content].
+
+```html
+<span class="accessibility-hidden">This is invisible, but accessible by screen readers</span>
+```
+
+## Tap Target
+
+This helper ensures that the active tap area of a link or button is large enough to be tapped on a mobile device.
+The minimum recommended tap area is 40 px by 40 px.
+
+```html
+<button type="button" class="accessibility-tap-target">Tap Me!</button>
+```
+
+ℹ️ If the element is larger than the minimum dimensions, the tap area will be the same size as the element.
+
+ℹ️ Currently, the tap target area size conforms to the [WCAG Level AA][wcag-tap-target-aa], but is smaller than
+the minimum size recommended by the [WCAG Level AAA][wcag-tap-target-aaa].
+
+## Stateful Button Label
+
+### Collapsed/Expanded
+
+This helper conditionally displays content based on the `aria-expanded` attribute. Use it to show different content depending on whether the element is expanded or collapsed.
+
+```html
+<button type="button" aria-expanded="false" aria-controls="#element-id">
+  <span class="accessibility-open">Hide content</span>
+  <span class="accessibility-closed">Show content</span>
+</button>
+```
+
+### Checked/Unchecked
+
+This helper conditionally displays content based on the `aria-checked` attribute. Commonly used for switch controls like the password visibility toggle.
+
+```html
+<button type="button" role="switch" aria-checked="false" aria-label="Show password">
+  <span class="accessibility-unchecked">
+    <svg class="Icon" width="20" height="20" aria-hidden="true">
+      <use xlink:href="/icons/sprite.svg#visibility-on" />
+    </svg>
+  </span>
+  <span class="accessibility-checked">
+    <svg class="Icon" width="20" height="20" aria-hidden="true">
+      <use xlink:href="/icons/sprite.svg#visibility-off" />
+    </svg>
+  </span>
+</button>
+```
+
+ℹ️ The checked and unchecked helpers use `inline-flex` display to properly align icon containers within buttons.
+
+[wcag-hiding-content]: https://www.w3.org/WAI/WCAG21/Techniques/css/C7
+[wcag-tap-target-aa]: https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html
+[wcag-tap-target-aaa]: https://www.w3.org/WAI/WCAG21/Understanding/target-size.html

--- a/packages/web/src/scss/helpers/accessibility/_accessibility.scss
+++ b/packages/web/src/scss/helpers/accessibility/_accessibility.scss
@@ -1,3 +1,6 @@
+// 1. Use custom properties to prevent inheritance issues.
+// 2. Remove whitespace from children, for example icons.
+
 @use '@tokens' as tokens;
 @use '../../tools/accessibility';
 
@@ -21,6 +24,7 @@ $_tap-target-size: 40px;
     }
 }
 
+// 1.
 [aria-expanded='true'] {
     --#{tokens.$css-variable-prefix}accessibility-expanded-open-display: initial;
     --#{tokens.$css-variable-prefix}accessibility-expanded-closed-display: none;
@@ -37,4 +41,23 @@ $_tap-target-size: 40px;
 
 [aria-expanded] .accessibility-closed {
     display: var(--#{tokens.$css-variable-prefix}accessibility-expanded-closed-display);
+}
+
+// 1.
+[aria-checked='true'] {
+    --#{tokens.$css-variable-prefix}accessibility-checked-checked-display: inline-flex; // 2.
+    --#{tokens.$css-variable-prefix}accessibility-checked-unchecked-display: none;
+}
+
+[aria-checked='false'] {
+    --#{tokens.$css-variable-prefix}accessibility-checked-checked-display: none;
+    --#{tokens.$css-variable-prefix}accessibility-checked-unchecked-display: inline-flex; // 2.
+}
+
+[aria-checked] .accessibility-checked {
+    display: var(--#{tokens.$css-variable-prefix}accessibility-checked-checked-display);
+}
+
+[aria-checked] .accessibility-unchecked {
+    display: var(--#{tokens.$css-variable-prefix}accessibility-checked-unchecked-display);
 }

--- a/packages/web/src/scss/helpers/accessibility/index.html
+++ b/packages/web/src/scss/helpers/accessibility/index.html
@@ -1,53 +1,73 @@
 {{#> web/layout/default title="Accessibility" parentPageName="Helpers" }}
 
-<section class="py-900 py-tablet-1000">
+<script>
+  // A custom function to toggle aria attributes on a button because, unlike in React, the native `toggleAttribute()`
+  // function removes the whole attribute when false.
+  const toggleAriaAttribute = (event, attributeName) => {
+    const element = event.currentTarget;
+    const currentValue = element.getAttribute(attributeName);
 
+    element.setAttribute(attributeName, currentValue === 'true' ? 'false' : 'true');
+  }
+</script>
+
+<section class="py-900 py-tablet-1000">
   <div class="Container">
 
-    <h2 class="docs-Heading">Accessibility</h2>
+    <h2 class="docs-Heading">Visually Hidden</h2>
 
     <div class="docs-Stack docs-Stack--start">
+      <p>
+        The following element is visually hidden, but still accessible by <abbr>AT</abbr> (Assistive Technology).
+        Use dev tools to check it's really there!
+      </p>
 
-      <div>
-        <p>
-          The following element is visually hidden, but still accessible by <abbr>AT</abbr> (Assistive Technology).
-          Use dev tools to check it's really there!
-        </p>
-
-        <p class="accessibility-hidden">This text is visually hidden</p>
-      </div>
-
-      <div>
-        <p>
-          Ensure the tap target area is large enough for the user to easily tap on the element. The size of the element
-          is not affected.
-        </p>
-
-        <button type="button" class="accessibility-tap-target" aria-label="Close">
-          <svg class="Icon" width="16" height="16" aria-hidden="true">
-            <use xlink:href="/assets/icons/svg/sprite.svg#close" />
-          </svg>
-        </button>
-      </div>
-
-      <div>
-        <p>Toggle display of an element inside the toggle button depending on <code>aria-expanded</code>.</p>
-
-        <button type="button" aria-expanded="true">
-          <span class="accessibility-open">Show less</span>
-          <span class="accessibility-closed">Show more</span>
-        </button>
-
-        <button type="button" aria-expanded="false">
-          <span class="accessibility-open">Show less</span>
-          <span class="accessibility-closed">Show more</span>
-        </button>
-      </div>
-
+      <p class="accessibility-hidden">This text is visually hidden</p>
     </div>
 
   </div>
+</section>
 
+<section class="py-900 py-tablet-1000">
+  <div class="Container">
+
+    <h2 class="docs-Heading">Tap Target Size</h2>
+
+    <div class="docs-Stack docs-Stack--start">
+      <p>
+        Ensure the tap target area is large enough for the user to easily tap on the element. The size of the element
+        is not affected.
+      </p>
+
+      <button type="button" class="accessibility-tap-target" aria-label="Close">
+        <svg class="Icon" width="16" height="16" aria-hidden="true">
+          <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+        </svg>
+      </button>
+    </div>
+
+  </div>
+</section>
+
+<section class="py-900 py-tablet-1000">
+  <div class="Container">
+
+    <h2 class="docs-Heading">Stateful Button Label</h2>
+
+    <div class="docs-Stack docs-Stack--start">
+      <p>Toggle display of an element inside the toggle button depending on its <code>aria</code> attribute.</p>
+
+      <button type="button" aria-expanded="false" onclick="toggleAriaAttribute(event, 'aria-expanded')">
+        <code class="accessibility-open">aria-expanded="true"</code>
+        <code class="accessibility-closed">aria-expanded="false"</code>
+      </button>
+
+      <button type="button" aria-checked="false" onclick="toggleAriaAttribute(event, 'aria-checked')">
+        <code class="accessibility-checked">aria-checked="true"</code>
+        <code class="accessibility-unchecked">aria-checked="false"</code>
+      </button>
+    </div>
+  </div>
 </section>
 
 {{/web/layout/default}}


### PR DESCRIPTION
## Description

The changes include:

- New accessibility helpers: `.accessibility-checked`, `.accessibility-unchecked`
- New accessibility helpers README
- `TextField` migration to use the new helpers instead of component-specific modifiers
- Deprecation notice for the old `TextField` icon modifiers

### Issue reference

https://jira.almacareer.tech/browse/DS-596

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/lmc-eu/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
