### PR TITLE
feat(repo): add Storybook preview CSS source switching

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -41,11 +41,22 @@ npmPreapprovedPackages: ['@alma-oss/*']
 # @see: https://yarnpkg.com/configuration/yarnrc#npmPublishProvenance
 npmPublishProvenance: true
 
+# GitHub Packages registry for @almacareer scope (used by apps/demo and catalogs).
+# Private packages (e.g. @almacareer/cyborg-design-tokens) require GITHUB_TOKEN with
+# read:packages; otherwise Yarn reports "No candidates found" for those versions.
+npmScopes:
+  almacareer:
+    npmAlwaysAuth: true
+    npmAuthToken: ${GITHUB_TOKEN}
+    npmPublishRegistry: 'https://npm.pkg.github.com'
+    npmRegistryServer: 'https://npm.pkg.github.com'
+
 # Catalogs provide centralized dependency version management for workspaces.
 # @see: https://yarnpkg.com/features/catalogs
 catalogs:
   # Core frontend framework dependencies
   frontend:
+    '@almacareer/cyborg-design-tokens': ^7.0.0
     next: 16.2.10
     react: 19.2.6
     react-dom: 19.2.6

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ See individual [packages](#packages) to learn how to get started.
 
 - `git clone ssh://git@github.com:alma-oss/spirit-design-system.git`
 - `cd spirit-design-system`
+- Export `GITHUB_TOKEN` with `read:packages` before installing dependencies.
+  This is required to download private `@almacareer/*` packages used by Storybook.
 
 Using Make (recommended):
 

--- a/apps/storybook/config/cssSource.ts
+++ b/apps/storybook/config/cssSource.ts
@@ -1,0 +1,88 @@
+import type { Decorator } from '@storybook/react';
+import React, { useEffect } from 'react';
+import {
+  DEFAULT_CSS_SOURCE_ID,
+  cssSourceEntries,
+} from '../cssSourceEntries';
+import { getCssSourceManifestUrl, getDefaultCssSourceHref, resolveCssSourceHref } from '../cssSourceUrls';
+import type { PreviewGlobals } from './types';
+
+const LINK_ID = 'storybook-css-source-link';
+
+let manifestCache: Record<string, string> | null = null;
+async function getManifest(): Promise<Record<string, string>> {
+  if (manifestCache) return manifestCache;
+  const res = await fetch(getCssSourceManifestUrl());
+  if (!res.ok) return {};
+  manifestCache = (await res.json()) as Record<string, string>;
+  return manifestCache;
+}
+
+function getPreviewCssSource(globals: PreviewGlobals): string {
+  const v = globals.previewCssSource;
+  return typeof v === 'string' && cssSourceEntries.some(({ id }) => id === v) ? v : DEFAULT_CSS_SOURCE_ID;
+}
+
+function ensureLink(): HTMLLinkElement | null {
+  if (typeof document === 'undefined') return null;
+  let link = document.getElementById(LINK_ID) as HTMLLinkElement | null;
+  if (link) return link;
+  link = document.createElement('link');
+  link.id = LINK_ID;
+  link.rel = 'stylesheet';
+  link.href = getDefaultCssSourceHref();
+  document.head.append(link);
+  return link;
+}
+
+function applyCssSource(sourceId: string) {
+  const link = ensureLink();
+  if (!link) return;
+  const defaultUrl = getDefaultCssSourceHref();
+  if (sourceId === DEFAULT_CSS_SOURCE_ID) {
+    link.href = defaultUrl;
+    return;
+  }
+  const apply = (manifest: Record<string, string>) => {
+    const url = manifest[sourceId];
+    if (url) link.href = resolveCssSourceHref(url);
+  };
+  if (manifestCache) {
+    apply(manifestCache);
+    return;
+  }
+  getManifest().then(apply);
+}
+
+const CSS_SOURCE_TOOLBAR_ITEMS = cssSourceEntries.map(({ id, label }) => ({ title: label, value: id }));
+
+export const cssSourceGlobalTypes = {
+  previewCssSource: {
+    name: 'CSS source',
+    description: `Token source for the preview stylesheet (${cssSourceEntries.map(({ label }) => label).join(', ')}).`,
+    defaultValue: DEFAULT_CSS_SOURCE_ID,
+    toolbar: {
+      icon: 'document',
+      items: CSS_SOURCE_TOOLBAR_ITEMS,
+      dynamicTitle: true,
+    },
+  },
+} as const;
+
+const CssSourceSync: React.FC<React.PropsWithChildren<{ sourceId: string }>> = ({
+  sourceId,
+  children,
+}) => {
+  useEffect(() => {
+    applyCssSource(sourceId);
+  }, [sourceId]);
+  return children as React.ReactElement;
+};
+
+const withCssSource: Decorator = (Story: any, context: any) => {
+  const sourceId = getPreviewCssSource(context.globals);
+  applyCssSource(sourceId);
+  return React.createElement(CssSourceSync, { sourceId }, Story(context));
+};
+
+export const cssSourceDecorators = [withCssSource];

--- a/apps/storybook/config/index.ts
+++ b/apps/storybook/config/index.ts
@@ -1,4 +1,5 @@
 export { themeArgType, themeArgs, themeDecorators, themeGlobalTypes, THEME_CONTROL_OPTIONS } from './theme';
+export { cssSourceDecorators, cssSourceGlobalTypes } from './cssSource';
 export { marginArgTypes, marginArgs, displayArgTypes, displayArgs } from './styleProps';
 export { escapeHatchArgTypes, escapeHatchArgs } from './escapeHatches';
 export type {

--- a/apps/storybook/cssSourceEntries.ts
+++ b/apps/storybook/cssSourceEntries.ts
@@ -1,0 +1,23 @@
+export const STORYBOOK_CSS_PREFIX = '/storybook-css';
+export const STORYBOOK_CSS_MANIFEST_PATH = `${STORYBOOK_CSS_PREFIX}/manifest.json`;
+export const DEFAULT_CSS_SOURCE_ID = 'default';
+export const DEFAULT_CSS_SOURCE_FILE_NAME = 'assets/storybook-spirit-default.css';
+
+export const cssSourceEntries = [
+  {
+    id: DEFAULT_CSS_SOURCE_ID,
+    label: 'Spirit',
+  },
+  {
+    id: 'jobs-cz',
+    label: 'jobs.cz',
+    scssSubpath: 'jobs.cz/scss',
+  },
+  {
+    id: 'prace-cz',
+    label: 'prace.cz',
+    scssSubpath: 'prace.cz/scss',
+  },
+] as const;
+
+export type CssSourceId = (typeof cssSourceEntries)[number]['id'];

--- a/apps/storybook/cssSourceUrls.ts
+++ b/apps/storybook/cssSourceUrls.ts
@@ -1,0 +1,23 @@
+import {
+  DEFAULT_CSS_SOURCE_FILE_NAME,
+  DEFAULT_CSS_SOURCE_ID,
+  STORYBOOK_CSS_MANIFEST_PATH,
+  STORYBOOK_CSS_PREFIX,
+} from './cssSourceEntries';
+
+const resolvePreviewAssetUrl = (path: string): string => {
+  if (typeof document === 'undefined') {
+    return path;
+  }
+
+  return new URL(path, document.baseURI).toString();
+};
+
+export const getDefaultCssSourceHref = (): string =>
+  import.meta.env.DEV ? `${STORYBOOK_CSS_PREFIX}/${DEFAULT_CSS_SOURCE_ID}.css` : resolvePreviewAssetUrl(DEFAULT_CSS_SOURCE_FILE_NAME);
+
+export const getCssSourceManifestUrl = (): string =>
+  import.meta.env.DEV ? STORYBOOK_CSS_MANIFEST_PATH : resolvePreviewAssetUrl('assets/storybook-css-sources.json');
+
+export const resolveCssSourceHref = (path: string): string =>
+  import.meta.env.DEV ? path : resolvePreviewAssetUrl(path);

--- a/apps/storybook/cssSources.ts
+++ b/apps/storybook/cssSources.ts
@@ -1,0 +1,17 @@
+import { join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { DEFAULT_CSS_SOURCE_ID, cssSourceEntries } from './cssSourceEntries';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const root = resolve(__dirname, '../..');
+const nodeModules = join(root, 'node_modules');
+const cyborgTokens = join(nodeModules, '@almacareer/cyborg-design-tokens');
+
+/** Add a new token set in cssSourceEntries.ts; load paths are derived here. */
+export const cssSources = cssSourceEntries.map(({ id, scssSubpath }) => ({
+  id,
+  loadPaths:
+    id === DEFAULT_CSS_SOURCE_ID
+      ? [nodeModules, join(nodeModules, '@alma-oss/spirit-design-tokens/src/scss')]
+      : [nodeModules, join(cyborgTokens, scssSubpath)],
+}));

--- a/apps/storybook/main.ts
+++ b/apps/storybook/main.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { mergeConfig } from 'vite';
+import { cssSources } from './cssSources';
+import { storybookCssPlugin } from './storybookCssPlugin';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -39,6 +41,7 @@ const config: StorybookConfig = {
         react({
           jsxRuntime: 'automatic',
         }),
+        storybookCssPlugin(cssSources),
       ],
       css: {
         postcss: resolve(__dirname, 'config'),

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -10,13 +10,16 @@
     "directory": "apps/storybook"
   },
   "scripts": {
+    "prestart": "yarn workspace @alma-oss/spirit-icons run build",
     "start": "storybook dev --config-dir ./ --port 6006 --no-open",
+    "prebuild": "yarn workspace @alma-oss/spirit-icons run build",
     "build": "storybook build --config-dir ./ --output-dir ./build --stats-json"
   },
   "devDependencies": {
     "@alma-oss/spirit-design-tokens": "workspace:^",
     "@alma-oss/spirit-icons": "workspace:^",
     "@alma-oss/spirit-web-react": "workspace:^",
+    "@almacareer/cyborg-design-tokens": "catalog:frontend",
     "@babel/core": "catalog:build",
     "@storybook/addon-a11y": "catalog:storybook",
     "@storybook/addon-docs": "catalog:storybook",
@@ -30,6 +33,7 @@
     "react": "catalog:frontend",
     "react-dom": "catalog:frontend",
     "react-image-crop": "catalog:frontend",
+    "sass-embedded": "catalog:build",
     "storybook": "catalog:storybook",
     "typescript": "catalog:types",
     "vite": "catalog:build"

--- a/apps/storybook/preview.ts
+++ b/apps/storybook/preview.ts
@@ -1,7 +1,9 @@
-import './assets/stylesheets/index.scss';
+import './previewCssLink';
 import { IconGlobalDecorator } from './decorators/IconGlobalDecorator';
 import SpiritTheme from './spirit.theme';
 import {
+  cssSourceDecorators,
+  cssSourceGlobalTypes,
   displayArgTypes,
   displayArgs,
   escapeHatchArgTypes,
@@ -67,8 +69,8 @@ export const args = {
 };
 
 // Global types
-export const globalTypes = themeGlobalTypes;
+export const globalTypes = { ...themeGlobalTypes, ...cssSourceGlobalTypes };
 
 // Decorators
-export const decorators = [...themeDecorators, IconGlobalDecorator];
+export const decorators = [...themeDecorators, ...cssSourceDecorators, IconGlobalDecorator];
 export const tags = ['autodocs'];

--- a/apps/storybook/previewCssLink.ts
+++ b/apps/storybook/previewCssLink.ts
@@ -1,0 +1,11 @@
+import { getDefaultCssSourceHref } from './cssSourceUrls';
+
+const LINK_ID = 'storybook-css-source-link';
+
+if (typeof document !== 'undefined' && !document.getElementById(LINK_ID)) {
+  const link = document.createElement('link');
+  link.id = LINK_ID;
+  link.rel = 'stylesheet';
+  link.href = getDefaultCssSourceHref();
+  document.head.append(link);
+}

--- a/apps/storybook/storybookCssPlugin.ts
+++ b/apps/storybook/storybookCssPlugin.ts
@@ -1,0 +1,139 @@
+import { existsSync } from 'fs';
+import { createRequire } from 'module';
+import { dirname, extname, resolve } from 'path';
+import { compile } from 'sass-embedded';
+import type { Plugin } from 'vite';
+import { fileURLToPath } from 'url';
+import {
+  DEFAULT_CSS_SOURCE_FILE_NAME,
+  DEFAULT_CSS_SOURCE_ID,
+  STORYBOOK_CSS_MANIFEST_PATH,
+  STORYBOOK_CSS_PREFIX,
+} from './cssSourceEntries';
+
+type CssSource = { id: string; loadPaths: readonly string[] };
+type CompiledScss = { css: string; loadedUrls: URL[] };
+
+/** Resolve Storybook app dir at runtime so it works when config is loaded from a different path (e.g. bundled). */
+function getStorybookDir(): string {
+  try {
+    const req = createRequire(import.meta.url);
+    return dirname(req.resolve('@alma-oss/spirit-storybook/package.json'));
+  } catch {
+    const cwd = process.cwd();
+    const entryHere = resolve(cwd, 'assets/stylesheets/index.scss');
+    return existsSync(entryHere) ? cwd : resolve(cwd, 'apps/storybook');
+  }
+}
+
+function compileScss(entryPath: string, loadPaths: string[]): CompiledScss {
+  const result = compile(entryPath, {
+    loadPaths,
+    silenceDeprecations: ['mixed-decls'],
+  } as Parameters<typeof compile>[1]);
+  return {
+    css: result.css,
+    loadedUrls: result.loadedUrls,
+  };
+}
+
+function getDefaultLoadPaths(storybookDir: string): string[] {
+  return [
+    resolve(storybookDir, '../../node_modules'),
+    resolve(storybookDir, '../../node_modules/@alma-oss/spirit-design-tokens/src/scss'),
+    resolve(storybookDir, '../../packages/design-tokens/src/scss'),
+  ];
+}
+
+function getLoadedFilePaths(loadedUrls: URL[]): string[] {
+  return loadedUrls
+    .filter(({ protocol }) => protocol === 'file:')
+    .map((url) => fileURLToPath(url));
+}
+
+export function storybookCssPlugin(cssSources: readonly CssSource[]): Plugin {
+  let builtManifest: Record<string, string> = {};
+  const watchedFiles = new Set<string>();
+
+  return {
+    name: 'storybook-css-sources',
+    configureServer(server) {
+      server.watcher.on('change', (changedFile) => {
+        if (!watchedFiles.has(changedFile)) {
+          return;
+        }
+
+        if (!['.css', '.sass', '.scss'].includes(extname(changedFile))) {
+          return;
+        }
+
+        server.ws.send({ type: 'full-reload', path: '*' });
+      });
+
+      server.middlewares.use((req, res, next) => {
+        const url = (req.url ?? '').split('?')[0];
+        if (url.startsWith(STORYBOOK_CSS_PREFIX)) {
+          const rest = url.slice(`${STORYBOOK_CSS_PREFIX}/`.length);
+          if (url === STORYBOOK_CSS_MANIFEST_PATH) {
+            const manifest: Record<string, string> = {};
+            cssSources.forEach((s) => {
+              manifest[s.id] = `${STORYBOOK_CSS_PREFIX}/${s.id}.css`;
+            });
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify(manifest));
+            return;
+          }
+          if (rest.endsWith('.css')) {
+            const id = rest.slice(0, -4);
+            const source = cssSources.find((s) => s.id === id);
+            if (source) {
+              try {
+                const dir = getStorybookDir();
+                const entry = resolve(dir, 'assets/stylesheets/index.scss');
+                const defaultPaths = getDefaultLoadPaths(dir);
+                const loadPaths =
+                  source.id === DEFAULT_CSS_SOURCE_ID ? defaultPaths : [...source.loadPaths, ...defaultPaths];
+                const { css, loadedUrls } = compileScss(entry, loadPaths);
+                const loadedFiles = getLoadedFilePaths(loadedUrls);
+                loadedFiles.forEach((file) => watchedFiles.add(file));
+                server.watcher.add(loadedFiles);
+                res.setHeader('Content-Type', 'text/css');
+                res.end(css);
+                return;
+              } catch (err) {
+                console.error(`[storybook-css-sources] Failed to compile ${id}:`, err);
+                res.statusCode = 500;
+                res.end();
+                return;
+              }
+            }
+          }
+        }
+        next();
+      });
+    },
+    generateBundle() {
+      const storybookDir = getStorybookDir();
+      const entryScssPath = resolve(storybookDir, 'assets/stylesheets/index.scss');
+      const resolvedDefaultPaths = getDefaultLoadPaths(storybookDir);
+      for (const source of cssSources) {
+        const loadPaths =
+          source.id === DEFAULT_CSS_SOURCE_ID ? resolvedDefaultPaths : [...source.loadPaths, ...resolvedDefaultPaths];
+        const { css } = compileScss(entryScssPath, loadPaths);
+        const ref = this.emitFile({
+          type: 'asset',
+          name: `storybook-${source.id}.css`,
+          source: css,
+          fileName: source.id === DEFAULT_CSS_SOURCE_ID ? DEFAULT_CSS_SOURCE_FILE_NAME : undefined,
+        });
+        builtManifest[source.id] = this.getFileName(ref);
+      }
+      this.emitFile({
+        type: 'asset',
+        name: 'storybook-css-sources.json',
+        source: JSON.stringify(builtManifest),
+        fileName: 'assets/storybook-css-sources.json',
+      });
+    },
+  };
+}

--- a/docs/contribution/development.md
+++ b/docs/contribution/development.md
@@ -34,6 +34,9 @@ For you to install all the dependencies in this project and successfully develop
 
 After you have set up all the requirements run the following command in your terminal:
 
+Before installing dependencies, export `GITHUB_TOKEN` with `read:packages`.
+Storybook depends on private `@almacareer/*` packages hosted on GitHub Packages.
+
 ```bash
 make install
 ```

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -9,7 +9,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - **repo:** drop support for Node.js v20 and require Node.js v22 #DS-2597
 - **design-tokens,web:** rename component tokens from `header` to `navigation` #DS-2589
-- **design-tokens,web:** Filled tokens are now renamed to fill.
+- **design-tokens,web:** rename Form Field Filled tokens to Fill #DS-2502
 
 ### Features
 

--- a/packages/web-react/CHANGELOG.md
+++ b/packages/web-react/CHANGELOG.md
@@ -26,79 +26,46 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web,web-react:** drop examples with emphasized label in the Toggle and Checkbox
 - **web,web-react:** remove formFieldMode and vertical spacing from form field components
 - **web,web-react:** replace `link-stretched` with `element-stretched` helper class #DS-2653
-- **web,web-react:** align File and FileUpload with design changes #DS-2554
 - **web:** align Pagination with new design #DS-2554
 - **web-react:** align `Toast` with new design #DS-2554
 - **web:** align `Tag` with new design #DS-2554
 - **web:** align `Navigation` with new design #DS-2554
 - **web:** align `Button` sizes with action typography tokens #DS-2554
-- **web,web-react:** Spacings in Checkbox, Radio and Toggle are
-  now set using padding utility. Review all your usages.
+- **web,web-react:** use padding for Checkbox, Radio, and Toggle vertical spacings
 - **web-react:** remove `hideOnCollapse` from `UncontrolledCollapse`
-- **web,web-react:** the `closeButton` prop on `DrawerPanel` is removed.
-  Compose the panel from `DrawerPanelHeader` and `DrawerPanelContent`
-  instead.
-- **web-react:** `DrawerCloseButton`, `ModalCloseButton`, `TooltipCloseButton`, and
-  their prop types are removed. Use `CloseButton` instead.
-- **web-react:** Toggle now requires explicit margin management when used within Stack components.
+- **web,web-react:** expose `DrawerPanel` composition sub-components #DS-2656
+- **web-react:** add `CloseButton` and remove component-specific close buttons #DS-2216
+- **web-react:** update Toggle component to use composition #DS-564
 - **web,web-react:** replace `TooltipCloseButton` button with `ControlButton`
 - **web,web-react:** replace `ToastBar` close button with `ControlButton` #DS-2216
 - **web,web-react:** replace `Button` with `ControlButton` in `ModalCloseButton` #DS-2216
 - **web,web-react:** replace `DrawerCloseButton` with `ControlButton` in `Drawer` #DS-2216
-- **web-react:** Radio now requires explicit margin management when used within Stack components.
-- **web-react:** Checkbox now requires explicit margin management
-  when used within Stack components.
-- **web,web-react:** Item no longer accepts label, helperText, iconName,
-  or selectionDecorator props. Use children with startSlot/endSlot
-  and compose Label, HelperText, ValidationText, and Icon explicitly.
-- **web,web-react:** Item now renders as a div by default instead of a button.
-  Set elementType="button" when button semantics are needed.
-- **web,web-react:** The web Item markup now uses Item**content
-  and Item**slot instead of Item\_\_icon and grid-positioned Label/HelperText item styles.
-- **web,web-react:** `--disabled` modifier classes are removed from the migrated components — consumers
-  should apply the disabled utility class alongside the native disabled attribute.
+- **web-react:** update Radio component to use composition #DS-564
+- **web-react:** update Checkbox component to use composition
+- **web,web-react:** compose Item content with slots #DS-2586
+- **web,web-react:** use disabled utility for disabled color-scheme states #DS-2468
 - **repo:** drop support for Node.js v20 and require Node.js v22 #DS-2597
-- **web-react:** Remove FileUploader compound component and stabilize
-  UNSTABLE_FileUpload and UNSTABLE_File as FileUpload and File.
-- **web-react:** removed indicator for selected state in vertical navigation
-- **web,web-react:** `ControlButton` now uses the expanded size scale by default.
-  The existing `small`/`medium`/`large` sizes are remapped to smaller heights and
-  `xsmall`/`xlarge` are added. Remove the
-  `spirit-feature-enable-v5-control-button-expanded-size-scale` CSS class and the
-  `$enable-v5-control-button-expanded-size-scale` Sass flag from your project; to
-  keep the previous rendering, shift the size up (`small` → `medium`,
-  `medium` → `large`, `large` → `xlarge`).
-
+- **web-react:** stabilize FileUpload and File, remove FileUploader #DS-2592
+- **web-react:** introduce NavigationItem slots #DS-2523
+- **web,web-react:** remove `ControlButton` expanded size scale feature flag #DS-2216
 - **web-react:** remove Stack StackItem deprecation notice #DS-2639
 - **web-react:** stabilize UNSTABLE_Header and remove deprecated Header
 - **web,web-react:** rename ScrollView's arrows to controls #DS-2271
-- **web,web-react:** The `ValidationText--inline` modifier and `formFieldMode`
-  handling in `ValidationText` have been removed. Use default `ValidationText`
-  styling for Checkbox and Toggle validation messages.
+- **web,web-react:** remove inline modifier from `ValidationText` components
 - **web-react:** rename hasValidationStateIcon to validationStateIcon #DS-2490
 - **web,web-react:** drop has prefix from Stack CSS modifiers #DS-1916
 - **web,web-react:** derive `ControlButton` colors from color scheme #DS-2591
 - **web,web-react:** replace check-plain with success icon for success state #DS-2098
-- **web:** Visual BC of all form fields
-- **web,web-react:** If Icon component parent sets Icon size, it is used.
-  Icon `boxSize` overrides this value.
-- **web,web-react:** `.Tag--<color>` and `.Tag--subtle` CSS rules are no
-  longer emitted. Consumers must apply a `color-scheme-on-*` class (the
-  React component does this automatically).
-- **web,web-react:** web `Button` emotion variants now require color-scheme
-  helper classes for surface colors in markup examples.
-- **web,web-react:** TooltipPopover now requires color-scheme helper for surface colors
-- **web,web-react:** web `Alert` variants now require color-scheme classes for surface colors.
+- **web:** update typography in ValidationText to use regular weight #DS-2472
+- **web,web-react:** the Icon now inherits composition size unless it explicitly overrides it
+- **web,web-react:** migrate `Tag` to color schemes #DS-2456
+- **web,web-react:** migrate `Button` and `ButtonLink` to color schemes
+- **web,web-react:** migrate `TooltipPopover` to neutral color-scheme
+- **web,web-react:** migrate `Alert` to color schemes
 - **web,web-react:** use `InputContainer` in `UNSTABLE_Picker` #DS-564
 - **web,web-react:** remove deprecated `isBlock` prop from Button and ButtonLink #DS-1897
-- **web:** TextArea now uses InputContainer instead of a custom component.
-  CharacterCounter component is now a standalone component.
-- **web,web-react:** The new `Tag` appearance (`inline-flex` layout with explicit
-  height and inside spacing) is now default. Delete the `$enable-v5-tag-appearance`
-  Sass variable and the `spirit-feature-enable-v5-tag-appearance` CSS class from
-  your project — they have no effect. See the Tag: Appearance Feature Flag Removed
-  sections in the web and web-react package Migration Guides to version 5.
-
+- **web:** use InputContainer in TextArea #DS-564
+- **web,web-react:** drop `Tag` appearance feature flag #DS-2456
 - **web,web-react:** remove deprecated `row` direction value from `Flex` #DS-1629
 
 ### Features

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -28,7 +28,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web,web-react:** remove formFieldMode and vertical spacing from form field components
 - **web,web-react:** replace `link-stretched` with `element-stretched` helper class #DS-2653
 - **web:** align inline form field components with new typography tokens #DS-2554
-- **web,web-react:** align File and FileUpload with design changes #DS-2554
 - **web:** align form field components with new typography tokens #DS-2554
 - **web:** align Pagination with new design #DS-2554
 - **web:** align `Tag` with new design #DS-2554
@@ -43,41 +42,23 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web:** align `Pill` with new design #DS-2554
 - **web:** align `Accordion` with new design #DS-2554
 - **web:** align `Button` sizes with action typography tokens #DS-2554
-- **web,web-react:** Spacings in Checkbox, Radio and Toggle are
-  now set using padding utility. Review all your usages.
-- **web,web-react:** the `closeButton` prop on `DrawerPanel` is removed.
-  Compose the panel from `DrawerPanelHeader` and `DrawerPanelContent`
-  instead.
-- **web:** Remove several styles from Toggle.
+- **web,web-react:** use padding for Checkbox, Radio, and Toggle vertical spacings
+- **web,web-react:** expose `DrawerPanel` composition sub-components #DS-2656
+- **web:** switch Toggle to composition and move its styles to the input only #DS-564
 - **web,web-react:** replace `TooltipCloseButton` button with `ControlButton`
 - **web,web-react:** replace `ToastBar` close button with `ControlButton` #DS-2216
 - **web,web-react:** replace `Button` with `ControlButton` in `ModalCloseButton` #DS-2216
 - **web,web-react:** replace `DrawerCloseButton` with `ControlButton` in `Drawer` #DS-2216
-- **web:** Remove several styles from Radio.
-- **web:** Remove several styles from Checkbox.
-- **web,web-react:** Item no longer accepts label, helperText, iconName,
-  or selectionDecorator props. Use children with startSlot/endSlot
-  and compose Label, HelperText, ValidationText, and Icon explicitly.
-- **web,web-react:** Item now renders as a div by default instead of a button.
-  Set elementType="button" when button semantics are needed.
-- **web,web-react:** The web Item markup now uses Item**content
-  and Item**slot instead of Item\_\_icon and grid-positioned Label/HelperText item styles.
-- **web,web-react:** `--disabled` modifier classes are removed from the migrated components — consumers
-  should apply the disabled utility class alongside the native disabled attribute.
+- **web:** switch Radio to composition and move its styles to the input only #DS-564
+- **web:** switch Checkbox to composition and move its styles to the input only #DS-564
+- **web,web-react:** compose Item content with slots #DS-2586
+- **web,web-react:** use disabled utility for disabled color-scheme states #DS-2468
 - **repo:** drop support for Node.js v20 and require Node.js v22 #DS-2597
-- **web:** Remove FileUploader SCSS/JS plugin and stabilize
-  UNSTABLE_FileUpload and UNSTABLE_File as FileUpload and File.
+- **web:** stabilize FileUpload and File, remove FileUploader #DS-2592
 - **web:** unify toggle html order with checkbox #DS-2322
-- **web:** removed indicator for selected state in vertical navigation
+- **web:** introduce NavigationItem slots #DS-2523
 - **web:** remove enable-v5-container-block-formatting-context feature flag
-- **web,web-react:** `ControlButton` now uses the expanded size scale by default.
-  The existing `small`/`medium`/`large` sizes are remapped to smaller heights and
-  `xsmall`/`xlarge` are added. Remove the
-  `spirit-feature-enable-v5-control-button-expanded-size-scale` CSS class and the
-  `$enable-v5-control-button-expanded-size-scale` Sass flag from your project; to
-  keep the previous rendering, shift the size up (`small` → `medium`,
-  `medium` → `large`, `large` → `xlarge`).
-
+- **web,web-react:** remove `ControlButton` expanded size scale feature flag #DS-2216
 - **web:** remove Stack StackItem backwards-compat CSS #DS-2639
 - **design-tokens,web:** rename component tokens from `header` to `navigation` #DS-2589
 - **web:** stabilize UNSTABLE_Header and remove deprecated Header scss
@@ -85,53 +66,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web:** replace `get-variable-if-exists` with relevant token #DS-2633
 - **web:** update `UNSTABLE_Picker` design #DS-2503
 - **web,web-react:** rename ScrollView's arrows to controls #DS-2271
-- **web:** All `InputContainer` elements now require either
-  `InputContainer--fill` or `InputContainer--outline` modifier.
-- **design-tokens,web:** Filled tokens are now renamed to fill.
-- **web,web-react:** The `ValidationText--inline` modifier and `formFieldMode`
-  handling in `ValidationText` have been removed. Use default `ValidationText`
-  styling for Checkbox and Toggle validation messages.
+- **web:** introduce fill and outline variants to form fields #DS-2502
+- **design-tokens,web:** rename Form Field Filled tokens to Fill #DS-2502
+- **web,web-react:** remove inline modifier from `ValidationText` components
 - **web,web-react:** drop has prefix from Stack CSS modifiers #DS-1916
 - **web,web-react:** derive `ControlButton` colors from color scheme #DS-2591
 - **web:** derive dynamic colors from color schemes #DS-2590
 - **web,web-react:** replace check-plain with success icon for success state #DS-2098
-- **web:** Visual BC of all form fields
-- **web,web-react:** If Icon component parent sets Icon size, it is used.
-  Icon `boxSize` overrides this value.
-- **web,web-react:** `.Tag--<color>` and `.Tag--subtle` CSS rules are no
-  longer emitted. Consumers must apply a `color-scheme-on-*` class (the
-  React component does this automatically).
-- **web,web-react:** web `Button` emotion variants now require color-scheme
-  helper classes for surface colors in markup examples.
-- **web,web-react:** TooltipPopover now requires color-scheme helper for surface colors
-- **web,web-react:** web `Alert` variants now require color-scheme classes for surface colors.
+- **web:** update typography in ValidationText to use regular weight #DS-2472
+- **web,web-react:** the Icon now inherits composition size unless it explicitly overrides it
+- **web,web-react:** migrate `Tag` to color schemes #DS-2456
+- **web,web-react:** migrate `Button` and `ButtonLink` to color schemes
+- **web,web-react:** migrate `TooltipPopover` to neutral color-scheme
+- **web,web-react:** migrate `Alert` to color schemes
 - **web,web-react:** use `InputContainer` in `UNSTABLE_Picker` #DS-564
 - **web,web-react:** remove deprecated `isBlock` prop from Button and ButtonLink #DS-1897
-- **web:** dictionaries.generate-colors for ToastBar is removed. Migrate
-  custom CSS or overrides from --spirit-toast-bar-\* to locals and color-scheme helpers.
-- **web:** Remove color-scheme from the utilities settings and move generation to
-  helpers/color-scheme. Consumers must import the color-scheme helper entry (or the updated
-  main bundle) instead of relying on utilities-only builds for color-scheme classes. Pill and
-  ControlButton use the new component token override mixin.
-- **web:** TextArea now uses InputContainer instead of a custom component.
-  CharacterCounter component is now a standalone component.
-- **web:** Remove most of the Select styles.
-- **web:** Refactor TextField to use InputContainer and InputAddon instead
-  of it's own styles. Use ControlButton for Password Toggle.
-- **web:** Remove all FieldGroup styles.
-- **web,web-react:** The new `Tag` appearance (`inline-flex` layout with explicit
-  height and inside spacing) is now default. Delete the `$enable-v5-tag-appearance`
-  Sass variable and the `spirit-feature-enable-v5-tag-appearance` CSS class from
-  your project — they have no effect. See the Tag: Appearance Feature Flag Removed
-  sections in the web and web-react package Migration Guides to version 5.
-
+- **web:** migrate ToastBar to color schemes
+- **web:** add color-scheme scss helpers and pill component overrides
+- **web:** use InputContainer in TextArea #DS-564
+- **web:** use InputAddon and InputContainer in Select #DS-1668
+- **web:** introduce InputContainer and InputAddon components #DS-1668
+- **web:** drop FieldGroup styles and use Flex and border utility #DS-564
+- **web,web-react:** drop `Tag` appearance feature flag #DS-2456
 - **web,web-react:** remove deprecated `row` direction value from `Flex` #DS-1629
-- **web:** Remove `.Slider__input` and replace it with `.Slider`.
+- **web:** simplify Slider styles #DS-564
 - **web:** require `InputDetails--disabled` for disabled details #DS-2496
-- **web:** Remove Dropdown and Tooltip placement modificators. Introduce placement helpers.
+- **web:** unify CSS placement in Dropdown and Tooltip #DS-1104
 - **web:** replace custom validation text with ValidationText component #DS-2397
 - **web,demo:** replace custom label elements with Label component #DS-2395
-- **web:** Button gaps are now set automatically, so the margins inside should be removed.
+- **web:** introduce auto gap in Button and ControlButton #DS-2344
 
 ### Features
 

--- a/packages/web/src/scss/settings/_utilities.scss
+++ b/packages/web/src/scss/settings/_utilities.scss
@@ -5,6 +5,7 @@
 @use '@tokens' as tokens;
 @use '../tools/color-scheme';
 @use '../tools/map' as spirit-map;
+@use '../tools/tokens' as tokens-tools;
 @use '../tools/utilities';
 
 $accent-prefix: 'accent-';
@@ -43,8 +44,14 @@ $utilities: (
                     tertiary: tokens.$background-tertiary,
                     neutral-basic: tokens.$neutral-background-basic,
                     neutral-subtle: tokens.$neutral-background-subtle,
-                    selected-basic: tokens.$selected-background-basic,
-                    selected-subtle: tokens.$selected-background-subtle,
+                    selected-basic: tokens-tools.get-variable-if-exists(
+                            'selected-background-basic',
+                            tokens.$background-primary
+                        ),
+                    selected-subtle: tokens-tools.get-variable-if-exists(
+                            'selected-background-subtle',
+                            tokens-tools.get-variable-if-exists('selected-background-basic', tokens.$background-primary)
+                        ),
                 )
             ),
     ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,6 +282,7 @@ __metadata:
     "@alma-oss/spirit-design-tokens": "workspace:^"
     "@alma-oss/spirit-icons": "workspace:^"
     "@alma-oss/spirit-web-react": "workspace:^"
+    "@almacareer/cyborg-design-tokens": "catalog:frontend"
     "@babel/core": "catalog:build"
     "@storybook/addon-a11y": "catalog:storybook"
     "@storybook/addon-docs": "catalog:storybook"
@@ -295,6 +296,7 @@ __metadata:
     react: "catalog:frontend"
     react-dom: "catalog:frontend"
     react-image-crop: "catalog:frontend"
+    sass-embedded: "catalog:build"
     storybook: "catalog:storybook"
     typescript: "catalog:types"
     vite: "catalog:build"
@@ -478,6 +480,13 @@ __metadata:
     vite: ">=5"
   languageName: unknown
   linkType: soft
+
+"@almacareer/cyborg-design-tokens@npm:^7.0.0":
+  version: 7.21.1
+  resolution: "@almacareer/cyborg-design-tokens@npm:7.21.1::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40almacareer%2Fcyborg-design-tokens%2F7.21.1%2F935faae6889009b285c4dc77334fa9f464df3a7f"
+  checksum: 10/3b713998dd4310a3b98cb5320e90f3458d26617348a87df5096b38c41635e179914ef8de10e0cc291418daba311b75781cb0ec7793288f5eb488554e49aa61eb
+  languageName: node
+  linkType: hard
 
 "@almacareer/remark-config@npm:0.1.0":
   version: 0.1.0


### PR DESCRIPTION
Move token-source switching into Storybook previews and add token fallbacks for Cyborg sources so Spirit, jobs.cz, and prace.cz all compile and switch without touching the demo app.