### PR TITLE
test(repo): persist hide-from-visual-tests CSS across page navigations

### DIFF
--- a/tests/helpers/hideFromVisualTests.ts
+++ b/tests/helpers/hideFromVisualTests.ts
@@ -1,5 +1,15 @@
 import { Page } from '@playwright/test';
 
 export const hideFromVisualTests = async (page: Page): Promise<void> => {
-  await page.addStyleTag({ content: '.hide-from-visual-tests { display: none !important }' });
+  const css = '.hide-from-visual-tests { display: none !important }';
+  // Re-inject on any future navigation (redirect, JS navigation) so the style survives page reloads.
+  // Uses the function+arg overload to avoid string interpolation brittleness.
+  // Falls back to documentElement in case head is not yet available early in the document lifecycle.
+  await page.addInitScript((styles: string) => {
+    const style = document.createElement('style');
+    style.textContent = styles;
+    (document.head ?? document.documentElement).appendChild(style);
+  }, css);
+  // Apply to the current page immediately
+  await page.addStyleTag({ content: css });
 };


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Some visual E2E tests were failing intermittently on production (Netlify) because
`page.addStyleTag()` injects a `<style>` tag that is destroyed when the page
navigates (redirect or JS navigation) during `toHaveScreenshot`. This added
`page.addInitScript()` alongside the existing `addStyleTag()` call, so the
hide-from-visual-tests CSS rule is automatically re-injected into every new
document — surviving any subsequent navigation.

### Additional context

Only components whose pages trigger a navigation AND have elements with the
`hide-from-visual-tests` class were affected (e.g. the `timeline` component
in web-react, which showed a 642px height mismatch). The `addInitScript` call
registers the style for future documents; `addStyleTag` still covers the
currently loaded page. No test files required changes.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->