### PR TITLE
fix(repo): update pre-commit hook for Yarn v4 compatibility

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn lint-staged
+yarn exec lint-staged


### PR DESCRIPTION
## Summary

`yarn lint-staged` no longer resolves workspace binaries in Yarn v4 — only `scripts` entries in `package.json` are matched. The pre-commit hook has been updated to `yarn exec lint-staged`, which correctly locates the installed binary.

## Test plan

- [ ] Run `git commit` and verify lint-staged executes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)