### PR TITLE
feat(eslint-config): require an empty line before the first `expect` in a group

### DIFF
--- a/configs/eslint-config-spirit/index.js
+++ b/configs/eslint-config-spirit/index.js
@@ -88,5 +88,13 @@ module.exports = {
         'jsdoc/check-tag-names': 'off',
       },
     },
+    {
+      files: ['test/**', '**/*.test.*', '**/*.spec.*'],
+      rules: {
+        // Require an empty line before the first `expect` in a group
+        // @see { @link https://github.com/dangreenisrael/eslint-plugin-jest-formatting }
+        'jest-formatting/padding-around-expect-groups': 'error',
+      },
+    },
   ],
 };

--- a/exporters/tokens/src/formatters/__tests__/unitFormatter.test.ts
+++ b/exporters/tokens/src/formatters/__tests__/unitFormatter.test.ts
@@ -13,6 +13,7 @@ describe('unitFormatter', () => {
         baseFontSize: FONT_SIZE_BASE_DEFAULT,
         isFontSizeBaseToken: false,
       };
+
       expect(formatUnitValue(undefined, 'px', ctx, [])).toBeUndefined();
       expect(formatUnitValue(0, 'px', ctx, [])).toBe(0);
     });
@@ -24,6 +25,7 @@ describe('unitFormatter', () => {
         baseFontSize: FONT_SIZE_BASE_DEFAULT,
         isFontSizeBaseToken: false,
       };
+
       expect(formatUnitValue(12, undefined, ctx, [])).toBe(12);
     });
 
@@ -34,6 +36,7 @@ describe('unitFormatter', () => {
         baseFontSize: FONT_SIZE_BASE_DEFAULT,
         isFontSizeBaseToken: false,
       };
+
       expect(formatUnitValue(50, '%', ctx, [])).toBe('50%');
       expect(formatUnitValue(2, 'rem', ctx, [])).toBe('2rem');
     });
@@ -48,6 +51,7 @@ describe('unitFormatter', () => {
       const rules: UnitFormatRule[] = [
         { tokenTypes: [TokenType.fontSize], shouldConvert: () => true, converterNames: ['pxToRem'] },
       ];
+
       expect(formatUnitValue(40, 'px', ctx, rules)).toBe('2.5rem');
     });
 
@@ -61,6 +65,7 @@ describe('unitFormatter', () => {
       const rules: UnitFormatRule[] = [
         { tokenTypes: [TokenType.dimension], shouldConvert: () => true, converterNames: ['pxToRem'] },
       ];
+
       expect(formatUnitValue(40, 'px', ctx, rules)).toBe('40px');
     });
 
@@ -74,6 +79,7 @@ describe('unitFormatter', () => {
       const rules: UnitFormatRule[] = [
         { tokenTypes: [TokenType.fontSize], shouldConvert: (c) => !c.isFontSizeBaseToken, converterNames: ['pxToRem'] },
       ];
+
       expect(formatUnitValue(18, 'px', ctx, rules)).toBe('18px');
     });
   });

--- a/exporters/tokens/src/generators/__tests__/stylesObjectGenerator.test.ts
+++ b/exporters/tokens/src/generators/__tests__/stylesObjectGenerator.test.ts
@@ -322,6 +322,7 @@ describe('stylesObjectGenerator', () => {
           undefined,
           fontSizeBaseMap,
         );
+
         expect(stylesObjectRef).toStrictEqual(expectedStyles);
       },
     );

--- a/exporters/tokens/src/helpers/__tests__/objectHelper.test.ts
+++ b/exporters/tokens/src/helpers/__tests__/objectHelper.test.ts
@@ -196,11 +196,13 @@ focus,`;
   describe('getTokenAlias', () => {
     it('should return token alias for non-numeric', () => {
       const token = exampleTypographyTokens.get('typographyRef2') as Token;
+
       expect(getTokenAlias(token, false)).toBe('bold-link');
     });
 
     it('should return token alias for non-numeric with js output', () => {
       const token = exampleTypographyTokens.get('typographyRef2') as Token;
+
       expect(getTokenAlias(token, true)).toBe('boldLink');
     });
   });
@@ -228,11 +230,13 @@ focus,`;
   describe('formatTypographyName', () => {
     it('should return correct typography name', () => {
       const tokenNameParts = ['heading', 'desktop', 'xLarge', 'bold'];
+
       expect(formatTypographyName(tokenNameParts)).toBe('heading-xLarge-bold');
     });
 
     it('should return correct typography name if tokenNameParts has less than 4 items', () => {
       const tokenNameParts = ['heading', 'desktop', 'xLarge'];
+
       expect(formatTypographyName(tokenNameParts)).toBe('heading-desktop-xLarge');
     });
   });

