### PR TITLE
feat(web-react): add dropdown popover keyboard support #DS-2501

### DIFF
--- a/docs/migrations/web-react/migration-v5.md
+++ b/docs/migrations/web-react/migration-v5.md
@@ -10,6 +10,7 @@ Introducing version 5 of the _spirit-web-react_ package.
 ## Overview
 
 - [Component Changes](#component-changes)
+  - [Dropdown: `DropdownPopover` Now Has `role="dialog"` by Default](#dropdown-dropdownpopover-now-has-roledialog-by-default)
   - [Collapse: `hideOnCollapse` Prop Renamed to `isDisposable`](#collapse-hideoncollapse-prop-renamed-to-isdisposable)
   - [Flex: Direction Prop Values Changed](#flex-direction-prop-values-changed)
   - [Form Components: `isFluid` Prop Removed](#form-components-isfluid-prop-removed)
@@ -20,6 +21,42 @@ Introducing version 5 of the _spirit-web-react_ package.
   - [Truncate: Component Name Stabilized and `lines` Prop Changed](#truncate-component-name-stabilized-and-lines-prop-changed)
 
 ## Component Changes
+
+### Dropdown: `DropdownPopover` Now Has `role="dialog"` by Default
+
+`DropdownPopover` now renders as a non-modal anchored dialog (`role="dialog"`) by default, and
+`DropdownTrigger` now has `aria-haspopup="dialog"` by default. Keyboard behavior is applied
+automatically:
+
+- **Escape** closes the popover and returns focus to the trigger (from anywhere inside, including the trigger itself)
+- **Tab** past the last focusable element closes the popover and returns focus to the trigger
+- **Shift+Tab** before the first focusable element closes the popover and returns focus to the trigger
+- When the popover opens, focus moves automatically to the first interactive element inside it
+
+#### What you need to do
+
+1. **Add an accessible name** to every `DropdownPopover` via `aria-label` or `aria-labelledby`.
+   ARIA dialogs are required to have an accessible name:
+
+   ```tsx
+   <DropdownPopover aria-label="Options">…</DropdownPopover>
+   ```
+
+2. **Update snapshot tests** — the rendered HTML now includes `role="dialog"` on the popover and
+   `aria-haspopup="dialog"` on the trigger.
+
+3. If you were manually setting `role="dialog"` on `DropdownPopover` (e.g. as a feature-flag workaround),
+   you can now remove that explicit prop.
+
+4. If you need to **opt out** of the dialog role for a specific popover (e.g. a navigation menu), override
+   both the popover role and the trigger's `aria-haspopup` to keep them consistent:
+
+   ```tsx
+   <Dropdown …>
+     <DropdownTrigger aria-haspopup="menu" elementType="button">Trigger</DropdownTrigger>
+     <DropdownPopover role="menu">…</DropdownPopover>
+   </Dropdown>
+   ```
 
 ### Collapse: `hideOnCollapse` Prop Renamed to `isDisposable`
 

--- a/packages/web-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/web-react/src/components/Dropdown/Dropdown.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import classNames from 'classnames';
-import React, { useRef } from 'react';
-import { useClickOutside, useStyleProps } from '../../hooks';
+import React, { type KeyboardEventHandler, type MutableRefObject, useCallback, useRef } from 'react';
+import { useOverlay, useStyleProps } from '../../hooks';
 import { type SpiritDropdownProps } from '../../types';
 import { DropdownProvider } from './DropdownContext';
 import { useDropdownStyleProps } from './useDropdownStyleProps';
@@ -17,29 +17,57 @@ const Dropdown = (props: SpiritDropdownProps) => {
     onAutoClose,
     onToggle,
     placement,
+    triggerRef: externalTriggerRef,
     ...rest
   } = props;
   const { classProps, props: modifiedProps } = useDropdownStyleProps({ isOpen, ...rest });
-  const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
+  const { styleProps, props: transferProps } = useStyleProps(modifiedProps);
+  const { onKeyDown: onUserKeyDown, ...otherProps } = transferProps;
 
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLDivElement>();
+  const internalTriggerRef = useRef<HTMLElement | null>(null);
+  const triggerRef: MutableRefObject<HTMLElement | null | undefined> = externalTriggerRef ?? internalTriggerRef;
 
-  const closeHandler = (event: Event) => {
-    if (!enableAutoClose) {
+  const closeOverlay = useCallback(() => {
+    if (!isOpen) {
       return;
     }
 
-    if (!triggerRef?.current?.contains(event?.target as Node)) {
-      if (onAutoClose) {
-        onAutoClose(event);
+    onToggle();
+
+    queueMicrotask(() => {
+      triggerRef.current?.focus();
+    });
+  }, [isOpen, onToggle, triggerRef]);
+
+  const closeOverlayFromOutside = useCallback(
+    (event: Event) => {
+      if (!isOpen) {
+        return;
       }
 
-      onToggle && isOpen && onToggle();
-    }
-  };
+      onAutoClose?.(event);
+      onToggle();
+    },
+    [isOpen, onAutoClose, onToggle],
+  );
 
-  useClickOutside({ ref: dropdownRef, callback: closeHandler });
+  const { onOverlayKeyDown } = useOverlay({
+    isOpen,
+    overlayRef: dropdownRef,
+    onClose: closeOverlay,
+    closeOnInteractOutside: enableAutoClose,
+    onCloseOnInteractOutside: closeOverlayFromOutside,
+  });
+
+  const handleKeyDown: KeyboardEventHandler<HTMLElement> = useCallback(
+    (event) => {
+      onUserKeyDown?.(event);
+      onOverlayKeyDown(event);
+    },
+    [onOverlayKeyDown, onUserKeyDown],
+  );
+  const mergedProps = { ...otherProps, onKeyDown: handleKeyDown };
 
   return (
     <DropdownProvider value={{ id, isOpen, fullWidthMode, placement, onToggle, dropdownRef, triggerRef }}>
@@ -47,7 +75,7 @@ const Dropdown = (props: SpiritDropdownProps) => {
         ref={dropdownRef}
         className={classNames(classProps.root, styleProps.className)}
         style={styleProps.style}
-        {...otherProps}
+        {...mergedProps}
       >
         {children}
       </div>

--- a/packages/web-react/src/components/Dropdown/DropdownContext.ts
+++ b/packages/web-react/src/components/Dropdown/DropdownContext.ts
@@ -10,9 +10,9 @@ type DropdownContextType = {
   fullWidthMode?: keyof typeof fullWidthModeKeys;
   id: string;
   isOpen: boolean;
-  onToggle: (event: ClickEvent) => void;
+  onToggle: (event?: ClickEvent) => void;
   placement?: PlacementDictionaryType;
-  triggerRef: MutableRefObject<HTMLElement | undefined>;
+  triggerRef: MutableRefObject<HTMLElement | null | undefined>;
 };
 
 const defaultContext: DropdownContextType = {
@@ -22,7 +22,7 @@ const defaultContext: DropdownContextType = {
   isOpen: false,
   onToggle: () => {},
   placement: Placements.BOTTOM_START,
-  triggerRef: { current: undefined },
+  triggerRef: { current: null },
 };
 
 const DropdownContext = createContext<DropdownContextType>(defaultContext);

--- a/packages/web-react/src/components/Dropdown/DropdownPopover.tsx
+++ b/packages/web-react/src/components/Dropdown/DropdownPopover.tsx
@@ -1,26 +1,33 @@
 'use client';
 
 import classNames from 'classnames';
-import React from 'react';
-import { useStyleProps } from '../../hooks';
+import React, { useRef } from 'react';
+import { useAutoFocus, useStyleProps } from '../../hooks';
 import { type SpiritDivElementProps } from '../../types';
 import { useDropdownContext } from './DropdownContext';
 import { useDropdownAriaProps } from './useDropdownAriaProps';
+import { useDropdownPopoverDialogKeyboard } from './useDropdownPopoverDialogKeyboard';
 import { useDropdownStyleProps } from './useDropdownStyleProps';
 
 interface DropdownPopoverProps extends SpiritDivElementProps {}
 
 const DropdownPopover = (props: DropdownPopoverProps) => {
   const { children, ...rest } = props;
-  const { id, isOpen, onToggle, fullWidthMode, placement } = useDropdownContext();
+  const { id, isOpen, onToggle, fullWidthMode, placement, triggerRef } = useDropdownContext();
   const { classProps, props: modifiedProps } = useDropdownStyleProps({ isOpen, placement, ...rest });
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
   const { contentProps } = useDropdownAriaProps({ id, isOpen, toggleHandler: onToggle, fullWidthMode });
+  const { onPopoverKeyDownCapture } = useDropdownPopoverDialogKeyboard({ isOpen, onToggle, triggerRef });
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useAutoFocus({ isActive: isOpen, containerRef: popoverRef });
 
   return (
     <div
+      ref={popoverRef}
       className={classNames(classProps.popover, styleProps.className)}
       style={styleProps.style}
+      onKeyDownCapture={onPopoverKeyDownCapture}
       {...contentProps}
       {...otherProps}
     >

--- a/packages/web-react/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/web-react/src/components/Dropdown/DropdownTrigger.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { type ElementType } from 'react';
-import { useStyleProps } from '../../hooks';
+import { useOpenOnArrowDown, useStyleProps } from '../../hooks';
 import { type DropdownTriggerProps } from '../../types';
 import { mergeStyleProps } from '../../utils';
 import { useDropdownContext } from './DropdownContext';
@@ -18,11 +18,26 @@ const DropdownTrigger = <E extends ElementType = 'button'>(props: DropdownTrigge
   const { id, isOpen, onToggle, fullWidthMode, triggerRef } = useDropdownContext();
   const { classProps, props: modifiedProps } = useDropdownStyleProps({ isOpen, ...rest });
   const { styleProps: triggerStyleProps, props: transferProps } = useStyleProps(modifiedProps);
+  const { onKeyDown: onUserKeyDown, ...otherProps } = transferProps;
   const mergedStyleProps = mergeStyleProps(ElementTag, { classProps: classProps.trigger, triggerStyleProps });
-  const { triggerProps } = useDropdownAriaProps({ id, isOpen, toggleHandler: onToggle, fullWidthMode });
+  const hasPopup = otherProps['aria-haspopup'];
+  const { triggerProps } = useDropdownAriaProps({
+    id,
+    isOpen,
+    toggleHandler: onToggle,
+    fullWidthMode,
+    hasPopup: typeof hasPopup === 'string' || typeof hasPopup === 'boolean' ? hasPopup : undefined,
+  });
+
+  const handleKeyDown = useOpenOnArrowDown({
+    isOpen,
+    onToggle,
+    onKeyDown: onUserKeyDown,
+  });
+  const mergedProps = { ...otherProps, ...triggerProps, onKeyDown: handleKeyDown };
 
   return (
-    <ElementTag {...transferProps} {...triggerProps} {...mergedStyleProps} ref={triggerRef}>
+    <ElementTag {...mergedProps} {...mergedStyleProps} ref={triggerRef}>
       {typeof children === 'function' ? children({ isOpen }) : children}
     </ElementTag>
   );

--- a/packages/web-react/src/components/Dropdown/README.md
+++ b/packages/web-react/src/components/Dropdown/README.md
@@ -13,10 +13,30 @@ export const Example = () => {
   return (
     <Dropdown id="dropdown-example" isOpen={isOpen} onToggle={onToggle}>
       <DropdownTrigger elementType="button">Trigger button</DropdownTrigger>
-      <DropdownPopover>…</DropdownPopover>
+      <DropdownPopover aria-label="Options">…</DropdownPopover>
     </Dropdown>
   );
 };
+```
+
+### Keyboard Behavior (Dialog Pattern)
+
+`DropdownPopover` follows the non-modal anchored dialog pattern:
+
+- When the popover **opens**, focus automatically moves to the **first interactive element** inside it.
+- **Escape** – closes the popover and returns focus to the trigger (works from both the trigger and items inside the popover)
+- **Tab** from the last focusable element inside the popover – closes the popover and returns focus to the trigger (no focus trap)
+- **Shift+Tab** from the first focusable element inside the popover – closes the popover and returns focus to the trigger
+
+Because the popover renders with `role="dialog"`, it must have an accessible name. Provide it via `aria-label` or `aria-labelledby`:
+
+```tsx
+<DropdownPopover aria-label="Options">…</DropdownPopover>;
+
+// or reference a visible heading inside the popover
+<DropdownPopover aria-labelledby="my-dropdown-title">
+  <h3 id="my-dropdown-title">Options</h3>…
+</DropdownPopover>;
 ```
 
 ### Dropdown with Item
@@ -34,7 +54,7 @@ export const Example = () => {
   return (
     <Dropdown id="dropdown-example" isOpen={isOpen} onToggle={onToggle}>
       <DropdownTrigger elementType="button">Trigger button</DropdownTrigger>
-      <DropdownPopover>
+      <DropdownPopover aria-label="Options">
         <Item elementType="a" href="#" label="Item label" />
       </DropdownPopover>
     </Dropdown>
@@ -52,7 +72,7 @@ export const Example = () => {
   return (
     <UncontrolledDropdown id="uncontrolled-dropdown-example">
       <DropdownTrigger elementType="button">Trigger button</DropdownTrigger>
-      <DropdownPopover>…</DropdownPopover>
+      <DropdownPopover aria-label="Options">…</DropdownPopover>
     </UncontrolledDropdown>
   );
 };
@@ -62,17 +82,18 @@ export const Example = () => {
 
 ### Dropdown
 
-| Name              | Type                                                                  | Default        | Required | Description                                                                                                                               |
-| ----------------- | --------------------------------------------------------------------- | -------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `alignmentX`      | \[ [AlignmentXExtended dictionary][dictionary-alignment] \| `object`] | `null`         | ✕        | Apply vertical alignment to trigger, use object to set responsive values, e.g. `{ mobile: 'left', tablet: 'center', desktop: 'right' }`   |
-| `alignmentY`      | \[ [AlignmentYExtended dictionary][dictionary-alignment] \| `object`] | `null`         | ✕        | Apply horizontal alignment to trigger, use object to set responsive values, e.g. `{ mobile: 'top', tablet: 'center', desktop: 'bottom' }` |
-| `enableAutoClose` | `bool`                                                                | `true`         | ✕        | Enables close on click outside of Dropdown                                                                                                |
-| `fullWidthMode`   | [`DropdownFullWidthMode`][dropdown-fullwidth-mode]                    | `off`          | ✕        | Full-width mode                                                                                                                           |
-| `id`              | `string`                                                              | —              | ✓        | Component id                                                                                                                              |
-| `isOpen`          | `bool`                                                                | `false`        | ✓        | Open state                                                                                                                                |
-| `onAutoClose`     | `(event: Event) => void`                                              | —              | ✕        | Callback on close on click outside of Dropdown                                                                                            |
-| `onToggle`        | `() => void`                                                          | —              | ✓        | Function for toggle open state of dropdown                                                                                                |
-| `placement`       | [Placement dictionary][dictionary-placement]                          | `bottom-start` | ✕        | Alignment of the component                                                                                                                |
+| Name              | Type                                                                  | Default        | Required | Description                                                                                                                                           |
+| ----------------- | --------------------------------------------------------------------- | -------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `alignmentX`      | \[ [AlignmentXExtended dictionary][dictionary-alignment] \| `object`] | `null`         | ✕        | Apply vertical alignment to trigger, use object to set responsive values, e.g. `{ mobile: 'left', tablet: 'center', desktop: 'right' }`               |
+| `alignmentY`      | \[ [AlignmentYExtended dictionary][dictionary-alignment] \| `object`] | `null`         | ✕        | Apply horizontal alignment to trigger, use object to set responsive values, e.g. `{ mobile: 'top', tablet: 'center', desktop: 'bottom' }`             |
+| `enableAutoClose` | `bool`                                                                | `true`         | ✕        | Enables close on click outside of Dropdown                                                                                                            |
+| `fullWidthMode`   | [`DropdownFullWidthMode`][dropdown-fullwidth-mode]                    | `off`          | ✕        | Full-width mode                                                                                                                                       |
+| `id`              | `string`                                                              | —              | ✓        | Component id                                                                                                                                          |
+| `isOpen`          | `bool`                                                                | `false`        | ✓        | Open state                                                                                                                                            |
+| `onAutoClose`     | `(event: Event) => void`                                              | —              | ✕        | Callback on close on click outside of Dropdown                                                                                                        |
+| `onToggle`        | `() => void`                                                          | —              | ✓        | Function for toggle open state of dropdown                                                                                                            |
+| `placement`       | [Placement dictionary][dictionary-placement]                          | `bottom-start` | ✕        | Alignment of the component                                                                                                                            |
+| `triggerRef`      | `MutableRefObject<HTMLElement \| null \| undefined>`                  | —              | ✕        | External trigger ref; supply when the trigger element is outside `DropdownTrigger` (e.g. custom pickers) so focus returns correctly on keyboard close |
 
 On top of the API options, the components accept [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]
@@ -93,7 +114,7 @@ at edge of the `Dropdown` element and on the place defined by the placement attr
 ```tsx
 <Dropdown alignmentX={{ mobile: 'right', tablet: 'left', desktop: 'center' }} alignmentY="center" id="#dropdown-alignment">
   <DropdownTrigger elementType={Button}>Button as anchor</DropdownTrigger>
-  <DropdownPopover>
+  <DropdownPopover aria-label="Options">
     <!-- ... -->
   </DropdownPopover>
 </Dropdown>
@@ -112,9 +133,26 @@ and [escape hatches][readme-escape-hatches].
 
 ### DropdownPopover
 
-| Name       | Type                       | Default | Required | Description                |
-| ---------- | -------------------------- | ------- | -------- | -------------------------- |
-| `children` | \[`string` \| `ReactNode`] | —       | ✓        | Content of trigger element |
+`DropdownPopover` renders as a non-modal anchored dialog (`role="dialog"`) by default.
+**An accessible name is required** — provide it via `aria-label` or `aria-labelledby`.
+
+Keyboard behavior is applied automatically: **Escape** closes the popover and returns focus to the
+trigger, and **Tab** / **Shift+Tab** out of the popover close it as focus leaves the dialog.
+
+When you override `role` (e.g. `role="menu"`), also pass the matching `aria-haspopup` value to
+`DropdownTrigger` to keep the trigger and popover semantics consistent:
+
+```tsx
+<Dropdown …>
+  <DropdownTrigger aria-haspopup="menu" elementType="button">Trigger</DropdownTrigger>
+  <DropdownPopover role="menu">…</DropdownPopover>
+</Dropdown>
+```
+
+| Name       | Type                       | Default    | Required | Description            |
+| ---------- | -------------------------- | ---------- | -------- | ---------------------- |
+| `children` | \[`string` \| `ReactNode`] | —          | ✓        | Content of the popover |
+| `role`     | `string`                   | `"dialog"` | ✕        | Override the ARIA role |
 
 On top of the API options, the components accept [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]

--- a/packages/web-react/src/components/Dropdown/UncontrolledDropdown.tsx
+++ b/packages/web-react/src/components/Dropdown/UncontrolledDropdown.tsx
@@ -1,29 +1,74 @@
 'use client';
 
 import classNames from 'classnames';
-import React, { useRef } from 'react';
-import { useStyleProps } from '../../hooks';
+import React, { type KeyboardEventHandler, type MutableRefObject, useCallback, useRef } from 'react';
+import { useOverlay, useStyleProps } from '../../hooks';
 import { type UncontrolledDropdownProps } from '../../types';
 import { DropdownProvider } from './DropdownContext';
 import { useDropdown } from './useDropdown';
 import { useDropdownStyleProps } from './useDropdownStyleProps';
 
 const UncontrolledDropdown = (props: UncontrolledDropdownProps) => {
-  const { children, enableAutoClose = true, fullWidthMode, id, onAutoClose, placement, ...rest } = props;
+  const {
+    children,
+    enableAutoClose = true,
+    fullWidthMode,
+    id,
+    onAutoClose,
+    placement,
+    triggerRef: externalTriggerRef,
+    ...rest
+  } = props;
   const { classProps, props: modifiedProps } = useDropdownStyleProps(rest);
-  const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
+  const { styleProps, props: transferProps } = useStyleProps(modifiedProps);
+  const { onKeyDown: onUserKeyDown, ...otherProps } = transferProps;
 
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLDivElement>();
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const mergedTriggerRef: MutableRefObject<HTMLElement | null | undefined> = externalTriggerRef ?? triggerRef;
 
-  const { isOpen, toggleHandler: onToggle } = useDropdown({ dropdownRef, triggerRef, enableAutoClose, onAutoClose });
+  const { isOpen, toggleHandler: onToggle } = useDropdown({
+    dropdownRef,
+    triggerRef: mergedTriggerRef,
+    enableAutoClose,
+    onAutoClose,
+  });
+  const closeOverlay = useCallback(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    onToggle();
+
+    queueMicrotask(() => {
+      mergedTriggerRef.current?.focus();
+    });
+  }, [isOpen, mergedTriggerRef, onToggle]);
+
+  const { onOverlayKeyDown } = useOverlay({
+    isOpen,
+    overlayRef: dropdownRef,
+    onClose: closeOverlay,
+    closeOnInteractOutside: false,
+  });
+
+  const handleKeyDown: KeyboardEventHandler<HTMLElement> = useCallback(
+    (event) => {
+      onUserKeyDown?.(event);
+      onOverlayKeyDown(event);
+    },
+    [onOverlayKeyDown, onUserKeyDown],
+  );
+  const mergedProps = { ...otherProps, onKeyDown: handleKeyDown };
 
   return (
-    <DropdownProvider value={{ id, isOpen, fullWidthMode, placement, onToggle, dropdownRef, triggerRef }}>
+    <DropdownProvider
+      value={{ id, isOpen, fullWidthMode, placement, onToggle, dropdownRef, triggerRef: mergedTriggerRef }}
+    >
       <div
         ref={dropdownRef}
         {...styleProps}
-        {...otherProps}
+        {...mergedProps}
         className={classNames(classProps.root, styleProps.className)}
       >
         {children}

--- a/packages/web-react/src/components/Dropdown/__tests__/Dropdown.accessibility.test.tsx
+++ b/packages/web-react/src/components/Dropdown/__tests__/Dropdown.accessibility.test.tsx
@@ -9,7 +9,7 @@ describe('Dropdown accessibility', () => {
   const DropdownTest = (props: Partial<SpiritDropdownProps>) => (
     <Dropdown id="dropdown-example" onToggle={() => {}} isOpen={false} {...props}>
       <DropdownTrigger>Trigger</DropdownTrigger>
-      <DropdownPopover>Dropdown content</DropdownPopover>
+      <DropdownPopover aria-label="Dropdown">Dropdown content</DropdownPopover>
     </Dropdown>
   );
 

--- a/packages/web-react/src/components/Dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/web-react/src/components/Dropdown/__tests__/Dropdown.test.tsx
@@ -12,6 +12,7 @@ import { type DropdownAlignmentXType, type DropdownAlignmentYType } from '../../
 import Dropdown from '../Dropdown';
 import DropdownPopover from '../DropdownPopover';
 import DropdownTrigger from '../DropdownTrigger';
+import UncontrolledDropdown from '../UncontrolledDropdown';
 
 describe('Dropdown', () => {
   classNamePrefixProviderTest(Dropdown, 'Dropdown');
@@ -33,12 +34,12 @@ describe('Dropdown', () => {
     render(
       <Dropdown id="dropdown" isOpen={false} onToggle={() => {}}>
         <DropdownTrigger>Trigger</DropdownTrigger>
-        <DropdownPopover data-testid="test-popover">Hello World</DropdownPopover>
+        <DropdownPopover aria-label="Dropdown">Hello World</DropdownPopover>
       </Dropdown>,
     );
 
     expect(screen.getByRole('button')).toHaveTextContent('Trigger');
-    expect(screen.getByTestId('test-popover')).toHaveTextContent('Hello World');
+    expect(screen.getByRole('dialog', { name: 'Dropdown' })).toHaveTextContent('Hello World');
   });
 
   it('should be opened', () => {
@@ -47,12 +48,12 @@ describe('Dropdown', () => {
     render(
       <Dropdown id="dropdown" isOpen onToggle={onToggle}>
         <DropdownTrigger>trigger</DropdownTrigger>
-        <DropdownPopover data-testid="test-popover">Hello World</DropdownPopover>
+        <DropdownPopover aria-label="Dropdown">Hello World</DropdownPopover>
       </Dropdown>,
     );
 
     expect(screen.getByRole('button')).toHaveClass('is-expanded');
-    expect(screen.getByTestId('test-popover')).toHaveClass('is-open');
+    expect(screen.getByRole('dialog', { name: 'Dropdown' })).toHaveClass('is-open');
   });
 
   it('should call toggle function', () => {
@@ -61,7 +62,7 @@ describe('Dropdown', () => {
     render(
       <Dropdown id="dropdown" isOpen={false} onToggle={onToggle}>
         <DropdownTrigger>trigger</DropdownTrigger>
-        <DropdownPopover>Hello World</DropdownPopover>
+        <DropdownPopover aria-label="Dropdown">Hello World</DropdownPopover>
       </Dropdown>,
     );
 
@@ -72,16 +73,137 @@ describe('Dropdown', () => {
     expect(onToggle).toHaveBeenCalled();
   });
 
+  it('should call toggle function on ArrowDown when trigger is focused and closed', () => {
+    const onToggle = jest.fn();
+
+    render(
+      <Dropdown id="dropdown" isOpen={false} onToggle={onToggle}>
+        <DropdownTrigger>trigger</DropdownTrigger>
+        <DropdownPopover aria-label="Dropdown">Hello World</DropdownPopover>
+      </Dropdown>,
+    );
+
+    const trigger = screen.getByRole('button');
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: 'ArrowDown', bubbles: true });
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call toggle function and focus trigger on Escape when open', async () => {
+    const onToggle = jest.fn();
+    const focusSpy = jest.spyOn(HTMLElement.prototype, 'focus');
+
+    try {
+      render(
+        <Dropdown id="dropdown" isOpen onToggle={onToggle}>
+          <DropdownTrigger>trigger</DropdownTrigger>
+          <DropdownPopover aria-label="Dropdown">Hello World</DropdownPopover>
+        </Dropdown>,
+      );
+
+      const root = screen.getByRole('button').closest('.Dropdown') as HTMLElement;
+
+      fireEvent.keyDown(root, { key: 'Escape', bubbles: true });
+
+      expect(onToggle).toHaveBeenCalledTimes(1);
+
+      await Promise.resolve();
+
+      expect(focusSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      focusSpy.mockRestore();
+    }
+  });
+
+  it('should not call toggle on Escape when closed', () => {
+    const onToggle = jest.fn();
+
+    render(
+      <Dropdown id="dropdown" isOpen={false} onToggle={onToggle}>
+        <DropdownTrigger>trigger</DropdownTrigger>
+        <DropdownPopover aria-label="Dropdown">Hello World</DropdownPopover>
+      </Dropdown>,
+    );
+
+    const root = screen.getByRole('button').closest('.Dropdown') as HTMLElement;
+
+    fireEvent.keyDown(root, { key: 'Escape', bubbles: true });
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('should close uncontrolled dropdown and focus trigger on Escape when open', async () => {
+    const focusSpy = jest.spyOn(HTMLElement.prototype, 'focus');
+
+    try {
+      render(
+        <UncontrolledDropdown id="dropdown">
+          <DropdownTrigger>trigger</DropdownTrigger>
+          <DropdownPopover aria-label="Dropdown">Hello World</DropdownPopover>
+        </UncontrolledDropdown>,
+      );
+
+      const trigger = screen.getByRole('button');
+      const popover = screen.getByRole('dialog', { name: 'Dropdown' });
+      const root = trigger.closest('.Dropdown') as HTMLElement;
+
+      fireEvent.click(trigger);
+
+      expect(popover).toHaveClass('is-open');
+
+      fireEvent.keyDown(root, { key: 'Escape', bubbles: true });
+
+      expect(popover).not.toHaveClass('is-open');
+
+      await Promise.resolve();
+
+      expect(focusSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      focusSpy.mockRestore();
+    }
+  });
+
+  it('should open uncontrolled dropdown on ArrowDown when trigger is focused', () => {
+    render(
+      <UncontrolledDropdown id="dropdown">
+        <DropdownTrigger>trigger</DropdownTrigger>
+        <DropdownPopover aria-label="Dropdown">Hello World</DropdownPopover>
+      </UncontrolledDropdown>,
+    );
+
+    const trigger = screen.getByRole('button');
+    const popover = screen.getByRole('dialog', { name: 'Dropdown' });
+    trigger.focus();
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown', bubbles: true });
+
+    expect(popover).toHaveClass('is-open');
+  });
+
+  it('should support external triggerRef in uncontrolled dropdown', () => {
+    const triggerRef = { current: null as HTMLElement | null | undefined };
+
+    render(
+      <UncontrolledDropdown id="dropdown" triggerRef={triggerRef}>
+        <DropdownTrigger>trigger</DropdownTrigger>
+        <DropdownPopover aria-label="Dropdown">Hello World</DropdownPopover>
+      </UncontrolledDropdown>,
+    );
+
+    expect(triggerRef.current).toBe(screen.getByRole('button'));
+  });
+
   it('should not have same id on trigger and popover', () => {
     render(
       <Dropdown id="dropdown" isOpen={false} onToggle={() => {}}>
         <DropdownTrigger>trigger</DropdownTrigger>
-        <DropdownPopover data-testid="test-popover">Hello World</DropdownPopover>
+        <DropdownPopover aria-label="Dropdown">Hello World</DropdownPopover>
       </Dropdown>,
     );
 
     expect(screen.getByRole('button')).not.toHaveAttribute('id', 'dropdown');
-    expect(screen.getByTestId('test-popover')).toHaveAttribute('id', 'dropdown');
+    expect(screen.getByRole('dialog', { name: 'Dropdown' })).toHaveAttribute('id', 'dropdown');
   });
 
   describe('Alignment tests', () => {

--- a/packages/web-react/src/components/Dropdown/__tests__/DropdownPopover.test.tsx
+++ b/packages/web-react/src/components/Dropdown/__tests__/DropdownPopover.test.tsx
@@ -22,23 +22,35 @@ describe('DropdownPopover', () => {
   ariaAttributesTest(DropdownPopover);
 
   it('should have children', () => {
-    const dom = render(<DropdownPopover>Popover</DropdownPopover>);
+    const dom = render(<DropdownPopover aria-label="Options">Popover</DropdownPopover>);
     const popover = dom.container.querySelector('.DropdownPopover') as HTMLElement;
 
     expect(popover).toHaveTextContent('Popover');
   });
 
-  it('should not set role when role prop is omitted', () => {
-    const dom = render(<DropdownPopover>Popover</DropdownPopover>);
-    const popover = dom.container.querySelector('.DropdownPopover') as HTMLElement;
-
-    expect(popover).not.toHaveAttribute('role');
-  });
-
-  it('should set role when role prop is provided', () => {
-    const dom = render(<DropdownPopover role="dialog">Popover</DropdownPopover>);
+  it('should have role="dialog" by default', () => {
+    const dom = render(<DropdownPopover aria-label="Options">Popover</DropdownPopover>);
     const popover = dom.container.querySelector('.DropdownPopover') as HTMLElement;
 
     expect(popover).toHaveAttribute('role', 'dialog');
+  });
+
+  it('should not have aria-modal by default', () => {
+    const dom = render(<DropdownPopover aria-label="Options">Popover</DropdownPopover>);
+    const popover = dom.container.querySelector('.DropdownPopover') as HTMLElement;
+
+    expect(popover).not.toHaveAttribute('aria-modal');
+  });
+
+  it('should allow overriding role via prop and must not have aria-modal', () => {
+    const dom = render(
+      <DropdownPopover role="listbox" aria-label="Options list">
+        Popover
+      </DropdownPopover>,
+    );
+    const popover = dom.container.querySelector('.DropdownPopover') as HTMLElement;
+
+    expect(popover).toHaveAttribute('role', 'listbox');
+    expect(popover).not.toHaveAttribute('aria-modal');
   });
 });

--- a/packages/web-react/src/components/Dropdown/__tests__/DropdownTrigger.test.tsx
+++ b/packages/web-react/src/components/Dropdown/__tests__/DropdownTrigger.test.tsx
@@ -28,4 +28,32 @@ describe('DropdownTrigger', () => {
 
     expect(trigger).toHaveTextContent('Trigger');
   });
+
+  it('should have aria-haspopup="dialog" by default', () => {
+    const dom = render(<DropdownTrigger>Trigger</DropdownTrigger>);
+    const trigger = dom.container.querySelector('button') as HTMLElement;
+
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+  });
+
+  it('should allow overriding aria-haspopup', () => {
+    const dom = render(<DropdownTrigger aria-haspopup="menu">Trigger</DropdownTrigger>);
+    const trigger = dom.container.querySelector('button') as HTMLElement;
+
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+  });
+
+  it('should allow boolean aria-haspopup override', () => {
+    const dom = render(<DropdownTrigger aria-haspopup>Trigger</DropdownTrigger>);
+    const trigger = dom.container.querySelector('button') as HTMLElement;
+
+    expect(trigger).toHaveAttribute('aria-haspopup', 'true');
+  });
+
+  it('should allow false aria-haspopup override', () => {
+    const dom = render(<DropdownTrigger aria-haspopup={false}>Trigger</DropdownTrigger>);
+    const trigger = dom.container.querySelector('button') as HTMLElement;
+
+    expect(trigger).toHaveAttribute('aria-haspopup', 'false');
+  });
 });

--- a/packages/web-react/src/components/Dropdown/__tests__/useDropdownAriaProps.test.ts
+++ b/packages/web-react/src/components/Dropdown/__tests__/useDropdownAriaProps.test.ts
@@ -11,11 +11,13 @@ const defaultProps = {
 const defaultTriggerPropsResult = {
   'aria-expanded': true,
   'aria-controls': 'test-dropdown-id',
+  'aria-haspopup': 'dialog',
   onClick: expect.any(Function),
 };
 
 const defaultContentPropsResult = {
   id: 'test-dropdown-id',
+  role: 'dialog',
 };
 
 describe('useDropdownAriaProps', () => {
@@ -34,7 +36,10 @@ describe('useDropdownAriaProps', () => {
     const { result } = renderHook(() => useDropdownAriaProps(props));
 
     expect(result.current.triggerProps).toEqual(defaultTriggerPropsResult);
-    expect(result.current.contentProps).toEqual({ ...defaultContentPropsResult, 'data-spirit-fullwidthmode': 'all' });
+    expect(result.current.contentProps).toEqual({
+      ...defaultContentPropsResult,
+      'data-spirit-fullwidthmode': 'all',
+    });
   });
 
   it('should return correct props when isOpen is false', () => {
@@ -45,6 +50,39 @@ describe('useDropdownAriaProps', () => {
     const { result } = renderHook(() => useDropdownAriaProps(props));
 
     expect(result.current.triggerProps).toEqual({ ...defaultTriggerPropsResult, 'aria-expanded': false });
+    expect(result.current.contentProps).toEqual(defaultContentPropsResult);
+  });
+
+  it('should allow overriding aria-haspopup', () => {
+    const props = {
+      ...defaultProps,
+      hasPopup: 'menu',
+    };
+    const { result } = renderHook(() => useDropdownAriaProps(props));
+
+    expect(result.current.triggerProps).toEqual({ ...defaultTriggerPropsResult, 'aria-haspopup': 'menu' });
+    expect(result.current.contentProps).toEqual(defaultContentPropsResult);
+  });
+
+  it('should allow boolean aria-haspopup override', () => {
+    const props = {
+      ...defaultProps,
+      hasPopup: true,
+    };
+    const { result } = renderHook(() => useDropdownAriaProps(props));
+
+    expect(result.current.triggerProps).toEqual({ ...defaultTriggerPropsResult, 'aria-haspopup': true });
+    expect(result.current.contentProps).toEqual(defaultContentPropsResult);
+  });
+
+  it('should allow false aria-haspopup override', () => {
+    const props = {
+      ...defaultProps,
+      hasPopup: false,
+    };
+    const { result } = renderHook(() => useDropdownAriaProps(props));
+
+    expect(result.current.triggerProps).toEqual({ ...defaultTriggerPropsResult, 'aria-haspopup': false });
     expect(result.current.contentProps).toEqual(defaultContentPropsResult);
   });
 });

--- a/packages/web-react/src/components/Dropdown/__tests__/useDropdownPopoverDialogKeyboard.test.ts
+++ b/packages/web-react/src/components/Dropdown/__tests__/useDropdownPopoverDialogKeyboard.test.ts
@@ -1,0 +1,215 @@
+import { act, renderHook } from '@testing-library/react';
+import { getFocusableElements } from '../../../utils';
+import { useDropdownPopoverDialogKeyboard } from '../useDropdownPopoverDialogKeyboard';
+
+describe('getFocusableElements helpers', () => {
+  it('should return focusable elements in document order', () => {
+    const root = document.createElement('div');
+    const first = document.createElement('input');
+    const second = document.createElement('button');
+
+    root.append(first, second);
+
+    expect(getFocusableElements(root)).toEqual([first, second]);
+  });
+
+  it('should skip disabled inputs', () => {
+    const root = document.createElement('div');
+    const enabled = document.createElement('input');
+    const disabled = document.createElement('input');
+
+    disabled.disabled = true;
+    root.append(enabled, disabled);
+
+    expect(getFocusableElements(root)).toEqual([enabled]);
+  });
+
+  it('should ignore hidden inputs', () => {
+    const root = document.createElement('div');
+    const hidden = document.createElement('input');
+    const visible = document.createElement('button');
+
+    hidden.type = 'hidden';
+    root.append(hidden, visible);
+
+    expect(getFocusableElements(root)).toEqual([visible]);
+  });
+
+  it('should ignore elements with tabindex="-1"', () => {
+    const root = document.createElement('div');
+    const excluded = document.createElement('button');
+    const included = document.createElement('button');
+
+    excluded.setAttribute('tabindex', '-1');
+    root.append(excluded, included);
+
+    expect(getFocusableElements(root)).toEqual([included]);
+  });
+});
+
+describe('useDropdownPopoverDialogKeyboard', () => {
+  const makeTriggerRef = () => ({ current: document.createElement('button') });
+
+  it('should call onToggle and focus trigger on Tab from last focusable when open', () => {
+    const onToggle = jest.fn();
+    const triggerRef = makeTriggerRef();
+    const focusSpy = jest.spyOn(triggerRef.current, 'focus');
+
+    const container = document.createElement('div');
+    const first = document.createElement('input');
+    const last = document.createElement('button');
+
+    container.append(first, last);
+
+    const { result } = renderHook(() => useDropdownPopoverDialogKeyboard({ isOpen: true, onToggle, triggerRef }));
+
+    const preventDefault = jest.fn();
+    act(() => {
+      result.current.onPopoverKeyDownCapture({
+        currentTarget: container,
+        key: 'Tab',
+        preventDefault,
+        shiftKey: false,
+        target: last,
+      } as never);
+    });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    return Promise.resolve().then(() => {
+      expect(focusSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should call onToggle and focus trigger on Shift+Tab from first focusable when open', () => {
+    const onToggle = jest.fn();
+    const triggerRef = makeTriggerRef();
+    const focusSpy = jest.spyOn(triggerRef.current, 'focus');
+
+    const container = document.createElement('div');
+    const first = document.createElement('input');
+    const last = document.createElement('button');
+
+    container.append(first, last);
+
+    const { result } = renderHook(() => useDropdownPopoverDialogKeyboard({ isOpen: true, onToggle, triggerRef }));
+
+    const preventDefault = jest.fn();
+    act(() => {
+      result.current.onPopoverKeyDownCapture({
+        currentTarget: container,
+        key: 'Tab',
+        preventDefault,
+        shiftKey: true,
+        target: first,
+      } as never);
+    });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    return Promise.resolve().then(() => {
+      expect(focusSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should not call onToggle on Shift+Tab from non-first focusable', () => {
+    const onToggle = jest.fn();
+    const triggerRef = makeTriggerRef();
+    const container = document.createElement('div');
+    const first = document.createElement('input');
+    const last = document.createElement('button');
+
+    container.append(first, last);
+
+    const { result } = renderHook(() => useDropdownPopoverDialogKeyboard({ isOpen: true, onToggle, triggerRef }));
+
+    const preventDefault = jest.fn();
+    act(() => {
+      result.current.onPopoverKeyDownCapture({
+        currentTarget: container,
+        key: 'Tab',
+        preventDefault,
+        shiftKey: true,
+        target: last,
+      } as never);
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('should not call onToggle when popover is closed', () => {
+    const onToggle = jest.fn();
+    const triggerRef = makeTriggerRef();
+    const container = document.createElement('div');
+    const last = document.createElement('button');
+
+    container.append(last);
+
+    const { result } = renderHook(() => useDropdownPopoverDialogKeyboard({ isOpen: false, onToggle, triggerRef }));
+
+    const preventDefault = jest.fn();
+    act(() => {
+      result.current.onPopoverKeyDownCapture({
+        currentTarget: container,
+        key: 'Tab',
+        preventDefault,
+        shiftKey: false,
+        target: last,
+      } as never);
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('should not call onToggle when Tab starts from non-last focusable', () => {
+    const onToggle = jest.fn();
+    const triggerRef = makeTriggerRef();
+    const container = document.createElement('div');
+    const first = document.createElement('input');
+    const last = document.createElement('button');
+
+    container.append(first, last);
+
+    const { result } = renderHook(() => useDropdownPopoverDialogKeyboard({ isOpen: true, onToggle, triggerRef }));
+
+    const preventDefault = jest.fn();
+    act(() => {
+      result.current.onPopoverKeyDownCapture({
+        currentTarget: container,
+        key: 'Tab',
+        preventDefault,
+        shiftKey: false,
+        target: first,
+      } as never);
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('should ignore Escape key (Escape is handled at the Dropdown wrapper level)', () => {
+    const onToggle = jest.fn();
+    const triggerRef = makeTriggerRef();
+    const container = document.createElement('div');
+
+    const { result } = renderHook(() => useDropdownPopoverDialogKeyboard({ isOpen: true, onToggle, triggerRef }));
+
+    const stopPropagation = jest.fn();
+    act(() => {
+      result.current.onPopoverKeyDownCapture({
+        currentTarget: container,
+        key: 'Escape',
+        stopPropagation,
+        shiftKey: false,
+        target: container,
+      } as never);
+    });
+
+    expect(stopPropagation).not.toHaveBeenCalled();
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web-react/src/components/Dropdown/stories/Dropdown.stories.tsx
+++ b/packages/web-react/src/components/Dropdown/stories/Dropdown.stories.tsx
@@ -97,7 +97,7 @@ const DropdownWithHooks = (args: SpiritDropdownProps) => {
   return (
     <Dropdown {...args} isOpen={isOpen || isDropdownOpen} onToggle={onDropdownToggle}>
       <DropdownTrigger elementType={Button}>Button as anchor</DropdownTrigger>
-      <DropdownPopover>{children}</DropdownPopover>
+      <DropdownPopover aria-label="Dropdown">{children}</DropdownPopover>
     </Dropdown>
   );
 };

--- a/packages/web-react/src/components/Dropdown/stories/DropdownPopover.stories.tsx
+++ b/packages/web-react/src/components/Dropdown/stories/DropdownPopover.stories.tsx
@@ -51,7 +51,7 @@ export const DropdownPopoverPlayground: Story = {
   render: (args) => (
     <Dropdown id="dropdown-example" isOpen onToggle={() => {}}>
       <DropdownTrigger elementType={Button}>Button as anchor</DropdownTrigger>
-      <DropdownPopover>{args.children}</DropdownPopover>
+      <DropdownPopover aria-label="Dropdown">{args.children}</DropdownPopover>
     </Dropdown>
   ),
 };

--- a/packages/web-react/src/components/Dropdown/stories/UncontolledDropdown.stories.tsx
+++ b/packages/web-react/src/components/Dropdown/stories/UncontolledDropdown.stories.tsx
@@ -77,7 +77,7 @@ export const UncontrolledDropdownPlayground: Story = {
   render: (args) => (
     <UncontrolledDropdown {...args}>
       <DropdownTrigger elementType={Button}>Button as anchor</DropdownTrigger>
-      <DropdownPopover>{args.children}</DropdownPopover>
+      <DropdownPopover aria-label="Dropdown">{args.children}</DropdownPopover>
     </UncontrolledDropdown>
   ),
 };

--- a/packages/web-react/src/components/Dropdown/useDropdown.ts
+++ b/packages/web-react/src/components/Dropdown/useDropdown.ts
@@ -12,12 +12,12 @@ export interface UseDropdownProps {
   /** on close callback */
   onAutoClose?: (event: Event) => void;
   /** trigger element reference */
-  triggerRef: MutableRefObject<HTMLElement | undefined>;
+  triggerRef: MutableRefObject<HTMLElement | null | undefined>;
 }
 
 export interface UseDropdownReturn {
   /** collapse handler */
-  toggleHandler: (event: ClickEvent) => void;
+  toggleHandler: (event?: ClickEvent) => void;
   /** collapsed state */
   isOpen: boolean;
 }
@@ -32,8 +32,8 @@ export const useDropdown = ({
 
   const collapseHandler = () => setOpen(!open);
 
-  const toggleHandler = (event: ClickEvent) => {
-    event.preventDefault();
+  const toggleHandler = (event?: ClickEvent) => {
+    event?.preventDefault();
     collapseHandler();
   };
 

--- a/packages/web-react/src/components/Dropdown/useDropdownAriaProps.ts
+++ b/packages/web-react/src/components/Dropdown/useDropdownAriaProps.ts
@@ -1,8 +1,10 @@
 import { type Booleanish, type ClickEvent, type DropdownFullWidthMode } from '../../types';
 
-const NAME_ARIA_EXPANDED = 'aria-expanded';
 const NAME_ARIA_CONTROLS = 'aria-controls';
+const NAME_ARIA_EXPANDED = 'aria-expanded';
+const NAME_ARIA_HASPOPUP = 'aria-haspopup';
 const NAME_DATA_FULLWIDTHMODE = 'data-spirit-fullwidthmode';
+const DIALOG_ROLE = 'dialog';
 
 export enum fullWidthModeKeys {
   'off' = 'off',
@@ -17,33 +19,39 @@ export interface UseDropdownAriaPropsProps {
   /** fullWidthMode */
   fullWidthMode: DropdownFullWidthMode | undefined;
   /** toggle callback */
-  toggleHandler: (event: ClickEvent) => void;
+  toggleHandler: (event?: ClickEvent) => void;
+  /** trigger's aria-haspopup override */
+  hasPopup?: Booleanish | string;
 }
 
 export interface UseDropdownAriaPropsReturn {
   /** content returned props */
   contentProps: {
     id: string;
+    role: string;
     [NAME_DATA_FULLWIDTHMODE]?: keyof typeof fullWidthModeKeys | undefined;
   };
   /** trigger returned props */
   triggerProps: {
     [NAME_ARIA_EXPANDED]: Booleanish;
     [NAME_ARIA_CONTROLS]: string;
-    onClick: (event: ClickEvent) => void;
+    [NAME_ARIA_HASPOPUP]: Booleanish | string;
+    onClick: (event?: ClickEvent) => void;
   };
 }
 
 export const useDropdownAriaProps = (props: UseDropdownAriaPropsProps): UseDropdownAriaPropsReturn => {
-  const { fullWidthMode, id, isOpen, toggleHandler } = props;
+  const { fullWidthMode, hasPopup = DIALOG_ROLE, id, isOpen, toggleHandler } = props;
 
   const triggerProps = {
     [NAME_ARIA_EXPANDED]: isOpen,
     [NAME_ARIA_CONTROLS]: String(id),
+    [NAME_ARIA_HASPOPUP]: hasPopup,
     onClick: toggleHandler,
   };
   const contentProps = {
     id,
+    role: DIALOG_ROLE,
     [NAME_DATA_FULLWIDTHMODE]: fullWidthMode,
   };
 

--- a/packages/web-react/src/components/Dropdown/useDropdownPopoverDialogKeyboard.ts
+++ b/packages/web-react/src/components/Dropdown/useDropdownPopoverDialogKeyboard.ts
@@ -1,0 +1,80 @@
+'use client';
+
+import { type KeyboardEvent, type KeyboardEventHandler, type MutableRefObject, useCallback } from 'react';
+import { type ClickEvent } from '../../types';
+import { getFocusableElements } from '../../utils';
+
+export interface UseDropdownPopoverDialogKeyboardOptions {
+  isOpen: boolean;
+  onToggle: (event?: ClickEvent) => void;
+  triggerRef: MutableRefObject<HTMLElement | null | undefined>;
+}
+
+/**
+ * Handles Tab-out keyboard interactions for a DropdownPopover used as a non-modal anchored dialog:
+ * - Tab from the last focusable element: closes the popover and returns focus to the trigger.
+ * - Shift+Tab from the first focusable element: closes the popover and returns focus to the trigger.
+ *
+ * Escape is handled at the Dropdown wrapper level so it works even when focus is on the trigger.
+ *
+ * @param options - Hook configuration.
+ * @param options.isOpen - Whether the popover is open.
+ * @param options.onToggle - Toggle the popover open/closed state.
+ * @param options.triggerRef - Ref to the trigger element; receives focus after the popover closes.
+ * @returns {{ onPopoverKeyDownCapture: KeyboardEventHandler<HTMLDivElement> }}
+ * Attach `onPopoverKeyDownCapture` to the popover content root.
+ */
+export const useDropdownPopoverDialogKeyboard = ({
+  isOpen,
+  onToggle,
+  triggerRef,
+}: UseDropdownPopoverDialogKeyboardOptions): {
+  onPopoverKeyDownCapture: KeyboardEventHandler<HTMLDivElement>;
+} => {
+  const close = useCallback(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    onToggle();
+
+    queueMicrotask(() => {
+      triggerRef.current?.focus();
+    });
+  }, [isOpen, onToggle, triggerRef]);
+
+  const onPopoverKeyDownCapture = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (!isOpen || event.key !== 'Tab') {
+        return;
+      }
+
+      const focusables = getFocusableElements(event.currentTarget);
+      const target = event.target instanceof Node ? event.target : null;
+      const active = document.activeElement;
+
+      if (event.shiftKey) {
+        const firstFocusable = focusables.length > 0 ? focusables[0]! : null;
+
+        if (!firstFocusable || (target !== firstFocusable && active !== firstFocusable)) {
+          return;
+        }
+
+        event.preventDefault();
+        close();
+      } else {
+        const lastFocusable = focusables.length > 0 ? focusables[focusables.length - 1]! : null;
+
+        if (!lastFocusable || (target !== lastFocusable && active !== lastFocusable)) {
+          return;
+        }
+
+        event.preventDefault();
+        close();
+      }
+    },
+    [close, isOpen],
+  );
+
+  return { onPopoverKeyDownCapture };
+};

--- a/packages/web-react/src/components/UNSTABLE_Picker/UNSTABLE_Picker.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Picker/UNSTABLE_Picker.tsx
@@ -4,7 +4,14 @@ import classNames from 'classnames';
 import React, { type ForwardedRef, forwardRef, useCallback, useImperativeHandle, useMemo, useRef } from 'react';
 import { MULTIPLE_SELECTION_MODE } from '../../constants';
 import { PropsProvider } from '../../context';
-import { getSelectedKeys, isSingleSelectionMode, useAriaDescribedBy, useI18n, useStyleProps } from '../../hooks';
+import {
+  getSelectedKeys,
+  isSingleSelectionMode,
+  useAriaDescribedBy,
+  useI18n,
+  useOpenOnArrowDown,
+  useStyleProps,
+} from '../../hooks';
 import { replaceTranslationParams } from '../../translations';
 import { type ForwardRefComponent } from '../../types';
 import { Dropdown, DropdownPopover } from '../Dropdown';
@@ -19,7 +26,6 @@ import { PickerPopoverContextProvider } from './PickerPopoverContext';
 import type { SpiritUnstablePickerProps, SpiritUnstablePickerRef } from './types';
 import UNSTABLE_PickerTag from './UNSTABLE_PickerTag';
 import { usePickerId } from './usePickerId';
-import { usePickerPopoverTabOutToTrigger } from './usePickerPopoverTabOutToTrigger';
 import { usePickerSelectionGridKeyboard } from './usePickerSelectionGridKeyboard';
 import { usePickerStyleProps } from './usePickerStyleProps';
 import {
@@ -110,10 +116,9 @@ const _UNSTABLE_Picker = (props: SpiritUnstablePickerProps, ref: ForwardedRef<Sp
       triggerRef.current?.focus();
     });
   }, [isOpen, onToggle]);
-
-  const { onPopoverKeyDownCapture } = usePickerPopoverTabOutToTrigger({
+  const handleTriggerKeyDown = useOpenOnArrowDown({
     isOpen,
-    onClose: close,
+    onToggle,
   });
 
   const selectionGridKeyboardRowCount = getPickerSelectionGridKeyboardRowCount(selectedPickerItems.length, {
@@ -211,7 +216,7 @@ const _UNSTABLE_Picker = (props: SpiritUnstablePickerProps, ref: ForwardedRef<Sp
           <Label id={labelId} elementType="span">
             {label}
           </Label>
-          <Dropdown id={popoverId} isOpen={isOpen} onToggle={onToggle}>
+          <Dropdown id={popoverId} isOpen={isOpen} onToggle={onToggle} triggerRef={triggerRef}>
             <div role="group" aria-label={label} className={classProps.inputContainer}>
               <div
                 ref={selectionGridRef}
@@ -234,18 +239,14 @@ const _UNSTABLE_Picker = (props: SpiritUnstablePickerProps, ref: ForwardedRef<Sp
                 aria-expanded={isOpen}
                 aria-controls={popoverId}
                 onClick={onToggle}
+                onKeyDown={handleTriggerKeyDown}
                 disabled={isDisabled}
               >
                 <VisuallyHidden>{isOpen ? closeButtonLabel : addButtonLabel}</VisuallyHidden>
                 <Icon name={`chevron-${isOpen ? 'up' : 'down'}`} boxSize={20} />
               </button>
             </div>
-            <DropdownPopover
-              aria-labelledby={labelId}
-              role="dialog"
-              aria-modal="true"
-              onKeyDownCapture={onPopoverKeyDownCapture}
-            >
+            <DropdownPopover aria-labelledby={labelId}>
               <PickerPopoverContextProvider value={popoverContextValue}>{children}</PickerPopoverContextProvider>
             </DropdownPopover>
           </Dropdown>

--- a/packages/web-react/src/components/UNSTABLE_Picker/__tests__/UNSTABLE_Picker.test.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Picker/__tests__/UNSTABLE_Picker.test.tsx
@@ -255,4 +255,14 @@ describe('UNSTABLE_Picker', () => {
 
     expect(screen.getByRole('button', { name: 'Add' })).toHaveAttribute('aria-expanded', 'false');
   });
+
+  it('should open popover on ArrowDown when trigger is focused', () => {
+    render(<TestPicker />);
+    const trigger = screen.getByRole('button', { name: 'Add' });
+
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: 'ArrowDown', bubbles: true });
+
+    expect(screen.getByRole('button', { name: 'Close' })).toHaveAttribute('aria-expanded', 'true');
+  });
 });

--- a/packages/web-react/src/components/UNSTABLE_Picker/index.html
+++ b/packages/web-react/src/components/UNSTABLE_Picker/index.html
@@ -1,1 +1,1 @@
-{{> web-react/demo title="UNSTABLE_Picker" parentPageName="Components" isUnstable=true }}
+{{> web-react/demo title="Picker" parentPageName="Components" isUnstable=true }}

--- a/packages/web-react/src/hooks/__tests__/useAutoFocus.test.ts
+++ b/packages/web-react/src/hooks/__tests__/useAutoFocus.test.ts
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react';
+import { useAutoFocus } from '../useAutoFocus';
+
+describe('useAutoFocus', () => {
+  const makeContainerRef = () => {
+    const container = document.createElement('div');
+    const first = document.createElement('button');
+    const second = document.createElement('input');
+
+    container.append(first, second);
+    document.body.append(container);
+
+    return { ref: { current: container }, first, second, container };
+  };
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should focus first focusable element when activated', () => {
+    const { ref, first } = makeContainerRef();
+    const focusSpy = jest.spyOn(first, 'focus');
+
+    renderHook(() => useAutoFocus({ isActive: true, containerRef: ref }));
+
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not focus when inactive', () => {
+    const { ref, first } = makeContainerRef();
+    const focusSpy = jest.spyOn(first, 'focus');
+
+    renderHook(() => useAutoFocus({ isActive: false, containerRef: ref }));
+
+    expect(focusSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not throw when no focusable elements exist', () => {
+    const container = document.createElement('div');
+    container.appendChild(document.createElement('span'));
+    document.body.append(container);
+
+    expect(() => {
+      renderHook(() => useAutoFocus({ isActive: true, containerRef: { current: container } }));
+    }).not.toThrow();
+  });
+
+  it('should focus again when activated repeatedly', () => {
+    const { ref, first } = makeContainerRef();
+    const focusSpy = jest.spyOn(first, 'focus');
+
+    const { rerender } = renderHook(({ isActive }) => useAutoFocus({ isActive, containerRef: ref }), {
+      initialProps: { isActive: false },
+    });
+
+    expect(focusSpy).not.toHaveBeenCalled();
+
+    rerender({ isActive: true });
+
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+
+    rerender({ isActive: false });
+    rerender({ isActive: true });
+
+    expect(focusSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/web-react/src/hooks/__tests__/useOverlay.test.ts
+++ b/packages/web-react/src/hooks/__tests__/useOverlay.test.ts
@@ -1,0 +1,160 @@
+import { act, renderHook } from '@testing-library/react';
+import { type MutableRefObject } from 'react';
+import { useOverlay } from '../useOverlay';
+
+describe('useOverlay', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  const createOverlayRef = (): MutableRefObject<HTMLElement | null> => ({
+    current: document.createElement('div'),
+  });
+
+  it('should close on Escape when open', () => {
+    const onClose = jest.fn();
+    const overlayRef = createOverlayRef();
+
+    const { result } = renderHook(() =>
+      useOverlay({
+        isOpen: true,
+        overlayRef,
+        onClose,
+      }),
+    );
+
+    act(() => {
+      result.current.onOverlayKeyDown({
+        key: 'Escape',
+      } as never);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should ignore Escape when closed', () => {
+    const onClose = jest.fn();
+    const overlayRef = createOverlayRef();
+
+    const { result } = renderHook(() =>
+      useOverlay({
+        isOpen: false,
+        overlayRef,
+        onClose,
+      }),
+    );
+
+    act(() => {
+      result.current.onOverlayKeyDown({
+        key: 'Escape',
+      } as never);
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('should ignore Escape when default is prevented', () => {
+    const onClose = jest.fn();
+    const overlayRef = createOverlayRef();
+
+    const { result } = renderHook(() =>
+      useOverlay({
+        isOpen: true,
+        overlayRef,
+        onClose,
+      }),
+    );
+
+    act(() => {
+      result.current.onOverlayKeyDown({
+        key: 'Escape',
+        defaultPrevented: true,
+      } as never);
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('should close on outside click when enabled', () => {
+    const onClose = jest.fn();
+    const onInteractOutside = jest.fn();
+    const overlayRef = createOverlayRef();
+    const outsideElement = document.createElement('button');
+
+    document.body.appendChild(overlayRef.current!);
+    document.body.appendChild(outsideElement);
+
+    renderHook(() =>
+      useOverlay({
+        isOpen: true,
+        overlayRef,
+        onClose,
+        closeOnInteractOutside: true,
+        onInteractOutside,
+      }),
+    );
+
+    act(() => {
+      outsideElement.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      outsideElement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onInteractOutside).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should ignore outside click when disabled', () => {
+    const onClose = jest.fn();
+    const onInteractOutside = jest.fn();
+    const overlayRef = createOverlayRef();
+    const outsideElement = document.createElement('button');
+
+    document.body.appendChild(overlayRef.current!);
+    document.body.appendChild(outsideElement);
+
+    renderHook(() =>
+      useOverlay({
+        isOpen: true,
+        overlayRef,
+        onClose,
+        closeOnInteractOutside: false,
+        onInteractOutside,
+      }),
+    );
+
+    act(() => {
+      outsideElement.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      outsideElement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onInteractOutside).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('should use onCloseOnInteractOutside instead of onClose when provided', () => {
+    const onClose = jest.fn();
+    const onCloseOnInteractOutside = jest.fn();
+    const overlayRef = createOverlayRef();
+    const outsideElement = document.createElement('button');
+
+    document.body.appendChild(overlayRef.current!);
+    document.body.appendChild(outsideElement);
+
+    renderHook(() =>
+      useOverlay({
+        isOpen: true,
+        overlayRef,
+        onClose,
+        onCloseOnInteractOutside,
+      }),
+    );
+
+    act(() => {
+      outsideElement.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      outsideElement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onCloseOnInteractOutside).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web-react/src/hooks/index.ts
+++ b/packages/web-react/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './styleProps';
+export * from './useAutoFocus';
 export * from './useAlignmentClass';
 export * from './useAriaIdRefs';
 export * from './useAriaIds';
@@ -24,4 +25,6 @@ export * from './useSelectionState';
 export * from './useSpacingStyle';
 export * from './useSymmetry';
 export * from './useToggle';
+export * from './useOverlay';
+export * from './useOpenOnArrowDown';
 export * from './useWrapClass';

--- a/packages/web-react/src/hooks/useAutoFocus.ts
+++ b/packages/web-react/src/hooks/useAutoFocus.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { type RefObject, useEffect } from 'react';
+import { getFocusableElements } from '../utils';
+
+export interface UseAutoFocusOptions {
+  /** Whether autofocus should run. */
+  isActive: boolean;
+  /** Ref to container where the first focusable is searched. */
+  containerRef: RefObject<HTMLElement | null>;
+}
+
+/**
+ * Focuses the first focusable descendant element when activated.
+ *
+ * @param options - Hook configuration.
+ * @param options.isActive - Whether autofocus should run.
+ * @param options.containerRef - Ref to container element.
+ */
+export const useAutoFocus = ({ isActive, containerRef }: UseAutoFocusOptions): void => {
+  useEffect(() => {
+    if (!isActive || !containerRef.current) {
+      return;
+    }
+
+    const first = getFocusableElements(containerRef.current)[0];
+
+    first?.focus();
+  }, [containerRef, isActive]);
+};

--- a/packages/web-react/src/hooks/useOpenOnArrowDown.ts
+++ b/packages/web-react/src/hooks/useOpenOnArrowDown.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { type KeyboardEventHandler, useCallback } from 'react';
+
+export interface UseOpenOnArrowDownProps {
+  /** Whether target overlay is already open. */
+  isOpen: boolean;
+  /** Callback to toggle overlay state. */
+  onToggle: () => void;
+  /** Optional consumer keydown handler invoked first. */
+  onKeyDown?: KeyboardEventHandler<HTMLElement>;
+}
+
+/**
+ * Composes keydown behavior to open an overlay on ArrowDown.
+ *
+ * @param props - Hook configuration.
+ * @param props.isOpen - Whether the overlay is already open.
+ * @param props.onToggle - Callback to open/close overlay.
+ * @param props.onKeyDown - Optional consumer keydown handler.
+ * @returns {KeyboardEventHandler<HTMLElement>} Composed keydown handler.
+ */
+export const useOpenOnArrowDown = ({
+  isOpen,
+  onToggle,
+  onKeyDown,
+}: UseOpenOnArrowDownProps): KeyboardEventHandler<HTMLElement> =>
+  useCallback(
+    (event) => {
+      onKeyDown?.(event);
+
+      if (event.defaultPrevented || event.key !== 'ArrowDown' || isOpen) {
+        return;
+      }
+
+      event.preventDefault();
+      onToggle();
+    },
+    [isOpen, onKeyDown, onToggle],
+  );

--- a/packages/web-react/src/hooks/useOverlay.ts
+++ b/packages/web-react/src/hooks/useOverlay.ts
@@ -1,0 +1,84 @@
+'use client';
+
+import { type KeyboardEvent, type KeyboardEventHandler, type MutableRefObject, useCallback } from 'react';
+import { useClickOutside } from './useClickOutside';
+
+export interface UseOverlayProps {
+  /** Whether the overlay is currently open. */
+  isOpen: boolean;
+  /** Ref to the overlay root element. */
+  overlayRef: MutableRefObject<HTMLElement | null>;
+  /** Callback called when the overlay should close. */
+  onClose: (event?: Event | KeyboardEvent<HTMLElement>) => void;
+  /** Whether Escape key should dismiss the overlay. */
+  closeOnEscape?: boolean;
+  /** Whether click outside should dismiss the overlay. */
+  closeOnInteractOutside?: boolean;
+  /** Optional callback fired before outside-interaction close. */
+  onInteractOutside?: (event: Event) => void;
+  /** Optional outside-interaction close callback. Overrides `onClose` for outside events. */
+  onCloseOnInteractOutside?: (event: Event) => void;
+}
+
+export interface UseOverlayReturn {
+  /** Attach to overlay root to handle keyboard dismissal. */
+  onOverlayKeyDown: KeyboardEventHandler<HTMLElement>;
+}
+
+/**
+ * Reusable overlay-close behavior for non-modal overlays.
+ * Handles Escape dismissal and click-outside dismissal.
+ *
+ * @param props - Hook configuration.
+ * @param props.isOpen - Whether overlay is currently open.
+ * @param props.overlayRef - Ref to the overlay root element.
+ * @param props.onClose - Callback called when overlay should close.
+ * @param props.closeOnEscape - Whether Escape should trigger close.
+ * @param props.closeOnInteractOutside - Whether outside interaction should trigger close.
+ * @param props.onInteractOutside - Optional callback fired on outside interaction before close.
+ * @param props.onCloseOnInteractOutside - Optional outside close callback overriding default `onClose`.
+ * @returns {UseOverlayReturn} Keyboard handlers for overlay close behavior.
+ */
+export const useOverlay = ({
+  isOpen,
+  overlayRef,
+  onClose,
+  closeOnEscape = true,
+  closeOnInteractOutside = true,
+  onInteractOutside,
+  onCloseOnInteractOutside,
+}: UseOverlayProps): UseOverlayReturn => {
+  const handleInteractOutside = useCallback(
+    (event: Event) => {
+      if (!isOpen || !closeOnInteractOutside) {
+        return;
+      }
+
+      onInteractOutside?.(event);
+
+      if (onCloseOnInteractOutside) {
+        onCloseOnInteractOutside(event);
+
+        return;
+      }
+
+      onClose(event);
+    },
+    [closeOnInteractOutside, isOpen, onClose, onCloseOnInteractOutside, onInteractOutside],
+  );
+
+  useClickOutside({ ref: overlayRef, callback: handleInteractOutside });
+
+  const onOverlayKeyDown = useCallback<KeyboardEventHandler<HTMLElement>>(
+    (event) => {
+      if (!isOpen || !closeOnEscape || event.key !== 'Escape' || event.defaultPrevented) {
+        return;
+      }
+
+      onClose(event);
+    },
+    [closeOnEscape, isOpen, onClose],
+  );
+
+  return { onOverlayKeyDown };
+};

--- a/packages/web-react/src/types/dropdown.ts
+++ b/packages/web-react/src/types/dropdown.ts
@@ -1,4 +1,10 @@
-import { type ComponentPropsWithRef, type ElementType, type LegacyRef, type ReactNode } from 'react';
+import {
+  type ComponentPropsWithRef,
+  type ElementType,
+  type LegacyRef,
+  type MutableRefObject,
+  type ReactNode,
+} from 'react';
 import {
   type AlignmentXExtendedDictionaryType,
   type AlignmentYExtendedDictionaryType,
@@ -54,6 +60,7 @@ export interface SpiritDropdownProps extends DropdownProps, ChildrenProps {
   onAutoClose?: (event: Event) => void;
   isOpen: boolean;
   onToggle: () => void;
+  triggerRef?: MutableRefObject<HTMLElement | null | undefined>;
 }
 
 export interface UncontrolledDropdownProps extends ChildrenProps, Omit<SpiritDropdownProps, 'isOpen' | 'onToggle'> {}

--- a/packages/web-react/src/utils/focusable.ts
+++ b/packages/web-react/src/utils/focusable.ts
@@ -1,0 +1,21 @@
+const focusableElements = [
+  'input:not([type="hidden"]):not([disabled]):not([tabindex="-1"]):not([aria-hidden="true"])',
+  'button:not([disabled]):not([tabindex="-1"]):not([aria-hidden="true"])',
+  'select:not([disabled]):not([tabindex="-1"]):not([aria-hidden="true"])',
+  'textarea:not([disabled]):not([tabindex="-1"]):not([aria-hidden="true"])',
+  'a[href]:not([tabindex="-1"]):not([aria-hidden="true"])',
+];
+
+/** CSS selector that matches tabbable interactive elements. */
+export const FOCUSABLE_SELECTOR =
+  `${focusableElements.join(':not([hidden]),')}:not([hidden]),` +
+  '[tabindex]:not([tabindex="-1"]):not([disabled]):not([hidden]):not([aria-hidden="true"])';
+
+/**
+ * Returns all focusable descendant elements of the given container in DOM order.
+ *
+ * @param container - The root element to search within.
+ * @returns {HTMLElement[]} Array of focusable elements.
+ */
+export const getFocusableElements = (container: HTMLElement): HTMLElement[] =>
+  Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));

--- a/packages/web-react/src/utils/index.ts
+++ b/packages/web-react/src/utils/index.ts
@@ -5,6 +5,7 @@ export * from './colorObjectGenerators';
 export * from './compose';
 export * from './debounce';
 export * from './delayedCallback';
+export * from './focusable';
 export * from './htmlReactParser';
 export * from './mergeStyleProps';
 export * from './router';

--- a/packages/web/src/scss/components/Item/_Item.scss
+++ b/packages/web/src/scss/components/Item/_Item.scss
@@ -16,6 +16,7 @@
 .Item {
     @include form-fields.item();
 
+    position: relative;
     display: grid;
     grid-template-columns: auto 1fr auto;
     align-items: center;

--- a/packages/web/src/scss/components/UNSTABLE_Picker/picker-demo.mjs
+++ b/packages/web/src/scss/components/UNSTABLE_Picker/picker-demo.mjs
@@ -245,11 +245,16 @@ export function initPopoverBehavior(triggerEl, popoverEl) {
       return;
     }
 
-    // Tab off last focusable element closes the popover (non-modal anchored dropdown pattern)
-    if (event.key === 'Tab' && !event.shiftKey) {
+    // Tab off last / Shift+Tab off first focusable element closes the popover (non-modal anchored dropdown pattern)
+    if (event.key === 'Tab') {
       const focusable = Array.from(popoverEl.querySelectorAll(SELECTOR_FOCUSABLE));
 
-      if (focusable.length > 0 && document.activeElement === focusable[focusable.length - 1]) {
+      if (event.shiftKey) {
+        if (focusable.length > 0 && document.activeElement === focusable[0]) {
+          event.preventDefault();
+          triggerEl.click();
+        }
+      } else if (focusable.length > 0 && document.activeElement === focusable[focusable.length - 1]) {
         event.preventDefault();
         triggerEl.click();
       }


### PR DESCRIPTION
## Description

`DropdownPopover` did not provide complete dialog semantics and keyboard behavior needed for accessible non-modal popovers.
This caused inconsistent screen reader expectations and non-predictable keyboard focus flow.

**Keyboard behavior (non-modal anchored dialog pattern):**
- On open, focus moves to the first interactive element inside the popover
- **Escape** closes the popover and returns focus to the trigger
- **Tab** from the last focusable element closes the popover and returns focus to the trigger
- **Shift+Tab** from the first focusable element closes the popover and returns focus to the trigger

### Additional context

- This keeps `Dropdown` and `UNSTABLE_Picker` behavior aligned and removes duplicated keyboard logic.
- `DropdownTrigger` supports overriding `aria-haspopup`, so trigger semantics can stay aligned with an overridden `DropdownPopover` role (e.g. `role="menu"` + `aria-haspopup="menu"`).
- Breaking change: `DropdownPopover` now requires an accessible name (`aria-label` or `aria-labelledby`).

### Demo links
#### Dropdown
https://deploy-preview-2615--spirit-design-system.netlify.app/packages/web-react/src/components/dropdown/

https://deploy-preview-2615--spirit-design-system-storybook.netlify.app/?path=/story/components-dropdown--dropdown-playground

#### Picker
https://deploy-preview-2615--spirit-design-system.netlify.app/packages/web-react/src/components/unstable_picker/

https://deploy-preview-2615--spirit-design-system-storybook.netlify.app/?path=/story/experimental-unstable-picker--playground

### Issue reference

[Dropdown | Implement `role="dialog"` including required JS behavior](https://jira.almacareer.tech/browse/DS-2501)