### PR TITLE
docs(repo): add JIRA agent instructions

### DIFF
--- a/.agents/instructions/jira.md
+++ b/.agents/instructions/jira.md
@@ -1,0 +1,37 @@
+---
+description: JIRA issue creation guidelines
+alwaysApply: true
+---
+
+# JIRA Guidelines
+
+This document covers conventions for creating and managing JIRA issues.
+
+## Creating Issues
+
+### Defaults
+
+- **Issue type:** Story (unless specified otherwise)
+- **Priority:** Medium (unless specified otherwise)
+- **Project key:** DS
+- **Template:** Spirit Feature Template
+
+### Summary
+
+Write a concise summary that describes the change or feature request. Use imperative mood (e.g., "Allow Tag to be interactive" not "Allowing Tag to be interactive").
+
+### Description
+
+Include:
+
+1. A brief explanation of what the issue is about
+2. Implementation notes (if available)
+3. Acceptance criteria
+
+### Labels
+
+Add labels by package name (taken from `package.json`, without the `@alma-oss/` namespace), e.g., `spirit-web`, `spirit-web-react`, `spirit-design-tokens`.
+
+### Components
+
+When applicable, set the Component field to one or more component names, e.g., Avatar, Button, Tag.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ This file provides AI assistants with context and guidelines for working with th
 - [Contributing Guide][contributing]
 - [Git Workflow Guidelines][agents-git-workflow] – branch naming, commit messages, and PRs
 - [Code Style Guidelines][agents-code-style] – formatting tools and naming conventions
+- [JIRA Guidelines][agents-jira] – issue creation conventions
 
 ## Project Overview
 
@@ -33,6 +34,7 @@ For comprehensive guidelines, see:
 
 [agents-code-style]: .agents/instructions/code-style.md
 [agents-git-workflow]: .agents/instructions/git-workflow.md
+[agents-jira]: .agents/instructions/jira.md
 [contributing]: CONTRIBUTING.md
 [development-guide-getting-started]: docs/contribution/development.md#getting-started
 [development-guide-common-tasks]: docs/contribution/development.md#common-tasks


### PR DESCRIPTION
## Description

Add JIRA issue creation guidelines for AI agents, covering default issue type, priority, summary style, labels, and components conventions.

## Additional context

New file `.agents/instructions/jira.md` with `alwaysApply: true` frontmatter, linked from `CLAUDE.md`.