### PR TITLE
docs(repo): introduce `review-figma-design` skill

### DIFF
--- a/.agents/skills/figma-to-spirit/SKILL.md
+++ b/.agents/skills/figma-to-spirit/SKILL.md
@@ -329,6 +329,18 @@ If you have access to browser automation tools (e.g. a browser MCP server, Playw
 
 **Note**: Always use full token names for accent colors (`accent-02-basic`, not `accent-02`). See [Typography Components](components/typography.md).
 
+### Link Text Styles
+
+In Figma, links are created by applying a text style whose name contains `link` (e.g. `Body/Medium/Link Regular`, `Body/Small/Link Regular`). A plain paragraph with such a style is the correct Figma representation of a link — it is NOT a mistake.
+
+When you encounter a text node using a `link` text style, implement it as the DS `Link` component:
+
+```tsx
+<Link href="...">Show more</Link>
+```
+
+Do not implement it as a `<p>` or `<span>` with manual underline styling.
+
 ### Link Color Tokens (CRITICAL for Card Detection)
 
 When Figma shows these color tokens on text, it indicates the element should be a **link**:
@@ -392,6 +404,7 @@ Before finalizing code:
 
 **Cards & Links:**
 
+- \[ \] Text nodes with a `link` text style (e.g. `Body/Medium/Link Regular`) implemented as DS `Link` component
 - \[ \] CardTitle with `themed/link/...` color tokens uses `CardLink` (not Heading with textColor)
 - \[ \] CardLink used inside CardTitle for clickable cards
 - \[ \] `isHeading` set on CardTitle when appropriate

--- a/.agents/skills/review-figma-design/README.md
+++ b/.agents/skills/review-figma-design/README.md
@@ -1,0 +1,291 @@
+# Review Figma Design
+
+**`/spirit:review-figma-design`** is a pre-handoff design review skill for [Spirit Design System](https://spirit.design) and design systems built on top of it.
+
+**Who it's for** — designers preparing a Figma frame for developer handoff, and design system reviewers checking compliance on their behalf.
+
+**What it does** — reads a Figma frame (page, component, or composition) via the Figma MCP and checks it against design tokens, deprecated components, icon availability, and Code Connect coverage. Findings are compiled into a shareable MD + HTML + PDF report with per-finding screenshots and proposed Figma comments that can be posted back to Figma automatically.
+
+---
+
+The skill can be run standalone or inside any repository — **no codebase is required**. All checks
+work out of the box with no configuration. External references (Spirit dictionaries, deprecation
+list, logo) are fetched from GitHub automatically when not available locally. Checks that depend
+on the local codebase (icon verification) are skipped gracefully when the relevant paths are
+absent.
+
+> When run inside the Spirit repository itself, the skill additionally cross-references open JIRA
+> tickets against findings and links them in the report.
+
+## Usage
+
+The skill supports the following scenarios:
+
+1. **Figma desktop app open with MCP enabled** — the agent reads the currently selected frame directly via the Figma MCP server. No URL needed.
+2. **Figma URL pointing to a specific frame** — the agent fetches that frame by URL. No active selection in Figma is needed; the frame is identified by the URL. The Figma desktop app must still be running as it provides the MCP server.
+3. **Figma URL pointing to a zoomed area or page** — when the URL has no `node-id` or targets a page/canvas, the agent detects all frames and asks: review all frames, or pick one? Reviewing all produces a separate report per frame, each in its own subdirectory. The Figma desktop app must still be running as it provides the MCP server.
+
+```text
+/spirit:review-figma-design [type] [issue-id] [figma-url] [--post-comments-to-figma]
+```
+
+All arguments are optional and positionally flexible — each is unambiguous by its format.
+
+**`[type]`** — When omitted, auto-detected from the frame structure:
+
+| Type          | When to use                                           | Auto-detected?                                |
+| ------------- | ----------------------------------------------------- | --------------------------------------------- |
+| `page`        | Full page design                                      | No — must be passed explicitly                |
+| `component`   | A single DS component                                 | Yes — when all children are variant symbols   |
+| `composition` | A multi-component composition that is not a full page | Yes — fallback when component is not detected |
+
+`page` is never auto-detected because the Section/Container structure it relies on is optional and may not be present. Pass it explicitly when reviewing a full page.
+
+**`[issue-id]`** — optional JIRA issue ID (e.g. `DS-2475`). When provided, it is prepended to the
+output directory: `design-reviews/DS-2475-reply-form/`. When omitted, the directory uses only the
+frame-name slug.
+
+**`[figma-url]`** — optional. When omitted, the frame currently selected in the Figma desktop app is reviewed. When provided, that specific frame is reviewed regardless of the current selection.
+
+**`[--post-comments-to-figma]`** — optional flag. When present, all proposed Figma comments are
+posted to Figma automatically at the end of the review without asking for confirmation. Requires
+the `FIGMA_PERSONAL_TOKEN` environment variable to be set (see [Requirements](#requirements)).
+Without the flag, comments are saved to `figma-comments.md` and can be posted in any later
+session.
+
+### Examples
+
+Review the currently selected frame (type auto-detected):
+
+```text
+/spirit:review-figma-design
+```
+
+Review the currently selected frame as a page:
+
+```text
+/spirit:review-figma-design page
+```
+
+Review the currently selected frame, tagged with a JIRA issue:
+
+```text
+/spirit:review-figma-design DS-2475
+```
+
+Review a specific frame by URL as a page, tagged with a JIRA issue:
+
+```text
+/spirit:review-figma-design page DS-2475 https://www.figma.com/design/abc123/My-Design?node-id=34675-59177
+```
+
+Review a frame and post Figma comments automatically after the report:
+
+```text
+/spirit:review-figma-design DS-2475 https://www.figma.com/design/abc123/My-Design?node-id=34675-59177 --post-comments-to-figma
+```
+
+---
+
+## Output
+
+Output is written to `design-reviews/` in the current working directory.
+
+```text
+design-reviews/<topic-slug>/
+  <report-name>.md
+  <report-name>.html
+  <report-name>.pdf
+  figma-comments.md
+  overview.png
+  finding-1.png
+  …
+```
+
+`<topic-slug>` is the slugified frame name (single-frame) or canvas name (multi-frame), optionally
+prefixed with the issue ID (e.g. `DS-2475-reply-form`). `<report-name>` follows the same prefix
+rule (`DS-2475-design-review` or `design-review`). Multi-frame reports include a **Frames Reviewed**
+section listing all frames with Figma links; findings are numbered sequentially across all frames.
+
+`figma-comments.md` contains proposed Figma comments for actionable findings (missing tokens,
+hardcoded values, etc.). Comments can be posted to Figma right after the report has been generated,
+or anytime later — ask your AI agent to read the file and post the comments on your behalf.
+
+---
+
+## Requirements
+
+| Requirement                         | macOS                        | Used for                                                                            |
+| ----------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------- |
+| **Figma desktop app** (MCP enabled) | [Download →][figma-download] | Reads design data directly from Figma. Requires a [paid Figma plan][figma-pricing]. |
+| **Node.js 22+**                     | [Install →][nodejs-download] | Saves Figma screenshots to disk; adds page numbers to the PDF footer                |
+| **Chrome or Chromium**              | [Install →][chrome-download] | Renders the HTML report to PDF                                                      |
+| **`curl`**                          | Built-in                     | Posts review comments to Figma via the REST API                                     |
+
+If Node.js 22+ is not available, `pdf-gen.js` exits with an error and the skill falls back to the
+plain Chrome CLI (PDF is generated without footer logo or page numbers). Chrome or Chromium is
+required — PDF generation fails if neither is installed.
+
+To post review comments to Figma, set the `FIGMA_PERSONAL_TOKEN` environment variable with a
+[Figma personal access token][figma-tokens]. Generate one under **Figma → Settings → Personal
+access tokens**.
+
+---
+
+## Configuration
+
+When installed in a repository, the skill reads `.agents/skills/review-figma-design/config.json`
+for local overrides:
+
+| Key         | Default | Description                                                                                                                                                                        |
+| ----------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `iconsPath` | `null`  | Custom icon search path (relative to the current working directory). Used as a fallback when neither `packages/icons/src/` nor `libs/design-icons/` exists. Set to `null` to skip. |
+
+The skill resolves the icon path in this order:
+
+1. `packages/icons/src/` — Spirit default
+2. `libs/design-icons/` — Cyborg convention
+3. `iconsPath` from `config.json` — custom override
+
+---
+
+## FAQ
+
+<details>
+<summary>How do I post Figma comments from the review?</summary>
+
+The skill posts Figma comments via the Figma REST API using `curl`. Set a `FIGMA_PERSONAL_TOKEN`
+environment variable with a [personal access token][figma-tokens], then ask your AI agent to post
+the comments. It reads `figma-comments.md` from the report directory and posts each pending
+comment. You can do this right after the review or in any later session.
+
+Each comment is prefixed with the review title (e.g. `DS-2475 — Reply Form:`) so designers can
+identify the context at a glance.
+
+</details>
+
+<details>
+<summary>Multi-frame reviews are slow and expensive — is that expected?</summary>
+
+Yes. When a URL points to a canvas or page with many frames and you choose to review all of them, the skill must call `get_design_context` for each frame sequentially (parallel calls tend to time out the Figma MCP). A canvas with 30+ frames can easily take 10–15 minutes and consume a large amount of tokens. For faster, cheaper reviews, pick a single frame or a small group instead of reviewing an entire canvas at once.
+
+</details>
+
+<details>
+<summary>The PDF footer on the cover page looks misaligned — is that a bug?</summary>
+
+The cover page footer cannot be precisely aligned: Chrome CDP footer templates only accept `px` units in inline styles (not `mm`), so the horizontal offset cannot be made to exactly match the CSS `@page` content margin, and attempts to suppress the footer on the cover page did not work.
+
+</details>
+
+<details>
+<summary>What tool does the skill use to generate the PDF?</summary>
+
+The skill uses a two-level fallback chain:
+
+1. **`pdf-gen.js` + Chrome CDP** (primary) — launches Chrome with remote debugging, calls
+   `Page.printToPDF` via the DevTools Protocol, and renders a footer with `1 / N` page numbers
+   on every page. Requires Node.js 22+ and Chrome or Chromium.
+2. **Chrome CLI** (fallback) — `--print-to-pdf` without a custom footer, used when `pdf-gen.js`
+   fails (e.g. older Node.js). No footer logo or page numbers.
+
+To ensure the best output, make sure Chrome or Chromium is installed and Node.js 22+ is active.
+
+</details>
+
+<details>
+<summary>Can the skill find matching JIRA issues for Required DS Changes?</summary>
+
+Only partially, and only when run inside the Spirit repository. The skill searches `git log` for DS ticket references in commit messages — if a ticket was referenced in a commit, it will be linked. Direct JIRA querying is not possible as there is no JIRA MCP available. Matches are therefore opportunistic: reliable when a commit reference exists, blind otherwise.
+
+</details>
+
+<details>
+<summary>Can the skill create JIRA issues for Required DS Changes with no existing ticket?</summary>
+
+No. Without a JIRA MCP, the skill cannot create issues. Rows with no known ticket are marked _to be created_ as a reminder to link them manually once the issues are created.
+
+</details>
+
+<details>
+<summary>The skill says "fileKey is required" when I try to review the current Figma selection.</summary>
+
+Some Figma MCP server versions require a `fileKey` argument even when reading the current
+selection. If you see this error, provide a Figma URL instead:
+
+```text
+/spirit:review-figma-design https://www.figma.com/design/<fileKey>/<fileName>?node-id=<nodeId>
+```
+
+The skill handles URL-based and selection-based modes identically — passing a URL is always a
+safe fallback. You can copy the URL from Figma using **Share → Copy link** while the target frame
+is selected.
+
+</details>
+
+<details>
+<summary>Claude asks for permission to run <code>git log</code> every time. How do I fix it?</summary>
+
+Add a permission rule to `~/.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(git log:*)"]
+  }
+}
+```
+
+Takes effect on the next Claude Code session.
+
+</details>
+
+<details>
+<summary>How can I add my own findings to the generated PDF?</summary>
+
+Edit the `.md` or `.html` report in the output folder, then regenerate the PDF. You can ask the AI to add, remove, or reword any finding in the report — it will update the file and re-run the PDF generation command from Step 11 of the skill. Alternatively, run the Chrome command directly:
+
+```bash
+CHROME=$(ls -1 \
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  "/Applications/Chromium.app/Contents/MacOS/Chromium" 2>/dev/null | head -1)
+node .agents/skills/review-figma-design/scripts/pdf-gen.js "$CHROME" \
+  "$(pwd)/design-reviews/<topic-slug>/<report-name>.html" \
+  "$(pwd)/design-reviews/<topic-slug>/<report-name>.pdf"
+```
+
+</details>
+
+---
+
+## Comparison with `/audit-design-system`
+
+> [`/audit-design-system`][audit-design-system] is an open-source skill by Edenspiekermann,
+> compatible with Claude Code, Codex, and Cursor.
+
+Both skills read Figma designs and report on design-system alignment, but they serve different
+purposes and should not be used in tandem — they overlap on the core checks and would fetch the
+same Figma data twice.
+
+| Dimension               | `/spirit:review-figma-design`                                                                                                                                                                        | `/audit-design-system`                                                                                                      |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **DS specificity**      | Spirit-specific (token prefixes, DICTIONARIES.md, DEPRECATIONS.md, Spirit icon paths, JIRA)                                                                                                          | DS-agnostic — works with any design system                                                                                  |
+| **Purpose**             | Pre-handoff compliance report that certifies a design is ready for dev                                                                                                                               | Drift detection — finds places where a design has diverged from its DS                                                      |
+| **Review types**        | `page`, `component`, `composition` — different checks per type                                                                                                                                       | Flat — no type distinction                                                                                                  |
+| **Output**              | MD + HTML + PDF, per-finding screenshots, pinned overview map, `figma-comments.md`                                                                                                                   | Findings list: markdown (default) or structured JSON                                                                        |
+| **Figma tools**         | `get_metadata`, `get_design_context`, `get_variable_defs`, `get_screenshot`; `search_design_system` (Codex/Cursor) or `get_code_connect_suggestions` (Figma desktop MCP) for replacement suggestions | `get_metadata`, `get_design_context`, `get_variable_defs`, `get_code_connect_map`, `get_screenshot`, `search_design_system` |
+| **Specific checks**     | Page Section/Container structure, variant/enum completeness, Code Connect coverage, deprecated components, icon existence in repo, git/JIRA cross-reference                                          | Missing component instances, hard-coded values vs tokens, repeated sibling structures, variant drift                        |
+| **Post-review actions** | Proposes Figma comments for designers; can post via REST API                                                                                                                                         | Routes to `fix-design-system-finding` or `apply-design-system` fix skills                                                   |
+| **Priority model**      | Severity: ✅ / ℹ️ / ⚠️ / 🚨                                                                                                                                                                          | Numeric priority 0–3 + confidence score 0.0–1.0                                                                             |
+
+**When to use which:**
+
+- **`/spirit:review-figma-design`** — a designer hands off a Spirit frame for implementation and wants a structured compliance sign-off, with a shareable PDF report and proposed Figma comments.
+- **`/audit-design-system`** — you want a quick structural check on any Figma node (not Spirit-specific), need machine-readable JSON output, or want to feed results into a downstream fix skill.
+
+[audit-design-system]: https://github.com/edenspiekermann/Skills/tree/main/skills/audit-design-system
+[chrome-download]: https://www.google.com/chrome/
+[figma-download]: https://www.figma.com/downloads/
+[figma-pricing]: https://www.figma.com/pricing/
+[figma-tokens]: https://www.figma.com/developers/api#access-tokens
+[nodejs-download]: https://nodejs.org/en/download/

--- a/.agents/skills/review-figma-design/SKILL.md
+++ b/.agents/skills/review-figma-design/SKILL.md
@@ -1,0 +1,851 @@
+---
+name: spirit:review-figma-design
+description: Review a Figma design from a Spirit Design System perspective before handoff to development. Use when a designer asks for a DS review, a design needs to be checked for DS compliance, or a handoff review is required. Requires the Figma MCP to be available.
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - mcp__figma__get_metadata
+  - mcp__figma__get_design_context
+  - mcp__figma__get_screenshot
+  - mcp__figma__get_variable_defs
+  - mcp__figma__get_code_connect_suggestions
+  - mcp__github__get_file_contents
+---
+
+# Spirit Design System — Review Figma Design
+
+This skill guides you through a structured design review from a Spirit Design System perspective,
+matching the team's handoff process. The output is a written report (for the ticket) and, if issues
+are found, a list of Figma comments to be added.
+
+---
+
+## Invocation
+
+```text
+/spirit:review-figma-design [type] [issue-id] [figma-url] [--post-comments-to-figma]
+```
+
+All arguments are optional and positionally flexible — each is unambiguous by its format:
+`type` is one of `page`, `component`, `composition`; `issue-id` matches `[A-Z]+-\d+` (e.g.
+`DS-2475`); `figma-url` starts with `https://`; `--post-comments-to-figma` is a literal flag.
+
+**`[type]`** — When omitted, auto-detected from the frame structure (see Step 1); falls back to
+`composition` if detection is inconclusive. `page` is never auto-detected — pass it explicitly
+when reviewing a full page.
+
+| Type          | When to use                                                       |
+| ------------- | ----------------------------------------------------------------- |
+| `page`        | Full page design — includes the Section/Container structure check |
+| `component`   | A single DS component being designed or updated                   |
+| `composition` | A multi-component composition that is not a full page             |
+
+**`[issue-id]`** — optional JIRA issue ID (e.g. `DS-2475`). When provided, it is prepended to the
+output directory name: `design-reviews/DS-2475-reply-form/`. When omitted, the directory uses only
+the frame-name slug.
+
+**`[figma-url]`** — optional Figma frame URL. Two behaviours:
+
+- **Omitted** — review the frame currently selected in the Figma desktop app. Call `get_metadata`
+  without a `nodeId`.
+- **Provided** — extract the `nodeId` from the URL and use it for all Figma MCP calls. The node ID
+  is the `node-id` query parameter with `-` replaced by `:` (e.g. `node-id=34675-59177` →
+  `nodeId: "34675:59177"`).
+
+**`[--post-comments-to-figma]`** — optional flag. When present, all proposed Figma comments are
+posted automatically at the end of the review without asking for confirmation (see Step 13).
+
+Checks that apply only to specific evaluation types are marked accordingly throughout this skill.
+
+---
+
+## Prerequisites
+
+- The **Figma desktop app must be open** — it exposes the Figma MCP server.
+- **Without a URL** — the target frame must be selected in the Figma desktop app.
+- **With a URL** — no frame selection is needed; the URL identifies the target node.
+- You must have access to the **Spirit component codebase** (for cross-referencing component existence).
+
+---
+
+## Workflow
+
+### Step 1: Fetch Design Data
+
+1. Determine the target node:
+   - **No URL provided** — call `get_metadata` without a `nodeId` (uses current Figma selection).
+     If the call fails with an error such as "fileKey is required", the MCP server in this
+     environment needs a file key. Stop and ask the user to provide a Figma URL, then proceed
+     with the URL-based path below.
+   - **URL provided** — extract the `nodeId` from the URL (see Invocation section) and pass it to
+     all subsequent Figma MCP calls. If the URL has no `node-id` parameter, call `get_metadata`
+     without a `nodeId` as well.
+
+2. **Detect multi-frame mode** — inspect the root node returned by `get_metadata`:
+   - If the root is a page or canvas (its direct children are `<frame>` elements rather than
+     component layers), the URL points to a zoomed area or page rather than a single frame.
+   - List the frames numbered and ask:
+     > This URL contains **N frames**:
+     >
+     > 1. Frame One
+     > 2. Frame Two
+     >    …
+     >    Review all N frames, or pick one? Enter a number to pick a single frame, or `all`.
+   - Wait for the user's answer before continuing.
+   - **User picks a number** — review only that frame in single-frame mode (continue with
+     step 3 below, using the picked frame's node ID as the target).
+   - **User answers `all`** — review all frames together and produce a **single combined report**.
+     Run Steps 3–8 for each `<frame>` child in order (collecting findings across all frames), then
+     write one report (Steps 9–11) that covers all frames. See Step 9 for the output path and
+     Step 10 for the Frames Reviewed section format.
+   - **Single-frame mode** (the normal case): the root node is already a single frame — continue
+     with step 3 below.
+
+3. If `[type]` was **not** provided, auto-detect it from the `get_metadata` output:
+   - Inspect the direct children of the root frame.
+   - If **all** direct children are `<symbol>` elements with names in `Property=Value` format
+     (e.g. `Color=Primary, Size=Medium`), set type to `component`.
+   - Otherwise, set type to `composition`.
+   - Log the detected type so the user can see which was chosen.
+   - If `[type]` **was** provided, use it as-is — skip detection entirely.
+
+4. Call `get_design_context` on the root node to extract:
+   - All component instances and their Code Connect snippets
+   - All token references (spacing, color, typography, radius, shadow)
+   - Raw hardcoded values (CSS literals without `var(--...)`)
+   - Any custom/raw HTML compositions that lack Code Connect mappings
+5. Call `get_variable_defs` on the root node to see exactly which variables are bound versus
+   unbound. Use this as corroborating evidence for token findings in Step 5 — a layer present
+   in `get_design_context` with a token reference but absent or unbound in `get_variable_defs`
+   confirms the token is not properly attached.
+6. Call `get_screenshot` on the root node for visual context.
+
+If the frame is large (> ~2000px tall), call `get_design_context` section by section using node IDs
+from `get_metadata` to avoid truncation.
+
+### Step 2: Check Page Structure (type=page Only)
+
+Inspect the top-level children of the root frame in the `get_metadata` output. The allowed
+structure, in order, is:
+
+1. An optional `Header` component instance (may be wrapped in a layer named `Header`)
+2. One or more `Section [Size]` layers, each containing a `Container [Size]` child layer
+3. An optional `Footer` component instance
+4. An optional `Modal` component instance
+
+Rules:
+
+- Section and Container sizes do not need to match (`Section Small` > `Container Large` is valid)
+- Any unnamed or unrecognised top-level layer (e.g. `Frame 12`) fails this check
+- Skip entirely for `component` and `composition` evaluations
+
+### Step 3: Check Variant Completeness (type=component Only)
+
+For each property dimension visible in the component, run two checks.
+
+#### Dictionary Enum Completeness
+
+Fetch [`docs/DICTIONARIES.md`](https://github.com/alma-oss/spirit-design-system/blob/main/docs/DICTIONARIES.md)
+from GitHub to get the current list of Spirit dictionaries and their values.
+If the component defines **any** value from a dictionary, it must define **all** values from that
+dictionary. Flag any missing values as ⚠️.
+
+If a property spans two dictionaries (e.g. a `Color` prop that combines `ComponentButtonColor`
+and `EmotionColor`), check completeness against both.
+
+#### Interaction State Completeness
+
+If the component has an `Interaction State` property, every other property combination must have
+all of: `Default`, `Hover`, `Focus`, `Active`, `Disabled`. Flag any combination that is missing
+one or more states as ⚠️.
+
+### Step 4: Check DS Component Usage
+
+For each visible UI element, verify it maps to an existing Spirit component:
+
+| Check                                          | What to look for                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Component instance**                         | Does the Figma layer have a Code Connect snippet? If not, it may be a custom composition or a missing DS component. **Exception:** plain `<text>` layers are not components in Figma — Spirit uses text styles (Body, Heading, etc.) for typography, not typography components. Never flag a text layer as a missing DS component. **Exception:** layout layers named `Container`, `Section`, `Stack`, or `Grid` are intentional named frames — they are not DS component instances and must not be flagged as missing components.                                                                         |
+| **Correct component**                          | Is the right DS component used? **Note:** there is no `Link` component in Figma — designers indicate links via text styles with `link` in the name (e.g. `Body/Medium/Link Regular`). This is correct design practice and must NOT be flagged as a finding. Instead, add a note to **Development Considerations** that these text layers should be implemented as the DS `Link` component in code.                                                                                                                                                                                                         |
+| **No links inside interactive element labels** | A `Link` (or link-styled text) placed inside the **label** of a form field (e.g. `TextField`, `Toggle`, `Checkbox`, `Radio`, `Select`) is a 🚨 blocker — a link nested inside a `<label>` is invalid HTML and causes serious accessibility issues. Links in **helper text** or **validation text** are acceptable, as those are plain text nodes, not interactive elements.                                                                                                                                                                                                                                |
+| **No unimplemented component features**        | Compare what the design shows for each component instance against its Code Connect output. If the design uses a variant, prop, or slot that is absent from the Code Connect snippet (e.g. a `description` text area on a `Toggle` that Code Connect never renders), the feature does not exist in the DS yet and must be added before the design can be implemented as shown. **Routing:** record it in **Development Considerations** with 🚨 severity **and** add a matching row to **Required DS Changes**. Do **not** include it in Findings — CC gaps are developer/DS work, not designer-actionable. |
+| **"NEW" suffix in layer name**                 | Layers named "XYZ NEW" signal a proposed new DS component that doesn't exist yet — flag as a required DS change.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| **Deprecated components**                      | Search for a `DEPRECATIONS.md` file in the repository (e.g. `packages/web-react/DEPRECATIONS.md` in Spirit). If not found locally, fetch it from [`packages/web-react/DEPRECATIONS.md`](https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/DEPRECATIONS.md) on GitHub as a reference. Check whether any components in the design appear in that file.                                                                                                                                                                                                                           |
+
+When a layer lacks a Code Connect snippet and its structure or name suggests it may correspond to
+a Spirit component, try to suggest a replacement:
+
+1. **`search_design_system`** _(preferred, if available)_ — call with the layer's role or name
+   (e.g. `"avatar"`, `"stat tile"`, `"navigation item"`). Available in Codex/Cursor environments.
+2. **`get_code_connect_suggestions`** _(fallback)_ — call on the specific node. Available in the
+   Figma desktop app MCP.
+
+Use whichever tool is available in the current environment; skip silently if neither is. Include
+a replacement suggestion in the finding only when the match is credible. Omit a suggestion when
+results are ambiguous or the match is implausible.
+
+### Step 5: Check Token Usage
+
+Inspect the `get_design_context` output for hardcoded CSS literals. These indicate missing token
+references in the design.
+
+All token references must use one of three valid prefixes: `device`, `global`, or `themed`.
+Any `var(--...)` that does not start with one of these is invalid regardless of which DS is in use.
+
+**Spacing tokens:**
+
+- Hardcoded `gap-[Xpx]`, `p-[Xpx]`, `m-[Xpx]` without a `var(--global/spacing/...)` reference → tokens missing; flag so the designer can attach the correct token.
+
+**Color tokens:**
+
+- Hardcoded hex/rgb values → tokens missing; flag as ⚠️.
+- Token-referenced colors that do **not** start with `themed` → wrong token scope; colors must use `var(--themed/...)` tokens; flag as ⚠️.
+- **Exception:** hardcoded colors on `<vector>` layers (SVG illustration paths) are expected and should NOT be flagged — illustrations embed colors by design and are not tokenised.
+
+**Typography:**
+
+- Verify text styles use `var(--device/typography/...)` tokens.
+- Custom font-weight/size combinations outside the scale should be flagged.
+
+**Radius / shadow:**
+
+- Verify `border-radius` uses `var(--global/radius/...)` tokens.
+- Verify `box-shadow` uses `var(--global/shadow/...)` or `var(--themed/shadow/...)` tokens.
+
+### Step 6: Check Icon Usage
+
+For every icon in the design:
+
+1. Resolve the icon search path by trying the following in order, stopping at the first match:
+   1. `packages/icons/src/` — Spirit's default icon path
+   2. `libs/design-icons/` — Cyborg convention
+   3. `iconsPath` value in `.agents/skills/review-figma-design/config.json` — custom override
+      (set `iconsPath` to a relative path from the repo root; `null` skips this step)
+
+   If none of the paths exist in the repository, skip the existence check and note in the report
+   that the icon path could not be resolved.
+
+2. Verify the icon name exists in the resolved path:
+   ```text
+   Grep for the icon name in <resolved-path>
+   ```
+3. Verify it is using `<Icon name="..." />` via Code Connect — not a raw SVG or image asset.
+4. Route failures by type:
+   - **Icon name missing from the codebase** — this is a joint designer + developer concern:
+     - Record in **Findings** with 🚨 severity — the designer should make sure the icon is
+       present in their Figma asset library and published so downstream consumers have access.
+     - Record in **Development Considerations** with 🚨 severity **and** add a matching row to
+       **Required DS Changes** (e.g. `Add missing icon "<name>"`) — the DS needs to ship the
+       icon in code before the design can be implemented.
+   - **Raw SVG / image asset instead of `<Icon name="..." />`** — this is a Code Connect
+     binding concern. Record in **Development Considerations** with 🚨 severity and, if a DS
+     fix is needed, add a row to **Required DS Changes**. Do **not** include it in Findings.
+
+### Step 7: Spirit Repo Checks (Spirit Repo Only)
+
+Check whether the skill is running inside the Spirit repo by testing for the presence of
+`packages/web-react/`. If the directory does not exist, skip this step entirely — all JIRA cells
+in the Required DS Changes table will be _to be created_.
+
+If running in Spirit, perform the following:
+
+1. **Cross-reference git history** — run `git log --oneline -50` and scan recent commit messages
+   for `DS-` ticket references (e.g. `#DS-2300`). If a commit relates to a component or feature
+   visible in the design (e.g. a recently shipped prop, a new component, a Code Connect update),
+   note the ticket number and annotate the relevant finding — either to flag it as already in
+   progress or to explain why something appears incomplete.
+
+2. **Populate JIRA column** — for each row in the Required DS Changes table, check whether a
+   matching `DS-` ticket was found in the git log. If yes, link it as
+   `[DS-XXXX](https://jira.almacareer.tech/browse/DS-XXXX)`. If no matching ticket was found,
+   write _to be created_.
+
+### Step 8: Identify Required DS Changes
+
+Based on your findings, list any changes needed in the DS itself:
+
+- New components (e.g., "File Upload NEW" → new `FileUpload` component needed) — always a 🚨 blocker, as development cannot proceed without a DS component or an agreed implementation path
+- Component updates (e.g., a prop variant that doesn't exist yet)
+- Token additions (e.g., a spacing value not in the Spirit scale)
+- Code Connect updates (e.g., a recently shipped feature not yet reflected in Code Connect)
+- Missing icons (e.g., a name referenced in the design that is not present in `packages/icons/src/`)
+
+Required DS Changes is the canonical work-item list for implementation issues. Every
+severity-tagged item recorded in **Development Considerations** that requires DS work must have a
+matching row here.
+
+Estimate effort for each: **Low** (< 2h), **Medium** (2–8h), **High** (> 8h).
+
+### Step 9: Compile Design Evaluation
+
+Based on all findings from Steps 2–8, compile the generic checks table. Each row either passes (✅)
+or fails (❌). This gives an at-a-glance view of what's correct as well as what isn't.
+
+| Check                                                          | What to verify                                                                                                                                                                                                                                                                                                                                                                                              |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Top-level frame uses Section/Container structure _(page only)_ | See Step 2 for the full structure rules. Omit this row for `component` and `composition`.                                                                                                                                                                                                                                                                                                                   |
+| Design tokens used for all values                              | No hardcoded `px`, hex, or rgb values — spacing, color, radius, shadow all use `var(--...)` tokens                                                                                                                                                                                                                                                                                                          |
+| DS components used for all UI elements                         | Every UI element maps to a DS component instance (`<instance>` in metadata, Code Connect present in design context); no custom compositions where a DS component exists                                                                                                                                                                                                                                     |
+| No detached or modified components                             | Detached instances appear as `<frame>` in metadata instead of `<instance>` — flag any `<frame>` whose name matches a known DS component. **Exception:** `<frame>` layers named `Container`, `Section`, `Stack`, or `Grid` are intentional named frames — skip these. Modified instances cannot be reliably detected via the Figma MCP; always show ❓ for the modified part and add a note below the table. |
+| No unimplemented component features                            | Every variant, prop, or slot visible in the design for each component instance appears in its Code Connect output; anything absent from Code Connect is not yet implemented in the DS                                                                                                                                                                                                                       |
+| No deprecated components                                       | No deprecated components or props used                                                                                                                                                                                                                                                                                                                                                                      |
+| Icons from DS icon set                                         | All icons use `<Icon name="..." />` with a name that exists in the resolved icon path (see Step 6)                                                                                                                                                                                                                                                                                                          |
+
+Specific findings do NOT go in this table — they are routed by audience per Steps 4 and 6:
+
+- **Designer-actionable** (wrong component choice, missing token in a particular spot, detached
+  component, deprecated component used, missing icon in the designer's asset library, etc.) →
+  **Findings** (see Step 11).
+- **Implementation-actionable** (Code Connect gaps, unimplemented component features, icon name
+  missing from the codebase, raw SVG used instead of the `Icon` component, etc.) →
+  **Development Considerations** with severity and, where DS work is required, a row in
+  **Required DS Changes**.
+
+See Step 11 for the detailed routing and format.
+
+### Step 10: Capture Per-Finding Screenshots
+
+1. Derive the output names:
+
+   **Slugification rule** (used throughout): lowercase the input, replace whitespace, hyphens,
+   pipes, and other non-alphanumeric characters with hyphens, collapse consecutive hyphens,
+   trim leading/trailing hyphens.
+   - **Single-frame mode:** `<topic-slug>` = slugified frame name, optionally prefixed with `[issue-id]-`.
+     Example: `DS-2475-user-account-settings`
+   - **Multi-frame mode (combined report):** `<topic-slug>` = slugified canvas/page name, optionally
+     prefixed with `[issue-id]-`. Example: `DS-2475-reply-form`
+   - `<report-name>` = `[issue-id]-design-review` (with issue ID) or `design-review` (without).
+   - Output (both modes): `design-reviews/<topic-slug>/<report-name>.{md|html|pdf}`
+
+2. Run `mkdir -p design-reviews/<topic-slug>` to create the output folder.
+3. For each finding that references a specific node ID (not just the root frame), call
+   `get_screenshot` with that node ID. The tool zooms to the node bounds automatically — no manual
+   crop needed. Do NOT capture a screenshot for findings that only reference the root frame (already
+   captured in Step 1).
+4. Save each screenshot to `design-reviews/<topic-slug>/` as `finding-{n}.png`, where `{n}`
+   matches the finding's number in the report (🚨 first, then ⚠️, then ℹ️, matching sort order).
+   In multi-frame mode findings are numbered sequentially across all frames.
+   The Figma MCP server returns images as base64 PNG — decode and save each one using the
+   `save-screenshots.js` script in this skill's `scripts/` directory. Each argument is a `NODE_ID:PATH` pair
+   (the script splits on the last colon, so node IDs like `2802:66561` work correctly):
+
+   ```bash
+   node .agents/skills/review-figma-design/scripts/save-screenshots.js \
+     "NODE_ID_1:design-reviews/SLUG/finding-1.png" \
+     "NODE_ID_2:design-reviews/SLUG/finding-2.png"
+   ```
+
+   Replace `NODE_ID_*` and `SLUG` with the actual values before running.
+
+5. Keep a numbered index (finding → screenshot filename) to use during report writing.
+6. If a finding spans multiple nodes and warrants more than one screenshot, use letters:
+   `finding-1a.png`, `finding-1b.png`, `finding-1c.png`, …
+
+7. Save the overview and compute pin positions for the HTML report:
+
+   a. Decode and save the root screenshot to `<output-folder>/overview.png` using the same
+   `save-screenshots.js` script (add an entry with the root node ID and path
+   `<output-folder>/overview.png`). **Capture the overview's natural dimensions from the
+   script's stdout** — the line has the form `Saved <path> (<width>x<height>)`. They are
+   needed in step 7d below to size the overview box on the HTML cover.
+
+   b. For each finding, compute its **absolute position within the root frame** by walking the
+   metadata tree from that node up to the root frame and summing the `x`/`y` offsets of **every**
+   ancestor (not including the root frame itself). This means building a parent map from the
+   XML tree and following it all the way up — not just adding one parent's offset. For deeply
+   nested nodes (e.g. a text layer inside a component inside a frame inside a section) every
+   intermediate `x`/`y` must be accumulated; skipping levels produces pins that cluster
+   incorrectly. Record:
+   - `center_x = abs_x + width / 2`
+   - `center_y = abs_y + height / 2`
+   - `pin_left = round(center_x / canvas_w * 100, 1)` — percentage of canvas width
+   - `pin_top  = round(center_y / canvas_h * 100, 1)` — percentage of canvas height
+
+   Store `(n, pin_left, pin_top)` for each finding — these become the `style` values for the
+   pin `<a>` elements in the HTML cover page (`style="left:XX.X%;top:YY.Y%"`).
+
+   c. The canvas dimensions used for pin percentages (`canvas_w`, `canvas_h`) must come from
+   the **root frame's bounding box** in `get_metadata`, not the overview PNG. The Figma
+   screenshot may be rendered at a different resolution than the frame's logical coordinates,
+   but the positions of findings are in logical units — matching the root frame is what keeps
+   pins aligned with features in the image.
+
+   d. Build the overview wrapper's inline style using the PNG dimensions captured in step 7a.
+   The HTML cover sizes the overview with `aspect-ratio`, so the wrapper needs the image's
+   natural ratio as a CSS custom property:
+
+   ```html
+   style="--overview-aspect: <width>/<height>;"</height></width>
+   ```
+
+   (note the leading space — the placeholder sits where an HTML attribute would). Substitute
+   this into `{{OVERVIEW_WRAP_STYLE}}` when writing the HTML. Without it, the overview box
+   falls back to an unconstrained aspect and the image will not fit the cover page correctly.
+
+### Step 11: Write the Report
+
+Output the complete report to the conversation first — the user reads it here. Then write the
+identical content to `design-reviews/<topic-slug>/<report-name>.md` immediately, without asking for
+confirmation. Both happen together; neither requires user approval.
+
+Produce a structured Markdown report with the sections below. Use the same tone and format as the
+team's existing reports — concise, developer-facing, no filler.
+
+#### Frames Reviewed (multi-Frame Mode Only)
+
+When running in multi-frame mode (combined report), include a **Frames Reviewed** section
+immediately after the report's title block (date / type) and before the Design Evaluation section.
+List every frame in the batch:
+
+- With a Figma URL: link each frame name to its node in Figma using the file key from the URL
+  (`https://www.figma.com/design/{fileKey}/{fileName}?node-id={nodeId}`).
+- Without a URL: plain text names only.
+
+```markdown
+## Frames Reviewed
+
+- [Frame One](https://www.figma.com/design/abc123/My-Design?node-id=100-200)
+- [Frame Two](https://www.figma.com/design/abc123/My-Design?node-id=100-300)
+- [Frame Three](https://www.figma.com/design/abc123/My-Design?node-id=100-400)
+- [Frame Four](https://www.figma.com/design/abc123/My-Design?node-id=100-500)
+```
+
+Omit this section entirely for single-frame reviews.
+
+#### Node ID Links
+
+Node IDs in the report body serve two audiences: designers who click them to open the node in
+Figma, and machines (search, scripts) that parse the source. The rendering rules differ by
+invocation mode:
+
+**Invoked with a Figma URL** — file key is available; render every node ID as a clickable link:
+
+- In the body: ``[`34809:7052`][n-34809-7052]``
+- At the end of the file, under an HTML comment `<!-- Node references -->`, add the definitions:
+  `[n-34809-7052]: https://www.figma.com/design/{fileKey}/{fileName}?node-id=34809-7052`
+
+The file key and file name come from the Figma URL passed at invocation. Node IDs in Figma URLs
+use hyphens instead of colons (`34809:7052` → `34809-7052`). Strip any leading `I` prefix from
+instance node IDs when constructing the URL (e.g. `I34809:7083` → `node-id=34809-7083`).
+
+**Invoked without a URL** — file key is not available; node IDs must not appear as visible
+text (they are meaningless to a reader who cannot click them). Instead, embed them in HTML
+comments so they remain machine-readable in the source but are invisible in rendered Markdown
+and PDF:
+
+- In the body: write the finding description naturally, without the node ID in the prose.
+  Append an HTML comment immediately after: `<!-- node:34809:7052 -->`
+- Example: `The label in the toggle composition uses a raw hex color.<!-- node:34809:7052 -->`
+
+Node IDs inside the fenced code block of Figma Comments are plain text and do not need links or
+comments.
+
+#### Score
+
+Before the Design Evaluation table, calculate and emit the design quality score:
+
+- **Score** = `round(✅_count / (✅_count + ❌_count) * 100)` — ❓ rows do not count toward either.
+- Emit as an HTML div so the report CSS can style it as a large centred number:
+  `<div class="score">72</div>`
+- Place it between the `## Design Evaluation` heading and the table.
+
+#### Design Evaluation Table
+
+Include the generic checks table compiled in Step 9. Specific findings do NOT go in the table —
+they are routed by audience:
+
+- **Designer-actionable** → **Findings** (see below)
+- **Implementation-actionable** (Code Connect gaps, unimplemented component features, icon name
+  missing from the codebase) → **Development Considerations** and, when DS work is needed,
+  **Required DS Changes**
+
+**Findings are designer-facing only.** Every item here must be something a designer can act on
+in Figma: wrong component, missing token, detached instance, deprecated component used,
+structural issue, missing icon in the designer's asset library. Code Connect gaps and
+unimplemented component features are implementation concerns and do not appear in Findings.
+
+**Finding validation gate** — apply this test to every candidate Finding before writing it:
+
+> Can the designer act on this in Figma, alone, without involving a developer?
+
+If NO, reroute to **Development Considerations** (with severity) and, when DS work is required,
+**Required DS Changes**. The Finding stays out of the Findings list.
+
+**Automatic reroute triggers** — if a candidate Finding's description contains any of these
+phrases it describes the state of Figma's Code Connect panel, not anything the designer can
+change. Reroute to Development Considerations:
+
+- "has no Code Connect" / "lacks Code Connect" / "no CC binding" / "CC is missing"
+- "CC snippet" / "CC mapping" / "CC output" / "CC not updated" / "CC not connected"
+- "Code Connect outputs …" / "Code Connect emits …" / "emits `X` snippet"
+- "prop is not reflected in CC" / "`X` prop missing from Code Connect"
+
+**Refresh caveat** — when re-running this skill against an existing report, do NOT preserve the
+prior report's structure. Re-evaluate every pre-existing Finding against the validation gate
+above; prior reviews may pre-date current routing rules.
+
+**❌ Anti-examples — these are NOT Findings, reroute to Development Considerations:**
+
+- `FileUpload has no Code Connect in Figma` → Dev Considerations 🚨 (+ Required DS Changes)
+- `TextArea Code Connect lacks counter prop` → Dev Considerations ⚠️ (+ Required DS Changes)
+- `Button Code Connect outputs placeholder icon name` → Dev Considerations ℹ️
+- `Attachment Item row has no CC snippet` → Dev Considerations 🚨 (+ Required DS Changes)
+
+- If a finding in **Findings** is already covered by a known DS ticket or in-progress work, add
+  the ticket reference inline (e.g. `DS-2300`). This signals no new action is needed.
+- Use collaborative, constructive language: "appears to", "should consider", "could use" rather than
+  "uses wrong", "must", "needs to fix".
+- Keep each finding to one sentence. State what and where — omit elaboration, rationale, and next steps unless they are non-obvious.
+- Sort findings by severity: 🚨 first, then ⚠️, then ℹ️.
+
+```markdown
+## Design Evaluation
+
+<div class="score">72</div>
+
+| Result       | Check                                                          |
+| ------------ | -------------------------------------------------------------- |
+| ✅ / ❌      | Top-level frame uses Section/Container structure _(page only)_ |
+| ✅ / ❌      | Design tokens used for all values                              |
+| ✅ / ❌      | DS components used for all UI elements                         |
+| ✅ / ❌ / ❓ | No detached or modified components                             |
+| ✅ / ❌      | No unimplemented component features                            |
+| ✅ / ❌      | No deprecated components                                       |
+| ✅ / ❌      | Icons from DS icon set                                         |
+
+> ❓ Modified component instances cannot be reliably detected via the Figma MCP. Please verify manually in Figma — modified instances show the message "The layout in this instance differs from the main component."
+
+_(Include the ❓ note only when ❓ appears in the table. Omit it when all checks are ✅ or ❌.)_
+
+### Findings
+
+![Findings overview](overview.png)
+
+_(With Figma URL — node IDs as clickable links):_
+
+1. 🚨 **Specific finding** — [description] in [`34809:7052`][n-34809-7052].
+
+   ![Finding 1: Short description](finding-1.png)
+
+2. ⚠️ **Specific finding** — [description, ticket reference if covered e.g. [DS-XXXX](https://jira.almacareer.tech/browse/DS-XXXX)].
+
+   ![Finding 2: Short description](finding-2.png)
+
+_(Without Figma URL — node IDs in HTML comments, invisible in rendered output):_
+
+1. 🚨 **Specific finding** — [description, no node ID in prose].<!-- node:34809:7052 -->
+
+   ![Finding 1: Short description](finding-1.png)
+
+2. ⚠️ **Specific finding** — [description, ticket reference if covered e.g. [DS-XXXX](https://jira.almacareer.tech/browse/DS-XXXX)].<!-- node:34809:7083 -->
+
+   ![Finding 2: Short description](finding-2.png)
+
+_(Omit the image line for findings that have no node-level screenshot.)_
+
+## Development Considerations
+
+### 🚨 Toggle `description` prop absent from Code Connect
+
+The design uses a description slot on `Toggle` that the current Code Connect snippet does not
+expose. Implementation is blocked until the DS ships it (see Required DS Changes #1).
+
+### ⚠️ Icon `sparkle` missing from codebase
+
+Referenced in the header but not present in `packages/icons/src/`. The DS needs to add it before
+the design can be implemented as shown (see Required DS Changes #2).
+
+### Composition pattern for hero block
+
+No DS `Hero` component exists. Use `Stack` with `gap-600` and the existing `Heading` + `Text`
+styles to reproduce the layout.
+
+## Required DS Changes
+
+| #   | Change                                  | Effort | JIRA            |
+| --- | --------------------------------------- | ------ | --------------- |
+| 1   | **New `XYZ` component** — ...           | High   | _to be created_ |
+| 2   | **Update Code Connect for `ABC`** — ... | Low    | _to be created_ |
+
+JIRA links are filled in by Step 7 when running in the Spirit repo. In all other repos, leave
+every JIRA cell as _to be created_.
+```
+
+Development Considerations accepts two kinds of entries:
+
+- **Severity-tagged implementation issues** — prefix the heading with the severity emoji
+  (🚨/⚠️/ℹ️). Use these for Code Connect gaps, unimplemented component features, icons missing
+  from the codebase, or any other implementation blocker that is not designer-actionable. Each
+  entry must have a matching row in **Required DS Changes** when DS work is required.
+- **Untagged notes** — composition patterns, known workarounds, anything non-obvious that the
+  developer needs to know but that is not a defect per se. Omit the severity emoji.
+
+Sort severity-tagged entries first (🚨 → ⚠️ → ℹ️), then notes.
+
+#### HTML Report
+
+After writing the MD, generate `<report-name>.html` in the same output folder. Write this file
+directly — the same way you write the MD. The HTML is the PDF source; it does not need to be
+readable as raw text.
+
+All external links in the HTML (Figma node links, Figma file links) must use `target="_blank"` so
+they open in a new tab when the report is viewed in a browser.
+
+Read the HTML template from [`report-template.html`](report-template.html) in this skill's directory
+and substitute all `{{PLACEHOLDER}}` values from the report:
+
+- `{{SUBJECT}}` — page/frame name (e.g. `DS-2475 — Handoff | Job reply form`)
+- `{{DATE}}` — review date (e.g. `2026-04-09`)
+- `{{REVIEW_TYPE}}` — `Page`, `Component`, or `Composition`
+- `{{SCORE}}` — numeric score (e.g. `67`)
+- `{{EVAL_ROWS}}` — one `<tr>` per evaluation check (result + label)
+- `{{OVERVIEW_WRAP_STYLE}}` — an HTML attribute string that sets the overview image's aspect
+  ratio (e.g. ` style="--overview-aspect: 1440/1024;"` — note the leading space). See Step 10
+  item 7d for how the width and height come from the overview PNG's dimensions
+- `{{PINS}}` — one `<a class="pin" href="#finding-N">` per finding (links to the finding anchor)
+- `{{FRAMES_REVIEWED}}` — _(multi-frame only)_ a `<div class="cover-footer">` block containing
+  only the `<h2 class="section-label">Frames Reviewed</h2>` heading and a `<ul>` of frame links
+  (no intro paragraph — it costs vertical space the cover page cannot spare); omit the entire
+  block for single-frame reviews
+- `{{FINDINGS}}` — one `.finding` block per finding
+- `{{DEV_NOTES}}` — one `<li>` per development consideration, each containing `<h3 class="note-heading">` + `<p>`
+- `{{DS_CHANGES}}` — required DS changes `<tr>` rows
+
+**Severity classes:** map emoji to HTML class — 🚨 → `critical`, ⚠️ → `warning`, ℹ️ → `info`.
+**Severity labels:** 🚨 → `Blocker`, ⚠️ → `Warning`, ℹ️ → `Info`.
+
+**`{{EVAL_ROWS}}` example** (one row per check, circle icon first):
+
+```html
+<tr>
+  <td><span class="check-icon check-pass">✓</span></td>
+  <td>Top-level frame uses Section/Container structure</td>
+</tr>
+<tr>
+  <td><span class="check-icon check-fail">✕</span></td>
+  <td>Design tokens used for all values</td>
+</tr>
+<tr>
+  <td><span class="check-icon check-doubt">?</span></td>
+  <td>No detached or modified components</td>
+</tr>
+```
+
+**`{{PINS}}` example** (one `<a>` per finding, linking to the finding anchor):
+
+```html
+<a href="#finding-1" class="pin" style="left:12.3%;top:45.6%">1</a>
+<a href="#finding-2" class="pin" style="left:67.8%;top:22.1%">2</a>
+```
+
+**`{{FINDINGS}}` example** (one `.finding` block per finding, with `id` for pin anchors):
+
+```html
+<div class="finding" id="finding-2">
+  <div class="finding-header warning">
+    <span class="finding-num">2</span>
+    <span class="finding-severity">Warning</span>
+    <span class="finding-title">Hardcoded spacing in profile promo section</span>
+  </div>
+  <div class="finding-body">
+    <p>
+      The feature-list container uses <code>gap: 12px</code> without a token reference — could use
+      <code>--global/spacing/space-600</code>.
+    </p>
+    <img src="finding-2a.png" alt="Finding 2" />
+  </div>
+</div>
+```
+
+Omit the `<img>` line for findings that have no node-level screenshot.
+
+If `{{DS_CHANGES}}` is empty (no required changes), omit the entire Required DS Changes section.
+
+### Step 12: Generate PDF
+
+After writing the HTML report, print it to PDF immediately without asking for confirmation.
+Use Chrome in headless mode — it renders the HTML faithfully (CSS Grid, `@page`, percentage
+positioning of pins all work correctly):
+
+```bash
+# Find Chrome / Chromium
+CHROME=$(ls -1 \
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  "/Applications/Chromium.app/Contents/MacOS/Chromium" \
+  "$(which google-chrome 2>/dev/null)" \
+  "$(which chromium 2>/dev/null)" 2>/dev/null | head -1)
+
+HTML="$(pwd)/<output-folder>/<report-name>.html"
+PDF="$(pwd)/<output-folder>/<report-name>.pdf"
+
+if [ -z "$CHROME" ]; then
+  echo "Error: Chrome or Chromium is required for PDF generation" >&2
+  exit 1
+fi
+
+# Primary path: Chrome CDP via pdf-gen.js
+# Renders the footer (Spirit logo + page numbers) on every page and applies
+# CSS @page named-page margins (cover: landscape, inner pages: portrait).
+# Requires Node.js 22+ for the built-in WebSocket global.
+node .agents/skills/review-figma-design/scripts/pdf-gen.js "$CHROME" "$HTML" "$PDF" || \
+  # Fallback: plain Chrome CLI (no custom footer)
+  "$CHROME" --headless=new \
+    --print-to-pdf="$PDF" \
+    --no-pdf-header-footer \
+    "file://$HTML"
+```
+
+- `pdf-gen.js` uses Chrome's DevTools Protocol so the footer template
+  (`<span class="pageNumber">` / `<span class="totalPages">`) renders on every page.
+- Chrome resolves `src="overview.png"` and `src="finding-1.png"` relative to the HTML file —
+  images in the same folder are embedded automatically.
+- All hyperlinks (Figma node links) are preserved as clickable links in the PDF.
+- If PDF generation fails, report success for the MD and HTML outputs and print a clear error
+  message with the failed command so the user can retry manually.
+
+### Step 13: Flag Figma Comments (if Needed)
+
+For each issue found that requires the **designer** to make a change in Figma before dev, prepare
+proposed Figma comments. Each comment must end with ` — <user-name> (via AI)` (the current git user name,
+obtained via `git config user.name`) so the author is identifiable and the team knows the comment
+was generated automatically — the whole team shares a single Figma account.
+
+**Comments are sourced from Findings only.** Because Findings is strictly designer-actionable,
+every item there is a candidate comment. Items in **Development Considerations** and
+**Required DS Changes** never become Figma comments — they are for developers and DS
+maintainers, not for the designer to act on in Figma.
+
+**Use Figma variable paths, not CSS syntax.** Designers work with Figma variables, not CSS.
+Reference variables without the `var(--...)` wrapper — write `global/spacing/space-1000`, not
+`var(--global/spacing/space-1000)`. The same applies to all token prefixes (`device/...`,
+`global/...`, `themed/...`).
+
+Each comment body must be prefixed with the review title (`<issue-id> — <frame/canvas name>:`)
+so readers can identify which review the comment belongs to. Example:
+`DS-2475 — Reply Form: "Composition" layer uses gap: 40px …`
+
+1. **Save to file** — write `figma-comments.md` in the report output folder
+   (`design-reviews/<topic-slug>/figma-comments.md`). Use this format:
+
+   ```markdown
+   # Figma Comments — <topic-slug>
+
+   Figma file: `<fileKey>` (<fileName>)
+   Figma page: `<pageNodeId>` (<pageName>)
+
+   - [ ] `1605:44215` — DS-2475 — Reply Form: "Composition" layer uses gap: 40px without a variable reference. Please attach a spacing variable.
+
+     — Jane Doe (via AI)
+
+   - [ ] `3999:14932` — DS-2475 — Reply Form: Vertical divider uses hardcoded #5c7dbf. Please attach a `themed/border/...` variable.
+
+     — Jane Doe (via AI)
+   ```
+
+   The checkbox `- [ ]` marks a pending comment; `- [x]` means posted. When a Figma URL was
+   provided, include the file key and file name so a future session can locate the file.
+
+2. **Output to conversation** — after the report, list all proposed comments in the conversation
+   so the user can review them immediately.
+
+Do NOT post comments to Figma automatically — **unless `--post-comments-to-figma` was passed** at
+invocation, in which case proceed directly to the Posting section below without asking for
+confirmation. Otherwise, wait for the user to explicitly ask — they may want to review, edit, or
+post the comments in a later session by asking the AI to read the `figma-comments.md` file.
+
+#### Posting Comments to Figma
+
+The Figma MCP server does not support posting comments. When the user asks to post, use the
+Figma REST API via `curl`. A personal access token is required — read it from the
+`FIGMA_PERSONAL_TOKEN` environment variable (prompt the user to set it if unset).
+
+To attach each comment to its target node:
+
+1. Use the **Figma page node ID** as `client_meta.node_id` — this ensures the comment lands on
+   the correct page. The page ID is the canvas node from `get_metadata` (e.g. `2802:66563`).
+   Store it in `figma-comments.md` alongside the file key.
+2. Use the **target node's absolute center** as `client_meta.node_offset` — fetch the node's
+   `absoluteBoundingBox` via `GET /v1/files/:key/nodes?ids=<nodeId>&depth=0` and compute
+   `x = abs_x + width/2`, `y = abs_y + height/2`.
+
+For each pending (`- [ ]`) comment in `figma-comments.md`, post it with:
+
+```bash
+curl -s -X POST "https://api.figma.com/v1/files/<fileKey>/comments" \
+  -H "X-Figma-Token: $FIGMA_PERSONAL_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "<comment text including signature>",
+    "client_meta": {
+      "node_id": "<pageNodeId>",
+      "node_offset": { "x": <center_x>, "y": <center_y> }
+    }
+  }'
+```
+
+- `<fileKey>` — from the `Figma file:` line in `figma-comments.md`.
+- `<pageNodeId>` — from the `Figma page:` line in `figma-comments.md`.
+- `<center_x>`, `<center_y>` — absolute center of the target node (from its bounding box).
+- `<comment text>` — the full comment including the review title prefix and signature.
+  Preserve the blank line before the signature: use `\n\n` in the JSON string.
+
+After a successful post (HTTP 200), flip the checkbox from `- [ ]` to `- [x]` in the file.
+If a post fails, print the error and leave the checkbox unchecked.
+
+---
+
+## Severity Guide
+
+| Severity    | Meaning                                  | Example                                                                      |
+| ----------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| ✅ No issue | Fully aligned with DS                    | Components and tokens used correctly                                         |
+| ℹ️ Minor    | Can be fixed easily before or during dev | Missing token reference, wrong spacing fallback                              |
+| ⚠️ Moderate | Should be fixed before dev starts        | Wrong component used, non-standard pattern                                   |
+| 🚨 Blocker  | Dev cannot start until resolved          | Custom component built where DS component exists, missing required DS change |
+
+---
+
+## What NOT to Flag
+
+- Placeholder content (dummy text, "Label", "Root item") — these are expected in design files.
+- Layout structure decisions (e.g., section order, padding choices) — these are design decisions, not DS issues.
+- Missing responsive variants unless the design explicitly covers multiple breakpoints.
+- Minor pixel rounding differences that result in the same visual outcome.
+
+---
+
+## Checklist
+
+Before writing the final report:
+
+- `get_metadata` called — root frame identified
+- `get_design_context` called on all major sections
+- `get_variable_defs` called — used to corroborate unbound token findings
+- `get_screenshot` called for visual reference
+- _(page)_ Top-level frame children checked for Section \[Size\] / Container \[Size\] naming
+- _(component)_ Dictionary enum completeness checked against DICTIONARIES.md
+- _(component)_ Interaction state completeness checked for all property combinations
+- All component instances checked for Code Connect mapping
+- `search_design_system` or `get_code_connect_suggestions` called for any layer with no Code Connect snippet that appears to be a custom primitive — replacement suggestion included when the match is credible
+- Detached components identified (frames with DS component names) → flagged as findings
+- Modified instances: not detectable via MCP — note in report that manual verification in Figma is required
+- "NEW" layer names identified → flagged as required DS changes
+- Spirit repo detected (`packages/web-react/` present) — if yes, `git log --oneline -50` checked, DS ticket references noted, JIRA column populated; if no, all JIRA cells set to _to be created_
+- Hardcoded spacing values identified → cross-referenced with Spirit scale
+- Hardcoded color values identified → flagged
+- Typography tokens verified
+- _(CC gaps)_ Every Finding passed the validation gate (Step 11): the designer can act on it alone in Figma. Code Connect gaps, CC mapping gaps, and unimplemented component features routed to **Development Considerations** (with severity) **and** **Required DS Changes** — never in Findings. When refreshing an existing report, every prior Finding was re-evaluated, not preserved as-is.
+- _(icons)_ Icon names verified against codebase; failures dual-routed: **Findings** with 🚨 (designer — publish asset in Figma) **and** **Development Considerations** + **Required DS Changes** (developer — add to code)
+- Output names derived per Step 10 — both modes: `design-reviews/<topic-slug>/`; multi-frame topic-slug comes from canvas name
+- Root frame (or first frame in multi-frame) saved as `overview.png`; per-finding pin percentages computed by walking the **full** parent chain (Step 10 item 7b) — verify pins are spread across the overview, not clustered
+- `get_screenshot` called for each finding with a node-level node ID — saved as `finding-{n}.png` (or `finding-{n}a.png`, `finding-{n}b.png` … for multi-screenshot findings); findings numbered sequentially across all frames in multi-frame mode
+- _(multi-frame)_ Frames Reviewed section included listing all frames with links — single combined report, no per-frame ➤ marker
+- Score calculated (✅ / (✅ + ❌) × 100) and emitted as `<div class="score">NN</div>` in the MD and as `{{SCORE}}` in the HTML
+- MD report written to `<report-name>.md` (Design Evaluation → Development Considerations → Required DS Changes); `overview.png` embedded before findings
+- HTML report written to `<report-name>.html` using the Step 11 template; cover page has score, eval table, and overview with CSS pin overlay
+- Node IDs rendered as clickable links (with URL) or hidden in `<!-- node:… -->` comments (without URL) — never as plain visible text
+- PDF generated from HTML via Chrome headless — or error printed if generation failed
+- Figma comments saved to `figma-comments.md` in the output folder (if any actionable findings exist); each comment ends with ` — <git user name>`; NOT posted without user confirmation

--- a/.agents/skills/review-figma-design/config.json
+++ b/.agents/skills/review-figma-design/config.json
@@ -1,0 +1,3 @@
+{
+  "iconsPath": null
+}

--- a/.agents/skills/review-figma-design/report-template.html
+++ b/.agents/skills/review-figma-design/report-template.html
@@ -1,0 +1,769 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{SUBJECT}} — Spirit AI Design Review</title>
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzgiIGhlaWdodD0iMzgiIHZpZXdCb3g9IjAgMCAzOCAzOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzQzNzQ5XzI1NDcpIj4KPG1hc2sgaWQ9Im1hc2swXzQzNzQ5XzI1NDciIHN0eWxlPSJtYXNrLXR5cGU6bHVtaW5hbmNlIiBtYXNrVW5pdHM9InVzZXJTcGFjZU9uVXNlIiB4PSIwIiB5PSIwIiB3aWR0aD0iMzgiIGhlaWdodD0iMzgiPgo8cGF0aCBkPSJNMzggMEgwVjM4SDM4VjBaIiBmaWxsPSJ3aGl0ZSIvPgo8L21hc2s+CjxnIG1hc2s9InVybCgjbWFzazBfNDM3NDlfMjU0NykiPgo8cGF0aCBkPSJNMCA4LjkwNjI1QzAgMy45ODc0NyAzLjk4NzQ3IDAgOC45MDYyNSAwSDI5LjA5MzhDMzQuMDEyNSAwIDM4IDMuOTg3NDcgMzggOC45MDYyNVYyOS4wOTM4QzM4IDM0LjAxMjUgMzQuMDEyNSAzOCAyOS4wOTM4IDM4SDguOTA2MjVDMy45ODc0NyAzOCAwIDM0LjAxMjUgMCAyOS4wOTM4VjguOTA2MjVaIiBmaWxsPSJ1cmwoI3BhaW50MF9saW5lYXJfNDM3NDlfMjU0NykiLz4KPHBhdGggZD0iTTI5LjA5MzggMzYuODEyNVYzOEg4LjkwNjI1VjM2LjgxMjVIMjkuMDkzOFpNMzYuODEyNSAyOS4wOTM4VjguOTA2MjVDMzYuODEyNSA0LjY0MzMgMzMuMzU2NyAxLjE4NzUgMjkuMDkzOCAxLjE4NzVIOC45MDYyNUM0LjY0MzMgMS4xODc1IDEuMTg3NSA0LjY0MzMgMS4xODc1IDguOTA2MjVWMjkuMDkzOEMxLjE4NzUgMzMuMzU2NyA0LjY0MzMgMzYuODEyNSA4LjkwNjI1IDM2LjgxMjVWMzhDMy45ODc0NyAzOCAwIDM0LjAxMjUgMCAyOS4wOTM4VjguOTA2MjVDMCAzLjk4NzQ3IDMuOTg3NDcgMCA4LjkwNjI1IDBIMjkuMDkzOEMzNC4wMTI1IDAgMzggMy45ODc0NyAzOCA4LjkwNjI1VjI5LjA5MzhDMzggMzQuMDEyNSAzNC4wMTI1IDM4IDI5LjA5MzggMzhWMzYuODEyNUMzMy4zNTY3IDM2LjgxMjUgMzYuODEyNSAzMy4zNTY3IDM2LjgxMjUgMjkuMDkzOFoiIGZpbGw9InVybCgjcGFpbnQxX2xpbmVhcl80Mzc0OV8yNTQ3KSIvPgo8cGF0aCBkPSJNMTguNzI2NSAxOS44OTdMMTMuNjU2MiAxMS4xNTU2QzEzLjgxNTcgMTAuMzA4MSAxNC4xMDIzIDkuNTM0OTkgMTQuNTE3MyA4LjgzNzUzTDE0LjUxOCA4LjgzNjVMMTQuNTE4NiA4LjgzNTQ3QzE1LjIxNzMgNy43MDE3NyAxNi4xOTI5IDYuODEwNDMgMTcuNDQwOCA2LjE2MTU1QzE4LjY4OTMgNS40ODg4NCAyMC4xMjU5IDUuMTE4NjIgMjEuNzQ3MSA1LjA0NzAzTDIxLjc1MDYgNS4wNDY4OEgyMS43NTQxQzIzLjg2MDIgNS4wNDY4OCAyNS41NzY5IDUuMjk1MyAyNi44OTcgNS43OTk3N0MyOC4yMjUzIDYuMjk4NDIgMjkuNDEzNCA2Ljg5Mjg4IDMwLjQ2MDYgNy41ODM4MUMzMC41Mjc4IDcuNjI4MDggMzAuNTUxNCA3LjcxNTQxIDMwLjUxNTcgNy43ODc0NkwyOC41NzI4IDExLjcxMjdDMjguNTMyNyAxMS43OTM4IDI4LjQzMzIgMTEuODI1IDI4LjM1MzkgMTEuNzgxNkMyNy4zNzI2IDExLjI0MzYgMjYuMzY4NCAxMC43OTk1IDI1LjM0MTEgMTAuNDQ5TDI1LjM0MDEgMTAuNDQ4NkMyNC4zNDEgMTAuMDk5NyAyMy40MDUxIDkuOTI3MDMgMjIuNTMxMiA5LjkyNzAzQzIxLjQ0MzggOS45MjcwMyAyMC42MDg3IDEwLjE0NzMgMjAuMDA4OCAxMC41Njk5QzE5LjQyMjIgMTAuOTgzMSAxOS4xMjI2IDExLjYwMjIgMTkuMTIyNiAxMi40NTUyQzE5LjEyMjYgMTMuMDIxMyAxOS4zMzggMTMuNTM2MiAxOS43ODI2IDE0LjAwNDVDMjAuMjYyNyAxNC40NjE3IDIwLjg3MTcgMTQuODc2NCAyMS42MTI0IDE1LjI0NzNDMjIuMzg0NiAxNS42MjIgMjMuMTgwMyAxNS45NjE3IDIzLjk5OTUgMTYuMjY2NEMyNC43NTk1IDE2LjU1MTcgMjUuNTA3OCAxNi44OTY0IDI2LjI0MzQgMTcuMzAwMUMyNy4wMTA2IDE3LjY4NDMgMjcuNjk0NCAxOC4xNzY4IDI4LjI5NDQgMTguNzc3MUMyOC45MDA4IDE5LjM2MDQgMjkuMzgzIDIwLjA5ODQgMjkuNzQzMiAyMC45ODc0QzMwLjEwNjYgMjEuODYxIDMwLjI4NSAyMi45MzIxIDMwLjI4NSAyNC4xOTUyQzMwLjI4NSAyNS41NDQzIDI5LjkzNTUgMjYuNzk4NyAyOS4yMzc2IDI3Ljk1NUMyOC41MzggMjkuMTE0MiAyNy41MTQ1IDMwLjA1MjQgMjYuMTc0MSAzMC43NzEzTDI2LjE3MjEgMzAuNzcyM0MyNS44ODQgMzAuOTIxNiAyNS41ODIxIDMxLjA1NDggMjUuMjY2MyAzMS4xNzE5TDIyLjY2OTQgMjYuNjk0N0MyMy4yMzAxIDI2LjUxMTMgMjMuNjg1NCAyNi4yMzAxIDI0LjA0MDUgMjUuODUzOEwyNC4wNDIgMjUuODUyMkwyNC4wNDM2IDI1Ljg1MDVDMjQuNDMwNCAyNS40NjMzIDI0LjYzMjggMjQuOTE4NyAyNC42MzI4IDI0LjE5NTJDMjQuNjMyOCAyMy43MTYzIDI0LjQ3MDkgMjMuMjgwNCAyNC4xMzk4IDIyLjg4MjdMMjQuMTM4MiAyMi44ODA2TDI0LjEzNjUgMjIuODc4NUMyMy44MjE3IDIyLjQ3MzMgMjMuMzc4OSAyMi4wOTY1IDIyLjgwMjYgMjEuNzUwM0wyMi44MDEzIDIxLjc0OTZMMjIuODAwMiAyMS43NDg4QzIyLjI0NDYgMjEuNDAxMiAyMS42MyAyMS4wOTkzIDIwLjk1NTkgMjAuODQzM0MyMC4yMzE2IDIwLjU2NjEgMTkuNDg4MiAyMC4yNTA1IDE4LjcyNjUgMTkuODk3WiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTEzLjU4NSAxOS44OTA2QzEzLjU4NSAxOS4zOTg4IDEzLjE4NjIgMTkgMTIuNjk0NCAxOUgxMS42NDk0QzExLjE1NzUgMTkgMTAuNzU4OCAxOS4zOTg4IDEwLjc1ODggMTkuODkwNlYyMS44NDk4QzEwLjc1ODggMjIuMzQxNyAxMC4zNiAyMi43NDA1IDkuODY4MTMgMjIuNzQwNUg4LjAxNTYzQzcuNTIzNzUgMjIuNzQwNSA3LjEyNSAyMy4xMzkyIDcuMTI1IDIzLjYzMTFWMjQuNzU5MkM3LjEyNSAyNS4yNTExIDcuNTIzNzUgMjUuNjQ5OCA4LjAxNTYzIDI1LjY0OThIOS44NjgxM0MxMC4zNiAyNS42NDk4IDEwLjc1ODggMjYuMDQ4NiAxMC43NTg4IDI2LjU0MDVWMjguNUMxMC43NTg4IDI4Ljk5MTkgMTEuMTU3NSAyOS4zOTA2IDExLjY0OTQgMjkuMzkwNkgxMi42OTQ0QzEzLjE4NjIgMjkuMzkwNiAxMy41ODUgMjguOTkxOSAxMy41ODUgMjguNVYyNi41NDA1QzEzLjU4NSAyNi4wNDg2IDEzLjk4MzggMjUuNjQ5OCAxNC40NzU2IDI1LjY0OThIMTYuMzI4MUMxNi44MiAyNS42NDk4IDE3LjIxODggMjUuMjUxMSAxNy4yMTg4IDI0Ljc1OTJWMjMuNjMxMUMxNy4yMTg4IDIzLjEzOTIgMTYuODIgMjIuNzQwNSAxNi4zMjgxIDIyLjc0MDVIMTQuNDc1NkMxMy45ODM4IDIyLjc0MDUgMTMuNTg1IDIyLjM0MTcgMTMuNTg1IDIxLjg0OThWMTkuODkwNloiIGZpbGw9IndoaXRlIi8+CjxwYXRoIGQ9Ik05LjQyNDMyIDMuNzcxNTJDOS42MzY4OCAzLjY0NzgzIDkuOTA5MzcgMy43MTk2OSAxMC4wMzMyIDMuOTMyMTRMMjcuNDAwNCAzMy43NjgxQzI3LjUyNCAzMy45ODA2IDI3LjQ1MjIgMzQuMjUzMSAyNy4yMzk3IDM0LjM3NjlDMjcuMDI3MyAzNC41MDA2IDI2Ljc1NDcgMzQuNDI4NyAyNi42MzA5IDM0LjIxNjNMOS4yNjM2OSA0LjM4MDM1QzkuMTQwMDMgNC4xNjc4NCA5LjIxMTkxIDMuODk1MjkgOS40MjQzMiAzLjc3MTUyWiIgZmlsbD0iI0MxQTJDMyIvPgo8L2c+CjwvZz4KPGRlZnM+CjxsaW5lYXJHcmFkaWVudCBpZD0icGFpbnQwX2xpbmVhcl80Mzc0OV8yNTQ3IiB4MT0iMTkiIHkxPSIwIiB4Mj0iMTkiIHkyPSIzOCIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgo8c3RvcCBzdG9wLWNvbG9yPSIjQ0I0M0QzIi8+CjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzM5MTUzQiIvPgo8L2xpbmVhckdyYWRpZW50Pgo8bGluZWFyR3JhZGllbnQgaWQ9InBhaW50MV9saW5lYXJfNDM3NDlfMjU0NyIgeDE9IjE5IiB5MT0iMCIgeDI9IjE5IiB5Mj0iMzgiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj4KPHN0b3Agc3RvcC1jb2xvcj0id2hpdGUiLz4KPHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjQ0I0M0QzIi8+CjwvbGluZWFyR3JhZGllbnQ+CjxjbGlwUGF0aCBpZD0iY2xpcDBfNDM3NDlfMjU0NyI+CjxyZWN0IHdpZHRoPSIzOCIgaGVpZ2h0PSIzOCIgZmlsbD0id2hpdGUiLz4KPC9jbGlwUGF0aD4KPC9kZWZzPgo8L3N2Zz4K" />
+    <style>
+      :root {
+        /* Root font sizes */
+        --font-size-root-print:  14px;
+        --font-size-root-screen: 16px;
+
+        /* Font sizes (rem @ 14px print root — ≈1.14× on 16px screen root) */
+        --font-size-score:     5.143rem; /* 72px  — score number              */
+        --font-size-score-sm:  4rem;     /* 56px  — score number (mobile)     */
+        --font-size-score-pct: 2.143rem; /* 30px  — score percentage sign     */
+        --font-size-heading:   1.429rem; /* 20px  — section headings          */
+        --font-size-base:      1rem;     /* 14px  — body text                 */
+        --font-size-sm:        0.929rem; /* 13px  — content / note text       */
+        --font-size-meta:      0.857rem; /* 12px  — meta, eval-table, num     */
+        --font-size-label:     0.714rem; /* 10px  — uppercase labels, icons   */
+
+        /* Spacings (rem @ 16px screen root — ×0.875 on 14px print root) */
+        --space-hair: 0.125rem; /*  2px screen —  1.75px print */
+        --space-1:    0.25rem;  /*  4px screen —  3.5px  print */
+        --space-2:    0.375rem; /*  6px screen —  5.25px print */
+        --space-3:    0.5rem;   /*  8px screen —  7px    print */
+        --space-4:    0.75rem;  /* 12px screen — 10.5px  print */
+        --space-5:    1rem;     /* 16px screen — 14px    print */
+        --space-6:    1.25rem;  /* 20px screen — 17.5px  print */
+        --space-7:    1.5rem;   /* 24px screen — 21px    print */
+        --space-8:    1.75rem;  /* 28px screen — 24.5px  print */
+        --space-9:    2rem;     /* 32px screen — 28px    print */
+        --space-10:   2.5rem;   /* 40px screen — 35px    print */
+        --space-11:   3rem;     /* 48px screen — 42px    print */
+
+        /* Brand */
+        --color-brand-bg: #370b45;
+        --color-brand-divider: #ffffff4f;
+
+        /* Text */
+        --color-text: #1d1d27;
+        --color-text-muted: #aaa;
+        --color-text-on-dark: #fff;
+
+        /* Links */
+        --color-link: #7847ff;
+
+        /* Surfaces */
+        --color-bg: #fff;
+        --color-bg-code: #f3f3f8;
+        --color-bg-table-head: #f4f4f9;
+        --color-bg-table-stripe: #f9f9fc;
+
+        /* Borders */
+        --color-border: #e5e5e5;
+
+        /* Severity */
+        --color-critical: #dc2626;
+        --color-critical-bg: #fef2f2;
+        --color-warning: #d97706;
+        --color-warning-bg: #fffbeb;
+        --color-info: #3b82f6;
+        --color-info-bg: #eff6ff;
+        --color-pass: #16a34a;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        color: var(--color-text);
+        font-size: var(--font-size-base);
+        line-height: 1.6;
+        background: var(--color-bg);
+      }
+      @media screen {
+        html {
+          font-size: var(--font-size-root-screen);
+        }
+        main {
+          max-width: 1024px;
+          margin-inline: auto;
+          margin-top: var(--space-11);
+        }
+        .cover {
+          border-bottom: 1px solid var(--color-border);
+        }
+      }
+      a {
+        color: var(--color-link);
+        text-decoration: underline;
+      }
+      /* JIRA issue keys (DS-XXXX) must not break across lines */
+      a[href*='jira'] {
+        white-space: nowrap;
+      }
+      code {
+        background: var(--color-bg-code);
+        padding: 1px var(--space-2);
+        border-radius: 3px;
+        font-size: 94%;
+        font-family: ui-monospace, monospace;
+      }
+
+      /* ---------- Print ---------- */
+      /* Inner pages: portrait A4, top breathing margin, bottom reserved for CDP footer. */
+      @page {
+        size: A4 portrait;
+        margin-top: 20mm;
+        margin-left: 5mm;
+        margin-right: 5mm;
+        margin-bottom: 24mm;
+      }
+      /* Cover page: landscape A4, zero side/top margins for full-bleed design.
+         Bottom margin matches inner pages so content stays clear of the footer. */
+      @page cover-page {
+        size: A4 landscape;
+        margin: 0 0 16mm;
+      }
+      .cover {
+        page: cover-page;
+      }
+      @media print {
+        html { font-size: var(--font-size-root-print); }
+        .cover {
+          page-break-after: always;
+        }
+        .cover-header,
+        .cover-body {
+          break-inside: avoid;
+        }
+        .finding {
+          page-break-inside: avoid;
+        }
+        /* Cap finding screenshots so a tall image doesn't push the finding
+           past a page break that page-break-inside: avoid can't rescue. */
+        .finding-body img {
+          max-height: 70vh;
+          object-fit: contain;
+        }
+        h2, h3 {
+          page-break-after: avoid;
+        }
+      }
+
+      /* ---------- Cover ---------- */
+      /* Layout: purple header (full width) → .cover-body (eval left, overview right). */
+      .cover {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+      /* Purple header — title on left, score on right */
+      .cover-header {
+        background: var(--color-brand-bg);
+        color: var(--color-text-on-dark);
+        padding: var(--space-7) var(--space-11);
+        display: flex;
+        align-items: center;
+        justify-content: start;
+        gap: var(--space-9);
+        flex-wrap: wrap;
+      }
+      .cover-header-logo {
+        width: auto;
+        height: 42px;
+        flex-shrink: 0;
+        margin-right: var(--space-5);
+      }
+      .cover-header-info {
+        padding-left: var(--space-9);
+        border-left: 1px solid var(--color-brand-divider);
+      }
+      .cover-header-info .label {
+        font-size: var(--font-size-label);
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        opacity: 0.7;
+        margin-bottom: var(--space-1);
+      }
+      .cover-header-info .subject {
+        font-size: var(--font-size-heading);
+        font-weight: 700;
+        line-height: 1.25;
+        margin-bottom: var(--space-2);
+      }
+      .cover-header-info .meta {
+        font-size: var(--font-size-meta);
+        opacity: 0.65;
+      }
+      .cover-header-score {
+        margin-left: auto;
+        text-align: right;
+        flex-shrink: 0;
+      }
+      .cover-header-score .score-num {
+        font-size: var(--font-size-score);
+        font-weight: 800;
+        line-height: 1;
+        letter-spacing: -0.028em;
+      }
+      .cover-header-score .score-pct {
+        font-size: var(--font-size-score-pct);
+        font-weight: 400;
+        opacity: 0.75;
+      }
+      .cover-header-score .score-label {
+        font-size: var(--font-size-label);
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        opacity: 0.65;
+        margin-top: var(--space-hair);
+      }
+      /* Mobile: two-row layout — logo + score on row 1, info block on row 2 */
+      @media (width <= 767px) {
+        .cover-header {
+          padding: var(--space-5) var(--space-6);
+          gap: var(--space-5);
+        }
+        .cover-header-logo {
+          margin-right: 0;
+        }
+        .cover-header-info {
+          flex: 0 0 100%;
+          order: 3;
+          border-left: none;
+          border-top: 1px solid var(--color-brand-divider);
+          padding-left: 0;
+          padding-top: var(--space-5);
+        }
+        .cover-header-score .score-num {
+          font-size: var(--font-size-score-sm);
+        }
+      }
+      /* Print: always use single-row layout regardless of viewport */
+      @media print {
+        .cover-header {
+          flex-wrap: nowrap;
+          padding: var(--space-7) var(--space-11);
+          gap: var(--space-9);
+        }
+        .cover-header-info {
+          flex: unset;
+          order: unset;
+          border-left: 1px solid var(--color-brand-divider);
+          border-top: none;
+          padding-left: var(--space-9);
+          padding-top: 0;
+        }
+        .cover-header-score .score-num {
+          font-size: var(--font-size-score);
+        }
+      }
+      /* Default (column): eval is above, overview below. */
+      .cover-overview {
+        padding: var(--space-5) var(--space-11) var(--space-10);
+      }
+      .cover-overview-label {
+        display: none;
+      }
+      .overview-wrap {
+        position: relative;
+        display: block;
+        width: 100%;
+        line-height: 0; /* removes inline gap beneath img */
+      }
+      .overview-wrap img {
+        width: 100%;
+        height: auto;
+        padding: 0; /* pins use % of wrap — padding would offset the raster */
+      }
+      .pin {
+        position: absolute;
+        width: 2em;
+        height: 2em;
+        border-radius: 50%;
+        background: var(--color-critical);
+        color: var(--color-text-on-dark);
+        font-size: var(--font-size-label);
+        font-weight: 700;
+        line-height: 2em;
+        text-align: center;
+        transform: translate(-50%, -50%);
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.45);
+        text-decoration: none;
+      }
+      /* Default (column): eval is first; 16px bottom gap before overview. */
+      .cover-eval {
+        padding: var(--space-6) var(--space-11) var(--space-5);
+      }
+      .eval-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: var(--font-size-meta);
+      }
+      .eval-table thead th {
+        text-align: left;
+        font-size: var(--font-size-label);
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        color: var(--color-text-muted);
+        padding: 0 0 var(--space-3);
+        border-bottom: 1px solid var(--color-border);
+      }
+      .eval-table td {
+        padding: var(--space-4) 0;
+        border-bottom: 1px solid var(--color-border);
+        vertical-align: middle;
+      }
+      .eval-table td:first-child {
+        width: 36px;
+      }
+      .check-icon {
+        width: 2em;
+        height: 2em;
+        border-radius: 50%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: var(--font-size-label);
+        font-weight: 700;
+        color: var(--color-text-on-dark);
+      }
+      .check-pass   { background: var(--color-pass); }
+      .check-fail   { background: var(--color-critical); }
+      .check-doubt  { background: var(--color-warning); }
+
+      /* Cover body: flex container for the two-column layout below the header. */
+      .cover-body {
+        display: flex;
+        flex-direction: column;
+      }
+      /* Desktop + print: .cover becomes a 3-row grid (header / body / footer),
+         body absorbs leftover height. The overview image is sized via the
+         wrap's aspect-ratio (set inline as --overview-aspect by the generator).
+         The aspect-ratio breaks the indefinite-parent-height cycle that
+         normally keeps max-height:% from resolving — with an aspect constraint
+         + both max dimensions at 100%, the wrap fits the largest rectangle
+         that preserves the image's natural ratio. The img then fills the wrap
+         exactly, so percentage-positioned pins stay aligned with features in
+         the image regardless of viewport / page size.
+         min-width/min-height:0 on the overview chain is deliberate: it removes
+         the image's intrinsic size from the body row's min-content, so a short
+         viewport (or small page) can shrink the image without the cover being
+         forced to grow to the image's natural size. The eval column's
+         min-content still sets the cover's floor, so nothing overlaps. */
+      @media (width >= 1000px) {
+        .cover {
+          min-height: 100vh;
+          display: grid;
+          grid-template-rows: auto 1fr auto;
+        }
+        .cover-body {
+          flex-direction: row;
+          align-items: stretch;
+          min-height: 0;
+        }
+        .cover-eval {
+          flex: 0 0 380px;
+          padding: var(--space-8) var(--space-7) var(--space-10) var(--space-11);
+        }
+        .cover-overview {
+          flex: 1;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          min-width: 0;
+          min-height: 0;
+          overflow: hidden;
+          contain: size;
+          padding: var(--space-8) var(--space-11) var(--space-10) var(--space-7);
+        }
+        .overview-wrap {
+          display: block;
+          width: auto;
+          height: auto;
+          min-width: 0;
+          min-height: 0;
+          max-width: 100%;
+          max-height: 100%;
+          aspect-ratio: var(--overview-aspect, auto);
+        }
+        .overview-wrap img {
+          display: block;
+          width: 100%;
+          height: 100%;
+          min-width: 0;
+          min-height: 0;
+          object-fit: contain;
+        }
+      }
+      @media print {
+        .cover {
+          min-height: 100vh;
+          display: grid;
+          grid-template-rows: auto 1fr auto;
+        }
+        .cover-body {
+          flex-direction: row;
+          align-items: stretch;
+          min-height: 0;
+        }
+        .cover-eval {
+          flex: 0 0 380px;
+          padding: var(--space-8) var(--space-7) var(--space-10) var(--space-11);
+        }
+        .cover-overview {
+          flex: 1;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          min-width: 0;
+          min-height: 0;
+          overflow: hidden;
+          contain: size;
+          padding: var(--space-8) var(--space-11) 0 var(--space-7);
+        }
+        .overview-wrap {
+          display: block;
+          width: auto;
+          height: auto;
+          min-width: 0;
+          min-height: 0;
+          max-width: 100%;
+          max-height: 100%;
+          aspect-ratio: var(--overview-aspect, auto);
+        }
+        .overview-wrap img {
+          display: block;
+          width: 100%;
+          height: 100%;
+          min-width: 0;
+          min-height: 0;
+          object-fit: contain;
+        }
+      }
+
+      /* ---------- Shared section layout ---------- */
+      .report-section {
+        padding: 0 var(--space-11) var(--space-11);
+      }
+      .section-heading {
+        font-size: var(--font-size-heading);
+        font-weight: 700;
+        padding-top: var(--space-10);
+        margin-bottom: var(--space-8);
+        border-top: 1px solid var(--color-border);
+      }
+      .report-section:first-of-type > .section-heading {
+        border-top: none;
+        padding-top: 0;
+      }
+      .section-label {
+        font-size: var(--font-size-label);
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        color: var(--color-text-muted);
+        padding: var(--space-5) 0 var(--space-3);
+        border-bottom: 1px solid var(--color-border);
+        margin-bottom: var(--space-4);
+      }
+
+      /* ---------- Findings ---------- */
+      .finding {
+        margin-bottom: var(--space-9);
+        scroll-margin-top: var(--space-9);
+      }
+      @keyframes finding-target-flash {
+        0%   { outline-color: var(--color-link); }
+        60%  { outline-color: var(--color-link); }
+        100% { outline-color: transparent; }
+      }
+      .finding:target {
+        outline: 3px solid var(--color-link);
+        outline-offset: var(--space-3);
+        border-radius: var(--space-2);
+        animation: finding-target-flash 2s ease-out forwards;
+      }
+      .finding-header {
+        display: flex;
+        align-items: center;
+        gap: var(--space-4);
+        padding: var(--space-5) var(--space-7) var(--space-5) var(--space-5);
+        border-radius: var(--space-2) var(--space-2) 0 0;
+        border-left: 4px solid transparent;
+      }
+      .finding-header.critical {
+        background: var(--color-critical-bg);
+        border-left-color: var(--color-critical);
+      }
+      .finding-header.warning {
+        background: var(--color-warning-bg);
+        border-left-color: var(--color-warning);
+      }
+      .finding-header.info {
+        background: var(--color-info-bg);
+        border-left-color: var(--color-info);
+      }
+      .finding-num {
+        width: 2em;
+        height: 2em;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: var(--font-size-meta);
+        font-weight: 700;
+        color: var(--color-text-on-dark);
+        flex-shrink: 0;
+      }
+      .critical .finding-num {
+        background: var(--color-critical);
+      }
+      .warning .finding-num {
+        background: var(--color-warning);
+      }
+      .info .finding-num {
+        background: var(--color-info);
+      }
+      .finding-severity {
+        font-size: var(--font-size-label);
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        flex-shrink: 0;
+      }
+      .critical .finding-severity {
+        color: var(--color-critical);
+      }
+      .warning .finding-severity {
+        color: var(--color-warning);
+      }
+      .info .finding-severity {
+        color: var(--color-info);
+      }
+      .finding-title {
+        font-size: var(--font-size-sm);
+        font-weight: 600;
+        color: var(--color-text);
+      }
+      .finding-body {
+        padding: var(--space-7);
+        border: 1px solid var(--color-border);
+        border-top: none;
+        border-radius: 0 0 var(--space-2) var(--space-2);
+        font-size: var(--font-size-sm);
+        line-height: 1.65;
+      }
+      .finding-body p {
+        margin-bottom: var(--space-3);
+      }
+      .finding-body p:last-child {
+        margin-bottom: 0;
+      }
+      .report-img,
+      .finding-body img {
+        max-width: 100%;
+        border: 1px solid var(--color-border);
+        border-radius: var(--space-2);
+        padding: var(--space-7);
+        background: var(--color-bg);
+        display: block;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+      }
+      .finding-body img {
+        margin-top: var(--space-7);
+        margin-bottom: var(--space-3);
+      }
+
+      /* ---------- Development Considerations ---------- */
+      .report-list {
+        list-style-type: upper-alpha;
+        padding-left: 1.5rem;
+      }
+      .report-list li {
+        padding-left: 0.5rem;
+        margin-bottom: var(--space-6);
+      }
+      .report-list li:last-child {
+        margin-bottom: 0;
+      }
+      .note-heading {
+        font-size: var(--font-size-sm);
+        font-weight: 700;
+        margin-bottom: var(--space-1);
+      }
+      .note-heading + p {
+        font-size: var(--font-size-sm);
+        line-height: 1.65;
+      }
+
+      /* ---------- Report tables ---------- */
+      .report-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: var(--space-1);
+      }
+      .report-table thead th {
+        text-align: left;
+        padding: var(--space-3) var(--space-4);
+        font-size: var(--font-size-label);
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        background: var(--color-bg-table-head);
+        border-bottom: 2px solid var(--color-border);
+      }
+      .report-table td {
+        padding: var(--space-3) var(--space-4);
+        border-bottom: 1px solid var(--color-border);
+        font-size: var(--font-size-sm);
+      }
+      .report-table tbody tr:nth-child(even) td {
+        background: var(--color-bg-table-stripe);
+      }
+      /* JIRA column must not wrap */
+      .report-table td:last-child {
+        white-space: nowrap;
+      }
+
+      /* ---------- Cover footer (Frames Reviewed) ---------- */
+      .cover-footer {
+        padding: 0 var(--space-11) var(--space-9);
+      }
+      .cover-footer ul {
+        padding-left: 1.25rem;
+        columns: 3;
+        column-gap: 2rem;
+      }
+      .cover-footer li {
+        margin-bottom: var(--space-1);
+        font-size: var(--font-size-sm);
+        break-inside: avoid;
+      }
+      @media (width <= 1023px) {
+        .cover-footer ul { columns: 2; }
+      }
+      @media (width <= 767px) {
+        .cover-footer ul { columns: 1; }
+      }
+      @media print {
+        .cover-footer ul { columns: 3; }
+      }
+    </style>
+  </head>
+  <body>
+
+    <!-- COVER PAGE -->
+    <header class="cover">
+      <!-- Purple header: title + score -->
+      <div class="cover-header">
+        <!-- Spirit logo -->
+        <svg width="127" height="38" viewBox="0 0 127 38" fill="none" xmlns="http://www.w3.org/2000/svg" class="cover-header-logo">
+          <title>Spirit</title>
+          <g clip-path="url(#clip0_43749_2546)">
+            <mask id="mask0_43749_2546" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="38" height="38">
+              <path d="M38 0H0V38H38V0Z" fill="white"/>
+            </mask>
+            <g mask="url(#mask0_43749_2546)">
+              <path d="M0 8.90625C0 3.98747 3.98747 0 8.90625 0H29.0938C34.0125 0 38 3.98747 38 8.90625V29.0938C38 34.0125 34.0125 38 29.0938 38H8.90625C3.98747 38 0 34.0125 0 29.0938V8.90625Z" fill="url(#paint0_linear_43749_2546)"/>
+              <path d="M29.0938 36.8125V38H8.90625V36.8125H29.0938ZM36.8125 29.0938V8.90625C36.8125 4.6433 33.3567 1.1875 29.0938 1.1875H8.90625C4.6433 1.1875 1.1875 4.6433 1.1875 8.90625V29.0938C1.1875 33.3567 4.6433 36.8125 8.90625 36.8125V38C3.98747 38 0 34.0125 0 29.0938V8.90625C0 3.98747 3.98747 0 8.90625 0H29.0938C34.0125 0 38 3.98747 38 8.90625V29.0938C38 34.0125 34.0125 38 29.0938 38V36.8125C33.3567 36.8125 36.8125 33.3567 36.8125 29.0938Z" fill="url(#paint1_linear_43749_2546)"/>
+              <path d="M18.7265 19.897L13.6562 11.1556C13.8157 10.3081 14.1023 9.53499 14.5173 8.83753L14.518 8.8365L14.5186 8.83547C15.2173 7.70177 16.1929 6.81043 17.4408 6.16155C18.6893 5.48884 20.1259 5.11862 21.7471 5.04703L21.7506 5.04688H21.7541C23.8602 5.04688 25.5769 5.2953 26.897 5.79977C28.2253 6.29842 29.4134 6.89288 30.4606 7.58381C30.5278 7.62808 30.5514 7.71541 30.5157 7.78746L28.5728 11.7127C28.5327 11.7938 28.4332 11.825 28.3539 11.7816C27.3726 11.2436 26.3684 10.7995 25.3411 10.449L25.3401 10.4486C24.341 10.0997 23.4051 9.92703 22.5312 9.92703C21.4438 9.92703 20.6087 10.1473 20.0088 10.5699C19.4222 10.9831 19.1226 11.6022 19.1226 12.4552C19.1226 13.0213 19.338 13.5362 19.7826 14.0045C20.2627 14.4617 20.8717 14.8764 21.6124 15.2473C22.3846 15.622 23.1803 15.9617 23.9995 16.2664C24.7595 16.5517 25.5078 16.8964 26.2434 17.3001C27.0106 17.6843 27.6944 18.1768 28.2944 18.7771C28.9008 19.3604 29.383 20.0984 29.7432 20.9874C30.1066 21.861 30.285 22.9321 30.285 24.1952C30.285 25.5443 29.9355 26.7987 29.2376 27.955C28.538 29.1142 27.5145 30.0524 26.1741 30.7713L26.1721 30.7723C25.884 30.9216 25.5821 31.0548 25.2663 31.1719L22.6694 26.6947C23.2301 26.5113 23.6854 26.2301 24.0405 25.8538L24.042 25.8522L24.0436 25.8505C24.4304 25.4633 24.6328 24.9187 24.6328 24.1952C24.6328 23.7163 24.4709 23.2804 24.1398 22.8827L24.1382 22.8806L24.1365 22.8785C23.8217 22.4733 23.3789 22.0965 22.8026 21.7503L22.8013 21.7496L22.8002 21.7488C22.2446 21.4012 21.63 21.0993 20.9559 20.8433C20.2316 20.5661 19.4882 20.2505 18.7265 19.897Z" fill="white"/>
+              <path d="M13.585 19.8906C13.585 19.3988 13.1862 19 12.6944 19H11.6494C11.1575 19 10.7588 19.3988 10.7588 19.8906V21.8498C10.7588 22.3417 10.36 22.7405 9.86813 22.7405H8.01563C7.52375 22.7405 7.125 23.1392 7.125 23.6311V24.7592C7.125 25.2511 7.52375 25.6498 8.01563 25.6498H9.86813C10.36 25.6498 10.7588 26.0486 10.7588 26.5405V28.5C10.7588 28.9919 11.1575 29.3906 11.6494 29.3906H12.6944C13.1862 29.3906 13.585 28.9919 13.585 28.5V26.5405C13.585 26.0486 13.9838 25.6498 14.4756 25.6498H16.3281C16.82 25.6498 17.2188 25.2511 17.2188 24.7592V23.6311C17.2188 23.1392 16.82 22.7405 16.3281 22.7405H14.4756C13.9838 22.7405 13.585 22.3417 13.585 21.8498V19.8906Z" fill="white"/>
+              <path d="M9.42432 3.77152C9.63688 3.64783 9.90937 3.71969 10.0332 3.93214L27.4004 33.7681C27.524 33.9806 27.4522 34.2531 27.2397 34.3769C27.0273 34.5006 26.7547 34.4287 26.6309 34.2163L9.26369 4.38035C9.14003 4.16784 9.21191 3.89529 9.42432 3.77152Z" fill="#C1A2C3"/>
+            </g>
+          </g>
+          <path d="M68.06 23.42C68.06 27.564 64.756 30.28 59.52 30.28C54.284 30.28 50.924 27.508 50.56 23.056H55.908C55.964 24.96 57.224 26.164 59.408 26.164C61.228 26.164 62.432 25.464 62.432 24.204C62.432 23.336 61.564 22.692 60.388 22.468L56.72 21.768C53.5 21.152 51.372 19.276 51.372 16.028C51.372 12.276 54.676 9.644 59.184 9.644C63.972 9.644 67.416 12.388 67.724 16.728H62.376C62.236 14.908 61.004 13.732 59.24 13.732C57.672 13.732 56.72 14.572 56.72 15.664C56.72 16.56 57.616 17.092 58.68 17.288L62.572 18.044C66.156 18.744 68.06 20.508 68.06 23.42ZM85.9765 22.468C85.9765 26.836 83.3165 30.28 79.2565 30.28C77.6885 30.28 76.3445 29.72 75.1685 28.6V35.404H70.3805V14.936H74.7765V16.644C76.0085 15.356 77.4925 14.656 79.2565 14.656C83.3165 14.656 85.9765 18.156 85.9765 22.468ZM80.9925 22.468C80.9925 20.116 79.5645 18.968 78.1085 18.968C76.6245 18.968 75.2245 20.116 75.2245 22.496C75.2245 24.904 76.6525 25.968 78.1085 25.968C79.5645 25.968 80.9925 24.876 80.9925 22.468ZM93.5859 11.436C93.5859 13.004 92.3259 14.152 90.5059 14.152C88.6859 14.152 87.4259 13.004 87.4259 11.436C87.4259 9.84 88.6859 8.692 90.5059 8.692C92.3259 8.692 93.5859 9.84 93.5859 11.436ZM92.9419 30H88.1539V14.936H92.9419V30ZM100.872 23.056V30H96.0836V14.936H100.48V17.596C101.628 15.832 104.008 14.824 106.416 14.824V19.808C103.028 19.472 100.872 19.724 100.872 23.056ZM113.684 11.436C113.684 13.004 112.424 14.152 110.604 14.152C108.784 14.152 107.524 13.004 107.524 11.436C107.524 9.84 108.784 8.692 110.604 8.692C112.424 8.692 113.684 9.84 113.684 11.436ZM113.04 30H108.252V14.936H113.04V30ZM126.289 25.296V29.468C125.225 30.056 124.217 30.28 122.873 30.28C119.485 30.28 117.497 28.264 117.497 24.82V19.108H114.697V14.936H117.497V10.512H122.285V14.936H126.401V19.108H122.285V23.7C122.285 25.156 122.901 25.828 124.217 25.828C125.001 25.828 125.757 25.632 126.289 25.296Z" fill="white"/>
+          <defs>
+            <linearGradient id="paint0_linear_43749_2546" x1="19" y1="0" x2="19" y2="38" gradientUnits="userSpaceOnUse">
+              <stop stop-color="#CB43D3"/>
+              <stop offset="1" stop-color="#39153B"/>
+            </linearGradient>
+            <linearGradient id="paint1_linear_43749_2546" x1="19" y1="0" x2="19" y2="38" gradientUnits="userSpaceOnUse">
+              <stop stop-color="white"/>
+              <stop offset="1" stop-color="#CB43D3"/>
+            </linearGradient>
+            <clipPath id="clip0_43749_2546">
+              <rect width="38" height="38" fill="white"/>
+            </clipPath>
+          </defs>
+        </svg>
+        <div class="cover-header-info">
+          <div class="label">AI Design Review</div>
+          <div class="subject">{{SUBJECT}}</div>
+          <div class="meta">{{DATE}} &nbsp;·&nbsp; {{REVIEW_TYPE}}</div>
+        </div>
+        <div class="cover-header-score">
+          <div class="score-num">{{SCORE}}<span class="score-pct">%</span></div>
+          <div class="score-label">Design Score</div>
+        </div>
+      </div>
+      <!-- Two-column body: eval (checks) left, overview (image + pins) right. -->
+      <div class="cover-body">
+        <div class="cover-eval">
+          <table class="eval-table">
+            <thead>
+              <tr>
+                <th colspan="2">Check</th>
+              </tr>
+            </thead>
+            <tbody>
+              {{EVAL_ROWS}}
+            </tbody>
+          </table>
+        </div>
+        <div class="cover-overview">
+          <div class="cover-overview-label">Findings Overview</div>
+          <div class="overview-wrap"{{OVERVIEW_WRAP_STYLE}}>
+            <img src="overview.png" alt="Design overview" class="report-img" />
+            {{PINS}}
+          </div>
+        </div>
+      </div>
+      <!-- FRAMES REVIEWED (multi-frame only, omit block when empty) -->
+      {{FRAMES_REVIEWED}}
+    </header>
+
+    <main>
+
+      <!-- FINDINGS -->
+      <section class="report-section">
+        <h2 class="section-heading">Findings</h2>
+        {{FINDINGS}}
+      </section>
+
+      <!-- DEVELOPMENT CONSIDERATIONS -->
+      <section class="report-section">
+        <h2 class="section-heading">Development Considerations</h2>
+        <ol class="report-list">
+          {{DEV_NOTES}}
+        </ol>
+      </section>
+
+      <!-- REQUIRED DS CHANGES -->
+      <section class="report-section">
+        <h2 class="section-heading">Required DS Changes</h2>
+        <table class="report-table">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Change</th>
+              <th>Effort</th>
+              <th>JIRA</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{DS_CHANGES}}
+          </tbody>
+        </table>
+      </section>
+
+    </main>
+
+  </body>
+</html>

--- a/.agents/skills/review-figma-design/scripts/pdf-gen.js
+++ b/.agents/skills/review-figma-design/scripts/pdf-gen.js
@@ -1,0 +1,213 @@
+// pdf-gen.js — Chrome CDP PDF generator for figma-design-review skill
+//
+// Usage: node pdf-gen.js <chrome-path> <html-path> <pdf-path>
+//
+// Prints the HTML report to PDF via Chrome's DevTools Protocol so page numbers
+// are rendered on every page.
+// Requires Node.js 22+ for the built-in WebSocket global.
+
+import { spawn } from 'child_process';
+import http from 'http';
+import net from 'net';
+import fs from 'fs';
+import path from 'path';
+
+const [, , CHROME, HTML, PDF] = process.argv;
+
+if (!CHROME || !HTML || !PDF) {
+  process.stderr.write('Usage: node pdf-gen.js <chrome-path> <html-path> <pdf-path>\n');
+  process.exit(1);
+}
+
+// --- Review title for footer -----------------------------------------------
+
+const htmlContent = fs.readFileSync(HTML, 'utf8');
+const subjectMatch = htmlContent.match(/<div class="subject">([^<]+)<\/div>/);
+const reviewTitle = subjectMatch ? subjectMatch[1] : 'Spirit Design System';
+// Extract tool name from <title> (the segment after the last em dash).
+// <title> is the single source of truth so pdf-gen.js stays in sync automatically.
+const toolMatch = htmlContent.match(/<title>[^<]*\u2014\s*([^\u2014<]+)\s*<\/title>/);
+const toolName = toolMatch ? toolMatch[1].trim() : 'Spirit AI Design Review';
+
+// --- Footer template -------------------------------------------------------
+// Chrome CDP renders <span class="pageNumber"> and <span class="totalPages">
+// inside the footerTemplate HTML. Inline styles only — no external CSS.
+
+// Chrome CDP scales footer template content to ~75% when rendering into the
+// physical margin area. A template height of 56px renders as ~42px on the page.
+//
+// Chrome populates .pageNumber/.totalPages spans before executing scripts in
+// the template, so a script can read the page number and hide the footer on
+// page 1 (the landscape cover), where the margin is 0 but CDP still renders
+// the template on top of the content.
+const footerTemplate = `
+  <div id="ft" style="width:100%;padding:0 62px;box-sizing:border-box;display:flex;
+              justify-content:space-between;align-items:center;
+              font-size:12px;font-family:system-ui,sans-serif;color:#555;height:56px;">
+    <span>${toolName}: ${reviewTitle}</span>
+    <span><span class="pageNumber"></span>&#8202;/&#8202;<span class="totalPages"></span></span>
+  </div>`;
+
+// --- Helpers ---------------------------------------------------------------
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// --- Local HTTP server for the HTML directory ------------------------------
+// Chrome CDP blocks file:// navigation; serving over localhost sidesteps it.
+
+function startServer(htmlPath) {
+  const dir = path.dirname(path.resolve(htmlPath));
+  const file = path.basename(htmlPath);
+
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const filePath = path.join(dir, decodeURIComponent(req.url.split('?')[0]));
+      fs.readFile(filePath, (err, data) => {
+        if (err) { res.writeHead(404); res.end(); return; }
+        const ext = path.extname(filePath).toLowerCase();
+        const mime = { '.html': 'text/html', '.png': 'image/png', '.svg': 'image/svg+xml' }[ext] || 'application/octet-stream';
+        res.writeHead(200, { 'Content-Type': mime });
+        res.end(data);
+      });
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ server, url: `http://127.0.0.1:${port}/${file}` });
+    });
+    server.on('error', reject);
+  });
+}
+
+// --- Helpers ---------------------------------------------------------------
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
+}
+
+function httpGet(url, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => resolve(data));
+    });
+    req.on('error', reject);
+    req.setTimeout(timeoutMs, () => {
+      req.destroy();
+      reject(new Error(`HTTP GET timed out: ${url}`));
+    });
+  });
+}
+
+// --- Chrome CDP ------------------------------------------------------------
+
+async function run() {
+  const CDP_PORT = await getFreePort();
+  const userDataDir = `/tmp/chrome-pdf-${Date.now()}`;
+
+  const { server, url: pageUrl } = await startServer(HTML);
+
+  const chrome = spawn(
+    CHROME,
+    [
+      '--headless=new',
+      `--remote-debugging-port=${CDP_PORT}`,
+      '--remote-debugging-address=127.0.0.1',
+      `--user-data-dir=${userDataDir}`,
+      '--no-sandbox',
+      '--disable-gpu',
+      '--disable-extensions',
+      '--disable-dev-shm-usage',
+    ],
+    { stdio: 'ignore' },
+  );
+
+  try {
+    // Wait for Chrome to start and retry /json until it responds
+    let jsonData;
+    for (let attempt = 0; attempt < 10; attempt++) {
+      await wait(600);
+      try {
+        jsonData = await httpGet(`http://127.0.0.1:${CDP_PORT}/json`);
+        break;
+      } catch {
+        // not ready yet — retry
+      }
+    }
+    if (!jsonData) throw new Error('Chrome CDP did not become ready');
+
+    // Find the main page tab (type:"page"), not extension background pages
+    const tabs = JSON.parse(jsonData);
+    const tab = tabs.find((t) => t.type === 'page' && t.webSocketDebuggerUrl);
+    if (!tab) throw new Error('No debuggable page tab found');
+    const wsUrl = tab.webSocketDebuggerUrl;
+
+    // Connect via WebSocket (Node.js 22+ built-in)
+    const ws = new WebSocket(wsUrl);
+    await new Promise((resolve, reject) => {
+      ws.addEventListener('open', resolve);
+      ws.addEventListener('error', (e) =>
+        reject(new Error(e.message || e.type || 'WebSocket connection failed')),
+      );
+    });
+
+    let msgId = 0;
+    const pending = new Map();
+
+    ws.addEventListener('message', (e) => {
+      const msg = JSON.parse(e.data);
+      if (msg.id !== undefined && pending.has(msg.id)) {
+        pending.get(msg.id)(msg);
+        pending.delete(msg.id);
+      }
+    });
+
+    const cdp = (method, params = {}) =>
+      new Promise((resolve) => {
+        const id = ++msgId;
+        pending.set(id, resolve);
+        ws.send(JSON.stringify({ id, method, params }));
+      });
+
+    // Navigate to the locally served HTML and wait for full render
+    await cdp('Page.enable');
+    await cdp('Page.navigate', { url: pageUrl });
+    await wait(3000); // allow images to decode
+
+    // Print to PDF
+    // preferCSSPageSize: true lets CSS @page rules control paper size and margins,
+    // which is required for the named cover-page to use A4 landscape while inner
+    // pages remain A4 portrait. Margins are set in CSS @page (margin-bottom: 0.65in
+    // on every page reserves the physical space for the footer template below).
+    const result = await cdp('Page.printToPDF', {
+      preferCSSPageSize: true,
+      printBackground: true,
+      displayHeaderFooter: true,
+      headerTemplate: '<div></div>',
+      footerTemplate,
+    });
+
+    if (result.error) throw new Error(`CDP error: ${result.error.message}`);
+    if (!result.result?.data) throw new Error('Page.printToPDF returned no data');
+
+    fs.writeFileSync(PDF, Buffer.from(result.result.data, 'base64'));
+    ws.close();
+    process.stdout.write(`PDF saved: ${PDF}\n`);
+  } finally {
+    chrome.kill();
+    server.close();
+  }
+}
+
+run().catch((err) => {
+  process.stderr.write(`pdf-gen.js failed: ${err.message}\n`);
+  process.exit(1);
+});