--- a/exporters/tokens/src/helpers/__tests__/specialCaseHelper.test.ts
+++ b/exporters/tokens/src/helpers/__tests__/specialCaseHelper.test.ts
@@ -23,11 +23,13 @@ describe('specialCaseHelper', () => {
 describe('handleInvariantTokens', () => {
   it('should return token alias for invariant case', () => {
     const token = exampleInvariantTokens.get('radiiRef') as Token;
+
     expect(getTokenAlias(token, false)).toBe('full');
   });
 
   it('should return token alias for non-invariant case', () => {
     const token = exampleDimensionAndStringTokens.get('dimensionRef') as Token;
+
     expect(getTokenAlias(token, false)).toBe('desktop');
   });
 });

--- a/exporters/tokens/src/objectProcessors/__tests__/globalObjectsProcessor.test.ts
+++ b/exporters/tokens/src/objectProcessors/__tests__/globalObjectsProcessor.test.ts
@@ -182,8 +182,10 @@ describe('globalObjectsProcessor', () => {
       const result = addGlobalTypographyToStylesObject(stylesObject, false);
 
       expect(result).toHaveProperty('$styles');
+
       // eslint-disable-next-line dot-notation -- $styles contains special character
       const stylesObj = result['$styles'] as { [key: string]: unknown } & { moveToTheEnd?: string };
+
       expect(stylesObj).toEqual({
         'heading-xlarge-bold': '$heading-xlarge-bold',
         'body-large': '$body-large',
@@ -202,7 +204,9 @@ describe('globalObjectsProcessor', () => {
       const result = addGlobalTypographyToStylesObject(stylesObject, true);
 
       expect(result).toHaveProperty('styles');
+
       const stylesObj = result.styles as { [key: string]: unknown } & { moveToTheEnd?: string };
+
       expect(stylesObj).toEqual({
         headingXlargeBold: 'headingXlargeBold',
         bodyLarge: 'bodyLarge',
@@ -242,8 +246,10 @@ describe('globalObjectsProcessor', () => {
       const result = addGlobalTypographyToStylesObject(stylesObject, false);
 
       expect(result).toHaveProperty('$styles');
+
       // eslint-disable-next-line dot-notation -- $styles contains special character
       const stylesObj = result['$styles'] as { [key: string]: unknown };
+
       expect(stylesObj).toHaveProperty('heading-xlarge-bold');
       expect(stylesObj).not.toHaveProperty('other-token');
       expect(stylesObj).not.toHaveProperty('not-typography');

--- a/exporters/tokens/src/objectProcessors/__tests__/nonTypographyObjectProcessor.test.ts
+++ b/exporters/tokens/src/objectProcessors/__tests__/nonTypographyObjectProcessor.test.ts
@@ -19,10 +19,14 @@ describe('nonTypographyObjectProcessor', () => {
       handleNonTypographyTokens(['Grid', 'spacing', 'desktop'], token, tokenGroups, true, stylesObject, false);
 
       expect(stylesObject).toHaveProperty('$grids');
+
       // eslint-disable-next-line dot-notation -- $grids contains special character
       const gridsObj = stylesObject['$grids'] as { [key: string]: unknown };
+
       expect(gridsObj).toHaveProperty('spacing');
+
       const spacingObj = gridsObj.spacing as { [key: string]: unknown };
+
       expect(spacingObj).toHaveProperty('desktop');
       expect(spacingObj.desktop).toBe('$grid-spacing-desktop');
     });
@@ -48,10 +52,14 @@ describe('nonTypographyObjectProcessor', () => {
       handleNonTypographyTokens(['Grid', 'spacing'], token, tokenGroups, true, stylesObject, false);
 
       expect(stylesObject).toHaveProperty('$grids');
+
       // eslint-disable-next-line dot-notation -- $grids contains special character
       const gridsObj = stylesObject['$grids'] as { [key: string]: unknown };
+
       expect(gridsObj).toHaveProperty('spacing');
+
       const spacingObj = gridsObj.spacing as { [key: string]: unknown };
+
       expect(spacingObj).toHaveProperty('mobile');
       expect(spacingObj.mobile).toBe('$grid-spacing-spacing-mobile');
     });
@@ -63,8 +71,10 @@ describe('nonTypographyObjectProcessor', () => {
       handleNonTypographyTokens(['Grid', 'Columns'], token, tokenGroups, true, stylesObject, false);
 
       expect(stylesObject).toHaveProperty('$grids');
+
       // eslint-disable-next-line dot-notation -- $grids contains special character
       const gridsObj = stylesObject['$grids'] as { [key: string]: unknown };
+
       expect(gridsObj).toHaveProperty('columns');
       expect(gridsObj.columns).toBe('$grid-columns');
     });
@@ -77,9 +87,13 @@ describe('nonTypographyObjectProcessor', () => {
 
       expect(stylesObject).toHaveProperty('grids');
       expect(stylesObject).not.toHaveProperty('$grids');
+
       const gridsObj = stylesObject.grids as { [key: string]: unknown };
+
       expect(gridsObj).toHaveProperty('spacing');
+
       const spacingObj = gridsObj.spacing as { [key: string]: unknown };
+
       expect(spacingObj.desktop).toBe('gridSpacingDesktop');
     });
 
@@ -142,9 +156,11 @@ describe('nonTypographyObjectProcessor', () => {
       handleNonTypographyTokens(['Grid', 'spacing', 'desktop'], token, tokenGroups, false, stylesObject, false);
 
       expect(stylesObject).toHaveProperty('$grids');
+
       // eslint-disable-next-line dot-notation -- $grids contains special character
       const gridsObj = stylesObject['$grids'] as { [key: string]: unknown };
       const spacingObj = gridsObj.spacing as { [key: string]: unknown };
+
       expect(spacingObj.desktop).toBe('$desktop');
     });
   });

--- a/exporters/tokens/src/objectProcessors/__tests__/typographyObjectProcessor.test.ts
+++ b/exporters/tokens/src/objectProcessors/__tests__/typographyObjectProcessor.test.ts
@@ -116,7 +116,9 @@ describe('typographyObjectProcessor', () => {
       );
 
       expect(stylesObject).toHaveProperty('$heading-xlarge-bold');
+
       const typographyObj = stylesObject['$heading-xlarge-bold'] as { [key: string]: unknown };
+
       expect(typographyObj).toHaveProperty('mobile');
       // Desktop might not be present if device dimensions don't include it
       expect(Object.keys(typographyObj).length).toBeGreaterThan(0);
@@ -143,6 +145,7 @@ describe('typographyObjectProcessor', () => {
       );
 
       expect(stylesObject).toHaveProperty('$heading-xlarge-bold');
+
       const typographyObj = stylesObject['$heading-xlarge-bold'] as { [key: string]: unknown };
 
       expect(Object.keys(typographyObj).length).toBeGreaterThan(0);
@@ -165,6 +168,7 @@ describe('typographyObjectProcessor', () => {
       handleTypographyTokens(['Heading', 'XLarge', 'Bold-Italic'], token, tokenGroups, true, stylesObject, false);
 
       expect(stylesObject).toHaveProperty('$heading-xlarge-bold-italic');
+
       const typographyObj = stylesObject['$heading-xlarge-bold-italic'] as { [key: string]: unknown };
       const mobileValue = typographyObj.mobile as string;
 

--- a/exporters/tokens/src/transformers/__tests__/tokensTransformer.test.ts
+++ b/exporters/tokens/src/transformers/__tests__/tokensTransformer.test.ts
@@ -59,6 +59,7 @@ describe('tokensTransformer', () => {
       const result = transformToMap([token]);
 
       const retrievedToken = result.get('token-1');
+
       expect(retrievedToken).toBe(token);
       expect(retrievedToken).toEqual(token);
     });

--- a/packages/analytics/src/helpers/__tests__/versions.test.ts
+++ b/packages/analytics/src/helpers/__tests__/versions.test.ts
@@ -29,6 +29,7 @@ describe('versions', () => {
 
       const pathToFolder = '/path/to/folder';
       const version = await getVersions(pathToFolder);
+
       expect(version).toBe('^1.2.0-beta.1');
     });
 
@@ -39,6 +40,7 @@ describe('versions', () => {
 
       const pathToFolder = '/path/to/folder';
       const version = await getVersions(pathToFolder);
+
       expect(version).toBe('');
     });
 
@@ -56,6 +58,7 @@ describe('versions', () => {
 
       const pathToFolder = '/path/to/folder';
       const version = await getVersions(pathToFolder);
+
       expect(version).toBe('1.0.0');
     });
   });

--- a/packages/common/src/utilities/__tests__/info.test.ts
+++ b/packages/common/src/utilities/__tests__/info.test.ts
@@ -28,6 +28,7 @@ describe('info', () => {
     info(falsyValue, message);
 
     expect(console.info).toHaveBeenCalledWith(`Info: ${message}`);
+
     // @ts-expect-error - mocking console.info
     console.info.mockClear();
   });

--- a/packages/common/src/utilities/__tests__/warning.test.ts
+++ b/packages/common/src/utilities/__tests__/warning.test.ts
@@ -31,6 +31,7 @@ describe('warning', () => {
     warning(falsyValue, message);
 
     expect(console.warn).toHaveBeenCalledWith(`Warning: ${message}`);
+
     // @ts-expect-error - mocking console.warn
     console.warn.mockClear();
   });

--- a/packages/web-react/src/common/utilities/__tests__/info.test.ts
+++ b/packages/web-react/src/common/utilities/__tests__/info.test.ts
@@ -29,6 +29,7 @@ describe('info', () => {
     info(falsyValue, message);
 
     expect(console.info).toHaveBeenCalledWith(`Info: ${message}`);
+
     // @ts-expect-error - mocking console.info
     console.info.mockClear();
   });

--- a/packages/web-react/src/common/utilities/__tests__/warning.test.ts
+++ b/packages/web-react/src/common/utilities/__tests__/warning.test.ts
@@ -32,6 +32,7 @@ describe('warning', () => {
     warning(falsyValue, message);
 
     expect(console.warn).toHaveBeenCalledWith(`Warning: ${message}`);
+
     // @ts-expect-error - mocking console.warn
     console.warn.mockClear();
   });

--- a/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
+++ b/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
@@ -33,6 +33,7 @@ describe('Alert', () => {
     const dom = render(<Alert />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element).toHaveClass('Alert--success');
   });
 
@@ -40,6 +41,7 @@ describe('Alert', () => {
     const dom = render(<Alert>Hello World</Alert>);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 
@@ -47,6 +49,7 @@ describe('Alert', () => {
     const dom = render(<Alert>Hello World</Alert>);
 
     const element = dom.container.querySelector('svg') as SVGSVGElement;
+
     expect(element).toBeInTheDocument();
   });
 });

--- a/packages/web-react/src/components/Button/__tests__/Button.test.tsx
+++ b/packages/web-react/src/components/Button/__tests__/Button.test.tsx
@@ -42,6 +42,7 @@ describe('Button', () => {
     const dom = render(<Button />);
 
     const element = dom.container.querySelector('button') as HTMLElement;
+
     expect(element).toHaveClass('Button--primary');
   });
 
@@ -49,6 +50,7 @@ describe('Button', () => {
     const dom = render(<Button>Hello World</Button>);
 
     const element = dom.container.querySelector('button') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 });

--- a/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
+++ b/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
@@ -42,6 +42,7 @@ describe('ButtonLink', () => {
     render(<ButtonLink />);
 
     const element = screen.getByRole('button');
+
     expect(element).toHaveClass('Button--primary');
   });
 
@@ -49,6 +50,7 @@ describe('ButtonLink', () => {
     render(<ButtonLink isDisabled />);
 
     const element = screen.getByRole('button');
+
     expect(element).toHaveClass('Button');
     expect(element).toHaveClass('Button--disabled');
   });
@@ -57,6 +59,7 @@ describe('ButtonLink', () => {
     render(<ButtonLink isBlock />);
 
     const element = screen.getByRole('button');
+
     expect(element).toHaveClass('Button');
     expect(element).toHaveClass('Button--block');
   });
@@ -65,6 +68,7 @@ describe('ButtonLink', () => {
     render(<ButtonLink size="medium" />);
 
     const element = screen.getByRole('button');
+
     expect(element).toHaveClass('Button');
     expect(element).toHaveClass('Button--medium');
   });
@@ -73,6 +77,7 @@ describe('ButtonLink', () => {
     render(<ButtonLink>Hello World</ButtonLink>);
 
     const element = screen.getByRole('button');
+
     expect(element.textContent).toBe('Hello World');
   });
 
@@ -80,6 +85,7 @@ describe('ButtonLink', () => {
     render(<ButtonLink />);
 
     const element = screen.getByRole('button');
+
     expect(element).not.toHaveAttribute('type');
   });
 
@@ -87,6 +93,7 @@ describe('ButtonLink', () => {
     render(<ButtonLink rel="noopener" />);
 
     const element = screen.getByRole('button');
+
     expect(element).toHaveAttribute('rel', 'noopener');
   });
 
@@ -94,6 +101,7 @@ describe('ButtonLink', () => {
     render(<ButtonLink target="_blank" />);
 
     const element = screen.getByRole('button');
+
     expect(element).toHaveAttribute('target', '_blank');
   });
 });

--- a/packages/web-react/src/components/Field/__tests__/ValidationText.test.tsx
+++ b/packages/web-react/src/components/Field/__tests__/ValidationText.test.tsx
@@ -106,6 +106,7 @@ describe('ValidationText', () => {
       expect(screen.queryByRole('list')).toBeInTheDocument();
 
       const listItems = screen.getAllByRole('listitem');
+
       expect(listItems[0]).toHaveTextContent('updated validation text');
       expect(listItems[1]).toHaveTextContent('new validation text');
     });

--- a/packages/web-react/src/components/Grid/__tests__/GridItem.test.tsx
+++ b/packages/web-react/src/components/Grid/__tests__/GridItem.test.tsx
@@ -28,6 +28,7 @@ describe('Grid', () => {
     const dom = render(<GridItem>Hello World</GridItem>);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 
@@ -35,6 +36,7 @@ describe('Grid', () => {
     const dom = render(<GridItem columnStart={4} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-column-start')).toBe('4');
   });
 
@@ -42,6 +44,7 @@ describe('Grid', () => {
     const dom = render(<GridItem columnStart={{ mobile: 4 }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-column-start')).toBe('4');
   });
 
@@ -49,6 +52,7 @@ describe('Grid', () => {
     const dom = render(<GridItem columnStart={{ tablet: 4 }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-column-start-tablet')).toBe('4');
   });
 
@@ -56,6 +60,7 @@ describe('Grid', () => {
     const dom = render(<GridItem columnStart={{ desktop: 4 }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-column-start-desktop')).toBe('4');
   });
 
@@ -63,6 +68,7 @@ describe('Grid', () => {
     const dom = render(<GridItem columnEnd={4} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-column-end')).toBe('4');
   });
 
@@ -70,6 +76,7 @@ describe('Grid', () => {
     const dom = render(<GridItem columnEnd={{ mobile: 4 }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-column-end')).toBe('4');
   });
 
@@ -77,6 +84,7 @@ describe('Grid', () => {
     const dom = render(<GridItem columnEnd={{ tablet: 4 }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-column-end-tablet')).toBe('4');
   });
 
@@ -84,6 +92,7 @@ describe('Grid', () => {
     const dom = render(<GridItem columnEnd={{ desktop: 4 }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-column-end-desktop')).toBe('4');
   });
 
@@ -91,6 +100,7 @@ describe('Grid', () => {
     const dom = render(<GridItem columnEnd="span 4" />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-column-end')).toBe('span 4');
   });
 
@@ -98,6 +108,7 @@ describe('Grid', () => {
     const dom = render(<GridItem columnEnd={{ mobile: 'span 4' }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-column-end')).toBe('span 4');
   });
 
@@ -105,6 +116,7 @@ describe('Grid', () => {
     const dom = render(<GridItem columnEnd={{ tablet: 'span 4' }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-column-end-tablet')).toBe('span 4');
   });
 
@@ -112,6 +124,7 @@ describe('Grid', () => {
     const dom = render(<GridItem columnEnd={{ desktop: 'span 4' }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-column-end-desktop')).toBe('span 4');
   });
 
@@ -119,6 +132,7 @@ describe('Grid', () => {
     const dom = render(<GridItem columnStart={1} columnEnd={2} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-column-start')).toBe('1');
     expect(element.style.getPropertyValue('--grid-item-column-end')).toBe('2');
   });
@@ -129,6 +143,7 @@ describe('Grid', () => {
     );
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-column-start')).toBe('1');
     expect(element.style.getPropertyValue('--grid-item-column-start-tablet')).toBe('2');
     expect(element.style.getPropertyValue('--grid-item-column-start-desktop')).toBe('3');
@@ -141,6 +156,7 @@ describe('Grid', () => {
     const dom = render(<GridItem rowStart={4} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-row-start')).toBe('4');
   });
 
@@ -148,6 +164,7 @@ describe('Grid', () => {
     const dom = render(<GridItem rowStart={{ mobile: 4 }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-row-start')).toBe('4');
   });
 
@@ -155,6 +172,7 @@ describe('Grid', () => {
     const dom = render(<GridItem rowStart={{ tablet: 4 }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-row-start-tablet')).toBe('4');
   });
 
@@ -162,6 +180,7 @@ describe('Grid', () => {
     const dom = render(<GridItem rowStart={{ desktop: 4 }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-row-start-desktop')).toBe('4');
   });
 
@@ -169,6 +188,7 @@ describe('Grid', () => {
     const dom = render(<GridItem rowEnd={4} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-row-end')).toBe('4');
   });
 
@@ -176,6 +196,7 @@ describe('Grid', () => {
     const dom = render(<GridItem rowEnd={{ mobile: 4 }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-row-end')).toBe('4');
   });
 
@@ -183,6 +204,7 @@ describe('Grid', () => {
     const dom = render(<GridItem rowEnd={{ tablet: 4 }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-row-end-tablet')).toBe('4');
   });
 
@@ -190,6 +212,7 @@ describe('Grid', () => {
     const dom = render(<GridItem rowEnd={{ desktop: 4 }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-row-end-desktop')).toBe('4');
   });
 
@@ -197,6 +220,7 @@ describe('Grid', () => {
     const dom = render(<GridItem rowEnd="span 4" />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-row-end')).toBe('span 4');
   });
 
@@ -204,6 +228,7 @@ describe('Grid', () => {
     const dom = render(<GridItem rowEnd={{ mobile: 'span 4' }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-row-end')).toBe('span 4');
   });
 
@@ -211,6 +236,7 @@ describe('Grid', () => {
     const dom = render(<GridItem rowEnd={{ tablet: 'span 4' }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-row-end-tablet')).toBe('span 4');
   });
 
@@ -218,6 +244,7 @@ describe('Grid', () => {
     const dom = render(<GridItem rowEnd={{ desktop: 'span 4' }} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-row-end-desktop')).toBe('span 4');
   });
 
@@ -225,6 +252,7 @@ describe('Grid', () => {
     const dom = render(<GridItem rowStart={1} rowEnd={2} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-row-start')).toBe('1');
     expect(element.style.getPropertyValue('--grid-item-row-end')).toBe('2');
   });
@@ -235,6 +263,7 @@ describe('Grid', () => {
     );
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-row-start')).toBe('1');
     expect(element.style.getPropertyValue('--grid-item-row-start-tablet')).toBe('2');
     expect(element.style.getPropertyValue('--grid-item-row-start-desktop')).toBe('3');
@@ -247,6 +276,7 @@ describe('Grid', () => {
     const dom = render(<GridItem columnStart={1} columnEnd={2} rowStart={1} rowEnd={2} />);
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.style.getPropertyValue('--grid-item-column-start')).toBe('1');
     expect(element.style.getPropertyValue('--grid-item-column-end')).toBe('2');
     expect(element.style.getPropertyValue('--grid-item-row-start')).toBe('1');

--- a/packages/web-react/src/components/Header/__tests__/Header.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/Header.test.tsx
@@ -25,6 +25,7 @@ describe('Header', () => {
     const dom = render(<Header id="test">Hello World</Header>);
 
     const element = dom.container.querySelector('header') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 });

--- a/packages/web-react/src/components/Header/__tests__/HeaderButton.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderButton.test.tsx
@@ -25,6 +25,7 @@ describe('HeaderButton', () => {
     const dom = render(<HeaderButton id="test">Hello World</HeaderButton>);
 
     const element = dom.container.querySelector('button') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 });

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialog.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialog.test.tsx
@@ -29,6 +29,7 @@ describe('HeaderDialog', () => {
     );
 
     const element = dom.container.querySelector('dialog') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 });

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogActions.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogActions.test.tsx
@@ -28,6 +28,7 @@ describe('HeaderDialogActions', () => {
     const dom = render(<HeaderDialogActions id="test">Hello World</HeaderDialogActions>);
 
     const element = dom.container.querySelector('nav') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 });

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogButton.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogButton.test.tsx
@@ -28,6 +28,7 @@ describe('HeaderDialogButton', () => {
     const dom = render(<HeaderDialogButton id="test">Hello World</HeaderDialogButton>);
 
     const element = dom.container.querySelector('button') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 });

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogCloseButton.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogCloseButton.test.tsx
@@ -30,6 +30,7 @@ describe('HeaderDialogCloseButton', () => {
     const dom = render(<HeaderDialogCloseButton id="test" label="Hello World" />);
 
     const element = dom.container.querySelector('button') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 });

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogLink.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogLink.test.tsx
@@ -31,6 +31,7 @@ describe('HeaderDialogLink', () => {
     const dom = render(<HeaderDialogLink id="test">Hello World</HeaderDialogLink>);
 
     const element = dom.container.querySelector('a') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 });

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogNav.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogNav.test.tsx
@@ -28,6 +28,7 @@ describe('HeaderDialogNav', () => {
     const dom = render(<HeaderDialogNav id="test">Hello World</HeaderDialogNav>);
 
     const element = dom.container.querySelector('ul') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 });

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogNavItem.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogNavItem.test.tsx
@@ -28,6 +28,7 @@ describe('HeaderDialogNavItem', () => {
     const dom = render(<HeaderDialogNavItem id="test">Hello World</HeaderDialogNavItem>);
 
     const element = dom.container.querySelector('li') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 });

--- a/packages/web-react/src/components/Header/__tests__/HeaderDialogText.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderDialogText.test.tsx
@@ -28,6 +28,7 @@ describe('HeaderDialogText', () => {
     const dom = render(<HeaderDialogText id="test">Hello World</HeaderDialogText>);
 
     const element = dom.container.querySelector('span') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 });

--- a/packages/web-react/src/components/Header/__tests__/HeaderLink.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderLink.test.tsx
@@ -28,6 +28,7 @@ describe('HeaderLink', () => {
     const dom = render(<HeaderLink id="test">Hello World</HeaderLink>);
 
     const element = dom.container.querySelector('a') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 });

--- a/packages/web-react/src/components/Header/__tests__/HeaderMobileActions.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderMobileActions.test.tsx
@@ -35,6 +35,7 @@ describe('HeaderMobileActions', () => {
     );
 
     const element = dom.container.querySelector('div') as HTMLElement;
+
     expect(element.textContent).toBe(`Hello World${HEADER_MENU_TOGGLE_LABEL_DEFAULT}`);
   });
 });

--- a/packages/web-react/src/components/Header/__tests__/HeaderNav.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderNav.test.tsx
@@ -25,6 +25,7 @@ describe('HeaderNav', () => {
     const dom = render(<HeaderNav id="test">Hello World</HeaderNav>);
 
     const element = dom.container.querySelector('ul') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 });

--- a/packages/web-react/src/components/Header/__tests__/HeaderNavItem.test.tsx
+++ b/packages/web-react/src/components/Header/__tests__/HeaderNavItem.test.tsx
@@ -25,6 +25,7 @@ describe('HeaderNavItem', () => {
     const dom = render(<HeaderNavItem id="test">Hello World</HeaderNavItem>);
 
     const element = dom.container.querySelector('li') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 });

--- a/packages/web-react/src/components/Item/__tests__/useItemStyleProps.test.ts
+++ b/packages/web-react/src/components/Item/__tests__/useItemStyleProps.test.ts
@@ -44,11 +44,13 @@ describe('useItemStyleProps', () => {
     const { result: iconResult } = renderHook(() =>
       useItemStyleProps({ isSelected: true, selectionDecorator: 'icon' } as SpiritItemProps),
     );
+
     expect(iconResult.current.classProps.root).toBe('Item');
 
     const { result: bothResult } = renderHook(() =>
       useItemStyleProps({ isSelected: true, selectionDecorator: 'both' } as SpiritItemProps),
     );
+
     expect(bothResult.current.classProps.root).toBe('Item Item--selected');
   });
 });

--- a/packages/web-react/src/components/Modal/__tests__/ModalCloseButton.test.tsx
+++ b/packages/web-react/src/components/Modal/__tests__/ModalCloseButton.test.tsx
@@ -36,6 +36,7 @@ describe('ModalCloseButton', () => {
     render(<ModalCloseButton label="close" id="test" isOpen onClose={() => {}} />);
 
     const buttonText = screen.getByRole('button').lastElementChild;
+
     expect(buttonText?.textContent).toBe('close');
     expect(buttonText).toHaveClass('accessibility-hidden');
   });

--- a/packages/web-react/src/components/Pagination/__tests__/UncontrolledPagination.test.tsx
+++ b/packages/web-react/src/components/Pagination/__tests__/UncontrolledPagination.test.tsx
@@ -17,9 +17,11 @@ describe('UncontrolledPagination', () => {
     );
 
     const items = screen.getAllByRole('button');
+
     expect(items).toHaveLength(2);
 
     const selectedPageItem = screen.getByText('test page 5').parentElement;
+
     expect(selectedPageItem).toHaveClass('Pagination__link Pagination__link--current');
   });
 
@@ -29,6 +31,7 @@ describe('UncontrolledPagination', () => {
     );
 
     const items = screen.getAllByRole('button');
+
     expect(items).toHaveLength(1);
 
     const firstPageItem = screen.getByText('test page 1').parentElement;
@@ -44,6 +47,7 @@ describe('UncontrolledPagination', () => {
     );
 
     const items = screen.getAllByRole('button');
+
     expect(items).toHaveLength(2);
 
     const nextPageItem = screen.getByText('test page 6');

--- a/packages/web-react/src/components/PricingPlan/__tests__/PricingPlanFeatureTitle.test.tsx
+++ b/packages/web-react/src/components/PricingPlan/__tests__/PricingPlanFeatureTitle.test.tsx
@@ -82,9 +82,11 @@ describe('PricingPlanFeatureTitle', () => {
       const tooltip = screen.getByRole('tooltip');
 
       fireEvent.click(trigger);
+
       expect(tooltip).not.toHaveClass('is-hidden');
 
       fireEvent.click(closeButton);
+
       expect(tooltip).toHaveClass('is-hidden');
     });
 
@@ -134,6 +136,7 @@ describe('PricingPlanFeatureTitle', () => {
       fireEvent.click(trigger);
 
       const modal = screen.getByRole('dialog');
+
       expect(modal).toHaveAttribute('id', 'tier-1-feature-3-modal');
     });
   });

--- a/packages/web-react/src/components/ScrollView/__tests__/ScrollView.test.tsx
+++ b/packages/web-react/src/components/ScrollView/__tests__/ScrollView.test.tsx
@@ -176,6 +176,7 @@ describe('ScrollView', () => {
       // First call cancels ongoing scroll (behavior: 'auto')
       const cancelScrollKey = Object.keys(expectedScroll)[0] as 'left' | 'top';
       const cancelScroll = { [cancelScrollKey]: 0, behavior: 'auto' as const };
+
       expect(scrollTo).toHaveBeenCalledWith(cancelScroll);
 
       // Advance timer to trigger the delayed scrollTo

--- a/packages/web-react/src/components/ScrollView/__tests__/useScrollCallback.test.ts
+++ b/packages/web-react/src/components/ScrollView/__tests__/useScrollCallback.test.ts
@@ -257,6 +257,7 @@ describe('useScrollCallback', () => {
 
       // First scroll - sets up timeout
       result.current.handleScroll(100);
+
       expect(scrollTo).toHaveBeenCalledTimes(1);
       expect(scrollTo).toHaveBeenCalledWith({ left: 0, behavior: 'auto' });
 
@@ -265,6 +266,7 @@ describe('useScrollCallback', () => {
 
       // Second scroll before first completes - should clear previous timeout and set new one
       result.current.handleScroll(100);
+
       expect(scrollTo).toHaveBeenCalledTimes(2);
       expect(scrollTo).toHaveBeenCalledWith({ left: 0, behavior: 'auto' });
       // Should still have only one timer (previous was cleared, new one set)
@@ -300,6 +302,7 @@ describe('useScrollCallback', () => {
 
       // Set up a timeout by calling handleScroll
       result.current.handleScroll(100);
+
       expect(scrollTo).toHaveBeenCalled();
 
       // Verify timeout was set

--- a/packages/web-react/src/components/SegmentedControl/__tests__/SegmentedControl.test.tsx
+++ b/packages/web-react/src/components/SegmentedControl/__tests__/SegmentedControl.test.tsx
@@ -55,11 +55,13 @@ describe('SegmentedControl', () => {
     (variant) => {
       it('should render label as visually hidden', () => {
         render(<ControlledSegmentedControl variant={variant}>Item</ControlledSegmentedControl>);
+
         expect(screen.getByText('Test label')).toBeInTheDocument();
       });
 
       it('should render children', () => {
         render(<ControlledSegmentedControl variant={variant}>Item</ControlledSegmentedControl>);
+
         expect(screen.getByText('Item')).toBeInTheDocument();
       });
 
@@ -69,6 +71,7 @@ describe('SegmentedControl', () => {
             Item
           </ControlledSegmentedControl>,
         );
+
         expect(screen.getByText('Item')).toHaveClass('SegmentedControl--fluid');
       });
 
@@ -174,6 +177,7 @@ describe('SegmentedControl', () => {
         expect(input2.checked).toBe(true);
 
         fireEvent.click(input1); // Should not change selection
+
         expect(input1.checked).toBe(false);
         expect(input2.checked).toBe(true);
       });

--- a/packages/web-react/src/components/Tabs/__tests__/TabLink.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabLink.test.tsx
@@ -25,6 +25,7 @@ describe('TabLink', () => {
     const dom = render(<TabLink href="https://www.example.com" />);
 
     const element = dom.container.querySelector('a') as HTMLElement;
+
     expect(element).toHaveClass('Tabs__link');
   });
 
@@ -36,6 +37,7 @@ describe('TabLink', () => {
     );
 
     const element = dom.container.querySelector('button') as HTMLElement;
+
     expect(element.textContent).toBe('Hello World');
   });
 });

--- a/packages/web-react/src/components/Tag/__tests__/Tag.test.tsx
+++ b/packages/web-react/src/components/Tag/__tests__/Tag.test.tsx
@@ -34,6 +34,7 @@ describe('Tag', () => {
     const dom = render(<Tag />);
 
     const element = dom.container.querySelector('span') as HTMLElement;
+
     expect(element).toHaveClass('Tag--neutral');
   });
 
@@ -41,6 +42,7 @@ describe('Tag', () => {
     const dom = render(<Tag>Tag</Tag>);
 
     const element = dom.container.querySelector('span') as HTMLElement;
+
     expect(element.textContent).toBe('Tag');
   });
 
@@ -48,6 +50,7 @@ describe('Tag', () => {
     const dom = render(<Tag color="neutral">333</Tag>);
 
     const element = dom.container.querySelector('span') as HTMLElement;
+
     expect(element).toHaveClass('Tag--neutral');
   });
 });

--- a/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
+++ b/packages/web-react/src/components/TextField/__tests__/TextField.test.tsx
@@ -120,7 +120,9 @@ describe('TextField', () => {
       const element = screen.getByLabelText('Label');
 
       expect(element).toHaveAttribute('type', 'password');
+
       fireEvent.click(screen.getByRole('switch'));
+
       expect(element).toHaveAttribute('type', 'text');
     });
 
@@ -128,7 +130,9 @@ describe('TextField', () => {
       const element = screen.getByRole('switch');
 
       expect(element).toHaveAttribute('aria-label', 'Show password');
+
       fireEvent.click(element);
+
       expect(element).toHaveAttribute('aria-label', 'Hide password');
     });
   });

--- a/packages/web-react/src/components/TextFieldBase/__tests__/TextFieldBase.test.tsx
+++ b/packages/web-react/src/components/TextFieldBase/__tests__/TextFieldBase.test.tsx
@@ -27,9 +27,11 @@ describe('TextFieldBase', () => {
       const dom = render(<TextFieldBase id="textfield-base" label="Label" type={type as TextFieldType} />);
 
       const labelElement = dom.container.querySelector('label') as HTMLElement;
+
       expect(labelElement).toHaveAttribute('for', 'textfield-base');
 
       const inputElement = dom.container.querySelector('input') as HTMLElement;
+
       expect(inputElement).toHaveAttribute('id', 'textfield-base');
     });
   });

--- a/packages/web-react/src/components/Truncate/__tests__/useTruncatedText.test.ts
+++ b/packages/web-react/src/components/Truncate/__tests__/useTruncatedText.test.ts
@@ -6,11 +6,13 @@ import { truncateByCharacters, truncateByLines, truncateByWords, useTruncatedTex
 describe('truncateByWords', () => {
   it('should truncate text by words', () => {
     const text = 'This is a very long text that should be truncated';
+
     expect(truncateByWords(text, 5)).toBe('This is a very long…');
   });
 
   it('should return original text if word count is less than limit', () => {
     const text = 'Short text';
+
     expect(truncateByWords(text, 10)).toBe('Short text');
   });
 
@@ -26,11 +28,13 @@ describe('truncateByWords', () => {
 describe('truncateByCharacters', () => {
   it('should truncate text by characters', () => {
     const text = 'This is a very long text';
+
     expect(truncateByCharacters(text, 10)).toBe('This is a …');
   });
 
   it('should return original text if character count is less than limit', () => {
     const text = 'Short';
+
     expect(truncateByCharacters(text, 10)).toBe('Short');
   });
 
@@ -42,6 +46,7 @@ describe('truncateByCharacters', () => {
 describe('truncateByLines', () => {
   it('should return original text unchanged', () => {
     const text = 'This is a text with multiple lines\nSecond line\nThird line';
+
     expect(truncateByLines(text)).toBe(text);
   });
 });
@@ -115,12 +120,15 @@ describe('useTruncatedText', () => {
     });
 
     const firstResult = result.current;
+
     expect(firstResult).toBe('This is a…');
 
     rerender({ mode: TruncateModes.WORDS, limit: 3 });
+
     expect(result.current).toBe(firstResult);
 
     rerender({ mode: TruncateModes.WORDS, limit: 4 });
+
     expect(result.current).toBe('This is a test…');
   });
 });

--- a/packages/web-react/src/components/UNSTABLE_Attachment/demo/__tests__/useFilePreviewUrl.test.ts
+++ b/packages/web-react/src/components/UNSTABLE_Attachment/demo/__tests__/useFilePreviewUrl.test.ts
@@ -22,6 +22,7 @@ describe('useFilePreviewUrl', () => {
     await waitFor(() => {
       expect(result.current).toBe('blob:mock-preview-url');
     });
+
     expect(URL.createObjectURL).toHaveBeenCalledWith(file);
   });
 
@@ -48,8 +49,11 @@ describe('useFilePreviewUrl', () => {
     await waitFor(() => {
       expect(result.current).toBe('blob:mock-preview-url');
     });
+
     expect(URL.createObjectURL).toHaveBeenCalledWith(file);
+
     unmount();
+
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-preview-url');
   });
 
@@ -72,6 +76,7 @@ describe('useFilePreviewUrl', () => {
     await waitFor(() => {
       expect(result.current).toBe('blob:url-b.png');
     });
+
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:url-a.png');
   });
 });

--- a/packages/web-react/src/components/UNSTABLE_FileUpload/demo/__tests__/useFileQueue.test.ts
+++ b/packages/web-react/src/components/UNSTABLE_FileUpload/demo/__tests__/useFileQueue.test.ts
@@ -118,6 +118,7 @@ describe('useFileQueue', () => {
     });
 
     const item = result.current.fileQueue.get('img1');
+
     expect(item?.label).toBe('test.png');
     expect(item?.previewUrl).toBeDefined();
     expect(typeof item?.previewUrl).toBe('string');

--- a/packages/web-react/src/components/UNSTABLE_FileUpload/demo/__tests__/useFileUploaderDemo.test.ts
+++ b/packages/web-react/src/components/UNSTABLE_FileUpload/demo/__tests__/useFileUploaderDemo.test.ts
@@ -38,12 +38,14 @@ describe('useFileUploaderDemo', () => {
     act(() => {
       result.current.onFilesSelected([file1]);
     });
+
     expect(result.current.items).toHaveLength(1);
     expect(result.current.items[0].label).toBe('a.txt');
 
     act(() => {
       result.current.onFilesSelected([file2]);
     });
+
     expect(result.current.items).toHaveLength(1);
     expect(result.current.items[0].label).toBe('b.txt');
   });
@@ -56,11 +58,13 @@ describe('useFileUploaderDemo', () => {
     act(() => {
       result.current.onFilesSelected([file1]);
     });
+
     expect(result.current.items).toHaveLength(1);
 
     act(() => {
       result.current.onFilesSelected([file2]);
     });
+
     expect(result.current.items).toHaveLength(2);
     expect(result.current.items[0].label).toBe('a.txt');
     expect(result.current.items[1].label).toBe('b.txt');
@@ -73,11 +77,13 @@ describe('useFileUploaderDemo', () => {
     act(() => {
       result.current.onFilesSelected([file]);
     });
+
     expect(result.current.items).toHaveLength(1);
 
     act(() => {
       result.current.onDismiss('file__x_txt');
     });
+
     expect(result.current.items).toHaveLength(0);
   });
 

--- a/packages/web-react/src/components/VisuallyHidden/__tests__/VisuallyHidden.test.tsx
+++ b/packages/web-react/src/components/VisuallyHidden/__tests__/VisuallyHidden.test.tsx
@@ -28,6 +28,7 @@ describe('Visually Hidden', () => {
     const dom = render(<VisuallyHidden>Label</VisuallyHidden>);
 
     const element = dom.container.querySelector('span') as HTMLElement;
+
     expect(element.className).toBe('accessibility-hidden');
     expect(element.textContent).toBe('Label');
   });

--- a/packages/web-react/src/hooks/__tests__/useDebouncedValue.test.ts
+++ b/packages/web-react/src/hooks/__tests__/useDebouncedValue.test.ts
@@ -16,9 +16,11 @@ describe('useDebouncedValue', () => {
     });
 
     expect(result.current).toBe('hello');
+
     act(() => {
       jest.advanceTimersByTime(500);
     });
+
     expect(result.current).toBe('hello');
   });
 
@@ -28,16 +30,19 @@ describe('useDebouncedValue', () => {
     });
 
     rerender({ value: 'b' });
+
     expect(result.current).toBe('a');
 
     act(() => {
       jest.advanceTimersByTime(199);
     });
+
     expect(result.current).toBe('a');
 
     act(() => {
       jest.advanceTimersByTime(1);
     });
+
     expect(result.current).toBe('b');
   });
 
@@ -67,6 +72,7 @@ describe('useDebouncedValue', () => {
     act(() => {
       jest.advanceTimersByTime(100);
     });
+
     expect(result.current).toBe('a');
 
     rerender({ value: 'c' });
@@ -74,11 +80,13 @@ describe('useDebouncedValue', () => {
     act(() => {
       jest.advanceTimersByTime(100);
     });
+
     expect(result.current).toBe('a');
 
     act(() => {
       jest.advanceTimersByTime(100);
     });
+
     expect(result.current).toBe('c');
   });
 
@@ -92,6 +100,7 @@ describe('useDebouncedValue', () => {
     act(() => {
       jest.advanceTimersByTime(100);
     });
+
     expect(result.current).toBe('y');
 
     rerender({ value: 'z', delay: 500 });
@@ -99,11 +108,13 @@ describe('useDebouncedValue', () => {
     act(() => {
       jest.advanceTimersByTime(100);
     });
+
     expect(result.current).toBe('y');
 
     act(() => {
       jest.advanceTimersByTime(400);
     });
+
     expect(result.current).toBe('z');
   });
 });

--- a/packages/web-react/src/hooks/__tests__/useStyleUtilities.test.ts
+++ b/packages/web-react/src/hooks/__tests__/useStyleUtilities.test.ts
@@ -366,6 +366,7 @@ describe('useStyleUtilities hook', () => {
       // all padding props should be passed through
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const restProps = result.current.props as Record<string, any>;
+
       expect(restProps.paddingX).toBe('space-100');
       expect(restProps.paddingY).toBe('space-200');
       expect(restProps.paddingTop).toBe('space-300');

--- a/packages/web-react/src/types/shared/__tests__/polymorphic.test.tsx
+++ b/packages/web-react/src/types/shared/__tests__/polymorphic.test.tsx
@@ -88,6 +88,7 @@ describe('PolymorphicComponentProps', () => {
       render(<TestButton>Default</TestButton>);
 
       const button = screen.getByTestId('test-button');
+
       expect(button.localName).toBe('button');
     });
 

--- a/packages/web-react/src/utils/__tests__/compose.test.ts
+++ b/packages/web-react/src/utils/__tests__/compose.test.ts
@@ -7,6 +7,7 @@ describe('#compose', () => {
     const fn3 = (x: number) => x + 3;
 
     const composed = compose(fn1, fn2, fn3);
+
     expect(composed(1)).toBe(9);
   });
 });

--- a/packages/web-react/src/utils/__tests__/htmlReactParser.test.ts
+++ b/packages/web-react/src/utils/__tests__/htmlReactParser.test.ts
@@ -46,6 +46,7 @@ describe('htmlReactParser', () => {
 
   it('returns string if it is not HTML', () => {
     const string = 'text';
+
     expect(htmlReactParser(string)).toBe(string);
   });
 
@@ -229,6 +230,7 @@ describe('htmlReactParser', () => {
 
     const decodedEntities = "asdf & ÿ ü '";
     const reactElement = htmlReactParser(`<i>${encodedEntities}</i>`) as JSX.Element;
+
     expect(reactElement.props.children).toBe(decodedEntities);
   });
 

--- a/packages/web-react/src/utils/__tests__/mergeStyleProps.test.tsx
+++ b/packages/web-react/src/utils/__tests__/mergeStyleProps.test.tsx
@@ -26,6 +26,7 @@ describe('mergeStyleProps', () => {
 
     it(`should merge class names and styles for ${label}`, () => {
       const result = mergeStyleProps(component, testProps);
+
       expect(result).toEqual({
         [classNameKey]: 'unsafe-test-class test-class',
         [styleKey]: { color: 'red', backgroundColor: 'blue', '--custom-var': '10px' },
@@ -40,6 +41,7 @@ describe('mergeStyleProps', () => {
         testStyle: {},
         testCustomVar: {},
       });
+
       expect(result).toEqual({
         [classNameKey]: '',
         [styleKey]: {},
@@ -51,6 +53,7 @@ describe('mergeStyleProps', () => {
         testUnsafeClass: testProps.testUnsafeClass,
         testClass: testProps.testClass,
       });
+
       expect(result).toEqual({
         [classNameKey]: 'unsafe-test-class test-class',
         [styleKey]: {},
@@ -63,6 +66,7 @@ describe('mergeStyleProps', () => {
         testStyle: testProps.testStyle,
         testCustomVar: testProps.testCustomVar,
       });
+
       expect(result).toEqual({
         [classNameKey]: '',
         [styleKey]: { color: 'red', backgroundColor: 'blue', '--custom-var': '10px' },

--- a/packages/web-react/src/utils/__tests__/string.test.ts
+++ b/packages/web-react/src/utils/__tests__/string.test.ts
@@ -16,6 +16,7 @@ describe('string', () => {
       ['themeLightDefault', 'theme-light-default'],
     ])('should convert camelCase string "%s" to kebab-case string "%s"', (input, expected) => {
       const result = camelCaseToKebabCase(input);
+
       expect(result).toEqual(expected);
     });
   });
@@ -30,6 +31,7 @@ describe('string', () => {
       ['kebab-case-test', 'kebabCaseTest'],
     ])('should convert kebab-case string "%s" to camelCase string "%s"', (input, expected) => {
       const result = kebabCaseToCamelCase(input);
+
       expect(result).toEqual(expected);
     });
   });
@@ -44,6 +46,7 @@ describe('string', () => {
       [{ test: 'kebab-case-test' }, { test: 'kebabCaseTest' }],
     ])('should convert kebab-case object "%s" to camelCase object "%s"', (input, expected) => {
       const result = kebabCaseToCamelCaseValues(input);
+
       expect(result).toEqual(expected);
     });
   });
@@ -60,6 +63,7 @@ describe('string', () => {
       [false, 'false'],
     ])('should normalize %s to %s', (input, expected) => {
       const result = normalizeStringValue(input);
+
       expect(result).toEqual(expected);
     });
   });
@@ -80,6 +84,7 @@ describe('string', () => {
       [{ test: 'kebab-case-test' }, { test: 'kebabCaseTest' }],
     ])('should convert kebab-case object "%s" to camelCase object "%s"', (input, expected) => {
       const result = stringOrObjectKebabCaseToCamelCase(input);
+
       expect(result).toEqual(expected);
     });
   });

--- a/packages/web-react/src/utils/__tests__/toPascalCase.test.ts
+++ b/packages/web-react/src/utils/__tests__/toPascalCase.test.ts
@@ -10,6 +10,7 @@ describe('string to pascal case', () => {
     ['kebab-case-test', 'KebabCaseTest'],
   ])('should convert kebab-case string "%s" to PascalCase string "%s"', (input, expected) => {
     const result = toPascalCase(input);
+
     expect(result).toBe(expected);
   });
 });

--- a/packages/web/src/js/__tests__/BaseComponent.test.ts
+++ b/packages/web/src/js/__tests__/BaseComponent.test.ts
@@ -89,6 +89,7 @@ describe('Base Component', () => {
     describe('dispose', () => {
       it('should dispose an component', () => {
         createInstance();
+
         expect(DummyClass.getInstance(element)).not.toBeNull();
 
         instance.dispose();

--- a/packages/web/src/js/__tests__/Collapse.test.ts
+++ b/packages/web/src/js/__tests__/Collapse.test.ts
@@ -78,6 +78,7 @@ describe('Collapse', () => {
       expect(target).toHaveClass(CLASS_NAME_TRANSITIONING);
 
       EventHandler.trigger(target, 'transitionend');
+
       expect(target).toHaveClass(CLASS_NAME_OPEN);
     });
 

--- a/packages/web/src/js/__tests__/FileUploader.test.ts
+++ b/packages/web/src/js/__tests__/FileUploader.test.ts
@@ -56,6 +56,7 @@ describe('FileUploader', () => {
     const fileUploaderEl = fixtureEl.querySelector('[data-spirit-toggle="fileUploader"]') as HTMLElement;
 
     const fileUploader = new FileUploader(fileUploaderEl);
+
     expect(fileUploader.getUpdatedFileName('test')).toBe('file_xjylrx_test');
 
     jest.spyOn(global.Math, 'random').mockRestore();
@@ -71,6 +72,7 @@ describe('FileUploader', () => {
     instance.addToQueue(file1);
     instance.addToQueue(file2);
     instance.clearFileQueue();
+
     expect(instance.getFileQueue.size).toBe(0);
   });
 
@@ -109,12 +111,14 @@ describe('FileUploader', () => {
     it('should read data-spirit-max-file-size attribute and set fileSizeLimit', () => {
       const fileUploaderEl = fixtureEl.querySelector('[data-spirit-toggle="fileUploader"]') as HTMLElement;
       const fileUploaderInstance = new FileUploader(fileUploaderEl);
+
       expect(fileUploaderInstance.fileSizeLimit).toBe(5000000);
     });
 
     it('should read data-spirit-file-queue-limit attribute and set fileQueueLimit', () => {
       const fileUploaderEl = fixtureEl.querySelector('[data-spirit-toggle="fileUploader"]') as HTMLElement;
       const fileUploaderInstance = new FileUploader(fileUploaderEl);
+
       expect(fileUploaderInstance.fileQueueLimit).toBe(5);
     });
 
@@ -126,6 +130,7 @@ describe('FileUploader', () => {
       `;
       const fileUploaderEl = fixtureEl.querySelector('[data-spirit-toggle="fileUploader"]') as HTMLElement;
       const fileUploaderInstance = new FileUploader(fileUploaderEl);
+
       expect(fileUploaderInstance.fileSizeLimit).toBe(10000000); // Default file size limit
       expect(fileUploaderInstance.fileQueueLimit).toBe(1); // Default file queue limit
     });
@@ -155,11 +160,13 @@ describe('FileUploader', () => {
     describe('checkAllowedFileType()', () => {
       it('should allow a supported file type', () => {
         const file = new File(['content'], 'example.jpg', { type: 'image/jpeg' });
+
         expect(() => fileUploader.checkAllowedFileType(file)).not.toThrow();
       });
 
       it('should throw an error for an unsupported file type', () => {
         const file = new File(['content'], 'example.txt', { type: 'text/plain' });
+
         expect(() => fileUploader.checkAllowedFileType(file)).toThrow(
           `example.txt: is not a supported file. Please ensure you are uploading a supported file format`,
         );

--- a/packages/web/src/js/__tests__/Modal.test.ts
+++ b/packages/web/src/js/__tests__/Modal.test.ts
@@ -90,6 +90,7 @@ describe('Modal', () => {
       const modal = new Modal(modalEl);
 
       modal.show();
+
       expect(modalEl.classList.contains('is-open')).toBe(true);
 
       const event = new Event('click');

--- a/packages/web/src/js/__tests__/Offcanvas.test.ts
+++ b/packages/web/src/js/__tests__/Offcanvas.test.ts
@@ -58,6 +58,7 @@ describe('Offcanvas', () => {
 
       offCanvasEl.addEventListener('shown.offcanvas', () => {
         expect(offCanvasEl).toHaveClass('is-open');
+
         const spy = jest.spyOn(offCanvas, 'hide');
 
         offCanvas.toggle(triggerEl);

--- a/packages/web/src/js/__tests__/Tabs.test.ts
+++ b/packages/web/src/js/__tests__/Tabs.test.ts
@@ -141,6 +141,7 @@ describe('Tabs', () => {
 
       triggerList[0].addEventListener('hide.tabs', (ev: MouseEvent) => {
         hideCalled = true;
+
         expect((ev.relatedTarget as HTMLElement)?.getAttribute('data-spirit-target')).toBe('#profile');
       });
 
@@ -263,6 +264,7 @@ describe('Tabs', () => {
 
       // @ts-ignore Argument of type 'Mock<any, any>' is not assignable to parameter of type 'HTMLElement'.
       tab.activate(null, spy);
+
       expect(spy).not.toHaveBeenCalled();
     });
   });
@@ -287,6 +289,7 @@ describe('Tabs', () => {
       expect(parent.getAttribute('role')).toBeNull();
       expect(tabEl.getAttribute('role')).toBeNull();
       expect(tabPanel.getAttribute('role')).toBeNull();
+
       Tabs.setInitialAttributes(parent, children);
 
       expect(parent.getAttribute('role')).toBe('tablist');
@@ -400,6 +403,7 @@ describe('Tabs', () => {
 
       tab1El.addEventListener('shown.tab', () => {
         expect(xTabs1El).toHaveClass('is-selected');
+
         tabNested2El.click();
       });
 

--- a/packages/web/src/js/__tests__/Tooltip.test.ts
+++ b/packages/web/src/js/__tests__/Tooltip.test.ts
@@ -131,6 +131,7 @@ describe('Tooltip', () => {
         tooltipEl.addEventListener('shown.tooltip', () => {
           expect(document.querySelector('.tooltip')).not.toBeNull();
           expect(spy).toHaveBeenCalledWith(expect.any(Object), 'mouseover', noop);
+
           document.documentElement.ontouchstart = undefined;
         });
 
@@ -204,10 +205,12 @@ describe('Tooltip', () => {
 
         setTimeout(() => {
           expect(tooltip.getTipElement()).toHaveClass('show');
+
           tooltipEl.dispatchEvent(createEvent('mouseout'));
 
           setTimeout(() => {
             expect(tooltip.getTipElement()).toHaveClass('show');
+
             tooltipEl.dispatchEvent(createEvent('mouseover'));
           }, 100);
 
@@ -282,6 +285,7 @@ describe('Tooltip', () => {
         tooltipEl.addEventListener('hidden.tooltip', () => {
           expect(document.querySelector('.tooltip')).toBeNull();
           expect(spy).toHaveBeenCalledWith(expect.any(Object), 'mouseover', noop);
+
           document.documentElement.ontouchstart = undefined;
         });
 

--- a/packages/web/src/js/common/utilities/__tests__/info.test.ts
+++ b/packages/web/src/js/common/utilities/__tests__/info.test.ts
@@ -29,6 +29,7 @@ describe('info', () => {
     info(falsyValue, message);
 
     expect(console.info).toHaveBeenCalledWith(`Info: ${message}`);
+
     // @ts-expect-error - mocking console.info
     console.info.mockClear();
   });

--- a/packages/web/src/js/common/utilities/__tests__/warning.test.ts
+++ b/packages/web/src/js/common/utilities/__tests__/warning.test.ts
@@ -32,6 +32,7 @@ describe('warning', () => {
     warning(falsyValue, message);
 
     expect(console.warn).toHaveBeenCalledWith(`Warning: ${message}`);
+
     // @ts-expect-error - mocking console.warn
     console.warn.mockClear();
   });

--- a/packages/web/src/js/dom/__tests__/Manipulator.test.ts
+++ b/packages/web/src/js/dom/__tests__/Manipulator.test.ts
@@ -19,6 +19,7 @@ describe('Manipulator', () => {
       const div = fixtureEl.querySelector('div') as HTMLDivElement;
 
       Manipulator.setDataAttribute(div, 'key', 'value');
+
       expect(div.getAttribute('data-spirit-key')).toBe('value');
     });
 
@@ -28,6 +29,7 @@ describe('Manipulator', () => {
       const div = fixtureEl.querySelector('div') as HTMLDivElement;
 
       Manipulator.setDataAttribute(div, 'testKey', 'value');
+
       expect(div.getAttribute('data-spirit-test-key')).toBe('value');
     });
   });
@@ -39,6 +41,7 @@ describe('Manipulator', () => {
       const div = fixtureEl.querySelector('div') as HTMLDivElement;
 
       Manipulator.removeDataAttribute(div, 'key');
+
       expect(div.getAttribute('data-spirit-key')).toBeNull();
       expect(div.getAttribute('data-key-spirit')).toBe('postfixed');
       expect(div.getAttribute('data-key')).toBe('value');
@@ -50,6 +53,7 @@ describe('Manipulator', () => {
       const div = fixtureEl.querySelector('div') as HTMLDivElement;
 
       Manipulator.removeDataAttribute(div, 'testKey');
+
       expect(div.getAttribute('data-spirit-test-key')).toBeNull();
     });
   });
@@ -111,9 +115,11 @@ describe('Manipulator', () => {
       expect(Manipulator.getDataAttribute(div, 'test')).toBeFalsy();
 
       div.setAttribute('data-spirit-test', 'true');
+
       expect(Manipulator.getDataAttribute(div, 'test')).toBeTruthy();
 
       div.setAttribute('data-spirit-test', '1');
+
       expect(Manipulator.getDataAttribute(div, 'test')).toBe(1);
     });
 
@@ -131,9 +137,11 @@ describe('Manipulator', () => {
       };
       const dataStr = JSON.stringify(objectData);
       div.setAttribute('data-spirit-test', encodeURIComponent(dataStr));
+
       expect(Manipulator.getDataAttribute(div, 'test')).toEqual(objectData);
 
       div.setAttribute('data-spirit-test', dataStr);
+
       expect(Manipulator.getDataAttribute(div, 'test')).toEqual(objectData);
     });
   });

--- a/packages/web/src/js/utils/__tests__/Config.test.ts
+++ b/packages/web/src/js/utils/__tests__/Config.test.ts
@@ -139,6 +139,7 @@ describe('Config', () => {
       };
 
       const obj = new DummyConfigClass();
+
       expect(() => {
         obj.typeCheckConfig(config);
       }).toThrow(

--- a/packages/web/src/js/utils/__tests__/index.test.ts
+++ b/packages/web/src/js/utils/__tests__/index.test.ts
@@ -93,6 +93,7 @@ describe('Util', () => {
       const div = fixtureEl.querySelector('div') as HTMLElement;
       const spy = jest.spyOn(div, 'offsetHeight', 'get').mockReturnValue(0);
       Util.reflow(div);
+
       expect(spy).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
