### PR TITLE
chore(ci): handle incorect sorting of review suggestions by Copilot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,7 +41,11 @@ Use [Conventional Comments](https://conventionalcomments.org/) for all findings.
 
 ### Finding Format
 
-When a code suggestion exists, place it first so reviewers see the fix immediately, and use GitHub’s PR review suggestion fence (` ```suggestion `), which allows reviewers to apply the fix with one click, but only in the "Apply suggestion" UX in PR review comments. When no code suggestion is possible, omit the code block::
+When a code suggestion exists, it **must appear as the very first element** — before the label line and before the `<details>` block. Use GitHub’s PR review suggestion fence (` ```suggestion `), which allows reviewers to apply the fix with one click. When no code suggestion is possible, omit the code block.
+
+**Order is mandatory.** Do not place the label, subject, or `<details>` block before the suggestion block.
+
+Correct format when a suggestion exists:
 
 ````markdown
 ```suggestion
@@ -57,6 +61,18 @@ When a code suggestion exists, place it first so reviewers see the fix immediate
   <br />
   <strong>Why:</strong> {why explanation}
 </details>
+````
+
+Incorrect — do not do this:
+
+````markdown
+**{label} ({decorations}):** {subject}
+
+<details>…</details>
+
+```suggestion
+{suggested code}
+```
 ````
 
 When there is no code suggestion:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Fixes the finding format in the Copilot code review instructions to enforce that `suggestion` code blocks always appear as the first element in a review comment.

Previously, the ordering rule was stated as "place it first" in a dependent clause mid-sentence, which was easy to overlook. Copilot was placing the label and `<details>` explanation block before the suggestion block instead of after it.

Changes:
- Strengthened the ordering rule: "must appear as the very first element — before the label line and before the `<details>` block"
- Added an explicit prohibition: "**Order is mandatory.** Do not place the label, subject, or `<details>` block before the suggestion block."
- Added a counter-example showing the incorrect order, clearly labelled "Incorrect — do not do this", to give Copilot a negative pattern to contrast against the correct format

### Additional context

The incorrect output that prompted this fix:

````
**issue (blocking):** {subject}

<details>…</details>

```suggestion
…
```
````

The suggestion block must come first so reviewers can use GitHub's one-click "Apply suggestion" UX without scrolling past the explanation.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->