### PR TITLE
chore(repo): add shared JetBrains run configurations to version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,8 @@ nx-cloud.env
 
 # Design reviews
 /design-reviews/
+
+# JetBrains IDE — ignore everything except shared run configurations
+!.idea/
+.idea/*
+!.idea/runConfigurations/

--- a/.idea/runConfigurations/Build.xml
+++ b/.idea/runConfigurations/Build.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Build" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
+    <makefile filename="$PROJECT_DIR$/Makefile" target="build" workingDirectory="$PROJECT_DIR$" arguments="">
+      <envs />
+    </makefile>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/End_to_end_tests.xml
+++ b/.idea/runConfigurations/End_to_end_tests.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="End-to-end tests" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
+    <makefile filename="$PROJECT_DIR$/Makefile" target="test-e2e" workingDirectory="$PROJECT_DIR$" arguments="">
+      <envs />
+    </makefile>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/End_to_end_tests_with_update.xml
+++ b/.idea/runConfigurations/End_to_end_tests_with_update.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="End-to-end tests with update" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
+    <makefile filename="$PROJECT_DIR$/Makefile" target="test-e2e-update" workingDirectory="$PROJECT_DIR$" arguments="">
+      <envs />
+    </makefile>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Format_check.xml
+++ b/.idea/runConfigurations/Format_check.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Format check" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
+    <makefile filename="$PROJECT_DIR$/Makefile" target="format" workingDirectory="$PROJECT_DIR$" arguments="">
+      <envs />
+    </makefile>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Format_fix.xml
+++ b/.idea/runConfigurations/Format_fix.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Format fix" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
+    <makefile filename="$PROJECT_DIR$/Makefile" target="format-fix" workingDirectory="$PROJECT_DIR$" arguments="">
+      <envs />
+    </makefile>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Install.xml
+++ b/.idea/runConfigurations/Install.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Install" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
+    <makefile filename="$PROJECT_DIR$/Makefile" target="install" workingDirectory="$PROJECT_DIR$" arguments="">
+      <envs />
+    </makefile>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Lint_check.xml
+++ b/.idea/runConfigurations/Lint_check.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Lint check" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
+    <makefile filename="$PROJECT_DIR$/Makefile" target="lint" workingDirectory="$PROJECT_DIR$" arguments="">
+      <envs />
+    </makefile>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Lint_fix.xml
+++ b/.idea/runConfigurations/Lint_fix.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Lint fix" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
+    <makefile filename="$PROJECT_DIR$/Makefile" target="lint-fix" workingDirectory="$PROJECT_DIR$" arguments="">
+      <envs />
+    </makefile>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Start.xml
+++ b/.idea/runConfigurations/Start.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Start" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
+    <makefile filename="$PROJECT_DIR$/Makefile" target="start" workingDirectory="$PROJECT_DIR$" arguments="">
+      <envs />
+    </makefile>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Test.xml
+++ b/.idea/runConfigurations/Test.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Test" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
+    <makefile filename="$PROJECT_DIR$/Makefile" target="test" workingDirectory="$PROJECT_DIR$" arguments="">
+      <envs />
+    </makefile>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.prettierignore
+++ b/.prettierignore
@@ -114,3 +114,6 @@ Caddyfile
 
 # Backstage Catalog Info
 catalog-info.yaml
+
+# JetBrains IDE
+.idea/


### PR DESCRIPTION
## Description

Tracks `.idea/runConfigurations/` in version control so JetBrains run configurations are shared across the team and across git worktrees without manual setup.

Also updates `.gitignore` (un-ignore `.idea/runConfigurations/` while keeping the rest of `.idea/` out of git) and `.prettierignore` (exclude `.idea/` from Prettier, which has no XML parser configured).

<img width="373" height="673" alt="image" src="https://github.com/user-attachments/assets/c8a8468e-f99f-408c-a040-30a14fd62e57" />

### Additional context

The global `~/.gitignore` typically ignores the entire `.idea/` directory. The approach used here — negating `.idea/` in the project `.gitignore`, then re-ignoring all its contents except `runConfigurations/` — overrides that globally so the configs are tracked for everyone cloning the repo.

### Issue reference

<!-- N/A -->