--- a/.agents/skills/review-figma-design/scripts/save-screenshots.js
+++ b/.agents/skills/review-figma-design/scripts/save-screenshots.js
@@ -1,0 +1,91 @@
+// save-screenshots.js — Save Figma screenshots via the Figma MCP server.
+//
+// Usage: node save-screenshots.js NODE_ID_1:PATH_1 [NODE_ID_2:PATH_2 ...]
+//
+// Each argument is a colon-separated pair of Figma node ID and output file path.
+// Node IDs contain colons (e.g. "2802:66561"), so the script splits on the LAST
+// colon to separate the node ID from the file path.
+
+import http from 'http';
+import fs from 'fs';
+
+const BASE_URL = 'http://localhost:3845/mcp';
+
+function post(sessionId, body) {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const headers = {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+      'Content-Length': Buffer.byteLength(data),
+    };
+    if (sessionId) headers['mcp-session-id'] = sessionId;
+
+    const req = http.request(BASE_URL, { method: 'POST', headers }, (res) => {
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => resolve({ headers: res.headers, body: Buffer.concat(chunks).toString() }));
+    });
+    req.on('error', reject);
+    req.setTimeout(15000, () => { req.destroy(); reject(new Error('Request timed out')); });
+    req.write(data);
+    req.end();
+  });
+}
+
+function parseSSE(raw) {
+  for (const line of raw.split('\n')) {
+    if (line.startsWith('data:')) return JSON.parse(line.slice(5));
+  }
+  return null;
+}
+
+async function initSession() {
+  const { headers } = await post(null, {
+    jsonrpc: '2.0', id: 0, method: 'initialize',
+    params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'x', version: '1' } },
+  });
+  return headers['mcp-session-id'];
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    process.stderr.write(`Usage: node save-screenshots.js NODE_ID:PATH [NODE_ID:PATH ...]\n`);
+    process.exit(1);
+  }
+
+  const findings = args.map((arg, i) => {
+    const last = arg.lastIndexOf(':');
+    if (last === -1) {
+      process.stderr.write(`Error: argument '${arg}' must be NODE_ID:PATH\n`);
+      process.exit(1);
+    }
+    return { id: i + 1, nodeId: arg.slice(0, last), path: arg.slice(last + 1) };
+  });
+
+  const session = await initSession();
+
+  for (const { id, nodeId, path } of findings) {
+    const { body } = await post(session, {
+      jsonrpc: '2.0', id, method: 'tools/call',
+      params: { name: 'get_screenshot', arguments: { nodeId } },
+    });
+    const msg = parseSSE(body);
+    for (const item of msg?.result?.content ?? []) {
+      if (item.type === 'image') {
+        const buf = Buffer.from(item.data, 'base64');
+        fs.writeFileSync(path, buf);
+        // PNG dimensions: IHDR chunk starts at byte 8; width at 16, height at 20 (big-endian uint32).
+        const w = buf.readUInt32BE(16);
+        const h = buf.readUInt32BE(20);
+        process.stdout.write(`Saved ${path} (${w}x${h})\n`);
+      }
+    }
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`save-screenshots.js failed: ${err.message}\n`);
+  process.exit(1);
+});

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ nx-cloud.env
 # Dotenv
 .env*
 !.env.*.example
