### PR TITLE
feat(web,web-react)!: update disabled behavior for InputDetails

### DIFF
--- a/packages/web-react/src/components/InputDetails/InputDetails.tsx
+++ b/packages/web-react/src/components/InputDetails/InputDetails.tsx
@@ -1,24 +1,38 @@
 'use client';
 
 import React, { type ElementType, useEffect } from 'react';
+import { useContextProps } from '../../context';
 import { useStyleProps } from '../../hooks';
-import { type InputDetailsProps } from '../../types';
+import { type FormFieldContextValue, type InputDetailsProps } from '../../types';
 import { mergeStyleProps } from '../../utils';
 import { useInputDetailsStyleProps } from './useInputDetailsStyleProps';
 
 const defaultProps: Partial<InputDetailsProps> = {
   elementType: 'div',
   id: undefined,
+  isDisabled: false,
   registerAriaDetails: undefined,
 };
 
 const InputDetails = <E extends ElementType = 'div'>(props: InputDetailsProps<E>) => {
-  const propsWithDefaults = { ...defaultProps, ...props };
-  const { classProps, props: modifiedProps } = useInputDetailsStyleProps(propsWithDefaults);
-  const { children, elementType, id, registerAriaDetails, ...restProps } = modifiedProps;
-  const { styleProps, props: otherProps } = useStyleProps(restProps);
-  const Component = (elementType || defaultProps.elementType) as ElementType;
-  const mergedStyleProps = mergeStyleProps(Component, { classProps, styleProps, otherProps });
+  const contextProps = useContextProps<Partial<FormFieldContextValue>>();
+  const propsWithDefaults = {
+    ...defaultProps,
+    isDisabled: contextProps.isDisabled,
+    ...props,
+  };
+  const {
+    children,
+    elementType: ElementTag = defaultProps.elementType as ElementType,
+    id,
+    isDisabled,
+    registerAriaDetails,
+    ...restProps
+  } = propsWithDefaults;
+
+  const { classProps } = useInputDetailsStyleProps({ isDisabled });
+  const { styleProps, props: transferProps } = useStyleProps(restProps);
+  const mergedStyleProps = mergeStyleProps(ElementTag, { classProps, styleProps, transferProps });
 
   useEffect(() => {
     if (id) {
@@ -33,9 +47,9 @@ const InputDetails = <E extends ElementType = 'div'>(props: InputDetailsProps<E>
   }, [id, registerAriaDetails]);
 
   return (
-    <Component {...otherProps} {...mergedStyleProps} id={id}>
+    <ElementTag {...transferProps} {...mergedStyleProps} id={id}>
       {children}
-    </Component>
+    </ElementTag>
   );
 };
 

--- a/packages/web-react/src/components/InputDetails/README.md
+++ b/packages/web-react/src/components/InputDetails/README.md
@@ -66,10 +66,21 @@ It can be used internally in the form components via `details` prop.
 
 ## Disabled State
 
-When the parent component is disabled, the text and links inside InputDetails are automatically dimmed.
+Use the `isDisabled` prop to render InputDetails in a disabled state.
+When InputDetails is used inside form components (Checkbox, Toggle), this prop is set automatically from the parent disabled state.
 You must manually set the `isDisabled` prop on interactive elements (Link, Button) inside the `details` prop.
 
 **Note:** The `isDisabled` prop on Link/Button components is required for proper keyboard and screen reader behavior.
+
+### Basic Disabled InputDetails
+
+```tsx
+<InputDetails isDisabled>
+  <Link elementType="button" color="inherit" underlined="always" isDisabled>
+    See full terms and conditions
+  </Link>
+</InputDetails>
+```
 
 ### With Disabled Checkbox
 
@@ -135,6 +146,7 @@ You must manually set the `isDisabled` prop on interactive elements (Link, Butto
 | `children`            | `ReactNode`           | —       | ✓        | Content to render, such as links or modal triggers |
 | `elementType`         | `ElementType`         | `div`   | ✕        | HTML element to render as                          |
 | `id`                  | `string`              | —       | ✕        | Element ID for `aria-details` linking              |
+| `isDisabled`          | `boolean`             | `false` | ✕        | Renders disabled styles for InputDetails           |
 | `registerAriaDetails` | `RegisterDetailsType` | —       | ✕        | Callback to register/unregister `aria-details` IDs |
 
 The component accepts [additional attributes][readme-additional-attributes].

--- a/packages/web-react/src/components/InputDetails/__tests__/InputDetails.test.tsx
+++ b/packages/web-react/src/components/InputDetails/__tests__/InputDetails.test.tsx
@@ -1,7 +1,13 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { elementTypePropsTest, restPropsTest, stylePropsTest, validHtmlAttributesTest } from '@local/tests';
+import {
+  elementTypePropsTest,
+  formFieldContextPropsTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
 import InputDetails from '../InputDetails';
 
 describe('InputDetails', () => {
@@ -12,6 +18,14 @@ describe('InputDetails', () => {
   elementTypePropsTest((props) => <InputDetails {...props}>Test content</InputDetails>);
 
   validHtmlAttributesTest((props) => <InputDetails {...props}>Test content</InputDetails>);
+
+  formFieldContextPropsTest({
+    renderComponent: (props) => <InputDetails {...props}>Content</InputDetails>,
+    text: 'Content',
+    classNamePrefix: 'InputDetails',
+    includeInlineVariant: false,
+    includeItemVariant: false,
+  });
 
   it('should render children content', () => {
     render(<InputDetails>See full terms</InputDetails>);

--- a/packages/web-react/src/components/InputDetails/__tests__/useInputDetailsStyleProps.test.ts
+++ b/packages/web-react/src/components/InputDetails/__tests__/useInputDetailsStyleProps.test.ts
@@ -3,9 +3,15 @@ import { useInputDetailsStyleProps } from '../useInputDetailsStyleProps';
 
 describe('useInputDetailsStyleProps', () => {
   it('should return defaults', () => {
-    const props = { children: 'Content' };
+    const props = {};
     const { result } = renderHook(() => useInputDetailsStyleProps(props));
 
     expect(result.current.classProps).toBe('InputDetails');
+  });
+
+  it('should return disabled class when disabled', () => {
+    const { result } = renderHook(() => useInputDetailsStyleProps({ isDisabled: true }));
+
+    expect(result.current.classProps).toBe('InputDetails InputDetails--disabled');
   });
 });

--- a/packages/web-react/src/components/InputDetails/useInputDetailsStyleProps.ts
+++ b/packages/web-react/src/components/InputDetails/useInputDetailsStyleProps.ts
@@ -1,19 +1,22 @@
-import type { ElementType } from 'react';
+import classNames from 'classnames';
 import { useClassNamePrefix } from '../../hooks';
-import { type InputDetailsProps } from '../../types';
 
-export interface InputDetailsStyles<T> {
-  classProps: string;
-  props: T;
+export interface InputDetailsStyleProps {
+  isDisabled?: boolean;
 }
 
-export function useInputDetailsStyleProps<E extends ElementType = 'div'>(
-  props: InputDetailsProps<E>,
-): InputDetailsStyles<InputDetailsProps<E>> {
+export interface InputDetailsStyles {
+  classProps: string;
+}
+
+export function useInputDetailsStyleProps(props: InputDetailsStyleProps): InputDetailsStyles {
+  const { isDisabled } = props;
   const inputDetailsClass = useClassNamePrefix('InputDetails');
+  const inputDetailsClassDisabled = `${inputDetailsClass}--disabled`;
 
   return {
-    classProps: inputDetailsClass,
-    props,
+    classProps: classNames(inputDetailsClass, {
+      [inputDetailsClassDisabled]: isDisabled,
+    }),
   };
 }

--- a/packages/web-react/src/types/inputDetails.ts
+++ b/packages/web-react/src/types/inputDetails.ts
@@ -8,6 +8,8 @@ export interface InputDetailsProps<T extends ElementType = 'div'> extends Childr
   elementType?: T;
   /** ID of the details element */
   id?: string;
+  /** Whether the input details are disabled */
+  isDisabled?: boolean;
   /** Callback to register aria-details ID */
   registerAriaDetails?: RegisterDetailsType;
 }

--- a/packages/web-react/tests/providerTests/formFieldContextPropsTest.tsx
+++ b/packages/web-react/tests/providerTests/formFieldContextPropsTest.tsx
@@ -12,6 +12,8 @@ interface BaseFormFieldTestConfig {
 
 interface FormFieldContextPropsTestConfig extends BaseFormFieldTestConfig {
   classNamePrefix: string;
+  includeInlineVariant?: boolean;
+  includeItemVariant?: boolean;
   text?: string;
 }
 
@@ -104,37 +106,51 @@ const expectClassForProps = ({
 
 export const formFieldContextPropsTest = ({
   classNamePrefix,
+  includeInlineVariant = true,
+  includeItemVariant = true,
   renderComponent,
   text = DEFAULT_LABEL_TEXT,
 }: FormFieldContextPropsTestConfig) => {
   describe('prop priority (1. direct props, 2. context, 3. defaultProps)', () => {
-    it('should use default formFieldVariant when no context and no direct prop', () => {
-      renderFieldComponent(renderComponent);
-      const element = screen.getByText(text);
+    if (includeInlineVariant || includeItemVariant) {
+      it('should use default formFieldVariant when no context and no direct prop', () => {
+        renderFieldComponent(renderComponent);
+        const element = screen.getByText(text);
 
-      expect(element.className).toMatch(new RegExp(`^${classNamePrefix}\\b`));
-      expect(element.className).not.toContain(`${classNamePrefix}--inline`);
-      expect(element.className).not.toContain(`${classNamePrefix}--item`);
-    });
+        expect(element.className).toMatch(new RegExp(`^${classNamePrefix}\\b`));
+        if (includeInlineVariant) {
+          expect(element.className).not.toContain(`${classNamePrefix}--inline`);
+        }
+        if (includeItemVariant) {
+          expect(element.className).not.toContain(`${classNamePrefix}--item`);
+        }
+      });
+    }
 
-    it('should use context formFieldVariant when context provides it and no direct prop', () => {
-      render(<PropsProvider value={{ formFieldVariant: FormFieldVariants.INLINE }}>{renderComponent()}</PropsProvider>);
-      const element = screen.getByText(text);
+    if (includeInlineVariant) {
+      it('should use context formFieldVariant when context provides it and no direct prop', () => {
+        render(
+          <PropsProvider value={{ formFieldVariant: FormFieldVariants.INLINE }}>{renderComponent()}</PropsProvider>,
+        );
+        const element = screen.getByText(text);
 
-      expect(element.className).toContain(`${classNamePrefix}--inline`);
-    });
+        expect(element.className).toContain(`${classNamePrefix}--inline`);
+      });
+    }
 
-    it('should use direct formFieldVariant over context (direct props override context)', () => {
-      render(
-        <PropsProvider value={{ formFieldVariant: FormFieldVariants.ITEM }}>
-          {renderComponent({ formFieldVariant: FormFieldVariants.INLINE })}
-        </PropsProvider>,
-      );
-      const element = screen.getByText(text);
+    if (includeInlineVariant && includeItemVariant) {
+      it('should use direct formFieldVariant over context (direct props override context)', () => {
+        render(
+          <PropsProvider value={{ formFieldVariant: FormFieldVariants.ITEM }}>
+            {renderComponent({ formFieldVariant: FormFieldVariants.INLINE })}
+          </PropsProvider>,
+        );
+        const element = screen.getByText(text);
 
-      expect(element.className).toContain(`${classNamePrefix}--inline`);
-      expect(element.className).not.toContain(`${classNamePrefix}--item`);
-    });
+        expect(element.className).toContain(`${classNamePrefix}--inline`);
+        expect(element.className).not.toContain(`${classNamePrefix}--item`);
+      });
+    }
 
     it('should use context isDisabled when no direct prop', () => {
       render(<PropsProvider value={{ isDisabled: true }}>{renderComponent()}</PropsProvider>);

--- a/packages/web/src/scss/components/Checkbox/_Checkbox.scss
+++ b/packages/web/src/scss/components/Checkbox/_Checkbox.scss
@@ -55,11 +55,6 @@ $_field-name: 'Checkbox';
 
 :is(.Checkbox--disabled, .Checkbox.is-disabled) {
     @include form-fields-tools.inline-field-root-disabled();
-
-    // @deprecated This style will be removed in the next major version.
-    // Migration: delete mixin `form-fields-tools.input-details-text-disabled` and generate class `InputDetails--disabled`.
-    // @see https://jira.almacareer.tech/browse/DS-2496
-    @include form-fields-tools.input-details-text-disabled();
 }
 
 :is(.Checkbox--disabled, .Checkbox.is-disabled) > .Checkbox__input,

--- a/packages/web/src/scss/components/InputDetails/README.md
+++ b/packages/web/src/scss/components/InputDetails/README.md
@@ -51,8 +51,7 @@ It can be used internally in the form components.
 
 ## Disabled State
 
-When the parent component is disabled, the text and links inside InputDetails are automatically dimmed.
-You must manually add the `disabled` attribute to interactive elements (buttons, links) inside InputDetails.
+To render the `InputDetails` component in a disabled state, add the `InputDetails--disabled` modifier class to the `InputDetails` element and the `disabled` attribute to the interactive elements (buttons, links) inside InputDetails.
 
 **Note:** The `disabled` attribute on buttons and links is required for proper keyboard and screen reader behavior.
 
@@ -73,7 +72,7 @@ You must manually add the `disabled` attribute to interactive elements (buttons,
     <label class="Checkbox__label Checkbox__label--required" for="consent">
       <span class="typography-body-medium-semibold">I agree to the terms and conditions</span>
     </label>
-    <div id="consent-details" class="InputDetails">
+    <div id="consent-details" class="InputDetails InputDetails--disabled">
       <p class="typography-body-medium-regular">We want to keep you informed</p>
       <button type="button" class="link-underlined link-inherit" disabled>See full terms and conditions</button>
     </div>
@@ -87,7 +86,7 @@ You must manually add the `disabled` attribute to interactive elements (buttons,
 <div class="Toggle Toggle--inputPositionEnd Toggle--disabled">
   <div class="Toggle__text">
     <label class="Toggle__label Toggle__label--required" for="consent">I agree to the terms and conditions</label>
-    <div id="consent-details" class="InputDetails">
+    <div id="consent-details" class="InputDetails InputDetails--disabled">
       <button type="button" class="link-underlined link-inherit" disabled>See full terms and conditions</button>
       <button type="button" class="link-underlined link-inherit" disabled>See privacy policy</button>
     </div>

--- a/packages/web/src/scss/components/InputDetails/_InputDetails.scss
+++ b/packages/web/src/scss/components/InputDetails/_InputDetails.scss
@@ -13,9 +13,9 @@
     gap: theme.$gap;
     align-items: flex-start;
     margin-top: theme.$margin-top;
+    color: theme.$color;
+}
 
-    // @deprecated This custom property will be removed in the next major version.
-    // Migration: delete custom property `var(--#{tokens.$css-variable-prefix}input-details-text-color)` and create new disabled modifier.
-    // @see https://jira.almacareer.tech/browse/DS-2496
-    color: var(--#{tokens.$css-variable-prefix}input-details-text-color, theme.$color);
+.InputDetails--disabled {
+    color: theme.$color-state-disabled;
 }

--- a/packages/web/src/scss/components/InputDetails/_theme.scss
+++ b/packages/web/src/scss/components/InputDetails/_theme.scss
@@ -3,4 +3,6 @@
 $typography: tokens.$body-small-regular;
 $gap: tokens.$space-400;
 $margin-top: tokens.$space-400;
+
 $color: tokens.$text-primary;
+$color-state-disabled: tokens.$disabled-content;

--- a/packages/web/src/scss/components/InputDetails/index.html
+++ b/packages/web/src/scss/components/InputDetails/index.html
@@ -61,7 +61,7 @@
         />
         <div class="Checkbox__text">
           <label class="Label Label--inline Label--required Label--disabled" for="input-details-checkbox-disabled"><span class="typography-body-medium-semibold">I agree to the terms and conditions</span></label>
-          <div id="input-details-checkbox-disabled-details" class="InputDetails">
+          <div id="input-details-checkbox-disabled-details" class="InputDetails InputDetails--disabled">
             <p class="typography-body-medium-regular mb-0">We want to keep you informed</p>
             <button
               type="button"
@@ -152,7 +152,7 @@
       <div class="Toggle Toggle--inputPositionEnd Toggle--disabled Toggle--danger">
         <div class="Toggle__text">
           <label class="Label Label--inline Label--required Label--disabled" for="input-details-toggle-disabled">I agree to the terms and conditions</label>
-          <div id="input-details-toggle-disabled-details" class="InputDetails">
+          <div id="input-details-toggle-disabled-details" class="InputDetails InputDetails--disabled">
             <button
               type="button"
               class="link-underlined link-inherit"

--- a/packages/web/src/scss/components/Toggle/_Toggle.scss
+++ b/packages/web/src/scss/components/Toggle/_Toggle.scss
@@ -122,11 +122,6 @@ $_field-name: 'Toggle';
 
 .Toggle:is(.Toggle--disabled, .is-disabled) {
     @include form-fields-tools.inline-field-root-disabled();
-
-    // @deprecated This style will be removed in the next major version.
-    // Migration: delete mixin `form-fields-tools.input-details-text-disabled` and generate class `InputDetails--disabled`.
-    // @see https://jira.almacareer.tech/browse/DS-2496
-    @include form-fields-tools.input-details-text-disabled();
 }
 
 .Toggle:is(.Toggle--disabled, .is-disabled) > .Toggle__input,

--- a/packages/web/src/scss/settings/_form-fields.scss
+++ b/packages/web/src/scss/settings/_form-fields.scss
@@ -31,12 +31,6 @@ $inline-field-input-border-color-checked-disabled: tokens.$disabled-background;
 $inline-field-input-border-width: tokens.$border-width-200;
 $inline-field-input-background-color-checked: tokens.$selected-state-default;
 
-// InputDetails component – Checkbox, Toggle
-// @deprecated This variable will be removed in the next major version.
-// Migration: delete variable `$input-details-text-color-state-disabled` and create a new one in InputDetails component.
-// @see https://jira.almacareer.tech/browse/DS-2496
-$input-details-text-color-state-disabled: tokens.$disabled-content;
-
 // Box field form components – TextField, TextArea, etc.
 $box-field-input-color-state-default: tokens.$form-field-filled-content;
 $box-field-input-border-width: tokens.$border-width-100;

--- a/packages/web/src/scss/tools/_form-fields.scss
+++ b/packages/web/src/scss/tools/_form-fields.scss
@@ -61,13 +61,6 @@
     cursor: cursors.$disabled;
 }
 
-// @deprecated This style will be removed in the next major version.
-// Migration: delete mixin `form-fields-tools.input-details-text-disabled` and generate class `InputDetails--disabled`.
-// @see https://jira.almacareer.tech/browse/DS-2496
-@mixin input-details-text-disabled() {
-    --#{tokens.$css-variable-prefix}input-details-text-color: #{form-fields-settings.$input-details-text-color-state-disabled};
-}
-
 @mixin box-field-root-responsive-border-radius($field-name) {
     @each $breakpoint-name, $breakpoint-value in tokens.$breakpoints {
         @include breakpoint.up($breakpoint-value) {


### PR DESCRIPTION
## Description

- introduces a breaking change in `web` where disabled styling for `InputDetails` now requires explicit `InputDetails--disabled` instead of inheriting from parent field disabled state
- updates `web-react` `InputDetails` to consume `isDisabled` from form field context and apply `InputDetails--disabled` class explicitly
- adjusts tests and docs to cover and explain the new disabled behavior

### Additional context

- reviewers should focus on BC impact in `packages/web` for `Checkbox` and `Toggle` integration, and matching behavior in `packages/web-react`
- this PR intentionally separates breaking SCSS behavior (`feat`) from React internal refactor (`refactor`) in commit history

### Issue reference

- https://jira.almacareer.tech/browse/DS-2496