### PR TITLE
feat(web,web-react)!: remove deprecated `isBlock` prop from Button and ButtonLink #DS-1897

### DIFF
--- a/.agents/skills/figma-to-spirit/SKILL.md
+++ b/.agents/skills/figma-to-spirit/SKILL.md
@@ -61,8 +61,6 @@ For detailed API references, examples, and common mistakes:
 
 ### Deprecated Props (Still Available but Will Be Removed)
 
-- **Button/ButtonLink: `isBlock` prop** - Deprecated with no replacement. If Figma shows a full-width button, handle via layout (e.g., wrap in Flex with `alignmentX="stretch"`) or ask the user for guidance.
-
 - **UncontrolledCollapse: `hideOnCollapse` prop** - Replaced by `isDisposable`. Always use `isDisposable` instead.
 
 ### Deprecated Components
@@ -369,7 +367,7 @@ Before finalizing code:
 - \[ \] Layer names checked for size/color/variant props
 - \[ \] Spacing values read from Figma autolayout properties
 - \[ \] Color tokens read exactly from Figma layer properties
-- \[ \] **No deprecated props used** (check: isBlock, hideOnCollapse, row/column direction values)
+- \[ \] **No deprecated props used** (check: hideOnCollapse, row/column direction values)
 - \[ \] **No deprecated components used** (Header → use UNSTABLE_Header)
 
 **Layout:**
