### PR TITLE
refactor(web-react): remove TransferProps from components

### DIFF
--- a/apps/docsite/src/mdx-components.tsx
+++ b/apps/docsite/src/mdx-components.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck -- MDX intrinsic element props include LegacyRef (string refs), which conflicts with Spirit Heading ref typing when spreading MDX props.
 import { Heading, ScrollView, UNSTABLE_Table } from '@alma-oss/spirit-web-react';
 import type { MDXComponents } from 'mdx/types';
 

--- a/packages/web-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -14,15 +14,16 @@ const defaultProps: Partial<SpiritBreadcrumbsProps> = {
 
 const Breadcrumbs = <E extends ElementType = 'nav'>(props: SpiritBreadcrumbsProps<E>): JSX.Element => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const { children, elementType: ElementTag = 'nav', goBackTitle, items, ...restProps } = propsWithDefaults;
+  const { children, elementType, goBackTitle, items, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { classProps, props: modifiedProps } = useBreadcrumbsStyleProps({ ...restProps });
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps: classProps.root, styleProps });
+  const mergedStyleProps = mergeStyleProps(Component, { classProps: classProps.root, styleProps });
 
   const isLast = (index: number, itemsCount: number) => index === itemsCount - 1;
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps} aria-label="Breadcrumb">
+    <Component {...otherProps} {...mergedStyleProps} aria-label="Breadcrumb">
       <ol>
         {children ||
           items?.map((item, index) => (
@@ -38,10 +39,11 @@ const Breadcrumbs = <E extends ElementType = 'nav'>(props: SpiritBreadcrumbsProp
             </Fragment>
           ))}
       </ol>
-    </ElementTag>
+    </Component>
   );
 };
 
 Breadcrumbs.spiritComponent = 'Breadcrumbs';
+Breadcrumbs.displayName = 'Breadcrumbs';
 
 export default Breadcrumbs;

--- a/packages/web-react/src/components/Breadcrumbs/demo/BreadcrumbsCustom.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/demo/BreadcrumbsCustom.tsx
@@ -32,7 +32,7 @@ const BreadcrumbsCustom = () => {
 
         const linkParams = {
           underlined: isLastItem ? UNDERLINED_OPTIONS.HOVER : UNDERLINED_OPTIONS.ALWAYS,
-          'aria-current': isLastItem ? 'page' : undefined,
+          'aria-current': isLastItem ? ('page' as const) : undefined,
           color: isLastItem ? LinkColors.SECONDARY : LinkColors.PRIMARY,
         };
 

--- a/packages/web-react/src/components/Card/Card.tsx
+++ b/packages/web-react/src/components/Card/Card.tsx
@@ -15,25 +15,20 @@ const defaultProps: Partial<SpiritCardProps> = {
 
 const Card = <E extends ElementType = 'article'>(props: SpiritCardProps<E>) => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const {
-    elementType: ElementTag = 'article',
-    alignmentY,
-    direction,
-    isBoxed,
-    children,
-    ...restProps
-  } = propsWithDefaults;
+  const { elementType, alignmentY, direction, isBoxed, children, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { classProps } = useCardStyleProps({ alignmentY, direction, isBoxed });
   const { styleProps, props: otherProps } = useStyleProps(restProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps: classProps.root, styleProps, otherProps });
+  const mergedStyleProps = mergeStyleProps(Component, { classProps: classProps.root, styleProps, otherProps });
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       {children}
-    </ElementTag>
+    </Component>
   );
 };
 
 Card.spiritComponent = 'Card';
+Card.displayName = 'Card';
 
 export default Card;

--- a/packages/web-react/src/components/Card/CardTitle.tsx
+++ b/packages/web-react/src/components/Card/CardTitle.tsx
@@ -13,18 +13,20 @@ const defaultProps: Partial<SpiritCardTitleProps> = {
 
 const CardTitle = <E extends ElementType = 'h4'>(props: SpiritCardTitleProps<E>) => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const { elementType: ElementTag = 'h4', children, isHeading, ...restProps } = propsWithDefaults;
+  const { elementType, children, isHeading, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { classProps } = useCardStyleProps({ isHeading });
   const { styleProps, props: otherProps } = useStyleProps(restProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps: classProps.title, styleProps, otherProps });
+  const mergedStyleProps = mergeStyleProps(Component, { classProps: classProps.title, styleProps, otherProps });
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       {children}
-    </ElementTag>
+    </Component>
   );
 };
 
 CardTitle.spiritComponent = 'CardTitle';
+CardTitle.displayName = 'CardTitle';
 
 export default CardTitle;

