### PR TITLE
chore(repo): enforce empty line before expect groups in tests

### DIFF
--- a/configs/eslint-config-spirit/index.js
+++ b/configs/eslint-config-spirit/index.js
@@ -23,7 +23,7 @@ module.exports = {
    * Disabled in:
    * @see { @link https://github.com/alma-oss/spirit-design-system/pull/2421 }
    */
-  plugins: ['promise', 'react', '@typescript-eslint', /* 'react-refresh' */],
+  plugins: ['jest-formatting', 'promise', 'react', '@typescript-eslint', /* 'react-refresh' */],
 
   rules: {
 
@@ -89,7 +89,7 @@ module.exports = {
       },
     },
     {
-      files: ['test/**', '**/*.test.*', '**/*.spec.*'],
+      files: ['test/**', 'tests/**', '**/*.test.*', '**/*.spec.*'],
       rules: {
         // Require an empty line before the first `expect` in a group
         // @see { @link https://github.com/dangreenisrael/eslint-plugin-jest-formatting }

--- a/exporters/tokens/eslint.config.mjs
+++ b/exporters/tokens/eslint.config.mjs
@@ -34,6 +34,9 @@ export default [
       // @see: https://github.com/alma-oss/spirit-design-system/issues/2243
       '**/*.json',
 
+      // Exclude SCSS files from being linted
+      '**/*.scss',
+
       // Unformatted fixtures
       '**/{fixtures}/**/unformatted*',
       '**/__fixtures__/unformatted*',

--- a/packages/web-react/tests/providerTests/classNamePrefixProviderTest.tsx
+++ b/packages/web-react/tests/providerTests/classNamePrefixProviderTest.tsx
@@ -14,6 +14,7 @@ export const classNamePrefixProviderTest = (Component: ComponentType<any>, class
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(`${prefix}-${className}`);
     });
   });
@@ -23,6 +24,7 @@ export const classNamePrefixProviderTest = (Component: ComponentType<any>, class
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(className);
     });
   });

--- a/packages/web-react/tests/providerTests/dictionaryPropsTest.tsx
+++ b/packages/web-react/tests/providerTests/dictionaryPropsTest.tsx
@@ -30,6 +30,7 @@ export const sizePropsTest = (Component: ComponentType<any>, testId?: string) =>
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element.getAttribute('class')).toContain(size);
     });
   });
@@ -41,6 +42,7 @@ export const sizeExtendedPropsTest = (Component: ComponentType<any>, testId?: st
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element.getAttribute('class')).toContain(size);
     });
   });
@@ -52,6 +54,7 @@ export const componentButtonColorPropsTest = (Component: ComponentType<any>, pre
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(`${prefix}${color}`);
     });
   });
@@ -63,6 +66,7 @@ export const actionLinkColorPropsTest = (Component: ComponentType<any>, prefix: 
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(`${prefix}${color}`);
     });
   });
@@ -74,6 +78,7 @@ export const emotionColorPropsTest = (Component: ComponentType<any>, prefix: str
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(`${prefix}${color}`);
     });
   });
@@ -85,6 +90,7 @@ export const textColorPropsTest = (Component: ComponentType<any>, testId?: strin
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(`text-${textColor}`);
     });
   });
@@ -96,6 +102,7 @@ export const validationStatePropsTest = (Component: ComponentType<any>, prefix: 
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(`${prefix}${state}`);
     });
   });
@@ -107,6 +114,7 @@ export const alignmentXPropsTest = (Component: ComponentType<any>, prefix?: stri
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(`${prefix}--alignmentX${alignment.charAt(0).toUpperCase() + alignment.slice(1)}`);
     });
   });
@@ -118,6 +126,7 @@ export const alignmentXExtendedPropsTest = (Component: ComponentType<any>, prefi
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(`${prefix}--alignmentX${alignment.charAt(0).toUpperCase() + alignment.slice(1)}`);
     });
   });
@@ -129,6 +138,7 @@ export const alignmentYPropsTest = (Component: ComponentType<any>, prefix?: stri
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(`${prefix}--alignmentY${alignment.charAt(0).toUpperCase() + alignment.slice(1)}`);
     });
   });
@@ -140,6 +150,7 @@ export const alignmentYExtendedPropsTest = (Component: ComponentType<any>, prefi
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(`${prefix}--alignmentY${alignment.charAt(0).toUpperCase() + alignment.slice(1)}`);
     });
   });

--- a/packages/web-react/tests/providerTests/itemPropsTest.tsx
+++ b/packages/web-react/tests/providerTests/itemPropsTest.tsx
@@ -7,6 +7,7 @@ export const itemPropsTest = (Component: ComponentType<any>) => {
 
     await waitFor(() => {
       const element = screen.queryByTestId('test');
+
       expect(element?.parentElement?.className).toContain('--item');
     });
   });

--- a/packages/web-react/tests/providerTests/loadingPropsTest.tsx
+++ b/packages/web-react/tests/providerTests/loadingPropsTest.tsx
@@ -7,6 +7,7 @@ export const loadingPropsTest = (Component: ComponentType<any>, selector: string
 
     await waitFor(() => {
       const element = dom.container.querySelector(selector) as HTMLElement;
+
       expect(element.getAttribute('class')).toContain('--loading');
     });
   });