+
+# Design reviews
+/design-reviews/

--- a/.prettierignore
+++ b/.prettierignore
@@ -70,9 +70,11 @@ makefile
 # Husky.js Files
 .husky/*
 
+# Miscellaneous
+console
+
 # Shell Scripts
 *.sh
-console
 
 # Favicon
 *.ico

--- a/.remarkignore
+++ b/.remarkignore
@@ -13,3 +13,6 @@ test-results
 
 # Heading capitalization problems
 migration-*
+
+# Generated design review reports (output of the figma-design-review skill)
+design-reviews


### PR DESCRIPTION
## Summary

- Adds a new `review-figma-design` AI agent skill for reviewing Figma designs against Spirit DS conventions before handoff to development
- The skill is invoked as `/spirit:review-figma-design` and lives in `.agents/skills/review-figma-design/`
- The skill produces a structured Markdown report with a generic checks table, severity-sorted findings, required DS changes, and ready-to-post Figma comments
- Extends the `figma-to-spirit` skill with a rule mapping Figma link text styles (style names containing &#34;link&#34;) to the DS `Link` component

## Test plan

- [x] Verify the `review-figma-design` skill can be invoked via `/spirit:review-figma-design`
- [x] Confirm the skill README documents usage and output format clearly
- [x] Review the `figma-to-spirit` skill update for the `Link` component mapping rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)