--- a/packages/web-react/src/components/Collapse/Collapse.tsx
+++ b/packages/web-react/src/components/Collapse/Collapse.tsx
@@ -27,20 +27,16 @@ const defaultProps: Partial<SpiritCollapseProps> = {
 
 const Collapse = (props: SpiritCollapseProps) => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const {
-    elementType: ElementTag = defaultProps.elementType as ElementType,
-    children,
-    transitionDuration = TRANSITION_DURATION,
-    ...restProps
-  } = propsWithDefaults;
+  const { elementType, children, transitionDuration = TRANSITION_DURATION, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
 
-  const rootElementRef: MutableRefObject<HTMLDivElement | null> = useRef(null);
-  const collapseElementRef: MutableRefObject<HTMLDivElement | null> = useRef(null);
+  const rootElementRef: MutableRefObject<HTMLElement | null> = useRef(null);
+  const collapseElementRef: MutableRefObject<HTMLElement | null> = useRef(null);
   const collapseHeight = useResizeHeight(collapseElementRef);
 
   const { classProps, styleProps: collapseStyleProps } = useCollapseStyleProps(
     restProps.isOpen,
-    ElementTag,
+    Component,
     collapseHeight,
   );
   const { ariaProps, props: otherProps } = useCollapseAriaProps(restProps);
@@ -52,7 +48,7 @@ const Collapse = (props: SpiritCollapseProps) => {
   };
 
   // For inline elements, when open, render content outside the collapse element
-  const isInlineElement = ElementTag === 'span';
+  const isInlineElement = Component === 'span';
   if (isInlineElement && restProps.isOpen) {
     return children;
   }
@@ -60,10 +56,10 @@ const Collapse = (props: SpiritCollapseProps) => {
   return (
     <Transition in={restProps.isOpen} nodeRef={rootElementRef} timeout={transitionDuration}>
       {(transitionState: TransitionStatus) => (
-        <ElementTag
+        <Component
           {...transferProps}
           {...ariaProps.root}
-          {...mergeStyleProps(ElementTag, {
+          {...mergeStyleProps(Component, {
             classProps: classProps.root,
             styleProps,
             collapseStyleProps: mergedCollapseStyleProps,
@@ -71,15 +67,16 @@ const Collapse = (props: SpiritCollapseProps) => {
           })}
           ref={rootElementRef}
         >
-          <ElementTag ref={collapseElementRef} className={classProps.content}>
+          <Component ref={collapseElementRef} className={classProps.content}>
             {children}
-          </ElementTag>
-        </ElementTag>
+          </Component>
+        </Component>
       )}
     </Transition>
   );
 };
 
 Collapse.spiritComponent = 'Collapse';
+Collapse.displayName = 'Collapse';
 
 export default Collapse;

--- a/packages/web-react/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/web-react/src/components/Dropdown/DropdownTrigger.tsx
@@ -14,20 +14,22 @@ const defaultProps = {
 
 const DropdownTrigger = <E extends ElementType = 'button'>(props: DropdownTriggerProps<E>) => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const { elementType: ElementTag = 'button', children, ...rest } = propsWithDefaults;
+  const { elementType, children, ...rest } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { id, isOpen, onToggle, fullWidthMode, triggerRef } = useDropdownContext();
   const { classProps, props: modifiedProps } = useDropdownStyleProps({ isOpen, ...rest });
   const { styleProps: triggerStyleProps, props: transferProps } = useStyleProps(modifiedProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps: classProps.trigger, triggerStyleProps });
+  const mergedStyleProps = mergeStyleProps(Component, { classProps: classProps.trigger, triggerStyleProps });
   const { triggerProps } = useDropdownAriaProps({ id, isOpen, toggleHandler: onToggle, fullWidthMode });
 
   return (
-    <ElementTag {...transferProps} {...triggerProps} {...mergedStyleProps} ref={triggerRef}>
+    <Component {...transferProps} {...triggerProps} {...mergedStyleProps} ref={triggerRef}>
       {typeof children === 'function' ? children({ isOpen }) : children}
-    </ElementTag>
+    </Component>
   );
 };
 
 DropdownTrigger.spiritComponent = 'DropdownTrigger';
+DropdownTrigger.displayName = 'DropdownTrigger';
 
 export default DropdownTrigger;

--- a/packages/web-react/src/components/Field/HelperText.tsx
+++ b/packages/web-react/src/components/Field/HelperText.tsx
@@ -13,15 +13,10 @@ const defaultProps: Partial<HelperTextProps> = {
 
 const HelperText = <E extends ElementType = 'div'>(props: HelperTextProps<E>) => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const {
-    helperText,
-    elementType: ElementTag = defaultProps.elementType as ElementType,
-    id,
-    registerAria,
-    ...restProps
-  } = propsWithDefaults;
+  const { helperText, elementType, id, registerAria, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { styleProps, props: transferProps } = useStyleProps(restProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, { styleProps, transferProps });
+  const mergedStyleProps = mergeStyleProps(Component, { styleProps, transferProps });
 
   useEffect(() => {
     helperText && registerAria?.({ add: id });
@@ -33,9 +28,9 @@ const HelperText = <E extends ElementType = 'div'>(props: HelperTextProps<E>) =>
 
   if (helperText) {
     return (
-      <ElementTag {...transferProps} {...mergedStyleProps} id={id}>
+      <Component {...transferProps} {...mergedStyleProps} id={id}>
         {helperText}
-      </ElementTag>
+      </Component>
     );
   }
 
@@ -43,5 +38,6 @@ const HelperText = <E extends ElementType = 'div'>(props: HelperTextProps<E>) =>
 };
 
 HelperText.spiritComponent = 'HelperText';
+HelperText.displayName = 'HelperText';
 
 export default HelperText;

--- a/packages/web-react/src/components/Field/Label.tsx
+++ b/packages/web-react/src/components/Field/Label.tsx
@@ -5,22 +5,25 @@ import { useStyleProps } from '../../hooks';
 import { type SpiritLabelProps } from '../../types';
 import { mergeStyleProps } from '../../utils';
 
+const defaultProps: Partial<SpiritLabelProps> = {
+  elementType: 'label',
+};
+
 const Label = <E extends ElementType = 'label'>(props: SpiritLabelProps<E>): JSX.Element => {
-  const { elementType: ElementTag = 'label', children, htmlFor, for: labelFor, ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const { elementType, children, htmlFor, for: labelFor, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { styleProps, props: otherProps } = useStyleProps(restProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, { styleProps, otherProps });
+  const mergedStyleProps = mergeStyleProps(Component, { styleProps, otherProps });
 
   return (
-    <ElementTag
-      {...otherProps}
-      {...mergedStyleProps}
-      htmlFor={ElementTag === 'label' ? labelFor || htmlFor : undefined}
-    >
+    <Component {...otherProps} {...mergedStyleProps} htmlFor={Component === 'label' ? labelFor || htmlFor : undefined}>
       {children}
-    </ElementTag>
+    </Component>
   );
 };
 
 Label.spiritComponent = 'Label';
+Label.displayName = 'Label';
 
 export default Label;

--- a/packages/web-react/src/components/Field/ValidationText.tsx
+++ b/packages/web-react/src/components/Field/ValidationText.tsx
@@ -16,18 +16,12 @@ const defaultProps: Partial<ValidationTextProps> = {
 
 const ValidationText = <E extends ElementType = 'div'>(props: ValidationTextProps<E>) => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const {
-    elementType: ElementTag = defaultProps.elementType as ElementType,
-    id,
-    hasValidationStateIcon,
-    registerAria,
-    role,
-    validationText,
-    ...restProps
-  } = propsWithDefaults;
+  const { elementType, hasValidationStateIcon, id, registerAria, role, validationText, ...restProps } =
+    propsWithDefaults;
+  const Component = elementType as ElementType;
   const validationIconName = useValidationIcon({ hasValidationStateIcon });
   const { styleProps, props: transferProps } = useStyleProps(restProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, { styleProps, transferProps });
+  const mergedStyleProps = mergeStyleProps(Component, { styleProps, transferProps });
 
   useEffect(() => {
     validationText && registerAria?.({ add: id });
@@ -44,7 +38,7 @@ const ValidationText = <E extends ElementType = 'div'>(props: ValidationTextProp
   const nonArrayValidationText = hasValidationStateIcon ? <div>{validationText}</div> : validationText;
 
   return (
-    <ElementTag {...transferProps} {...mergedStyleProps} id={id} role={role}>
+    <Component {...transferProps} {...mergedStyleProps} id={id} role={role}>
       {hasValidationStateIcon && <Icon name={validationIconName} boxSize={20} />}
       {Array.isArray(validationText) ? (
         <ul>
@@ -55,10 +49,11 @@ const ValidationText = <E extends ElementType = 'div'>(props: ValidationTextProp
       ) : (
         nonArrayValidationText
       )}
-    </ElementTag>
+    </Component>
   );
 };
 
 ValidationText.spiritComponent = 'ValidationText';
+ValidationText.displayName = 'ValidationText';
 
 export default ValidationText;

--- a/packages/web-react/src/components/Field/__tests__/ValidationText.test.tsx
+++ b/packages/web-react/src/components/Field/__tests__/ValidationText.test.tsx
@@ -6,7 +6,7 @@ import { A11Y_ALERT_ROLE } from '../constants';
 import { type ValidationTextProps } from '../types';
 import ValidationText from '../ValidationText';
 
-const renderValidationText = <E extends ElementType = 'div'>(props: Partial<ValidationTextProps<E>>) =>
+const renderValidationText = (props: Partial<ValidationTextProps<ElementType>>) =>
   render(<ValidationText UNSAFE_className="ValidationText__validationText" {...props} />);
 
 describe('ValidationText', () => {
@@ -46,7 +46,7 @@ describe('ValidationText', () => {
   });
 
   it('should render as span element', () => {
-    renderValidationText<'span'>({
+    renderValidationText({
       validationText: ['validation text', 'another validation text'],
       elementType: 'span',
     });

--- a/packages/web-react/src/components/Field/types.ts
+++ b/packages/web-react/src/components/Field/types.ts
@@ -1,25 +1,25 @@
 import { type ElementType, type ReactNode } from 'react';
 import { type RegisterType } from '../../hooks/useAriaIdRefs';
-import { type ChildrenProps, type StyleProps, type TransferProps, type ValidationTextProp } from '../../types';
+import {
+  type ChildrenProps,
+  type PolymorphicComponentProps,
+  type StyleProps,
+  type ValidationTextProp,
+} from '../../types';
 
-export interface FieldElementTypeProps<E extends ElementType = 'div'> {
-  /**
-   * The HTML element or React element used to render the pill, e.g. 'div', 'span'.
-   *
-   * @default 'div'
-   */
-  elementType?: E;
-}
-
-export interface FieldProps<E extends ElementType = 'div'> extends FieldElementTypeProps<E> {
+/** ===== INTERNAL API ===== */
+export interface FieldBaseProps {
   id?: string;
   registerAria?: RegisterType;
 }
 
-export interface HelperTextProps<T extends ElementType = 'div'>
-  extends FieldProps<T>, StyleProps, ChildrenProps, TransferProps {
+export interface HelperTextBaseProps extends FieldBaseProps, StyleProps, ChildrenProps {
   helperText: ReactNode;
 }
 
-export interface ValidationTextProps<T extends ElementType = 'div'>
-  extends FieldProps<T>, ValidationTextProp, StyleProps, ChildrenProps, TransferProps {}
+export interface ValidationTextBaseProps extends FieldBaseProps, ValidationTextProp, StyleProps, ChildrenProps {}
+
+/** ===== PUBLIC API ===== */
+export type HelperTextProps<E extends ElementType = 'div'> = PolymorphicComponentProps<E, HelperTextBaseProps>;
+
+export type ValidationTextProps<E extends ElementType = 'div'> = PolymorphicComponentProps<E, ValidationTextBaseProps>;

--- a/packages/web-react/src/components/Heading/Heading.tsx
+++ b/packages/web-react/src/components/Heading/Heading.tsx
@@ -16,7 +16,8 @@ const Heading = <E extends ElementType = 'h1', S = void, Emph = void>(
   props: SpiritHeadingProps<E, S, Emph>,
 ): JSX.Element => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const { elementType: ElementTag, children, ...restProps } = propsWithDefaults;
+  const { elementType, children, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { classProps, props: modifiedProps } = useHeadingStyleProps({ ...restProps });
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps, {
     isTextBalanced: HeadingStyleProps.isTextBalanced,
@@ -24,16 +25,16 @@ const Heading = <E extends ElementType = 'h1', S = void, Emph = void>(
     textHyphens: TextStyleProps.textHyphens,
     textWordBreak: TextStyleProps.textWordBreak,
   });
-  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps, styleProps, otherProps });
+  const mergedStyleProps = mergeStyleProps(Component, { classProps, styleProps, otherProps });
 
   return (
-    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-    <ElementTag {...(otherProps as any)} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       {children}
-    </ElementTag>
+    </Component>
   );
 };
 
 Heading.spiritComponent = 'Heading';
+Heading.displayName = 'Heading';
 
 export default Heading;

--- a/packages/web-react/src/components/Heading/__tests__/useHeadingStyleProps.ts
+++ b/packages/web-react/src/components/Heading/__tests__/useHeadingStyleProps.ts
@@ -1,13 +1,12 @@
 import { renderHook } from '@testing-library/react';
-import { type ElementType } from 'react';
 import { Emphasis, SizesExtended, TextColors } from '../../../constants';
-import { type SpiritHeadingProps } from '../../../types';
+import { type HeadingProps } from '../../../types';
 import { useHeadingStyleProps } from '../useHeadingStyleProps';
 import headingSizeDataProvider from './headingSizeDataProvider';
 
 describe('useHeadingStyleProps', () => {
   it.each(headingSizeDataProvider)('should return typography heading class', (size, emphasis, expectedClassName) => {
-    const props = { emphasis, size } as SpiritHeadingProps<ElementType, void, void>;
+    const props = { emphasis, size } as HeadingProps;
     const { result } = renderHook(() => useHeadingStyleProps(props));
 
     expect(result.current.classProps).toBe(expectedClassName);
@@ -16,7 +15,7 @@ describe('useHeadingStyleProps', () => {
   it.each(Object.values(TextColors))('should return %s color class', (textColor) => {
     const emphasis = Emphasis.BOLD;
     const size = SizesExtended.MEDIUM;
-    const props = { emphasis, size, textColor } as SpiritHeadingProps<ElementType, void, void>;
+    const props = { emphasis, size, textColor } as HeadingProps;
     const { result } = renderHook(() => useHeadingStyleProps(props));
 
     expect(result.current.classProps).toBe(`typography-heading-${size}-${emphasis} text-${textColor}`);

--- a/packages/web-react/src/components/Heading/useHeadingStyleProps.ts
+++ b/packages/web-react/src/components/Heading/useHeadingStyleProps.ts
@@ -1,18 +1,8 @@
 import classNames from 'classnames';
-import { type ElementType } from 'react';
 import { useClassNamePrefix } from '../../hooks';
-import { type HeadingProps, type SpiritHeadingProps } from '../../types';
+import { type HeadingProps } from '../../types';
 
-export interface HeadingStyles<E extends ElementType> {
-  /** className props */
-  classProps: string | null;
-  /** props to be passed to the input element */
-  props: Omit<HeadingProps<E>, 'elementType'>;
-}
-
-export function useHeadingStyleProps<E extends ElementType, S = void, Emph = void>(
-  props: Omit<SpiritHeadingProps<E, S, Emph>, 'elementType'>,
-): HeadingStyles<E> {
+export function useHeadingStyleProps<S = void, Emph = void, C = void>(props: HeadingProps<S, Emph, C>) {
   const { emphasis, size, textColor, ...restProps } = props;
 
   const headingClass = useClassNamePrefix('typography-heading');

--- a/packages/web-react/src/components/InputDetails/InputDetails.tsx
+++ b/packages/web-react/src/components/InputDetails/InputDetails.tsx
@@ -40,5 +40,6 @@ const InputDetails = <E extends ElementType = 'div'>(props: InputDetailsProps<E>
 };
 
 InputDetails.spiritComponent = 'InputDetails';
+InputDetails.displayName = 'InputDetails';
 
 export default InputDetails;

--- a/packages/web-react/src/components/Item/Item.tsx
+++ b/packages/web-react/src/components/Item/Item.tsx
@@ -9,17 +9,16 @@ import { HelperText } from '../Field';
 import { Icon } from '../Icon';
 import { useItemStyleProps } from './useItemStyleProps';
 
+const defaultProps: Partial<SpiritItemProps> = {
+  elementType: 'button',
+  selectionDecorator: ITEM_SELECTION_DECORATOR_ICON,
+};
+
 const Item = <E extends ElementType = 'button'>(props: SpiritItemProps<E>): JSX.Element => {
-  const {
-    label,
-    elementType: ElementTag = 'button',
-    iconName,
-    helperText,
-    isSelected,
-    isDisabled,
-    selectionDecorator = ITEM_SELECTION_DECORATOR_ICON,
-    ...restProps
-  } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const { elementType, helperText, iconName, isDisabled, isSelected, label, selectionDecorator, ...restProps } =
+    propsWithDefaults;
+  const Component = elementType as ElementType;
   const { classProps, props: modifiedProps } = useItemStyleProps({
     isSelected,
     isDisabled,
@@ -27,14 +26,14 @@ const Item = <E extends ElementType = 'button'>(props: SpiritItemProps<E>): JSX.
     ...restProps,
   });
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps: classProps.root, styleProps, otherProps });
+  const mergedStyleProps = mergeStyleProps(Component, { classProps: classProps.root, styleProps, otherProps });
 
   const showSelectedIcon =
     isSelected &&
     (selectionDecorator === ITEM_SELECTION_DECORATOR_ICON || selectionDecorator === ITEM_SELECTION_DECORATOR_BOTH);
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps} disabled={!!isDisabled && ElementTag === 'button'}>
+    <Component {...otherProps} {...mergedStyleProps} disabled={!!isDisabled && Component === 'button'}>
       {iconName && (
         <span className={classNames(classProps.icon.root, classProps.icon.start)}>
           <Icon name={iconName} />
@@ -47,10 +46,11 @@ const Item = <E extends ElementType = 'button'>(props: SpiritItemProps<E>): JSX.
           <Icon name="check-plain" />
         </span>
       )}
-    </ElementTag>
+    </Component>
   );
 };
 
 Item.spiritComponent = 'Item';
+Item.displayName = 'Item';
 
 export default Item;

--- a/packages/web-react/src/components/Matrix/Matrix.tsx
+++ b/packages/web-react/src/components/Matrix/Matrix.tsx
@@ -25,7 +25,8 @@ const defaultProps: Partial<SpiritMatrixProps> = {
 const Matrix = <E extends ElementType = 'div'>(props: SpiritMatrixProps<E>) => {
   const propsWithDefaults = { ...defaultProps, ...props };
 
-  const { elementType: ElementTag = 'div', children, ...restProps } = propsWithDefaults;
+  const { elementType, children, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const itemsCount: number = Children.count(children);
   const {
     classProps,
@@ -36,15 +37,16 @@ const Matrix = <E extends ElementType = 'div'>(props: SpiritMatrixProps<E>) => {
     itemsCount,
   });
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps, styleProps, otherProps, matrixStyleProps });
+  const mergedStyleProps = mergeStyleProps(Component, { classProps, styleProps, otherProps, matrixStyleProps });
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       {children}
-    </ElementTag>
+    </Component>
   );
 };
 
 Matrix.spiritComponent = 'Matrix';
+Matrix.displayName = 'Matrix';
 
 export default Matrix;

--- a/packages/web-react/src/components/Matrix/__tests__/useMatrixStyleProps.test.tsx
+++ b/packages/web-react/src/components/Matrix/__tests__/useMatrixStyleProps.test.tsx
@@ -4,7 +4,7 @@ import { useDefaultResponsiveRowsStyle, useMatrixStyleProps } from '../useMatrix
 
 describe('useMatrixStyleProps', () => {
   it('should return default className', () => {
-    const props = {};
+    const props = { itemsCount: 0 };
     const { result } = renderHook(() => useMatrixStyleProps(props));
 
     expect(result.current.classProps).toBe('Matrix');
@@ -68,7 +68,7 @@ describe('useMatrixStyleProps', () => {
     ['rows', undefined, {}],
     ['itemRows', undefined, {}],
   ])('should return %s CSS properties', (propName, value, expectedStyle) => {
-    const props = value !== undefined ? { [propName]: value } : {};
+    const props = value !== undefined ? { [propName]: value, itemsCount: 0 } : { itemsCount: 0 };
     const { result } = renderHook(() => useMatrixStyleProps(props));
 
     expect(result.current.styleProps).toEqual(expectedStyle);

--- a/packages/web-react/src/components/Matrix/useMatrixStyleProps.ts
+++ b/packages/web-react/src/components/Matrix/useMatrixStyleProps.ts
@@ -1,9 +1,9 @@
 import { cssVariablePrefix } from '@alma-oss/spirit-design-tokens';
 import classNames from 'classnames';
-import { type CSSProperties, type ElementType } from 'react';
+import { type CSSProperties } from 'react';
 import { DirectionAxis } from '../../constants';
 import { type DimensionCSSProperties, useClassNamePrefix, useDimensionStyle, useSpacingStyle } from '../../hooks';
-import { type DimensionType, type SpiritMatrixProps } from '../../types';
+import { type DimensionType, type MatrixProps } from '../../types';
 import { MATRIX_ROWS_DEFAULT } from './constants';
 
 export interface MatrixStyles<T> {
@@ -14,6 +14,10 @@ export interface MatrixStyles<T> {
   /** Style props for the element */
   styleProps: CSSProperties;
 }
+
+export type UseMatrixStyleProps = MatrixProps & {
+  itemsCount: number;
+};
 
 /**
  * Generates default responsive row styles for the Matrix component.
@@ -45,9 +49,7 @@ export const useDefaultResponsiveRowsStyle = (
   return style;
 };
 
-export function useMatrixStyleProps(
-  props: SpiritMatrixProps<ElementType>,
-): MatrixStyles<SpiritMatrixProps<ElementType>> {
+export function useMatrixStyleProps(props: UseMatrixStyleProps): MatrixStyles<MatrixProps> {
   const { cols, itemsCount, itemRows, rows, spacing, spacingX, spacingY, ...restProps } = props;
 
   const matrixClass = useClassNamePrefix('Matrix');
@@ -57,7 +59,7 @@ export function useMatrixStyleProps(
     ...useDimensionStyle(cols, `${matrixPrefix}-columns`),
     ...useDimensionStyle(rows, `${matrixPrefix}-rows`),
     ...useDimensionStyle(itemRows, `${matrixPrefix}-item-rows`),
-    ...useDefaultResponsiveRowsStyle(cols, rows, itemsCount as number, matrixPrefix),
+    ...useDefaultResponsiveRowsStyle(cols, rows, itemsCount, matrixPrefix),
     ...useSpacingStyle(spacing, matrixPrefix, DirectionAxis.X),
     ...useSpacingStyle(spacing, matrixPrefix, DirectionAxis.Y),
     ...useSpacingStyle(spacingX, matrixPrefix, DirectionAxis.X),

--- a/packages/web-react/src/components/Navigation/demo/NavigationAvatarWithDropdown.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationAvatarWithDropdown.tsx
@@ -29,7 +29,7 @@ const NavigationAvatarWithDropdown = () => {
           onToggle={toggleDropdown}
         >
           <DropdownTrigger
-            elementType={NavigationAvatarAsDropdownTrigger as unknown as HTMLButtonElement}
+            elementType={NavigationAvatarAsDropdownTrigger}
             avatarContent={AVATAR_CONTENT}
             aria-label={AVATAR_ARIA_LABEL}
           >
@@ -48,7 +48,7 @@ const NavigationAvatarWithDropdown = () => {
           onToggle={toggleSquareDropdown}
         >
           <DropdownTrigger
-            elementType={NavigationAvatarAsDropdownTrigger as unknown as HTMLButtonElement}
+            elementType={NavigationAvatarAsDropdownTrigger}
             avatarContent={AVATAR_CONTENT}
             isSquare
             aria-label={AVATAR_ARIA_LABEL}

--- a/packages/web-react/src/components/Navigation/demo/NavigationHorizontalWithDropdown.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationHorizontalWithDropdown.tsx
@@ -34,7 +34,7 @@ const NavigationHorizontalWithDropdown = () => {
           isOpen={isNavigationActionDropdownOpen}
           onToggle={() => setIsNavigationActionDropdownOpen(!isNavigationActionDropdownOpen)}
         >
-          <DropdownTrigger elementType={NavigationActionAsDropdownTrigger as unknown as HTMLButtonElement}>
+          <DropdownTrigger elementType={NavigationActionAsDropdownTrigger}>
             Dropdown
             <Icon name={`chevron-${isNavigationActionDropdownOpen ? 'up' : 'down'}`} boxSize={20} />
           </DropdownTrigger>

--- a/packages/web-react/src/components/Pill/Pill.tsx
+++ b/packages/web-react/src/components/Pill/Pill.tsx
@@ -14,18 +14,20 @@ const defaultProps: Partial<SpiritPillProps> = {
 
 const Pill = <E extends ElementType = 'span', C = void>(props: SpiritPillProps<E, C>): JSX.Element => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const { elementType: ElementTag = 'span', children, ...restProps } = propsWithDefaults;
+  const { elementType, children, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { classProps, props: modifiedProps } = usePillStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps, styleProps, otherProps });
+  const mergedStyleProps = mergeStyleProps(Component, { classProps, styleProps, otherProps });
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       {children}
-    </ElementTag>
+    </Component>
   );
 };
 
 Pill.spiritComponent = 'Pill';
+Pill.displayName = 'Pill';
 
 export default Pill;

--- a/packages/web-react/src/components/Pill/usePillStyleProps.ts
+++ b/packages/web-react/src/components/Pill/usePillStyleProps.ts
@@ -1,16 +1,15 @@
 import classNames from 'classnames';
-import { type ElementType } from 'react';
 import { useClassNamePrefix } from '../../hooks';
-import { type SpiritPillProps } from '../../types';
+import { type PillProps } from '../../types';
 
-export interface PillStyles {
+export interface PillStyles<C = void> {
   /** className props */
   classProps: string;
   /** props to be passed to the element */
-  props: Partial<SpiritPillProps>;
+  props: Partial<PillProps<C>>;
 }
 
-export function usePillStyleProps<E extends ElementType = 'span', C = void>(props: SpiritPillProps<E, C>): PillStyles {
+export function usePillStyleProps<C = void>(props: PillProps<C>): PillStyles<C> {
   const { color, ...modifiedProps } = props;
 
   const pillClass = useClassNamePrefix('Pill');

--- a/packages/web-react/src/components/PricingPlan/PricingPlan.tsx
+++ b/packages/web-react/src/components/PricingPlan/PricingPlan.tsx
@@ -9,6 +9,7 @@ import { NUMBER_OF_PLAN_ROWS_DEFAULT } from './constants';
 import { usePricingPlanStyleProps } from './usePricingPlanStyleProps';
 
 const defaultProps: Partial<SpiritPricingPlanProps> = {
+  elementType: 'article',
   hasComparableFeatures: false,
   isHighlighted: false,
   rows: NUMBER_OF_PLAN_ROWS_DEFAULT,
@@ -16,23 +17,25 @@ const defaultProps: Partial<SpiritPricingPlanProps> = {
 
 const PricingPlan = <E extends ElementType = 'article'>(props: SpiritPricingPlanProps<E>) => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const { elementType: ElementTag = 'article', children, ...restProps } = propsWithDefaults;
+  const { elementType, children, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
 
   const { classProps, props: modifiedProps, styleProps: pricingPlanStyleProps } = usePricingPlanStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, {
+  const mergedStyleProps = mergeStyleProps(Component, {
     classProps: classProps.root,
     pricingPlanStyleProps,
     styleProps,
   });
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       <div className={classNames(classProps.layout)}>{children}</div>
-    </ElementTag>
+    </Component>
   );
 };
 
 PricingPlan.spiritComponent = 'PricingPlan';
+PricingPlan.displayName = 'PricingPlan';
 
 export default PricingPlan;

--- a/packages/web-react/src/components/PricingPlan/PricingPlanBody.tsx
+++ b/packages/web-react/src/components/PricingPlan/PricingPlanBody.tsx
@@ -9,25 +9,27 @@ import { usePricingPlanStyleProps } from './usePricingPlanStyleProps';
 
 const defaultProps: Partial<SpiritPricingPlanBodyProps> = {
   description: undefined,
+  elementType: 'div',
   features: [],
 };
 
 const PricingPlanBody = <E extends ElementType = 'div'>(props: SpiritPricingPlanBodyProps<E>) => {
   const propsWithDefaults = { ...defaultProps, ...props };
 
-  const { description, elementType: ElementTag = 'div', features = [], id, ...restProps } = propsWithDefaults;
+  const { description, elementType, features, id, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { classProps, props: modifiedProps } = usePricingPlanStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, {
+  const mergedStyleProps = mergeStyleProps(Component, {
     classProps: classProps.body.root,
     styleProps,
   });
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       {description && <div>{description}</div>}
       <ul className={classProps.body.featureList}>
-        {features.map((feature, featureIndex) => {
+        {(features ?? []).map((feature, featureIndex) => {
           const featureItemKey = `featureItem-${featureIndex}`;
           const featureId = `${id}-feature-${featureIndex}`;
 
@@ -39,7 +41,7 @@ const PricingPlanBody = <E extends ElementType = 'div'>(props: SpiritPricingPlan
           );
         })}
       </ul>
-    </ElementTag>
+    </Component>
   );
 };
 

--- a/packages/web-react/src/components/PricingPlan/PricingPlanFooter.tsx
+++ b/packages/web-react/src/components/PricingPlan/PricingPlanFooter.tsx
@@ -6,17 +6,23 @@ import type { SpiritPricingPlanFooterProps } from '../../types';
 import { mergeStyleProps } from '../../utils';
 import { usePricingPlanStyleProps } from './usePricingPlanStyleProps';
 
+const defaultProps: Partial<SpiritPricingPlanFooterProps> = {
+  elementType: 'footer',
+};
+
 const PricingPlanFooter = <E extends ElementType = 'footer'>(props: SpiritPricingPlanFooterProps<E>) => {
-  const { children, elementType: ElementTag = 'footer', ...restProps } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const { children, elementType, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
 
   const { classProps, props: modifiedProps } = usePricingPlanStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps: classProps.footer, styleProps });
+  const mergedStyleProps = mergeStyleProps(Component, { classProps: classProps.footer, styleProps });
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       {children}
-    </ElementTag>
+    </Component>
   );
 };
 

--- a/packages/web-react/src/components/PricingPlan/PricingPlanHeader.tsx
+++ b/packages/web-react/src/components/PricingPlan/PricingPlanHeader.tsx
@@ -10,6 +10,7 @@ import { usePricingPlanStyleProps } from './usePricingPlanStyleProps';
 const defaultProps: Partial<SpiritPricingPlanHeaderProps> = {
   action: undefined,
   badge: undefined,
+  elementType: 'header',
   note: undefined,
   price: undefined,
   subtitle: undefined,
@@ -18,18 +19,19 @@ const defaultProps: Partial<SpiritPricingPlanHeaderProps> = {
 
 const PricingPlanHeader = <E extends ElementType = 'header'>(props: SpiritPricingPlanHeaderProps<E>) => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const { elementType: ElementTag = 'header', ...restProps } = propsWithDefaults;
+  const { elementType, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
 
   const { classProps, props: modifiedProps } = usePricingPlanStyleProps(restProps);
   const { badge, title, subtitle, price, action, note } = propsWithDefaults;
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, {
+  const mergedStyleProps = mergeStyleProps(Component, {
     classProps: classProps.header.root,
     styleProps,
   });
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       {badge && <div className={classProps.header.badge}>{badge}</div>}
       <div className={classProps.header.content}>
         {title && <h3 className={classProps.header.title}>{title}</h3>}
@@ -38,7 +40,7 @@ const PricingPlanHeader = <E extends ElementType = 'header'>(props: SpiritPricin
         {action && <div className={classProps.header.action}>{action}</div>}
         {note && <div className={classProps.header.note}>{note}</div>}
       </div>
-    </ElementTag>
+    </Component>
   );
 };
 

--- a/packages/web-react/src/components/SegmentedControl/stories/SegmentedControl.stories.tsx
+++ b/packages/web-react/src/components/SegmentedControl/stories/SegmentedControl.stories.tsx
@@ -2,7 +2,7 @@ import { Markdown } from '@storybook/addon-docs/blocks';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React, { useEffect, useState } from 'react';
 import { FillVariants } from '../../../constants';
-import { type SegmentedControlProps } from '../../../types/segmentedControl';
+import { type SpiritSegmentedControlProps } from '../../../types/segmentedControl';
 import { Icon } from '../../Icon';
 import { VisuallyHidden } from '../../VisuallyHidden';
 import ReadMe from '../README.md?raw';
@@ -82,7 +82,7 @@ const meta: Meta<typeof SegmentedControl> = {
 export default meta;
 type Story = StoryObj<typeof SegmentedControl>;
 
-const SegmentedControlWithHooks = ({ name, label, children, ...args }: SegmentedControlProps) => {
+const SegmentedControlWithHooks = ({ name, label, children, ...args }: SpiritSegmentedControlProps) => {
   const defaultSingleValue = 'value-1';
   const defaultMultipleValue = ['value-1'];
 

--- a/packages/web-react/src/components/SegmentedControl/useSegmentedControlStyleProps.ts
+++ b/packages/web-react/src/components/SegmentedControl/useSegmentedControlStyleProps.ts
@@ -3,7 +3,7 @@ import { FillVariants } from '../../constants';
 import { useClassNamePrefix } from '../../hooks';
 import { type SpiritSegmentedControlProps } from '../../types/segmentedControl';
 
-export interface UseSegmentedControlStylesProps extends Omit<SpiritSegmentedControlProps, 'name'> {}
+export interface UseSegmentedControlStylesProps extends Partial<Omit<SpiritSegmentedControlProps, 'name'>> {}
 
 export interface UseSegmentedControlStylesReturn {
   /** className props */
@@ -13,7 +13,7 @@ export interface UseSegmentedControlStylesReturn {
     label: string;
   };
   /** props to be passed to the element */
-  props: Omit<SpiritSegmentedControlProps, 'name'>;
+  props: UseSegmentedControlStylesProps;
 }
 
 export const useSegmentedControlStyleProps = (

--- a/packages/web-react/src/components/Skeleton/SkeletonHeading.tsx
+++ b/packages/web-react/src/components/Skeleton/SkeletonHeading.tsx
@@ -16,10 +16,11 @@ const defaultProps: Partial<SpiritSkeletonProps> = {
 };
 const SkeletonHeading = <E extends ElementType = 'div', C = void>(props: SpiritSkeletonProps<E, C>): ReactElement => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const { elementType: ElementTag = 'div', lines, ...restProps } = propsWithDefaults;
+  const { elementType, lines, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { classProps, props: modifiedProps } = useSkeletonStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, {
+  const mergedStyleProps = mergeStyleProps(Component, {
     classProps: classProps.root,
     classPropsHeading: classProps.heading,
     styleProps,
@@ -28,14 +29,15 @@ const SkeletonHeading = <E extends ElementType = 'div', C = void>(props: SpiritS
   const linesToRender = [...Array(lines ?? LINES_COUNT_DEFAULT).keys()];
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       {linesToRender.map((lineNumber) => (
         <SkeletonItem key={`skeleton-item-${lineNumber.toString()}`} />
       ))}
-    </ElementTag>
+    </Component>
   );
 };
 
 SkeletonHeading.spiritComponent = 'SkeletonHeading';
+SkeletonHeading.displayName = 'SkeletonHeading';
 
 export default SkeletonHeading;

--- a/packages/web-react/src/components/Skeleton/SkeletonShape.tsx
+++ b/packages/web-react/src/components/Skeleton/SkeletonShape.tsx
@@ -15,19 +15,21 @@ const SkeletonShape = <E extends ElementType = 'div', C = void>(
   props: SpiritSkeletonShapeProps<E, C>,
 ): ReactElement => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const { elementType: ElementTag = 'div', ...restProps } = propsWithDefaults;
+  const { elementType, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { classProps, skeletonShapeStyleProps, props: modifiedProps } = useSkeletonShapeStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, {
+  const mergedStyleProps = mergeStyleProps(Component, {
     classProps,
     styleProps,
     skeletonShapeStyleProps,
     otherProps,
   });
 
-  return <ElementTag {...otherProps} {...mergedStyleProps} />;
+  return <Component {...otherProps} {...mergedStyleProps} />;
 };
 
 SkeletonShape.spiritComponent = 'SkeletonShape';
+SkeletonShape.displayName = 'SkeletonShape';
 
 export default SkeletonShape;

--- a/packages/web-react/src/components/Skeleton/SkeletonText.tsx
+++ b/packages/web-react/src/components/Skeleton/SkeletonText.tsx
@@ -16,10 +16,11 @@ const defaultProps: Partial<SpiritSkeletonProps> = {
 };
 const SkeletonText = <E extends ElementType = 'div', C = void>(props: SpiritSkeletonProps<E, C>): ReactElement => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const { elementType: ElementTag = 'div', lines, ...restProps } = propsWithDefaults;
+  const { elementType, lines, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { classProps, props: modifiedProps } = useSkeletonStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, {
+  const mergedStyleProps = mergeStyleProps(Component, {
     classProps: classProps.root,
     classPropsText: classProps.text,
     styleProps,
@@ -28,14 +29,15 @@ const SkeletonText = <E extends ElementType = 'div', C = void>(props: SpiritSkel
   const linesToRender = [...Array(lines ?? LINES_COUNT_DEFAULT).keys()];
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       {linesToRender.map((lineNumber) => (
         <SkeletonItem key={`skeleton-item-${lineNumber.toString()}`} />
       ))}
-    </ElementTag>
+    </Component>
   );
 };
 
 SkeletonText.spiritComponent = 'SkeletonText';
+SkeletonText.displayName = 'SkeletonText';
 
 export default SkeletonText;

--- a/packages/web-react/src/components/Skeleton/useSkeletonShapeStyleProps.ts
+++ b/packages/web-react/src/components/Skeleton/useSkeletonShapeStyleProps.ts
@@ -1,8 +1,8 @@
 import { cssVariablePrefix } from '@alma-oss/spirit-design-tokens';
 import classNames from 'classnames';
-import { type CSSProperties, type ElementType } from 'react';
+import { type CSSProperties } from 'react';
 import { useClassNamePrefix } from '../../hooks';
-import { type SkeletonShapeStyleProps, type SpiritSkeletonShapeProps } from '../../types';
+import { type SkeletonShapeBaseProps } from '../../types';
 
 interface CustomizedCSSProperties extends CSSProperties {
   [key: string]: string | undefined | number;
@@ -36,15 +36,7 @@ const setCustomBorderRadius = (
   return style;
 };
 
-export interface SkeletonShapeStyles<T extends ElementType = 'div', E = void> {
-  classProps: string;
-  skeletonShapeStyleProps: CustomizedCSSProperties;
-  props: Omit<SpiritSkeletonShapeProps<T, E>, keyof SkeletonShapeStyleProps<T, E>>;
-}
-
-export const useSkeletonShapeStyleProps = <T extends ElementType = 'div', E = void>(
-  props: SpiritSkeletonShapeProps<T, E>,
-): SkeletonShapeStyles<T, E> => {
+export const useSkeletonShapeStyleProps = <E = void>(props: SkeletonShapeBaseProps<E>) => {
   const { height, width, borderRadius, ...otherProps } = props;
 
   const skeletonClass = useClassNamePrefix('Skeleton');

--- a/packages/web-react/src/components/Skeleton/useSkeletonStyleProps.ts
+++ b/packages/web-react/src/components/Skeleton/useSkeletonStyleProps.ts
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
-import { type ElementType } from 'react';
 import { useClassNamePrefix } from '../../hooks';
-import { type SkeletonProps, type SpiritSkeletonProps } from '../../types';
+import { type SkeletonBaseProps, type SkeletonProps } from '../../types';
 
 export interface SkeletonStyles {
   /** className props */
@@ -15,9 +14,7 @@ export interface SkeletonStyles {
   props: SkeletonProps;
 }
 
-export function useSkeletonStyleProps<E extends ElementType = 'div', C = void>(
-  props?: SpiritSkeletonProps<E, C>,
-): SkeletonStyles {
+export function useSkeletonStyleProps<C = void>(props?: Omit<SkeletonBaseProps<C>, 'lines'>): SkeletonStyles {
   const { size, ...restProps } = props || {};
 
   const skeletonClass = useClassNamePrefix('Skeleton');

--- a/packages/web-react/src/components/Tabs/__tests__/TabLink.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabLink.test.tsx
@@ -30,11 +30,7 @@ describe('TabLink', () => {
   });
 
   it('should render button element', () => {
-    const dom = render(
-      <TabLink href="https://www.example.com" elementType="button">
-        Hello World
-      </TabLink>,
-    );
+    const dom = render(<TabLink elementType="button">Hello World</TabLink>);
 
     const element = dom.container.querySelector('button') as HTMLElement;
 

--- a/packages/web-react/src/components/Tag/useTagStyleProps.ts
+++ b/packages/web-react/src/components/Tag/useTagStyleProps.ts
@@ -1,17 +1,9 @@
 import { emotionColors } from '@alma-oss/spirit-design-tokens';
 import classNames from 'classnames';
-import { type ElementType } from 'react';
 import { Intensity } from '../../constants';
 import { ColorPrefixes } from '../../constants/colors';
 import { useClassNamePrefix } from '../../hooks';
-import { type SpiritTagProps } from '../../types';
-
-export interface TagStyles {
-  /** className props */
-  classProps: string;
-  /** props to be passed to the element */
-  props: Partial<SpiritTagProps>;
-}
+import { type TagProps } from '../../types';
 
 const getColorClasses = (color: string | undefined, isSubtle: boolean | undefined) => {
   if (!color) {
@@ -31,9 +23,7 @@ const getColorClasses = (color: string | undefined, isSubtle: boolean | undefine
   };
 };
 
-export function useTagStyleProps<E extends ElementType = 'span', C = void, S = void>(
-  props: SpiritTagProps<E, C, S>,
-): TagStyles {
+export function useTagStyleProps<C = void, S = void>(props: TagProps<C, S>) {
   const { color, isDisabled, isSubtle, size, ...modifiedProps } = props;
 
   const tagClass = useClassNamePrefix('Tag');
@@ -51,6 +41,6 @@ export function useTagStyleProps<E extends ElementType = 'span', C = void, S = v
 
   return {
     classProps,
-    props: modifiedProps as Partial<SpiritTagProps>,
+    props: modifiedProps,
   };
 }

--- a/packages/web-react/src/components/Text/Text.tsx
+++ b/packages/web-react/src/components/Text/Text.tsx
@@ -7,7 +7,7 @@ import { type SpiritTextProps } from '../../types';
 import { mergeStyleProps } from '../../utils';
 import { useTextStyleProps } from './useTextStyleProps';
 
-const defaultProps: Partial<SpiritTextProps> = {
+const defaultProps: Partial<SpiritTextProps<ElementType, void, void, void>> = {
   elementType: 'p',
   emphasis: Emphasis.REGULAR,
   size: SizesExtended.MEDIUM,
@@ -17,7 +17,8 @@ const Text = <E extends ElementType = 'p', S = void, Emph = void, C = void>(
   props: SpiritTextProps<E, S, Emph, C>,
 ): JSX.Element => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const { elementType: ElementTag = 'p', children, ...restProps } = propsWithDefaults;
+  const { elementType, children, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { classProps, props: modifiedProps } = useTextStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps, {
     isTextBalanced: TextStyleProps.isTextBalanced,
@@ -25,15 +26,16 @@ const Text = <E extends ElementType = 'p', S = void, Emph = void, C = void>(
     textHyphens: TextStyleProps.textHyphens,
     textWordBreak: TextStyleProps.textWordBreak,
   });
-  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps, styleProps, otherProps });
+  const mergedStyleProps = mergeStyleProps(Component, { classProps, styleProps, otherProps });
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       {children}
-    </ElementTag>
+    </Component>
   );
 };
 
 Text.spiritComponent = 'Text';
+Text.displayName = 'Text';
 
 export default Text;

--- a/packages/web-react/src/components/Text/__tests__/Text.test.tsx
+++ b/packages/web-react/src/components/Text/__tests__/Text.test.tsx
@@ -50,7 +50,7 @@ describe('Text', () => {
   it.each(textPropsDataProvider)('should have classname', (size, emphasis, expectedClassName) => {
     render(
       <Text
-        size={size as SizesDictionaryType<string> as SizeExtendedDictionaryType<string>}
+        size={size as SizesDictionaryType as SizeExtendedDictionaryType}
         emphasis={emphasis as EmphasisDictionaryType}
       >
         Text

--- a/packages/web-react/src/components/Text/useTextStyleProps.ts
+++ b/packages/web-react/src/components/Text/useTextStyleProps.ts
@@ -1,18 +1,8 @@
 import classNames from 'classnames';
-import { type ElementType } from 'react';
 import { useClassNamePrefix } from '../../hooks';
-import { type SpiritTextProps, type TextProps } from '../../types';
+import { type TextProps } from '../../types';
 
-export interface TextStyles<E extends ElementType = 'p'> {
-  /** className props */
-  classProps: string | null;
-  /** props to be passed to the input element */
-  props: TextProps<E>;
-}
-
-export function useTextStyleProps<E extends ElementType = 'p', S = void, Emph = void, C = void>(
-  props: SpiritTextProps<E, S, Emph, C>,
-): TextStyles<E> {
+export function useTextStyleProps<S = void, Emph = void, C = void>(props: TextProps<S, Emph, C>) {
   const { emphasis, size, textColor, ...restProps } = props;
 
   const textClass = useClassNamePrefix('typography-body');

--- a/packages/web-react/src/components/TextFieldBase/useTextFieldBaseInputStyleProps.ts
+++ b/packages/web-react/src/components/TextFieldBase/useTextFieldBaseInputStyleProps.ts
@@ -1,5 +1,5 @@
 import { useClassNamePrefix } from '../../hooks';
-import { type SpiritTextFieldBaseInputProps, type TextFieldBaseProps } from '../../types';
+import { type RequiredProps, type TextFieldBaseInputProps, type TextFieldBaseProps } from '../../types';
 
 export interface TextFieldBaseInputStyles {
   /** className props */
@@ -10,7 +10,9 @@ export interface TextFieldBaseInputStyles {
   props: TextFieldBaseProps;
 }
 
-export function useTextFieldBaseInputStyleProps(props: SpiritTextFieldBaseInputProps): TextFieldBaseInputStyles {
+export function useTextFieldBaseInputStyleProps(
+  props: RequiredProps & TextFieldBaseInputProps,
+): TextFieldBaseInputStyles {
   const { isMultiline, id, ...restProps } = props;
 
   const TextFieldBaseClass = useClassNamePrefix(isMultiline ? 'TextArea' : 'TextField');

--- a/packages/web-react/src/components/Timeline/Timeline.tsx
+++ b/packages/web-react/src/components/Timeline/Timeline.tsx
@@ -14,18 +14,20 @@ const defaultProps: Partial<SpiritTimelineProps> = {
 
 const Timeline = <E extends ElementType = 'ol'>(props: SpiritTimelineProps<E>) => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const { elementType: ElementTag = 'ol', children, size, ...restProps } = propsWithDefaults;
+  const { elementType, children, size, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { classProps } = useTimelineStyleProps({ markerSize: size });
   const { styleProps, props: otherProps } = useStyleProps(restProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps: classProps.root, styleProps, otherProps });
+  const mergedStyleProps = mergeStyleProps(Component, { classProps: classProps.root, styleProps, otherProps });
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       {children}
-    </ElementTag>
+    </Component>
   );
 };
 
 Timeline.spiritComponent = 'Timeline';
+Timeline.displayName = 'Timeline';
 
 export default Timeline;

--- a/packages/web-react/src/components/Timeline/TimelineStep.tsx
+++ b/packages/web-react/src/components/Timeline/TimelineStep.tsx
@@ -12,18 +12,20 @@ const defaultProps: Partial<SpiritTimelineStepProps> = {
 
 const TimelineStep = <E extends ElementType = 'li'>(props: SpiritTimelineStepProps<E>) => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const { elementType: ElementTag = 'li', children, ...restProps } = propsWithDefaults;
+  const { elementType, children, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { classProps } = useTimelineStyleProps();
   const { styleProps, props: otherProps } = useStyleProps(restProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps: classProps.step, styleProps, otherProps });
+  const mergedStyleProps = mergeStyleProps(Component, { classProps: classProps.step, styleProps, otherProps });
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       {children}
-    </ElementTag>
+    </Component>
   );
 };
 
 TimelineStep.spiritComponent = 'TimelineStep';
+TimelineStep.displayName = 'TimelineStep';
 
 export default TimelineStep;

--- a/packages/web-react/src/components/Timeline/useTimelineStyleProps.ts
+++ b/packages/web-react/src/components/Timeline/useTimelineStyleProps.ts
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
-import { type ElementType } from 'react';
 import { useClassNamePrefix } from '../../hooks';
-import type { SingleOrResponsive, SizesDictionaryType, SpiritTimelineProps, TimelineMarkerProps } from '../../types';
+import type { SingleOrResponsive, SizesDictionaryType, TimelineMarkerProps } from '../../types';
 import { generateResponsiveClassNames } from '../../utils';
 import { TIMELINE_MARKER, TIMELINE_SIZE_DEFAULT } from './constants';
 
@@ -13,20 +12,7 @@ export interface UseTimelineStyleProps {
   markerSize?: SingleOrResponsive<SizesDictionaryType>;
 }
 
-export interface TimelineStyles<T> {
-  /** className props */
-  classProps: {
-    content: string;
-    heading: string;
-    marker: string;
-    root: string;
-    step: string;
-  };
-  /** props to be passed to the element */
-  props: T;
-}
-
-export function useTimelineStyleProps(props?: UseTimelineStyleProps): TimelineStyles<SpiritTimelineProps<ElementType>> {
+export function useTimelineStyleProps(props?: UseTimelineStyleProps) {
   const {
     markerBackgroundColor,
     markerBorderColor,

--- a/packages/web-react/src/components/Tooltip/TooltipTrigger.tsx
+++ b/packages/web-react/src/components/Tooltip/TooltipTrigger.tsx
@@ -1,30 +1,32 @@
 'use client';
 
-import React from 'react';
+import React, { type ElementType } from 'react';
 import { useStyleProps } from '../../hooks';
 import { type TooltipTriggerProps } from '../../types';
 import { mergeStyleProps } from '../../utils';
 import { useTooltipContext } from './TooltipContext';
 
-const defaultProps: Partial<TooltipTriggerProps> = {
+const defaultProps: Partial<TooltipTriggerProps<ElementType>> = {
   elementType: 'button',
   children: null,
 };
 
-const TooltipTrigger = (props: TooltipTriggerProps) => {
+const TooltipTrigger = <E extends ElementType = 'button'>(props: TooltipTriggerProps<E>) => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const { elementType: ElementTag = 'button', children, ...restProps } = propsWithDefaults;
+  const { elementType, children, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { id, isOpen, triggerRef, getReferenceProps } = useTooltipContext();
   const { styleProps: triggerStyleProps, props: transferProps } = useStyleProps(restProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, { triggerStyleProps, transferProps });
+  const mergedStyleProps = mergeStyleProps(Component, { triggerStyleProps, transferProps });
 
   return (
-    <ElementTag {...transferProps} {...mergedStyleProps} id={id} ref={triggerRef} {...getReferenceProps()}>
+    <Component {...transferProps} {...mergedStyleProps} id={id} ref={triggerRef} {...getReferenceProps()}>
       {typeof children === 'function' ? children({ isOpen }) : children}
-    </ElementTag>
+    </Component>
   );
 };
 
 TooltipTrigger.spiritComponent = 'TooltipTrigger';
+TooltipTrigger.displayName = 'TooltipTrigger';
 
 export default TooltipTrigger;

--- a/packages/web-react/src/components/Truncate/Truncate.tsx
+++ b/packages/web-react/src/components/Truncate/Truncate.tsx
@@ -13,7 +13,8 @@ const defaultProps = {
 
 const Truncate = <E extends ElementType = 'span'>(props: SpiritTruncateProps<E>): JSX.Element => {
   const propsWithDefaults = { ...defaultProps, ...props };
-  const { children, elementType: ElementTag = 'span', ...restProps } = propsWithDefaults;
+  const { children, elementType, ...restProps } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const {
     classProps,
     props: modifiedProps,
@@ -33,15 +34,16 @@ const Truncate = <E extends ElementType = 'span'>(props: SpiritTruncateProps<E>)
       ...truncateStyle,
     },
   };
-  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps, styleProps, truncateStyleProps });
+  const mergedStyleProps = mergeStyleProps(Component, { classProps, styleProps, truncateStyleProps });
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       {truncatedText}
-    </ElementTag>
+    </Component>
   );
 };
 
 Truncate.spiritComponent = 'Truncate';
+Truncate.displayName = 'Truncate';
 
 export default Truncate;

--- a/packages/web-react/src/components/Truncate/useTruncateStyleProps.ts
+++ b/packages/web-react/src/components/Truncate/useTruncateStyleProps.ts
@@ -1,20 +1,12 @@
-import { type CSSProperties, type ElementType } from 'react';
+import { type CSSProperties } from 'react';
 import { useClassNamePrefix } from '../../hooks';
-import { type SpiritTruncateProps, type TruncateMode, TruncateModes } from '../../types';
+import { TruncateModes, type TruncateProps } from '../../types';
 
 interface TruncateCSSProperties extends CSSProperties {
   '--text-truncate-lines'?: number;
 }
 
-export interface TruncateStyles<E extends ElementType> {
-  classProps: string;
-  props: SpiritTruncateProps<E>;
-  styleProps: TruncateCSSProperties;
-  effectiveMode: TruncateMode;
-  effectiveLimit?: number;
-}
-
-export const useTruncateStyleProps = <E extends ElementType>(props: SpiritTruncateProps<E>): TruncateStyles<E> => {
+export const useTruncateStyleProps = (props: TruncateProps) => {
   const { limit, mode = TruncateModes.LINES, ...restProps } = props;
 
   const truncateClassName = useClassNamePrefix(mode === TruncateModes.LINES ? 'text-truncate-multiline' : '');

--- a/packages/web-react/src/components/UNSTABLE_Header/UNSTABLE_HeaderLogo.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Header/UNSTABLE_HeaderLogo.tsx
@@ -11,7 +11,7 @@ import {
 import { mergeStyleProps } from '../../utils';
 import { useUnstableHeaderStyleProps } from './useUnstableHeaderStyleProps';
 
-const defaultProps: Partial<HeaderLogoProps> = {
+const defaultProps: Partial<SpiritHeaderLogoProps> = {
   elementType: 'a',
 };
 

--- a/packages/web-react/src/components/UNSTABLE_Header/demo/HeaderWithNavigation/SecondaryHorizontalNavigationDropdown.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Header/demo/HeaderWithNavigation/SecondaryHorizontalNavigationDropdown.tsx
@@ -36,7 +36,7 @@ const SecondaryHorizontalNavigationDropdown = ({
       placement="bottom-end"
     >
       <DropdownTrigger
-        elementType={NavigationAvatarAsDropdownTrigger as unknown as HTMLButtonElement}
+        elementType={NavigationAvatarAsDropdownTrigger}
         avatarContent={<Icon name="profile" boxSize={20} />}
         aria-label="Profile of Jiří Bárta"
         isSquare={isSquare}

--- a/packages/web-react/src/components/UNSTABLE_Header/demo/HeaderWithNavigationAndNestedItems/MainHorizontalNavigationDropdown.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Header/demo/HeaderWithNavigationAndNestedItems/MainHorizontalNavigationDropdown.tsx
@@ -40,7 +40,7 @@ const MainHorizontalNavigationDropdown = () => {
       onToggle={() => setIsNavigationActionDropdownOpen(!isNavigationActionDropdownOpen)}
       placement="bottom-end"
     >
-      <DropdownTrigger elementType={NavigationActionAsDropdownTrigger as unknown as HTMLButtonElement}>
+      <DropdownTrigger elementType={NavigationActionAsDropdownTrigger}>
         Menu
         <Icon name={`chevron-${isNavigationActionDropdownOpen ? 'up' : 'down'}`} boxSize={20} />
       </DropdownTrigger>

--- a/packages/web-react/src/components/UNSTABLE_Table/types.ts
+++ b/packages/web-react/src/components/UNSTABLE_Table/types.ts
@@ -1,6 +1,6 @@
-import { type SpiritDetailedHTMLProps, type StyleProps, type TransferProps } from '../../types/shared';
+import { type SpiritDetailedHTMLProps, type StyleProps } from '../../types/shared';
 
-export interface UnstableTableProps extends StyleProps, TransferProps {
+export interface UnstableTableProps extends StyleProps {
   isStriped?: boolean;
   isBordered?: boolean;
   isCompact?: boolean;

--- a/packages/web-react/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/web-react/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -6,19 +6,26 @@ import { type SpiritVisuallyHiddenProps } from '../../types';
 import { mergeStyleProps } from '../../utils';
 import { useVisuallyHiddenProps } from './useVisuallyHiddenProps';
 
+const defaultProps: Partial<SpiritVisuallyHiddenProps> = {
+  elementType: 'span',
+};
+
 const VisuallyHidden = <E extends ElementType = 'span'>(props: SpiritVisuallyHiddenProps<E>): JSX.Element => {
-  const { children, elementType: ElementTag = 'span', ...rest } = props;
+  const propsWithDefaults = { ...defaultProps, ...props };
+  const { children, elementType, ...rest } = propsWithDefaults;
+  const Component = elementType as ElementType;
   const { classProps, props: modifiedProps } = useVisuallyHiddenProps(rest);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
-  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps, styleProps, otherProps });
+  const mergedStyleProps = mergeStyleProps(Component, { classProps, styleProps, otherProps });
 
   return (
-    <ElementTag {...otherProps} {...mergedStyleProps}>
+    <Component {...otherProps} {...mergedStyleProps}>
       {children}
-    </ElementTag>
+    </Component>
   );
 };
 
 VisuallyHidden.spiritComponent = 'VisuallyHidden';
+VisuallyHidden.displayName = 'VisuallyHidden';
 
 export default VisuallyHidden;

--- a/packages/web-react/src/components/VisuallyHidden/useVisuallyHiddenProps.ts
+++ b/packages/web-react/src/components/VisuallyHidden/useVisuallyHiddenProps.ts
@@ -1,17 +1,14 @@
-import { type ElementType } from 'react';
 import { useClassNamePrefix } from '../../hooks';
-import { type SpiritVisuallyHiddenProps, type VisuallyHiddenProps } from '../../types';
+import { type VisuallyHiddenProps } from '../../types';
 
-export interface VisuallyHiddenStyles<E extends ElementType = 'span'> {
+export interface VisuallyHiddenStyles {
   /** className props */
   classProps: string | null;
   /** props to be passed to the element */
-  props: VisuallyHiddenProps<E>;
+  props: VisuallyHiddenProps;
 }
 
-export function useVisuallyHiddenProps<E extends ElementType = 'span'>(
-  props: SpiritVisuallyHiddenProps<E>,
-): VisuallyHiddenStyles<E> {
+export function useVisuallyHiddenProps(props: VisuallyHiddenProps): VisuallyHiddenStyles {
   const { ...restProps } = props;
 
   const visuallyHiddenClass = useClassNamePrefix('accessibility-hidden');

--- a/packages/web-react/src/types/actionGroup.ts
+++ b/packages/web-react/src/types/actionGroup.ts
@@ -1,4 +1,4 @@
-import { type FlexProps } from './flex';
-import { type ChildrenProps, type StyleProps, type TransferProps } from './shared';
+import { type ElementType } from 'react';
+import { type SpiritFlexProps } from './flex';
 
-export interface SpiritActionGroupProps extends FlexProps, ChildrenProps, StyleProps, TransferProps {}
+export type SpiritActionGroupProps<E extends ElementType = 'div'> = SpiritFlexProps<E>;

--- a/packages/web-react/src/types/breadcrumbs.ts
+++ b/packages/web-react/src/types/breadcrumbs.ts
@@ -1,5 +1,5 @@
 import { type ElementType } from 'react';
-import { type ChildrenProps, type StyleProps, type TransferProps } from './shared';
+import { type ChildrenProps, type PolymorphicComponentProps, type StyleProps } from './shared';
 
 type BreadcrumbsItem = {
   title: string;
@@ -16,21 +16,15 @@ export interface SpiritBreadcrumbsItemProps extends ChildrenProps {
   isGoBackOnly?: boolean;
 }
 
-export interface AriaBreadcrumbsElementTypeProps<E extends ElementType = 'nav'> {
-  /**
-   * The HTML element or React element used to render the breadcrumbs, e.g. 'div', 'span'.
-   *
-   * @default 'nav'
-   */
-  elementType?: E;
-}
-
-export interface BreadcrumbsStyleProps extends StyleProps, TransferProps {
+export interface BreadcrumbsStyleProps extends StyleProps {
   isGoBackOnly?: boolean;
 }
 
-export interface SpiritBreadcrumbsProps<T extends ElementType = 'nav'>
-  extends AriaBreadcrumbsElementTypeProps<T>, StyleProps, ChildrenProps {
+/** ===== INTERNAL API ===== */
+export interface BreadcrumbsProps extends StyleProps, ChildrenProps {
   goBackTitle?: string;
   items?: BreadcrumbsItems;
 }
+
+/** ===== PUBLIC API ===== */
+export type SpiritBreadcrumbsProps<E extends ElementType = 'nav'> = PolymorphicComponentProps<E, BreadcrumbsProps>;

--- a/packages/web-react/src/types/card.ts
+++ b/packages/web-react/src/types/card.ts
@@ -11,7 +11,6 @@ import {
   type PolymorphicComponentProps,
   type SingleOrResponsive,
   type StyleProps,
-  type TransferProps,
 } from './shared';
 
 export const CardSizes = {
@@ -26,28 +25,20 @@ export type CardAlignmentXType = SingleOrResponsive<NonNullable<AlignmentXDictio
 
 export type CardAlignmentYType = SingleOrResponsive<NonNullable<AlignmentYDictionaryType>>;
 
-export interface CardElementTypeProps<E extends ElementType = 'article'> {
-  /**
-   * The HTML element or React element used to render the Card, e.g. 'div'.
-   *
-   * @default 'article'
-   */
-  elementType?: E;
-}
-
 // Card types
 export type CardDirectionType =
   | NonNullable<DirectionExtendedDictionaryType>
   | { [key: string]: NonNullable<DirectionExtendedDictionaryType> };
 
-export interface CardProps<E extends ElementType = 'article'> extends CardElementTypeProps<E> {
+/** ===== INTERNAL API ===== */
+export interface CardProps extends ChildrenProps, StyleProps {
   alignmentY?: CardAlignmentYType;
   direction?: CardDirectionType;
   isBoxed?: boolean;
 }
 
-export interface SpiritCardProps<T extends ElementType = 'article'>
-  extends CardProps<T>, ChildrenProps, StyleProps, TransferProps {}
+/** ===== PUBLIC API ===== */
+export type SpiritCardProps<E extends ElementType = 'article'> = PolymorphicComponentProps<E, CardProps>;
 
 export type CardMediaBackgroundColorsType =
   | BackgroundColorsDictionaryType
@@ -64,44 +55,43 @@ export interface CardMediaProps {
   size?: CardSizesDictionaryType;
 }
 
-export interface SpiritCardMediaProps extends CardMediaProps, ChildrenProps, StyleProps, TransferProps {}
+export interface SpiritCardMediaProps extends CardMediaProps, ChildrenProps, StyleProps {}
 
 // CardLogo types
-export interface SpiritCardLogoProps extends ChildrenProps, StyleProps, TransferProps {}
+export interface SpiritCardLogoProps extends ChildrenProps, StyleProps {}
 
 // CardArtwork types
 export interface CardArtworkProps {
   alignmentX?: CardAlignmentXType;
 }
-export interface SpiritCardArtworkProps extends CardArtworkProps, ChildrenProps, StyleProps, TransferProps {}
+export interface SpiritCardArtworkProps extends CardArtworkProps, ChildrenProps, StyleProps {}
 
 // CardBody types
 export interface CardBodyProps {
   isSelectable?: boolean;
 }
 
-export interface SpiritCardBodyProps extends CardBodyProps, ChildrenProps, StyleProps, TransferProps {}
+export interface SpiritCardBodyProps extends CardBodyProps, ChildrenProps, StyleProps {}
 
 // CardEyebrow types
-export interface SpiritCardEyebrowProps extends ChildrenProps, StyleProps, TransferProps {}
+export interface SpiritCardEyebrowProps extends ChildrenProps, StyleProps {}
 
 // CardTitle types
-export interface CardTitleProps {
+export interface CardTitleProps extends ChildrenProps, StyleProps {
   isHeading?: boolean;
 }
 
-export interface SpiritCardTitleProps<T extends ElementType = 'h4'>
-  extends CardTitleProps, CardElementTypeProps<T>, ChildrenProps, StyleProps, TransferProps {}
+export type SpiritCardTitleProps<E extends ElementType = 'h4'> = PolymorphicComponentProps<E, CardTitleProps>;
 
 // CardFooter types
 export interface CardFooterProps {
   alignmentX?: CardAlignmentXType;
 }
 
-export interface SpiritCardFooterProps extends CardFooterProps, ChildrenProps, StyleProps, TransferProps {}
+export interface SpiritCardFooterProps extends CardFooterProps, ChildrenProps, StyleProps {}
 
 // CardLink types
-export interface CardLinkProps extends ChildrenProps, StyleProps, TransferProps {
+export interface CardLinkProps extends ChildrenProps, StyleProps {
   href?: string;
 }
 

--- a/packages/web-react/src/types/container.ts
+++ b/packages/web-react/src/types/container.ts
@@ -1,6 +1,14 @@
-import type { ChildrenProps, ContainerSizesType, StyleProps, TextAlignmentType, TransferProps } from './shared';
+import type {
+  ChildrenProps,
+  ContainerSizesType,
+  DataAttributeProps,
+  SpiritDivElementProps,
+  StyleProps,
+  TextAlignmentType,
+} from './shared';
 
-export interface ContainerProps extends ChildrenProps, ContainerTextStyleProps, StyleProps, TransferProps {}
+export interface ContainerProps
+  extends ChildrenProps, ContainerTextStyleProps, DataAttributeProps, StyleProps, SpiritDivElementProps {}
 
 export type ContainerSize<C> = ContainerSizesType | C;
 

--- a/packages/web-react/src/types/divider.ts
+++ b/packages/web-react/src/types/divider.ts
@@ -1,3 +1,4 @@
-import { type StyleProps, type TransferProps } from './shared';
+import { type ComponentPropsWithoutRef } from 'react';
+import { type StyleProps } from './shared';
 
-export interface SpiritDividerProps extends StyleProps, TransferProps {}
+export interface SpiritDividerProps extends StyleProps, Omit<ComponentPropsWithoutRef<'hr'>, 'className' | 'style'> {}

--- a/packages/web-react/src/types/dropdown.ts
+++ b/packages/web-react/src/types/dropdown.ts
@@ -1,4 +1,4 @@
-import { type ComponentPropsWithRef, type ElementType, type LegacyRef, type ReactNode } from 'react';
+import { type ElementType, type LegacyRef, type ReactNode } from 'react';
 import {
   type AlignmentXExtendedDictionaryType,
   type AlignmentYExtendedDictionaryType,
@@ -6,6 +6,7 @@ import {
   type ChildrenProps,
   type ClickEvent,
   type PlacementDictionaryType,
+  type PolymorphicComponentProps,
   type StyleProps,
 } from './shared';
 
@@ -57,8 +58,13 @@ export interface SpiritDropdownProps extends DropdownProps, ChildrenProps {
 
 export interface UncontrolledDropdownProps extends ChildrenProps, Omit<SpiritDropdownProps, 'isOpen' | 'onToggle'> {}
 
-export type DropdownTriggerProps<E extends ElementType> = {
-  elementType?: E;
+/** ===== INTERNAL API ===== */
+export interface DropdownTriggerBaseProps extends StyleProps {
   children: string | ReactNode | ((props: { isOpen: boolean }) => ReactNode);
-} & ComponentPropsWithRef<E> &
-  StyleProps;
+}
+
+/** ===== PUBLIC API ===== */
+export type DropdownTriggerProps<E extends ElementType = 'button'> = PolymorphicComponentProps<
+  E,
+  DropdownTriggerBaseProps
+>;

--- a/packages/web-react/src/types/fieldGroup.ts
+++ b/packages/web-react/src/types/fieldGroup.ts
@@ -8,10 +8,8 @@ import {
   type ValidationTextType,
 } from './shared';
 
-export type FieldGroupElementBaseProps = SpiritFieldGroupElementPropsWithRef;
-
 export interface FieldGroupProps
-  extends FieldGroupElementBaseProps, LabelProps, HelperTextProps, RequiredProps, Validation {
+  extends SpiritFieldGroupElementPropsWithRef, LabelProps, HelperTextProps, RequiredProps, Validation {
   isDisabled?: boolean;
   isFluid?: boolean;
   isLabelHidden?: boolean;

--- a/packages/web-react/src/types/header.ts
+++ b/packages/web-react/src/types/header.ts
@@ -10,7 +10,6 @@ import {
   type SpiritSpanElementProps,
   type SpiritUListElementProps,
   type StyleProps,
-  type TransferProps,
 } from './shared';
 
 /** ===== BASE API ===== */
@@ -68,11 +67,11 @@ export interface HeaderNavProps extends SpiritUListElementProps, ChildrenProps {
 export interface HeaderNavItemProps extends SpiritLItemElementProps, ChildrenProps {}
 
 /** ===== STYLE API ===== */
-export interface HeaderDialogLinkStyleProps extends ChildrenProps, StyleProps, TransferProps, RouterLinkProps {
+export interface HeaderDialogLinkStyleProps extends ChildrenProps, StyleProps, RouterLinkProps {
   isCurrent?: boolean;
 }
 
-export interface HeaderLinkStyleProps extends ChildrenProps, StyleProps, TransferProps, RouterLinkProps {
+export interface HeaderLinkStyleProps extends ChildrenProps, StyleProps, RouterLinkProps {
   isCurrent?: boolean;
 }
 

--- a/packages/web-react/src/types/heading.ts
+++ b/packages/web-react/src/types/heading.ts
@@ -3,30 +3,31 @@ import type {
   ChildrenProps,
   EmphasisDictionaryType,
   EmphasisProps,
+  PolymorphicComponentProps,
   SizeExtendedDictionaryType,
   SizeProps,
   StyleProps,
   TextColorProps,
   TextColorsType,
-  TransferProps,
   TypographyBaseProps,
 } from './shared';
 
 export type HeadingColorsType<C = undefined> = TextColorsType<C>;
 
-export interface HeadingElementTypeProps<E extends ElementType> {
-  /**
-   * The HTML element or React element used to render the Heading, e.g. 'h2'.
-   */
-  elementType: E;
-}
-
-export interface HeadingProps<T extends ElementType>
-  extends HeadingElementTypeProps<T>, ChildrenProps, StyleProps, TransferProps, TypographyBaseProps {}
-
-export interface SpiritHeadingProps<T extends ElementType, S = void, Emph = void, C = void>
+/** ===== INTERNAL API ===== */
+export interface HeadingProps<S = void, Emph = void, C = void>
   extends
-    HeadingProps<T>,
+    ChildrenProps,
+    StyleProps,
+    TypographyBaseProps,
     SizeProps<SizeExtendedDictionaryType<S>>,
     EmphasisProps<EmphasisDictionaryType<Emph>>,
     TextColorProps<HeadingColorsType<C>> {}
+
+/** ===== PUBLIC API ===== */
+export type SpiritHeadingProps<
+  E extends ElementType = 'h1',
+  S = void,
+  Emph = void,
+  C = void,
+> = PolymorphicComponentProps<E, HeadingProps<S, Emph, C>>;

--- a/packages/web-react/src/types/inputDetails.ts
+++ b/packages/web-react/src/types/inputDetails.ts
@@ -1,14 +1,16 @@
 import type { ElementType, ReactNode } from 'react';
 import type { RegisterType as RegisterDetailsType } from '../hooks/useAriaIdRefs';
-import type { ChildrenProps, StyleProps } from './shared';
+import type { ChildrenProps, PolymorphicComponentProps, StyleProps } from './shared';
 
-export interface InputDetailsProps<T extends ElementType = 'div'> extends ChildrenProps, StyleProps {
+/** ===== INTERNAL API ===== */
+export interface InputDetailsBaseProps extends ChildrenProps, StyleProps {
   /** Details content */
   children: ReactNode;
-  /** Type of element used as container */
-  elementType?: T;
   /** ID of the details element */
   id?: string;
   /** Callback to register aria-details ID */
   registerAriaDetails?: RegisterDetailsType;
 }
+
+/** ===== PUBLIC API ===== */
+export type InputDetailsProps<E extends ElementType = 'div'> = PolymorphicComponentProps<E, InputDetailsBaseProps>;

--- a/packages/web-react/src/types/item.ts
+++ b/packages/web-react/src/types/item.ts
@@ -1,5 +1,5 @@
 import { type ElementType, type ReactNode } from 'react';
-import { type StyleProps, type TransferProps } from './shared';
+import { type PolymorphicComponentProps, type StyleProps } from './shared';
 
 export const ITEM_SELECTION_DECORATOR_BACKGROUND = 'background';
 export const ITEM_SELECTION_DECORATOR_BOTH = 'both';
@@ -10,23 +10,14 @@ export type ItemSelectionDecorator =
   | typeof ITEM_SELECTION_DECORATOR_BOTH
   | typeof ITEM_SELECTION_DECORATOR_ICON;
 
-export interface AriaItemElementTypeProps<E extends ElementType = 'button'> {
-  /**
-   * The HTML element or React element used to render the item, e.g. 'div', 'span'.
-   *
-   * @default 'button'
-   */
-  elementType?: E;
-}
-
-export interface ItemStyleProps extends StyleProps, TransferProps {
+export interface ItemStyleProps extends StyleProps {
   isDisabled?: boolean;
   isSelected?: boolean;
   selectionDecorator?: ItemSelectionDecorator;
 }
 
-export interface SpiritItemProps<T extends ElementType = 'button'>
-  extends AriaItemElementTypeProps<T>, StyleProps, TransferProps {
+/** ===== INTERNAL API ===== */
+export interface ItemBaseProps extends StyleProps {
   helperText?: string;
   iconName?: string;
   isDisabled?: boolean;
@@ -34,3 +25,6 @@ export interface SpiritItemProps<T extends ElementType = 'button'>
   label: string | ReactNode;
   selectionDecorator?: ItemSelectionDecorator;
 }
+
+/** ===== PUBLIC API ===== */
+export type SpiritItemProps<E extends ElementType = 'button'> = PolymorphicComponentProps<E, ItemBaseProps>;

--- a/packages/web-react/src/types/label.ts
+++ b/packages/web-react/src/types/label.ts
@@ -1,14 +1,5 @@
 import { type ElementType, type ReactNode } from 'react';
-import { type StyleProps, type TransferProps } from './shared';
-
-export type LabelElementProps<E extends ElementType> = {
-  /**
-   * The HTML element or React element used to render the label, e.g. 'label'.
-   *
-   * @default 'label'
-   */
-  elementType?: E;
-};
+import { type PolymorphicComponentProps, type StyleProps } from './shared';
 
 export interface LabelProps {
   children?: ReactNode;
@@ -16,5 +7,10 @@ export interface LabelProps {
   for?: string;
 }
 
-export interface SpiritLabelProps<T extends ElementType = 'label'>
-  extends LabelElementProps<T>, LabelProps, StyleProps, TransferProps {}
+/** ===== INTERNAL API ===== */
+export interface LabelBaseProps extends LabelProps, StyleProps {
+  id?: string;
+}
+
+/** ===== PUBLIC API ===== */
+export type SpiritLabelProps<E extends ElementType = 'label'> = PolymorphicComponentProps<E, LabelBaseProps>;

--- a/packages/web-react/src/types/link.ts
+++ b/packages/web-react/src/types/link.ts
@@ -6,7 +6,6 @@ import type {
   PolymorphicComponentProps,
   RouterLinkProps,
   StyleProps,
-  TransferProps,
 } from './shared';
 
 /** ===== BASE API ===== */
@@ -24,12 +23,14 @@ export type LinkColorsExtendedNamesType = (typeof LinkColorsExtended)[keyof type
 
 export type LinkColor<C> = LinkColorsDictionaryType | LinkColorsExtendedNamesType | C;
 
-export interface LinkBaseProps extends ChildrenProps, StyleProps, TransferProps, RouterLinkProps {}
+export interface LinkBaseProps extends ChildrenProps, StyleProps, RouterLinkProps {}
 
 /** ===== STYLE API ===== */
 export interface LinkStyleProps<C = void> extends LinkBaseProps {
   /** Color of the Link */
   color?: LinkColor<C>;
+  /** Allow link to have visited style */
+  hasVisitedStyleAllowed?: boolean;
   /** When is the Link underlined */
   underlined?: UnderlineOptions;
   /** Whether is the Link disabled */

--- a/packages/web-react/src/types/matrix.ts
+++ b/packages/web-react/src/types/matrix.ts
@@ -2,20 +2,11 @@ import { type ElementType } from 'react';
 import {
   type ChildrenProps,
   type GridColumns,
+  type PolymorphicComponentProps,
   type SingleOrResponsive,
   type SpaceToken,
   type StyleProps,
-  type TransferProps,
 } from './shared';
-
-export interface MatrixElementTypeProps<E extends ElementType = 'div'> {
-  /**
-   * The HTML element or React element used to render the Matrix, e.g. 'div'.
-   *
-   * @default 'div'
-   */
-  elementType?: E;
-}
 
 export interface MatrixCustomLayoutProps {
   /** Custom columns in the matrix */
@@ -32,8 +23,8 @@ export interface MatrixCustomLayoutProps {
   spacingY?: SingleOrResponsive<SpaceToken>;
 }
 
-export interface MatrixProps<T extends ElementType = 'div'>
-  extends MatrixElementTypeProps<T>, MatrixCustomLayoutProps {}
+/** ===== INTERNAL API ===== */
+export interface MatrixProps extends MatrixCustomLayoutProps, ChildrenProps, StyleProps {}
 
-export interface SpiritMatrixProps<T extends ElementType = 'div'>
-  extends MatrixProps<T>, ChildrenProps, StyleProps, TransferProps {}
+/** ===== PUBLIC API ===== */
+export type SpiritMatrixProps<E extends ElementType = 'div'> = PolymorphicComponentProps<E, MatrixProps>;

--- a/packages/web-react/src/types/pill.ts
+++ b/packages/web-react/src/types/pill.ts
@@ -1,25 +1,16 @@
-import { type ComponentPropsWithRef, type ElementType } from 'react';
+import { type ElementType } from 'react';
 import { type PillColorsExtended } from '../components/Pill';
-import type { ChildrenProps, EmotionColorNamesType, StyleProps, TransferProps } from './shared';
+import type { ChildrenProps, EmotionColorNamesType, PolymorphicComponentProps, StyleProps } from './shared';
 
 export type PillColorsExtendedNamesType = (typeof PillColorsExtended)[keyof typeof PillColorsExtended];
 
 export type PillColor<C> = EmotionColorNamesType<C> | PillColorsExtendedNamesType | C;
 
-export interface AriaPillElementTypeProps<E extends ElementType = 'span'> {
-  /**
-   * The HTML element or React element used to render the pill, e.g. 'div', 'span'.
-   *
-   * @default 'span'
-   */
-  elementType?: E;
+/** ===== INTERNAL API ===== */
+export interface PillProps<C = void> extends ChildrenProps, StyleProps {
+  /** The color of the pill. */
+  color?: PillColor<C>;
 }
 
-export interface PillProps extends ChildrenProps, StyleProps, TransferProps {}
-
-export type SpiritPillProps<E extends ElementType = 'span', C = void> = AriaPillElementTypeProps<E> &
-  ComponentPropsWithRef<E> &
-  PillProps & {
-    /** The color of the pill. */
-    color?: PillColor<C>;
-  };
+/** ===== PUBLIC API ===== */
+export type SpiritPillProps<E extends ElementType = 'span', C = void> = PolymorphicComponentProps<E, PillProps<C>>;

--- a/packages/web-react/src/types/pricingPlan.ts
+++ b/packages/web-react/src/types/pricingPlan.ts
@@ -1,5 +1,5 @@
 import type { ElementType, ReactNode } from 'react';
-import type { ChildrenProps, RequiredProps, SpiritPolymorphicElementPropsWithRef, StyleProps } from './shared';
+import type { ChildrenProps, PolymorphicComponentProps, RequiredProps, StyleProps } from './shared';
 
 export interface PricingPlanBaseProps extends ChildrenProps, StyleProps {
   /** If pricing plan has comparable features  */
@@ -39,25 +39,22 @@ export interface PricingPlanBodyBaseProps extends StyleProps, RequiredProps {
   features?: PricingPlanFeature[];
 }
 
-export type PricingPlanProps<E extends ElementType> = {
-  /**
-   * The HTML element or React element used to render the plan, e.g. 'div', 'a', or `RouterLink`.
-   *
-   * @default 'article'
-   */
-  elementType?: E;
-};
+export interface PricingPlanFooterBaseProps extends StyleProps, ChildrenProps {}
 
-export type SpiritPricingPlanProps<E extends ElementType = 'article'> = PricingPlanProps<E> &
-  PricingPlanBaseProps &
-  SpiritPolymorphicElementPropsWithRef<E, PricingPlanProps<E>>;
-export type SpiritPricingPlanHeaderProps<E extends ElementType = 'header'> = PricingPlanProps<E> &
-  PricingPlanHeaderBaseProps &
-  Omit<SpiritPolymorphicElementPropsWithRef<E, PricingPlanProps<E>>, 'title'>;
-export type SpiritPricingPlanBodyProps<E extends ElementType = 'div'> = PricingPlanProps<E> &
-  PricingPlanBodyBaseProps &
-  SpiritPolymorphicElementPropsWithRef<E, PricingPlanProps<E>>;
-export type SpiritPricingPlanFooterProps<E extends ElementType = 'footer'> = PricingPlanProps<E> &
-  StyleProps &
-  ChildrenProps &
-  SpiritPolymorphicElementPropsWithRef<E, PricingPlanProps<E>>;
+/** ===== PUBLIC API ===== */
+export type SpiritPricingPlanProps<E extends ElementType = 'article'> = PolymorphicComponentProps<
+  E,
+  PricingPlanBaseProps
+>;
+export type SpiritPricingPlanHeaderProps<E extends ElementType = 'header'> = PolymorphicComponentProps<
+  E,
+  PricingPlanHeaderBaseProps
+>;
+export type SpiritPricingPlanBodyProps<E extends ElementType = 'div'> = PolymorphicComponentProps<
+  E,
+  PricingPlanBodyBaseProps
+>;
+export type SpiritPricingPlanFooterProps<E extends ElementType = 'footer'> = PolymorphicComponentProps<
+  E,
+  PricingPlanFooterBaseProps
+>;

--- a/packages/web-react/src/types/segmentedControl.ts
+++ b/packages/web-react/src/types/segmentedControl.ts
@@ -2,8 +2,8 @@ import {
   type ChildrenProps,
   type FillVariantDictionaryType,
   type SpiritInputElementProps,
+  type SpiritSegmentedControlElementProps,
   type StyleProps,
-  type TransferProps,
 } from './shared';
 
 export interface SegmentedControlBaseProps extends SegmentedControlMultiselectProps {
@@ -18,11 +18,11 @@ export interface SegmentedControlMultiselectProps {
   isMultiselect?: boolean;
 }
 
-export interface SegmentedControlItemProps extends StyleProps, SpiritInputElementProps, ChildrenProps, TransferProps {
+export interface SegmentedControlItemProps extends StyleProps, SpiritInputElementProps, ChildrenProps {
   isDisabled?: boolean;
 }
 
-export interface SegmentedControlProps extends ChildrenProps, StyleProps, TransferProps {}
+export interface SegmentedControlProps extends ChildrenProps, StyleProps, SpiritSegmentedControlElementProps {}
 
 export interface SpiritSegmentedControlItemProps extends SegmentedControlItemProps {}
 

--- a/packages/web-react/src/types/shared/element.ts
+++ b/packages/web-react/src/types/shared/element.ts
@@ -59,6 +59,9 @@ export type SpiritPolymorphicElementPropsWithoutRef<E extends ElementType, P> = 
   keyof P
 >;
 
+/** Allows passing arbitrary `data-*` attributes in typed object literals. */
+export type DataAttributeProps = { [key: `data-${string}`]: unknown };
+
 export type SpiritElementBaseProps = SpiritDetailedHTMLProps<HTMLElement>;
 export type SpiritAnchorElementBaseProps = SpiritCombinedHTMLProps<HTMLButtonElement>;
 export type SpiritButtonElementBaseProps = SpiritCombinedHTMLProps<HTMLButtonElement>;
@@ -71,6 +74,7 @@ export type SpiritSpanElementBaseProps = SpiritDetailedHTMLProps<HTMLSpanElement
 export type SpiritTextAreaElementBaseProps = SpiritCombinedHTMLProps<HTMLTextAreaElement>;
 export type SpiritUListElementBaseProps = SpiritDetailedHTMLProps<HTMLUListElement>;
 export type SpiritFieldGroupElementBaseProps = SpiritDetailedHTMLProps<HTMLFieldSetElement>;
+export type SpiritSegmentedControlElementBaseProps = SpiritDetailedHTMLProps<HTMLFieldSetElement>;
 
 export type SpiritElementProps = OverloadStyleProps<SpiritElementBaseProps>;
 export type SpiritAnchorElementProps = OverloadStyleProps<SpiritAnchorElementBaseProps>;
@@ -90,6 +94,7 @@ export type SpiritTextAreaElementProps = Omit<
 >;
 export type SpiritUListElementProps = OverloadStyleProps<SpiritUListElementBaseProps>;
 export type SpiritFieldGroupElementProps = OverloadStyleProps<SpiritFieldGroupElementBaseProps>;
+export type SpiritSegmentedControlElementProps = OverloadStyleProps<SpiritSegmentedControlElementBaseProps>;
 
 export type SpiritInputElementPropsWithRef = Omit<
   SpiritInputElementProps & ComponentPropsWithRef<'input'>,

--- a/packages/web-react/src/types/shared/index.ts
+++ b/packages/web-react/src/types/shared/index.ts
@@ -17,7 +17,6 @@ export * from './positions';
 export * from './radii';
 export * from './refs';
 export * from './responsive';
-export * from './rest';
 export * from './router';
 export * from './sizes';
 export * from './style';

--- a/packages/web-react/src/types/shared/rest.ts
+++ b/packages/web-react/src/types/shared/rest.ts
@@ -1,5 +1,0 @@
-type TransferPropsValue = unknown;
-
-export interface TransferProps {
-  [key: string]: TransferPropsValue;
-}

--- a/packages/web-react/src/types/skeleton.ts
+++ b/packages/web-react/src/types/skeleton.ts
@@ -2,26 +2,17 @@ import { type ElementType } from 'react';
 import {
   type BorderRadiiDictionaryType,
   type ChildrenProps,
+  type PolymorphicComponentProps,
   type SingleOrResponsive,
   type SizeExtendedDictionaryType,
   type StyleProps,
-  type TransferProps,
 } from './shared';
-
-export interface AriaSkeletonElementTypeProps<E extends ElementType = 'div'> {
-  /**
-   * The HTML element or React element used to render the Skeleton, e.g. 'div', 'span'.
-   *
-   * @default 'div'
-   */
-  elementType?: E;
-}
 
 export type SkeletonSize<C> = SizeExtendedDictionaryType | C;
 
 export type SkeletonRadius<C> = SingleOrResponsive<BorderRadiiDictionaryType> | C;
 
-export interface SkeletonProps extends ChildrenProps, StyleProps, TransferProps {}
+export interface SkeletonProps extends ChildrenProps, StyleProps {}
 
 export interface SkeletonStyleProps<C = void> {
   width: number;
@@ -29,16 +20,28 @@ export interface SkeletonStyleProps<C = void> {
   borderRadius?: SkeletonRadius<C>;
 }
 
-export interface SpiritSkeletonProps<T extends ElementType = 'div', C = void>
-  extends AriaSkeletonElementTypeProps<T>, SkeletonProps {
+/** ===== INTERNAL API ===== */
+export interface SkeletonBaseProps<C = void> extends SkeletonProps {
   size?: SkeletonSize<C>;
   lines?: number;
 }
+
+/** ===== PUBLIC API ===== */
+export type SpiritSkeletonProps<E extends ElementType = 'div', C = void> = PolymorphicComponentProps<
+  E,
+  SkeletonBaseProps<C>
+>;
 
 export type SkeletonShapeStyleProps<T extends ElementType = 'div', C = void> = Pick<
   SpiritSkeletonShapeProps<T, C>,
   keyof SkeletonStyleProps<C>
 >;
 
-export interface SpiritSkeletonShapeProps<T extends ElementType = 'div', C = void>
-  extends AriaSkeletonElementTypeProps<T>, SkeletonProps, SkeletonStyleProps<C> {}
+/** ===== INTERNAL API ===== */
+export interface SkeletonShapeBaseProps<C = void> extends SkeletonProps, SkeletonStyleProps<C> {}
+
+/** ===== PUBLIC API ===== */
+export type SpiritSkeletonShapeProps<E extends ElementType = 'div', C = void> = PolymorphicComponentProps<
+  E,
+  SkeletonShapeBaseProps<C>
+>;

--- a/packages/web-react/src/types/skipLink.ts
+++ b/packages/web-react/src/types/skipLink.ts
@@ -1,8 +1,8 @@
 import { type ElementType } from 'react';
 import { type LinkTarget } from './link';
-import { type ChildrenProps, type StyleProps, type TransferProps } from './shared';
+import { type ChildrenProps, type StyleProps } from './shared';
 
-export interface SkipLinkBaseProps extends ChildrenProps, StyleProps, TransferProps {
+export interface SkipLinkBaseProps extends ChildrenProps, StyleProps {
   /** SkipLink's href attribute */
   href?: string;
   /** SkipLink's target attribute */

--- a/packages/web-react/src/types/splitButton.ts
+++ b/packages/web-react/src/types/splitButton.ts
@@ -3,16 +3,17 @@ import type {
   ChildrenProps,
   ComponentButtonColorNamesType,
   PlacementDictionaryType,
+  SpiritDivElementProps,
   StyleProps,
-  TransferProps,
 } from './shared';
 
-export interface SplitButtonProps extends TransferProps, StyleProps, ChildrenProps {}
+export interface SplitButtonProps extends StyleProps, ChildrenProps, Omit<SpiritDivElementProps, 'color'> {}
 
 export type SplitButtonColorType<C> = Exclude<ComponentButtonColorNamesType<C>, 'plain'>;
 
 export interface SpiritSplitButtonProps<C = void, S = void> extends SplitButtonProps {
   color?: SplitButtonColorType<C>;
+  isDisabled?: boolean;
   size?: ButtonSize<S>;
 }
 

--- a/packages/web-react/src/types/tabs.ts
+++ b/packages/web-react/src/types/tabs.ts
@@ -5,19 +5,21 @@ import {
   type PolymorphicComponentProps,
   type RouterLinkProps,
   type SpacingProp,
+  type SpiritButtonElementProps,
+  type SpiritDivElementProps,
+  type SpiritUListElementProps,
   type StyleProps,
-  type TransferProps,
 } from './shared';
 
 export type TabId = string | number;
 
-export type TabListProps = ChildrenProps & TransferProps;
+export type TabListProps = ChildrenProps & SpiritUListElementProps;
 
 export interface TabsOnSelectionChange {
   onSelectionChange?: (previousId: TabId, currentId?: TabId) => void;
 }
 
-export interface TabItemProps extends ChildrenProps, TransferProps, ClickEvents {
+export interface TabItemProps extends ChildrenProps, ClickEvents, Omit<SpiritButtonElementProps, 'onClick'> {
   forTabPane: TabId;
 }
 
@@ -30,7 +32,7 @@ export interface SpiritTabsProps extends SpacingProp {
   forTabPane?: TabId;
 }
 
-export interface TabsProps extends ChildrenProps, SpacingProp, TransferProps, TabsOnSelectionChange {
+export interface TabsProps extends ChildrenProps, SpacingProp, TabsOnSelectionChange {
   selectedTab: TabId;
   toggle: TabsToggler;
 }
@@ -38,7 +40,7 @@ export interface TabsProps extends ChildrenProps, SpacingProp, TransferProps, Ta
 export type TabLinkItemProps = StyleProps & HTMLProps<HTMLLIElement>;
 
 /** ===== BASE API ===== */
-export interface TabLinkBaseProps extends ChildrenProps, StyleProps, TransferProps, RouterLinkProps {}
+export interface TabLinkBaseProps extends ChildrenProps, StyleProps, RouterLinkProps {}
 
 /** ===== STYLE API ===== */
 export interface TabLinkStyleProps extends TabLinkBaseProps {
@@ -58,12 +60,12 @@ export interface TabsContextType extends SpacingProp, TabsOnSelectionChange {
   selectTab: TabsToggler;
 }
 
-export interface TabPaneProps extends ChildrenProps, TransferProps {
+export interface TabPaneProps extends ChildrenProps, Omit<SpiritDivElementProps, 'id'> {
   id: TabId;
 }
 
-export type TabContentProps = ChildrenProps & TransferProps;
+export type TabContentProps = ChildrenProps & SpiritDivElementProps;
 
-export interface UncontrolledTabsProps extends ChildrenProps, SpacingProp, TransferProps, TabsOnSelectionChange {
+export interface UncontrolledTabsProps extends ChildrenProps, SpacingProp, TabsOnSelectionChange {
   defaultSelectedTab: TabId;
 }

--- a/packages/web-react/src/types/tag.ts
+++ b/packages/web-react/src/types/tag.ts
@@ -3,9 +3,9 @@ import { type TagColorsExtended } from '..';
 import type {
   ChildrenProps,
   EmotionColorNamesType,
+  PolymorphicComponentProps,
   SizeExtendedDictionaryType,
   StyleProps,
-  TransferProps,
 } from './shared';
 
 export type TagColorsExtendedNamesType = (typeof TagColorsExtended)[keyof typeof TagColorsExtended];
@@ -14,21 +14,16 @@ export type TagColor<C> = EmotionColorNamesType | TagColorsExtendedNamesType | C
 
 export type TagSize<S> = SizeExtendedDictionaryType | S;
 
-export interface AriaTagElementTypeProps<E extends ElementType = 'span'> {
-  /**
-   * The HTML element or React element used to render the tag, e.g. 'div', 'span'.
-   *
-   * @default 'span'
-   */
-  elementType?: E;
-}
-
-export interface TagProps<E extends ElementType = 'span', C = void, S = void>
-  extends ChildrenProps, StyleProps, TransferProps, AriaTagElementTypeProps<E> {
+/** ===== INTERNAL API ===== */
+export interface TagProps<C = void, S = void> extends ChildrenProps, StyleProps {
   color?: TagColor<C>;
   isDisabled?: boolean;
   isSubtle?: boolean;
   size?: TagSize<S>;
 }
 
-export type SpiritTagProps<E extends ElementType = 'span', C = void, S = void> = TagProps<E, C, S>;
+/** ===== PUBLIC API ===== */
+export type SpiritTagProps<E extends ElementType = 'span', C = void, S = void> = PolymorphicComponentProps<
+  E,
+  TagProps<C, S>
+>;

--- a/packages/web-react/src/types/text.ts
+++ b/packages/web-react/src/types/text.ts
@@ -3,30 +3,27 @@ import type {
   ChildrenProps,
   EmphasisDictionaryType,
   EmphasisProps,
+  PolymorphicComponentProps,
   SizeExtendedDictionaryType,
   SizeProps,
   StyleProps,
   TextColorProps,
   TextColorsType,
-  TransferProps,
   TypographyBaseProps,
 } from './shared';
 
-export interface TextElementTypeProps<E extends ElementType = 'p'> {
-  /**
-   * The HTML element or React element used to render the Text, e.g. 'p'.
-   *
-   * @default 'p'
-   */
-  elementType?: E;
-}
-
-export interface TextProps<T extends ElementType = 'p'>
-  extends TextElementTypeProps<T>, ChildrenProps, StyleProps, TransferProps, TypographyBaseProps {}
-
-export interface SpiritTextProps<T extends ElementType = 'p', S = void, Emph = void, C = void>
+/** ===== INTERNAL API ===== */
+export interface TextProps<S = void, Emph = void, C = void>
   extends
-    TextProps<T>,
+    ChildrenProps,
+    StyleProps,
+    TypographyBaseProps,
     SizeProps<SizeExtendedDictionaryType<S>>,
     EmphasisProps<EmphasisDictionaryType<Emph>>,
     TextColorProps<TextColorsType<C>> {}
+
+/** ===== PUBLIC API ===== */
+export type SpiritTextProps<E extends ElementType = 'p', S = void, Emph = void, C = void> = PolymorphicComponentProps<
+  E,
+  TextProps<S, Emph, C>
+>;

--- a/packages/web-react/src/types/timeline.ts
+++ b/packages/web-react/src/types/timeline.ts
@@ -8,6 +8,7 @@ import type {
   BorderColorsDictionaryType,
   BorderEmotionColorsType,
   ChildrenProps,
+  PolymorphicComponentProps,
   SingleOrResponsive,
   SizesDictionaryType,
   StyleProps,
@@ -17,24 +18,6 @@ import type {
 export type TimelineBaseProps = {
   /** Size of the timeline. */
   size?: SingleOrResponsive<SizesDictionaryType>;
-};
-
-export type TimelineProps<E extends ElementType> = {
-  /**
-   * The HTML element or React element used to render the plan, e.g. 'div', 'a', or `RouterLink`.
-   *
-   * @default 'ol'
-   */
-  elementType?: E;
-};
-
-export type TimelineStepProps<E extends ElementType> = {
-  /**
-   * The HTML element or React element used to render the plan, e.g. 'div', 'a', or `RouterLink`.
-   *
-   * @default 'li'
-   */
-  elementType?: E;
 };
 
 export type TimelineMarkerType = (typeof TIMELINE_MARKER)[keyof typeof TIMELINE_MARKER];
@@ -58,11 +41,15 @@ export interface TimelineMarkerProps {
   borderColor?: BorderAccentColorsType | BorderEmotionColorsType | BorderColorsDictionaryType;
 }
 
-export interface SpiritTimelineProps<T extends ElementType = 'ol'>
-  extends TimelineProps<T>, TimelineBaseProps, ChildrenProps, StyleProps {}
+/** ===== INTERNAL API ===== */
+export interface TimelineProps extends TimelineBaseProps, ChildrenProps, StyleProps {}
 
-export interface SpiritTimelineStepProps<T extends ElementType = 'li'>
-  extends TimelineStepProps<T>, ChildrenProps, StyleProps {}
+export interface TimelineStepProps extends ChildrenProps, StyleProps {}
+
+/** ===== PUBLIC API ===== */
+export type SpiritTimelineProps<E extends ElementType = 'ol'> = PolymorphicComponentProps<E, TimelineProps>;
+
+export type SpiritTimelineStepProps<E extends ElementType = 'li'> = PolymorphicComponentProps<E, TimelineStepProps>;
 
 export interface SpiritTimelineMarkerProps extends TimelineMarkerProps, ChildrenProps, StyleProps {}
 

--- a/packages/web-react/src/types/tooltip.ts
+++ b/packages/web-react/src/types/tooltip.ts
@@ -1,13 +1,6 @@
 import { type Placement, type Strategy } from '@floating-ui/react';
 import type { ElementType, ReactNode } from 'react';
-import type {
-  ChildrenProps,
-  ClickEvent,
-  ElementTypeProp,
-  PolymorphicComponentProps,
-  StyleProps,
-  TransferProps,
-} from './shared';
+import type { ChildrenProps, ClickEvent, PolymorphicComponentProps, SpiritDivElementProps, StyleProps } from './shared';
 
 /** ===== BASE API ===== */
 export const TOOLTIP_TRIGGER = {
@@ -58,9 +51,9 @@ export interface TooltipStyleProps extends TooltipBaseProps, TooltipState, Toolt
 export interface TooltipProps extends TooltipStyleProps {}
 
 // Sub-components receive props from JSX, but get state/handlers from context
-export interface TooltipPopoverProps extends ChildrenProps, StyleProps, TransferProps {}
-export interface TooltipTriggerProps extends StyleProps, TransferProps {
-  elementType?: ElementTypeProp;
+export interface TooltipPopoverProps extends ChildrenProps, SpiritDivElementProps {}
+
+export interface TooltipTriggerBaseProps extends StyleProps {
   children?: string | ReactNode | ((props: { isOpen: boolean }) => ReactNode);
 }
 
@@ -68,3 +61,8 @@ export interface UncontrolledTooltipProps extends TooltipStyleProps {}
 
 /** ===== PUBLIC API ===== */
 export type SpiritTooltipProps<E extends ElementType = 'div'> = PolymorphicComponentProps<E, TooltipProps>;
+
+export type TooltipTriggerProps<E extends ElementType = 'button'> = PolymorphicComponentProps<
+  E,
+  TooltipTriggerBaseProps
+>;

--- a/packages/web-react/src/types/truncate.ts
+++ b/packages/web-react/src/types/truncate.ts
@@ -1,5 +1,5 @@
 import { type ElementType } from 'react';
-import { type ChildrenProps, type PositiveInteger, type StyleProps } from './shared';
+import { type ChildrenProps, type PolymorphicComponentProps, type PositiveInteger, type StyleProps } from './shared';
 
 /**
  * The modes of truncation.
@@ -16,8 +16,8 @@ export const TruncateModes = {
 
 export type TruncateMode = (typeof TruncateModes)[keyof typeof TruncateModes];
 
-export interface SpiritTruncateProps<E extends ElementType> extends StyleProps, ChildrenProps {
-  elementType?: E;
+/** ===== INTERNAL API ===== */
+export interface TruncateProps extends StyleProps, ChildrenProps {
   /**
    * The limit for the truncation (lines, words, or characters).
    *
@@ -33,3 +33,6 @@ export interface SpiritTruncateProps<E extends ElementType> extends StyleProps, 
    */
   mode?: TruncateMode;
 }
+
+/** ===== PUBLIC API ===== */
+export type SpiritTruncateProps<E extends ElementType = 'span'> = PolymorphicComponentProps<E, TruncateProps>;

--- a/packages/web-react/src/types/unstableHeader.ts
+++ b/packages/web-react/src/types/unstableHeader.ts
@@ -1,18 +1,12 @@
 import { type ElementType } from 'react';
 import { type LinkTarget } from './link';
-import {
-  type ChildrenProps,
-  type PolymorphicComponentProps,
-  type SpiritElementProps,
-  type StyleProps,
-  type TransferProps,
-} from './shared';
+import { type ChildrenProps, type PolymorphicComponentProps, type SpiritElementProps, type StyleProps } from './shared';
 
 /** ===== BASE API ===== */
 export interface HeaderBaseProps extends ChildrenProps, StyleProps {}
 
 /** ===== STYLE API ===== */
-export interface HeaderLogoStyleProps extends ChildrenProps, StyleProps, TransferProps {
+export interface HeaderLogoStyleProps extends ChildrenProps, StyleProps {
   /** Header's href attribute */
   href?: string;
   /** Header's target attribute */

--- a/packages/web-react/src/types/visuallyHidden.ts
+++ b/packages/web-react/src/types/visuallyHidden.ts
@@ -1,16 +1,11 @@
 import { type ElementType } from 'react';
-import { type ChildrenProps, type StyleProps, type TransferProps } from './shared';
+import { type ChildrenProps, type PolymorphicComponentProps, type StyleProps } from './shared';
 
-export interface VisuallyHiddenElementTypeProps<E extends ElementType = 'span'> {
-  /**
-   * The HTML element or React element used to render the VisuallyHidden component, e.g. 'span'.
-   *
-   * @default 'span'
-   */
-  elementType?: E;
-}
+/** ===== INTERNAL API ===== */
+export interface VisuallyHiddenProps extends ChildrenProps, StyleProps {}
 
-export interface VisuallyHiddenProps<T extends ElementType = 'span'>
-  extends VisuallyHiddenElementTypeProps<T>, ChildrenProps, StyleProps, TransferProps {}
-
-export interface SpiritVisuallyHiddenProps<E extends ElementType = 'span'> extends VisuallyHiddenProps<E> {}
+/** ===== PUBLIC API ===== */
+export type SpiritVisuallyHiddenProps<E extends ElementType = 'span'> = PolymorphicComponentProps<
+  E,
+  VisuallyHiddenProps
+>;


### PR DESCRIPTION
## Description

- Removes the `TransferProps` escape hatch (`[key: string]: unknown`) from all component types so the IDE and TypeScript catch invalid/misspelled props.
- Unifies the polymorphic-old components on a single pattern: internal `*BaseProps` + public `Spirit*Props<E> = PolymorphicComponentProps<E, ...>`.

### Additional context

### Issue reference

Resolves [DS-2282](https://jira.almacareer.tech/browse/DS-2282).
