### PR TITLE
docs(repo): remove negative example from copilot review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,18 +63,6 @@ Correct format when a suggestion exists:
 </details>
 ````
 
-Incorrect — do not do this:
-
-````markdown
-**{label} ({decorations}):** {subject}
-
-<details>…</details>
-
-```suggestion
-{suggested code}
-```
-````
-
 When there is no code suggestion:
 
 ```markdown


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Copilot was placing `suggestion` blocks after the label and explanation despite the instructions mandating they come first. The negative "do not do this" example in the finding format section showed the wrong order in a fenced code block, and models pattern-match on code blocks regardless of surrounding label text — causing the wrong layout to be reinforced. Removing the counter-example eliminates the conflicting signal without weakening the rule.

### Issue reference

<!-- No Jira issue -->