@@ -16,6 +17,7 @@ export const loadingPropsTest = (Component: ComponentType<any>, selector: string
 
     await waitFor(() => {
       const element = dom.container.querySelector('svg:last-child') as SVGElement;
+
       expect(element).toHaveClass('animation-spin-clockwise');
     });
   });

--- a/packages/web-react/tests/providerTests/restPropsTest.tsx
+++ b/packages/web-react/tests/providerTests/restPropsTest.tsx
@@ -8,6 +8,7 @@ export const restPropsTest = (Component: ComponentType<any>, selector: string) =
 
     await waitFor(() => {
       const element = dom.container.querySelector(selector) as HTMLElement;
+
       expect(element).toHaveAttribute('data-testid', testId);
     });
   });

--- a/packages/web-react/tests/providerTests/stylePropsTest.tsx
+++ b/packages/web-react/tests/providerTests/stylePropsTest.tsx
@@ -12,6 +12,7 @@ export const stylePropsTest = (Component: ComponentType<any>, testId?: string) =
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(testClassName);
     });
   });
@@ -23,6 +24,7 @@ export const stylePropsTest = (Component: ComponentType<any>, testId?: string) =
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveStyle(expectedStyle);
     });
   });
@@ -93,6 +95,7 @@ export const stylePropsTest = (Component: ComponentType<any>, testId?: string) =
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(expected.className);
     });
   });

--- a/packages/web-react/tests/providerTests/textAlignmentPropsTest.tsx
+++ b/packages/web-react/tests/providerTests/textAlignmentPropsTest.tsx
@@ -9,6 +9,7 @@ export const textAlignmentPropsTest = (Component: ComponentType<any>, testId?: s
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(`text-${textAlignment}`);
     });
   });

--- a/packages/web-react/tests/providerTests/textHyphensPropsTest.tsx
+++ b/packages/web-react/tests/providerTests/textHyphensPropsTest.tsx
@@ -9,6 +9,7 @@ export const textHyphensPropsTest = (Component: ComponentType<any>, testId?: str
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(`text-hyphens-${textHyphen}`);
     });
   });

--- a/packages/web-react/tests/providerTests/textIsBalancedPropsTest.tsx
+++ b/packages/web-react/tests/providerTests/textIsBalancedPropsTest.tsx
@@ -11,6 +11,7 @@ export const textIsBalancedPropsTest = async (
 
   await waitFor(() => {
     const element = getElement(dom, testId);
+
     expect(element).toHaveClass(expectedClassName);
   });
 };

--- a/packages/web-react/tests/providerTests/textWordBreakPropsTest.tsx
+++ b/packages/web-react/tests/providerTests/textWordBreakPropsTest.tsx
@@ -9,6 +9,7 @@ export const textWordBreakPropsTest = (Component: ComponentType<any>, testId?: s
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(`text-word-break-${textWordBreak}`);
     });
   });

--- a/packages/web-react/tests/providerTests/themePropsTest.tsx
+++ b/packages/web-react/tests/providerTests/themePropsTest.tsx
@@ -12,6 +12,7 @@ export const themePropsTest = (Component: ComponentType<any>, testId?: string) =
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(DEFAULT_THEME);
     });
   });
@@ -21,6 +22,7 @@ export const themePropsTest = (Component: ComponentType<any>, testId?: string) =
 
     await waitFor(() => {
       const element = getElement(dom, testId);
+
       expect(element).toHaveClass(NORMALIZED_THEME);
     });
   });

--- a/packages/web-react/tests/providerTests/toBeInDocumentProviderTest.tsx
+++ b/packages/web-react/tests/providerTests/toBeInDocumentProviderTest.tsx
@@ -12,6 +12,7 @@ export const toBeInDocumentProviderTest = (Component: ComponentType<any>, select
 
     await waitFor(() => {
       const element = testId ? screen.getByTestId(testId) : (dom.container.querySelector(selector!) as HTMLElement);
+
       expect(element).toBeInTheDocument();
     });
   });

--- a/packages/web-react/tests/providerTests/validationTextPropsTest.tsx
+++ b/packages/web-react/tests/providerTests/validationTextPropsTest.tsx
@@ -21,6 +21,7 @@ export const validationTextPropsTest = (
 
     await waitFor(() => {
       const element = dom.container.querySelector(selector) as HTMLElement;
+
       expect(element.textContent).toBe('text');
     });
   });
@@ -39,6 +40,7 @@ export const validationTextPropsTest = (
 
     await waitFor(() => {
       const element = screen.getByText('text') as HTMLElement;
+
       expect(element.previousElementSibling).toContainHTML('svg');
     });
   });
@@ -56,6 +58,7 @@ export const validationTextPropsTest = (
 
     await waitFor(() => {
       const element = dom.container.querySelector(selector) as HTMLElement;
+
       expect(element.children[0]).toContainHTML('ul');
     });
   });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

This PR updates the shared ESLint configuration to enforce spacing around Jest expect groups, and applies the resulting formatting updates across existing `packages/web-react `provider test helpers.

Changes:

Added eslint-plugin-jest-formatting rule configuration to require padding around expect groups in test files.
Updated multiple `packages/web-react/tests/providerTests/*` helpers to include an empty line before `expect(...)` calls.
Updated the tokens exporter flat ESLint config to ignore *.scss files.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