@@ -486,9 +484,6 @@ The rule: If CodeConnect shows `iconName="placeholder"`, your code MUST use `ico
 // CORRECT - use current direction values
 <Flex direction="horizontal" />
 <Flex direction="vertical" />
-
-// WRONG - using deprecated Button isBlock prop
-<Button isBlock>Full Width Button</Button>
 
 // CORRECT - handle full-width buttons via layout
 <Flex alignmentX="stretch">

--- a/docs/migrations/web-react/migration-v5.md
+++ b/docs/migrations/web-react/migration-v5.md
@@ -19,6 +19,7 @@ Introducing version 5 of the _spirit-web-react_ package.
   - [EmptyState: Component Name Stabilized](#emptystate-component-name-stabilized)
   - [Toggle: Component Name Stabilized](#toggle-component-name-stabilized)
   - [Truncate: Component Name Stabilized and `lines` Prop Changed](#truncate-component-name-stabilized-and-lines-prop-changed)
+  - [Button and ButtonLink: `isBlock` Prop Removed](#button-and-buttonlink-isblock-prop-removed)
   - [Tag: Appearance Feature Flag Removed](#tag-appearance-feature-flag-removed)
 
 ## Component Changes
@@ -255,6 +256,57 @@ Manually replace the component name and prop in your project.
 - `<Truncate lines={3} … />` → `<Truncate mode="lines" limit={3} … />`
 </details>
 
+### Button and ButtonLink: `isBlock` Prop Removed
+
+The deprecated `isBlock` prop has been removed from `Button` and `ButtonLink` components.
+
+To achieve full-width buttons, use CSS utility classes or the `Grid` component instead.
+
+#### Migration Guide
+
+<details>
+  <summary>🔧 Manual Migration Steps</summary>
+
+Remove the `isBlock` prop and use layout to achieve a full-width button instead.
+
+Responsive on all breakpoints:
+
+```tsx
+// Before
+<Button isBlock>Full-width Button</Button>
+
+// After
+<div className="d-grid">
+  <Button>Full-width Button</Button>
+</div>
+```
+
+Full-width on mobile only:
+
+```tsx
+// Before
+<Button isBlock>Full-width on mobile</Button>
+
+// After
+<div className="d-grid d-tablet-block">
+  <Button>Full-width on mobile</Button>
+</div>
+```
+
+Responsive full-width with [`Grid`][readme-grid]:
+
+```tsx
+// Before
+<Button isBlock>Responsive Button</Button>
+
+// After
+<Grid cols={{ mobile: 1, tablet: 2 }}>
+  <Button>Responsive Button</Button>
+</Grid>
+```
+
+</details>
+
 ### Tag: Appearance Feature Flag Removed
 
 The feature flag enabling the new `Tag` appearance was removed and the new appearance
@@ -271,3 +323,4 @@ Please refer back to these instructions or reach out to our team if you encounte
 
 [migration-guide-web]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/migrations/web/
 [readme-codemods]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/codemods/README.md
+[readme-grid]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/Grid/README.md

--- a/docs/migrations/web/migration-v5.md
+++ b/docs/migrations/web/migration-v5.md
@@ -7,10 +7,62 @@ Introducing version 5 of the _spirit-web_ package.
 ## Overview
 
 - [Component Changes](#component-changes)
+  - [Button: `Button--block` Modifier Removed](#button-button--block-modifier-removed)
   - [Flex: Direction Modifier Classes Changed](#flex-direction-modifier-classes-changed)
   - [Tag: Appearance Feature Flag Removed](#tag-appearance-feature-flag-removed)
 
 ## Component Changes
+
+### Button: `Button--block` Modifier Removed
+
+The deprecated `Button--block` CSS modifier has been removed.
+
+To achieve full-width buttons, use CSS utility classes or the [`Grid`][readme-grid] component instead.
+
+#### Migration Guide
+
+<details>
+  <summary>🔧 Manual Migration Steps</summary>
+
+Remove the `Button--block` modifier class and use layout to achieve a full-width button instead.
+
+Responsive on all breakpoints:
+
+```html
+<!-- Before -->
+<button type="button" class="Button Button--primary Button--medium Button--block">Full-width Button</button>
+
+<!-- After -->
+<div class="d-grid">
+  <button type="button" class="Button Button--primary Button--medium">Full-width Button</button>
+</div>
+```
+
+Full-width on mobile only:
+
+```html
+<!-- Before -->
+<button type="button" class="Button Button--primary Button--medium Button--block">Full-width Button</button>
+
+<!-- After -->
+<div class="d-grid d-tablet-block">
+  <button type="button" class="Button Button--primary Button--medium">Full-width Button</button>
+</div>
+```
+
+Responsive full-width with [`Grid`][readme-grid]:
+
+```html
+<!-- Before -->
+<button type="button" class="Button Button--primary Button--medium Button--block">Responsive Button</button>
+
+<!-- After -->
+<div class="Grid Grid--cols-1 Grid--tablet--cols-2">
+  <button type="button" class="Button Button--primary Button--medium">Responsive Button</button>
+</div>
+```
+
+</details>
 
 ### Flex: Direction Modifier Classes Changed
 
@@ -38,3 +90,5 @@ You can now safely delete the Sass variable `$enable-v5-tag-appearance` and the 
 ---
 
 Please refer back to these instructions or reach out to our team if you encounter any issues during migration.
+
+[readme-grid]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/Grid/README.md

--- a/packages/web-react/CONTRIBUTING.md
+++ b/packages/web-react/CONTRIBUTING.md
@@ -174,7 +174,6 @@ The complete set of component-specific props, combining all the above. This is t
 
 ```typescript
 interface ButtonProps<C = void, S = void> extends ButtonStyleProps<C, S>, ChildrenProps, ClickEvents {
-  isBlock?: boolean;
   isDisabled?: boolean;
   isLoading?: boolean;
   type?: ButtonType;
@@ -238,7 +237,6 @@ export type ButtonProps<E extends ElementType = 'button', C = void, S = void> = 
 ```typescript
 interface ButtonStyleProps {
   color?: ButtonColor;
-  isBlock?: boolean;
   size?: ButtonSize;
 }
 

--- a/packages/web-react/DEPRECATIONS.md
+++ b/packages/web-react/DEPRECATIONS.md
@@ -56,14 +56,6 @@ If you are using the `Stack` component with dividers, you must wrap each item in
 </Stack>
 ```
 
-### Button and ButtonLink
-
-The `isBlock` property will be removed in the next major version.
-
-For more information, see documentation for [Button][button] and [ButtonLink][button-link] components.
-
-[button]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/Button/README.md#how-to-make-a-fluid-button
-[button-link]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/ButtonLink/README.md#how-to-make-a-fluid-buttonlink
 [codemod-collapse]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/codemods/src/transforms/v4/web-react/README.md#v4web-reactcollapse-isdisposable-prop--uncontrolledcollapse-hideoncollapse-to-isdisposable-prop-change
 [codemod-flex]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/codemods/src/transforms/v4/web-react/README.md#v4web-reactflex-direction-values---flex-direction-prop-values-row-to-horizontal-and-column-to-vertical
 [readme-deprecations]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/README.md#deprecations

--- a/packages/web-react/src/components/Button/Button.tsx
+++ b/packages/web-react/src/components/Button/Button.tsx
@@ -12,11 +12,6 @@ import { useButtonStyleProps } from './useButtonStyleProps';
 const defaultProps = {
   color: 'primary',
   elementType: 'button',
-  /**
-   * @deprecated "isBlock" property will be removed in the next major version. Please read component's README for more information.
-   * @see https://jira.almacareer.tech/browse/DS-1897
-   */
-  isBlock: false,
   isDisabled: false,
   isLoading: false,
   isSymmetrical: false,

--- a/packages/web-react/src/components/Button/README.md
+++ b/packages/web-react/src/components/Button/README.md
@@ -142,12 +142,6 @@ Responsive full-width buttons with [Grid][readme-grid]:
 </Grid>
 ```
 
-### DEPRECATION NOTICE
-
-Property `isBlock` is deprecated and will be removed in the next major release.
-
-For more information, please read the [Full-Width Button](#full-width-button) section.
-
 ## Accessibility
 
 ⚠️ **Accessibility note:** Always use `VisuallyHidden` for the accessible label and add `aria-hidden="true"` to the
@@ -247,21 +241,20 @@ Custom responsive spacing:
 
 ## API
 
-| Name            | Type                                                                                           | Default     | Required | Description                                                                                                                                 |
-| --------------- | ---------------------------------------------------------------------------------------------- | ----------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `children`      | `ReactNode`                                                                                    | `null`      | ✕        | Content of the Button                                                                                                                       |
-| `color`         | [ComponentButtonColorType][readme-generated-types], [EmotionColorType][readme-generated-types] | `primary`   | ✕        | Color variant                                                                                                                               |
-| `elementType`   | `ElementType`                                                                                  | `button`    | ✕        | Type of element                                                                                                                             |
-| `isBlock`       | `bool`                                                                                         | `false`     | ✕        | [**DEPRECATED**](#deprecation-notice) Span the element to the full width of its parent, see [Full-Width Button](#full-width-button) section |
-| `isDisabled`    | `bool`                                                                                         | `false`     | ✕        | If true, Button is disabled                                                                                                                 |
-| `isLoading`     | `bool`                                                                                         | `false`     | ✕        | If true, Button is in a loading state, disabled and the Spinner is visible                                                                  |
-| `isSymmetrical` | `bool` \| `Responsive<bool>`                                                                   | `false`     | ✕        | If true, Button has symmetrical dimensions, use object to set responsive values, e.g. `{ mobile: true, tablet: false }`                     |
-| `name`          | `string`                                                                                       | —           | ✕        | For use a button as a form data reference                                                                                                   |
-| `onClick`       | `(event: ClickEvent) => void`                                                                  | —           | ✕        | JS function to call on click                                                                                                                |
-| `ref`           | `ForwardedRef<HTMLButtonElement>`                                                              | —           | ✕        | Button element reference                                                                                                                    |
-| `size`          | [Size dictionary][dictionary-size]                                                             | `medium`    | ✕        | Size variant                                                                                                                                |
-| `spacing`       | `SpaceToken` \| `Responsive<SpaceToken>`                                                       | `space-400` | ✕        | Apply [custom spacing](#custom-spacing) between button content items                                                                        |
-| `type`          | `string`                                                                                       | `button`    | ✕        | Type of the Button                                                                                                                          |
+| Name            | Type                                                                                           | Default     | Required | Description                                                                                                             |
+| --------------- | ---------------------------------------------------------------------------------------------- | ----------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `children`      | `ReactNode`                                                                                    | `null`      | ✕        | Content of the Button                                                                                                   |
+| `color`         | [ComponentButtonColorType][readme-generated-types], [EmotionColorType][readme-generated-types] | `primary`   | ✕        | Color variant                                                                                                           |
+| `elementType`   | `ElementType`                                                                                  | `button`    | ✕        | Type of element                                                                                                         |
+| `isDisabled`    | `bool`                                                                                         | `false`     | ✕        | If true, Button is disabled                                                                                             |
+| `isLoading`     | `bool`                                                                                         | `false`     | ✕        | If true, Button is in a loading state, disabled and the Spinner is visible                                              |
+| `isSymmetrical` | `bool` \| `Responsive<bool>`                                                                   | `false`     | ✕        | If true, Button has symmetrical dimensions, use object to set responsive values, e.g. `{ mobile: true, tablet: false }` |
+| `name`          | `string`                                                                                       | —           | ✕        | For use a button as a form data reference                                                                               |
+| `onClick`       | `(event: ClickEvent) => void`                                                                  | —           | ✕        | JS function to call on click                                                                                            |
+| `ref`           | `ForwardedRef<HTMLButtonElement>`                                                              | —           | ✕        | Button element reference                                                                                                |
+| `size`          | [Size dictionary][dictionary-size]                                                             | `medium`    | ✕        | Size variant                                                                                                            |
+| `spacing`       | `SpaceToken` \| `Responsive<SpaceToken>`                                                       | `space-400` | ✕        | Apply [custom spacing](#custom-spacing) between button content items                                                    |
+| `type`          | `string`                                                                                       | `button`    | ✕        | Type of the Button                                                                                                      |
 
 For more information see the [Button][button] component. Button can also bear any appropriate
 attributes according to the type of element. The default element type for Button is `<button>`.

--- a/packages/web-react/src/components/Button/__tests__/useButtonStyleProps.test.ts
+++ b/packages/web-react/src/components/Button/__tests__/useButtonStyleProps.test.ts
@@ -4,42 +4,20 @@ import { useButtonStyleProps } from '../useButtonStyleProps';
 
 describe('useButtonStyleProps', () => {
   it.each([
-    // color, size, isBlock, isDisabled, isLoading, isSymmetrical, expectedClasses
-    ['primary', 'medium', false, false, false, false, 'Button Button--primary Button--medium'],
-    ['secondary', 'medium', false, false, false, false, 'Button Button--secondary Button--medium'],
-    ['tertiary', 'medium', false, false, false, false, 'Button Button--tertiary Button--medium'],
-    ['plain', 'medium', false, false, false, false, 'Button Button--plain Button--medium'],
-    ['danger', 'medium', false, false, false, false, 'Button Button--danger Button--medium'],
-    ['primary', 'medium', true, false, false, false, 'Button Button--primary Button--medium Button--block'],
-    ['primary', 'medium', false, true, false, false, 'Button Button--primary Button--medium Button--disabled'],
-    [
-      'primary',
-      'medium',
-      false,
-      false,
-      true,
-      false,
-      'Button Button--primary Button--medium Button--disabled Button--loading',
-    ],
-    ['primary', 'medium', false, false, false, true, 'Button Button--primary Button--medium Button--symmetrical'],
-  ])('should return classes', (color, size, isBlock, isDisabled, isLoading, isSymmetrical, expectedClasses) => {
-    const props = { color, size, isBlock, isDisabled, isLoading, isSymmetrical } as SpiritButtonProps;
+    // color, size, isDisabled, isLoading, isSymmetrical, expectedClasses
+    ['primary', 'medium', false, false, false, 'Button Button--primary Button--medium'],
+    ['secondary', 'medium', false, false, false, 'Button Button--secondary Button--medium'],
+    ['tertiary', 'medium', false, false, false, 'Button Button--tertiary Button--medium'],
+    ['plain', 'medium', false, false, false, 'Button Button--plain Button--medium'],
+    ['danger', 'medium', false, false, false, 'Button Button--danger Button--medium'],
+    ['primary', 'medium', true, false, false, 'Button Button--primary Button--medium Button--disabled'],
+    ['primary', 'medium', false, true, false, 'Button Button--primary Button--medium Button--disabled Button--loading'],
+    ['primary', 'medium', false, false, true, 'Button Button--primary Button--medium Button--symmetrical'],
+  ])('should return classes', (color, size, isDisabled, isLoading, isSymmetrical, expectedClasses) => {
+    const props = { color, isDisabled, isLoading, isSymmetrical, size } as SpiritButtonProps;
     const { result } = renderHook(() => useButtonStyleProps(props));
 
     expect(result.current.classProps).toBe(expectedClasses);
-  });
-
-  it('should warn when using unsupported sizes on body', () => {
-    process.env.NODE_ENV = 'development';
-
-    const consoleWarnMock = jest.spyOn(global.console, 'warn').mockImplementation();
-
-    const props = { color: 'primary', size: 'medium', isBlock: true, isSymmetrical: true } as SpiritButtonProps;
-    renderHook(() => useButtonStyleProps(props));
-
-    expect(consoleWarnMock).toHaveBeenCalledWith('Warning: isBlock and isSymmetrical props are mutually exclusive');
-
-    consoleWarnMock.mockRestore();
   });
 
   it('should return responsive symmetrical classes for mobile only', () => {
@@ -88,24 +66,6 @@ describe('useButtonStyleProps', () => {
     const { result } = renderHook(() => useButtonStyleProps(props));
 
     expect(result.current.classProps).toBe('Button Button--primary Button--medium');
-  });
-
-  it('should warn when isBlock conflicts with responsive isSymmetrical', () => {
-    process.env.NODE_ENV = 'development';
-
-    const consoleWarnMock = jest.spyOn(global.console, 'warn').mockImplementation();
-
-    const props = {
-      color: 'primary',
-      size: 'medium',
-      isBlock: true,
-      isSymmetrical: { mobile: true, tablet: false },
-    } as SpiritButtonProps;
-    renderHook(() => useButtonStyleProps(props));
-
-    expect(consoleWarnMock).toHaveBeenCalledWith('Warning: isBlock and isSymmetrical props are mutually exclusive');
-
-    consoleWarnMock.mockRestore();
   });
 
   it.each([

--- a/packages/web-react/src/components/Button/stories/Button.stories.tsx
+++ b/packages/web-react/src/components/Button/stories/Button.stories.tsx
@@ -39,11 +39,6 @@ const meta: Meta<typeof Button> = {
         defaultValue: { summary: ComponentButtonColors.PRIMARY },
       },
     },
-    isBlock: {
-      control: 'boolean',
-      description:
-        "**DEPRECATED**: The property will be deleted in the next major release. Please read component's documentation for more information.",
-    },
     isDisabled: {
       control: 'boolean',
     },
@@ -72,7 +67,6 @@ const meta: Meta<typeof Button> = {
   args: {
     children: 'Click me',
     color: ComponentButtonColors.PRIMARY,
-    isBlock: false,
     isDisabled: false,
     isLoading: false,
     isSymmetrical: false,

--- a/packages/web-react/src/components/Button/useButtonStyleProps.ts
+++ b/packages/web-react/src/components/Button/useButtonStyleProps.ts
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import { type CSSProperties, type ElementType } from 'react';
-import { warning } from '../../common/utilities';
-import { useClassNamePrefix, useDeprecationMessage, useSpacingStyle, useSymmetry } from '../../hooks';
+import { useClassNamePrefix, useSpacingStyle, useSymmetry } from '../../hooks';
 import { type ButtonColor, type ButtonSize, type SpacingType, type SpiritButtonProps } from '../../types';
 import { applyColor, applySize } from '../../utils/classname';
 import { compose } from '../../utils/compose';
@@ -29,37 +28,19 @@ export interface ButtonStyles {
 export function useButtonStyleProps<T extends ElementType = 'button', C = void, S = void>(
   props: SpiritButtonProps<T, C, S>,
 ): ButtonStyles {
-  const { color, isBlock, isDisabled, isLoading, isSymmetrical, size, spacing, ...restProps } = props;
-
-  // @see https://jira.almacareer.tech/browse/DS-1897
-  useDeprecationMessage({
-    method: 'custom',
-    trigger: !!isBlock,
-    componentName: 'Button',
-    customText:
-      "The `isBlock` property will be deleted in the next major release. Please read component's documentation for more information.",
-  });
+  const { color, isDisabled, isLoading, isSymmetrical, size, spacing, ...restProps } = props;
 
   const buttonClass = useClassNamePrefix('Button');
-  const buttonBlockClass = `${buttonClass}--block`;
   const buttonDisabledClass = `${buttonClass}--disabled`;
   const buttonLoadingClass = `${buttonClass}--loading`;
 
-  const { isSymmetricalActive, symmetricalClassName } = useSymmetry(buttonClass, isSymmetrical);
-
-  if (isBlock && isSymmetricalActive) {
-    warning(false, 'isBlock and isSymmetrical props are mutually exclusive');
-  }
-
-  // @deprecated "isBlock" will be removed in the next major version. Please read component's documentation for more information.
-  const shouldApplyBlock = () => isBlock && !isSymmetricalActive;
+  const { symmetricalClassName } = useSymmetry(buttonClass, isSymmetrical);
 
   const classProps = classNames(
     buttonClass,
     getButtonColorClassname(buttonClass, color as ButtonColor<C>),
     getButtonSizeClassname(buttonClass, size as ButtonSize<S>),
     {
-      [buttonBlockClass]: shouldApplyBlock(),
       [buttonDisabledClass]: isDisabled || isLoading,
       [buttonLoadingClass]: isLoading,
     },

--- a/packages/web-react/src/components/ButtonLink/ButtonLink.tsx
+++ b/packages/web-react/src/components/ButtonLink/ButtonLink.tsx
@@ -18,11 +18,6 @@ import { useButtonLinkStyleProps } from './useButtonLinkStyleProps';
 const defaultProps = {
   color: 'primary',
   elementType: 'a',
-  /**
-   * @deprecated "isBlock" property will be removed in the next major version. Please read component's README for more information.
-   * @see https://jira.almacareer.tech/browse/DS-1897
-   */
-  isBlock: false,
   isDisabled: false,
   isLoading: false,
   isSymmetrical: false,

--- a/packages/web-react/src/components/ButtonLink/README.md
+++ b/packages/web-react/src/components/ButtonLink/README.md
@@ -73,28 +73,21 @@ To span a `ButtonLink` to the full width of its parent, you can use display util
 </Grid>
 ```
 
-### DEPRECATION NOTICE
-
-Property `isBlock` is deprecated and will be removed in the next major release.
-
-For more information, please read the section [How to Make a Fluid ButtonLink](#how-to-make-a-fluid-buttonlink).
-
 ### API
 
-| Name            | Type                                                                                          | Default   | Required | Description                                                                                                                                                           |
-| --------------- | --------------------------------------------------------------------------------------------- | --------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `children`      | `ReactNode`                                                                                   | `null`    | ✕        | Content of the ButtonLink                                                                                                                                             |
-| `color`         | [Component Button dictionary][dictionary-color], [Emotion Color dictionary][dictionary-color] | `primary` | ✕        | Color variant                                                                                                                                                         |
-| `elementType`   | `ElementType`                                                                                 | `a`       | ✕        | Type of element                                                                                                                                                       |
-| `href`          | `string`                                                                                      | —         | ✓        | Link URL                                                                                                                                                              |
-| `isBlock`       | `bool`                                                                                        | `false`   | ✕        | [**DEPRECATED**](#deprecation-notice) Span the element to the full width of its parent, see [How to Make a Fluid ButtonLink](#how-to-make-a-fluid-buttonlink) section |
-| `isDisabled`    | `bool`                                                                                        | `false`   | ✕        | If true, ButtonLink is disabled                                                                                                                                       |
-| `isLoading`     | `bool`                                                                                        | `false`   | ✕        | If true, ButtonLink is in a loading state, disabled and the Spinner is visible                                                                                        |
-| `isSymmetrical` | `bool` \| `Responsive<bool>`                                                                  | `false`   | ✕        | If true, ButtonLink has symmetrical dimensions, use object to set responsive values, e.g. `{ mobile: true, tablet: false }`                                           |
-| `onClick`       | `(event: ClickEvent) => void`                                                                 | —         | ✕        | JS function to call on click                                                                                                                                          |
-| `ref`           | `ForwardedRef<HTMLAnchorElement>`                                                             | —         | ✕        | Anchor element reference                                                                                                                                              |
-| `size`          | [Size dictionary][dictionary-size]                                                            | `medium`  | ✕        | Size variant                                                                                                                                                          |
-| `target`        | `string`                                                                                      | `null`    | ✕        | Link target                                                                                                                                                           |
+| Name            | Type                                                                                          | Default   | Required | Description                                                                                                                 |
+| --------------- | --------------------------------------------------------------------------------------------- | --------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `children`      | `ReactNode`                                                                                   | `null`    | ✕        | Content of the ButtonLink                                                                                                   |
+| `color`         | [Component Button dictionary][dictionary-color], [Emotion Color dictionary][dictionary-color] | `primary` | ✕        | Color variant                                                                                                               |
+| `elementType`   | `ElementType`                                                                                 | `a`       | ✕        | Type of element                                                                                                             |
+| `href`          | `string`                                                                                      | —         | ✓        | Link URL                                                                                                                    |
+| `isDisabled`    | `bool`                                                                                        | `false`   | ✕        | If true, ButtonLink is disabled                                                                                             |
+| `isLoading`     | `bool`                                                                                        | `false`   | ✕        | If true, ButtonLink is in a loading state, disabled and the Spinner is visible                                              |
+| `isSymmetrical` | `bool` \| `Responsive<bool>`                                                                  | `false`   | ✕        | If true, ButtonLink has symmetrical dimensions, use object to set responsive values, e.g. `{ mobile: true, tablet: false }` |
+| `onClick`       | `(event: ClickEvent) => void`                                                                 | —         | ✕        | JS function to call on click                                                                                                |
+| `ref`           | `ForwardedRef<HTMLAnchorElement>`                                                             | —         | ✕        | Anchor element reference                                                                                                    |
+| `size`          | [Size dictionary][dictionary-size]                                                            | `medium`  | ✕        | Size variant                                                                                                                |
+| `target`        | `string`                                                                                      | `null`    | ✕        | Link target                                                                                                                 |
 
 For more information see [Button][button] component. ButtonLink also contain all the appropriate
 attributes according to the type of element.

--- a/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
+++ b/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
@@ -56,15 +56,6 @@ describe('ButtonLink', () => {
     expect(element).toHaveClass('Button--disabled');
   });
 
-  it('should have block classname', () => {
-    render(<ButtonLink isBlock />);
-
-    const element = screen.getByRole('button');
-
-    expect(element).toHaveClass('Button');
-    expect(element).toHaveClass('Button--block');
-  });
-
   it('should have size classname', () => {
     render(<ButtonLink size="medium" />);
 

--- a/packages/web-react/src/components/ButtonLink/__tests__/useButtonLinkStyleProps.test.ts
+++ b/packages/web-react/src/components/ButtonLink/__tests__/useButtonLinkStyleProps.test.ts
@@ -4,42 +4,20 @@ import { useButtonLinkStyleProps } from '../useButtonLinkStyleProps';
 
 describe('useButtonLinkStyleProps', () => {
   it.each([
-    // color, size, isBlock, isDisabled, isLoading, isSymmetrical, expectedClasses
-    ['primary', 'medium', false, false, false, false, 'Button Button--primary Button--medium'],
-    ['secondary', 'medium', false, false, false, false, 'Button Button--secondary Button--medium'],
-    ['tertiary', 'medium', false, false, false, false, 'Button Button--tertiary Button--medium'],
-    ['plain', 'medium', false, false, false, false, 'Button Button--plain Button--medium'],
-    ['danger', 'medium', false, false, false, false, 'Button Button--danger Button--medium'],
-    ['primary', 'medium', true, false, false, false, 'Button Button--primary Button--medium Button--block'],
-    ['primary', 'medium', false, true, false, false, 'Button Button--primary Button--medium Button--disabled'],
-    [
-      'primary',
-      'medium',
-      false,
-      false,
-      true,
-      false,
-      'Button Button--primary Button--medium Button--disabled Button--loading',
-    ],
-    ['primary', 'medium', false, false, false, true, 'Button Button--primary Button--medium Button--symmetrical'],
-  ])('should return classes', (color, size, isBlock, isDisabled, isLoading, isSymmetrical, expectedClasses) => {
-    const props = { color, size, isBlock, isDisabled, isLoading, isSymmetrical } as SpiritButtonProps;
+    // color, size, isDisabled, isLoading, isSymmetrical, expectedClasses
+    ['primary', 'medium', false, false, false, 'Button Button--primary Button--medium'],
+    ['secondary', 'medium', false, false, false, 'Button Button--secondary Button--medium'],
+    ['tertiary', 'medium', false, false, false, 'Button Button--tertiary Button--medium'],
+    ['plain', 'medium', false, false, false, 'Button Button--plain Button--medium'],
+    ['danger', 'medium', false, false, false, 'Button Button--danger Button--medium'],
+    ['primary', 'medium', true, false, false, 'Button Button--primary Button--medium Button--disabled'],
+    ['primary', 'medium', false, true, false, 'Button Button--primary Button--medium Button--disabled Button--loading'],
+    ['primary', 'medium', false, false, true, 'Button Button--primary Button--medium Button--symmetrical'],
+  ])('should return classes', (color, size, isDisabled, isLoading, isSymmetrical, expectedClasses) => {
+    const props = { color, size, isDisabled, isLoading, isSymmetrical } as SpiritButtonProps;
     const { result } = renderHook(() => useButtonLinkStyleProps(props));
 
     expect(result.current.classProps).toBe(expectedClasses);
-  });
-
-  it('should warn when using unsupported sizes on body', () => {
-    process.env.NODE_ENV = 'development';
-
-    const consoleWarnMock = jest.spyOn(global.console, 'warn').mockImplementation();
-
-    const props = { color: 'primary', size: 'medium', isBlock: true, isSymmetrical: true } as SpiritButtonProps;
-    renderHook(() => useButtonLinkStyleProps(props));
-
-    expect(consoleWarnMock).toHaveBeenCalledWith('Warning: isBlock and isSymmetrical props are mutually exclusive');
-
-    consoleWarnMock.mockRestore();
   });
 
   it('should return responsive symmetrical classes for mobile only', () => {
@@ -88,23 +66,5 @@ describe('useButtonLinkStyleProps', () => {
     const { result } = renderHook(() => useButtonLinkStyleProps(props));
 
     expect(result.current.classProps).toBe('Button Button--primary Button--medium');
-  });
-
-  it('should warn when isBlock conflicts with responsive isSymmetrical', () => {
-    process.env.NODE_ENV = 'development';
-
-    const consoleWarnMock = jest.spyOn(global.console, 'warn').mockImplementation();
-
-    const props = {
-      color: 'primary',
-      size: 'medium',
-      isBlock: true,
-      isSymmetrical: { mobile: true, tablet: false },
-    } as SpiritButtonProps;
-    renderHook(() => useButtonLinkStyleProps(props));
-
-    expect(consoleWarnMock).toHaveBeenCalledWith('Warning: isBlock and isSymmetrical props are mutually exclusive');
-
-    consoleWarnMock.mockRestore();
   });
 });

--- a/packages/web-react/src/components/ButtonLink/stories/ButtonLink.stories.tsx
+++ b/packages/web-react/src/components/ButtonLink/stories/ButtonLink.stories.tsx
@@ -43,11 +43,6 @@ const meta: Meta<typeof ButtonLink> = {
       control: 'text',
       defaultValue: 'https://www.example.com',
     },
-    isBlock: {
-      control: 'boolean',
-      description:
-        "**DEPRECATED**: The property will be deleted in the next major release. Please read component's documentation for more information.",
-    },
     isDisabled: {
       control: 'boolean',
     },
@@ -68,7 +63,6 @@ const meta: Meta<typeof ButtonLink> = {
     children: 'Click me',
     color: ComponentButtonColors.PRIMARY,
     href: 'https://www.example.com',
-    isBlock: false,
     isDisabled: false,
     isLoading: false,
     isSymmetrical: false,

--- a/packages/web-react/src/components/ButtonLink/useButtonLinkStyleProps.ts
+++ b/packages/web-react/src/components/ButtonLink/useButtonLinkStyleProps.ts
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
-import { warning } from '../../common/utilities';
-import { useClassNamePrefix, useDeprecationMessage, useSymmetry } from '../../hooks';
+import { useClassNamePrefix, useSymmetry } from '../../hooks';
 import { type ButtonColor, type ButtonLinkStyleProps, type ButtonSize } from '../../types';
 import { applyColor, applySize } from '../../utils/classname';
 import { compose } from '../../utils/compose';
@@ -13,37 +12,19 @@ const getButtonLinkSizeClassname = <S = void>(className: string, size: ButtonSiz
   compose(applySize<ButtonSize<S>>(size))(className);
 
 export function useButtonLinkStyleProps<C = void, S = void>(props: Omit<ButtonLinkStyleProps<C, S>, 'routerOptions'>) {
-  const { color, isBlock, isDisabled, isLoading, isSymmetrical, size, ...restProps } = props;
-
-  // @see https://jira.almacareer.tech/browse/DS-1897
-  useDeprecationMessage({
-    method: 'custom',
-    trigger: !!isBlock,
-    componentName: 'ButtonLink',
-    customText:
-      "The `isBlock` property will be deleted in the next major release. Please read component's documentation for more information.",
-  });
+  const { color, isDisabled, isLoading, isSymmetrical, size, ...restProps } = props;
 
   const buttonClass = useClassNamePrefix('Button');
-  const buttonBlockClass = `${buttonClass}--block`;
   const buttonDisabledClass = `${buttonClass}--disabled`;
   const buttonLoadingClass = `${buttonClass}--loading`;
 
-  const { isSymmetricalActive, symmetricalClassName } = useSymmetry(buttonClass, isSymmetrical);
-
-  if (isBlock && isSymmetricalActive) {
-    warning(false, 'isBlock and isSymmetrical props are mutually exclusive');
-  }
-
-  // @deprecated "isBlock" will be removed in the next major version. Please read component's documentation for more information.
-  const shouldApplyBlock = () => isBlock && !isSymmetricalActive;
+  const { symmetricalClassName } = useSymmetry(buttonClass, isSymmetrical);
 
   const classProps = classNames(
     buttonClass,
     getButtonLinkColorClassname(buttonClass, color as ButtonColor<C>),
     getButtonLinkSizeClassname(buttonClass, size as ButtonSize<S>),
     {
-      [buttonBlockClass]: shouldApplyBlock(),
       [buttonDisabledClass]: isDisabled || isLoading,
       [buttonLoadingClass]: isLoading,
     },

--- a/packages/web-react/src/types/button.ts
+++ b/packages/web-react/src/types/button.ts
@@ -27,8 +27,6 @@ export interface ButtonStyleProps<C = void, S = void> extends ButtonBaseProps {
   color?: ButtonColor<C>;
   /** Whether the button is disabled. */
   isDisabled?: boolean;
-  /** Whether the button should be displayed with a block style. */
-  isBlock?: boolean;
   /** Whether the button should be in a loading state. */
   isLoading?: boolean;
   /** Whether the button should be symmetrical. */

--- a/packages/web/DEPRECATIONS.md
+++ b/packages/web/DEPRECATIONS.md
@@ -8,12 +8,6 @@ This document lists all deprecations that will be removed in the next major vers
 
 👉 [What are deprecations?][readme-deprecations]
 
-### Button
-
-The `Button--block` modifier will be removed in the next major version.
-
-For more information, see documentation of the [Button][button] component.
-
 ### Collapse `data-spirit-is-disposable`
 
 The `data-spirit-more` attribute was removed, please use `data-spirit-is-disposable` instead.
@@ -92,6 +86,5 @@ For more information, see documentation of the [TextField][text-field] component
 <span class="TextField__passwordToggle__icon accessibility-checked"><!-- … --></span>
 ```
 
-[button]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/Button/README.md
 [readme-deprecations]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/README.md#deprecations
 [text-field]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/TextField/README.md

--- a/packages/web/MIGRATIONS.md
+++ b/packages/web/MIGRATIONS.md
@@ -8,7 +8,11 @@ You can find the migration guide for a specific version by following the links b
 - [Migration Guide to version 1][migration-guide-v1]
 - [Migration Guide to version 2][migration-guide-v2]
 - [Migration Guide to version 3][migration-guide-v3]
+- [Migration Guide to version 4][migration-guide-v4]
+- [Migration Guide to version 5][migration-guide-v5]
 
 [migration-guide-v1]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/migrations/web/migration-v1.md
 [migration-guide-v2]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/migrations/web/migration-v2.md
 [migration-guide-v3]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/migrations/web/migration-v3.md
+[migration-guide-v4]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/migrations/web/migration-v4.md
+[migration-guide-v5]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/migrations/web/migration-v5.md

--- a/packages/web/src/scss/components/Button/README.md
+++ b/packages/web/src/scss/components/Button/README.md
@@ -189,12 +189,6 @@ Responsive full-width buttons with [Grid][readme-grid]:
 </div>
 ```
 
-### DEPRECATION NOTICE
-
-The `Button--block` modifier is deprecated and will be removed in the next major release.
-
-For more information, please read the [Full-Width Button](#full-width-button) section.
-
 ## Disabled Button
 
 There are several ways to disable a Button:

--- a/packages/web/src/scss/components/Button/_Button.scss
+++ b/packages/web/src/scss/components/Button/_Button.scss
@@ -97,14 +97,6 @@ $_component-name: 'Button';
     $config: theme.$size-config
 );
 
-// @deprecated The `block` modifier will be removed in the next major version.
-// Migration: delete 'Button--block' class
-// @see https://jira.almacareer.tech/browse/DS-1897
-.Button--block {
-    display: block;
-    width: 100%;
-}
-
 @each $breakpoint-name, $breakpoint-value in theme.$breakpoints {
     $infix: breakpoint.get-modifier('infix', $breakpoint-name, $breakpoint-value);
 

--- a/packages/web/src/scss/helpers/dynamic-color/index.html
+++ b/packages/web/src/scss/helpers/dynamic-color/index.html
@@ -869,12 +869,12 @@
                 <button
                   type="button"
                   id="dynamic-color-playground-copy-config"
-                  class="Button Button--block Button--primary Button--medium"
+                  class="Button Button--primary Button--medium"
                 >Copy CSS config</button>
                 <button
                   type="reset"
                   id="dynamic-color-playground-reset"
-                  class="Button Button--block Button--secondary Button--medium"
+                  class="Button Button--secondary Button--medium"
                 >Reset to defaults</button>
               </div>
             </form>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description                                                                                                                                                                                                       
                                                                                                                                                                                                                     
  - Removes deprecated `isBlock` prop from `Button` and `ButtonLink` React components (types, hooks, default props, stories, tests, READMEs)
  - Removes deprecated `Button--block` CSS modifier from `spirit-web` (SCSS, HTML demo, README)                                                                                                                      
  - Adds migration guide entries for `spirit-web-react` (v5) and creates new `spirit-web` migration guide (v5)                                                                                                       
  - Cleans up all remaining references in `DEPRECATIONS.md`, `CONTRIBUTING.md`, and agent skills                                                                                                                     
                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                       
                                                                                                                                                                                                                     
  - [x] All existing tests pass (343 suites, 4627 tests)                                                                                                                                                             
  - [x] Lint passes (0 errors)                                                                                                                                                                                       
  - [x] No remaining `isBlock` / `Button--block` references outside migration guides and CHANGELOG   

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
