### PR TITLE
feat(web): deprecate FileUploader component and subcomponents #DS-2444

### DIFF
--- a/.agents/skills/component-deprecation/README.md
+++ b/.agents/skills/component-deprecation/README.md
@@ -1,0 +1,53 @@
+# Component Deprecation Skill
+
+Standard workflow for deprecating and removing deprecations in Spirit across both packages:
+
+- `web-react` (React)
+- `web` (SCSS + vanilla JS)
+
+The skill is designed to stay valid over time, so it focuses on **patterns** and **git-history-backed workflow**, not static file references.
+
+## Usage
+
+```text
+/spirit:component-deprecation
+```
+
+Use when you need to:
+
+- Deprecate a full component (or subcomponents)
+- Deprecate a prop or prop value
+- Mark a currently optional API as required in next major
+- Remove previously deprecated APIs in a breaking release
+
+## What It Covers
+
+1. Runtime warnings strategy (`useDeprecationMessage` in `web-react`, optional guarded `warning` in `web`)
+2. Package-level `DEPRECATIONS.md` updates
+3. Component README deprecation notice and migration wording
+4. Props deprecation variants:
+   - rename prop
+   - remove prop
+   - rename prop value
+   - contract/behavior changes with custom messaging
+5. Major-release cleanup checklist (remove warnings/docs/aliases/tests drift)
+
+## Historical Anchors
+
+The skill references proven commit patterns from repository history (component deprecation, props deprecation, and major removal), so behavior is based on what was actually done in Spirit.
+
+## Recommended Flow
+
+1. Search current codebase for existing deprecation patterns.
+2. Inspect relevant historical commits for the same migration type.
+3. Implement runtime + docs updates in both packages (when applicable).
+4. Update demos/stories/API docs to push consumers toward the new API.
+5. Run focused lint/tests and smoke-check warning behavior.
+
+## Output Quality Checklist
+
+- Warning text clearly states **removal in next major**
+- Migration path is explicit (replacement component/prop/value)
+- No duplicate warnings caused by wrapper components
+- README + DEPRECATIONS list are consistent
+- Breaking-release cleanup removes all stale deprecation references

--- a/.agents/skills/component-deprecation/SKILL.md
+++ b/.agents/skills/component-deprecation/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: spirit:component-deprecation
+description: >-
+  Deprecate or remove deprecations for Spirit components and props across web-react (React) and web (vanilla SCSS/JS).
+  Covers useDeprecationMessage, DEPRECATIONS.md, README notices, and optional web JS warnings. Use when deprecating
+  a component, preparing a major release, or mirroring deprecations in both packages.
+category: spirit
+displayName: Spirit Component Deprecation
+---
+
+# Spirit Component Deprecation
+
+Use this skill when deprecating a **component**, **subcomponents**, or **props** in Spirit, or when **removing deprecations** for the next major version (for example work on a long-lived `release/*` branch).
+
+Do **not** rely on hard-coded links to specific source files in this skill: deprecations are removed over time and examples move. Instead, search current code and git history by pattern (`useDeprecationMessage`, `DEPRECATION NOTICE`, `DEPRECATIONS.md`, `deprecatedDataAttribute`).
+
+**Do not copy-paste example commit hashes from documentation** as if they were the canonical migration: agents and humans tend to treat listed SHAs as the answer. Always discover fresh precedents with git.
+
+## Proven Historical Patterns (from Git History)
+
+Find precedents yourself—use the same steps every time:
+
+1. List recent work on the component or hook: `git log --oneline -- <path>`.
+2. Optionally list preparation branches: `git branch -a | grep release` (or your team's convention) and inspect the **latest** relevant `release/*` branch for how deprecations are **removed** before major.
+3. In the log, open commits whose messages mention deprecate, migration, or breaking.
+4. Compare the touched files: runtime warning, package `DEPRECATIONS.md`, component README, tests/demos.
+
+### Template (what to Record After You Inspect Git)
+
+Use this as private notes or in the PR description—not as permanent skill text with frozen SHAs:
+
+```text
+Precedent search:
+- Component / prop: …
+- git log --oneline -- <paths>: …
+- Release-prep branch checked (if any): …
+- Pattern observed: [ ] useDeprecationMessage [ ] DEPRECATIONS.md [ ] README notice [ ] web JS warning
+```
+
+What good deprecation commits usually include:
+
+1. Runtime signal in dev mode.
+2. Central package deprecations list update.
+3. Component README notice + migration guidance.
+4. When applicable, demos/stories/API tables are aligned with the new approach.
+5. In major-release cleanup, deprecations are removed together with migration notes.
+
+## Packages and Patterns
+
+### Web-React
+
+- **Runtime warning:** `useDeprecationMessage` in the root component (or in a style/aria hook for props).
+- **Central list:** `DEPRECATIONS.md` at the **web-react** package root.
+- **Component docs:** that component's `README.md`, including a **DEPRECATION NOTICE** section.
+
+### Web
+
+- **Runtime warning (optional):** `warning()` from the web JS `common/utilities` module, guarded by `isDevelopment()` from `common/constants/environments`, in the plugin constructor.
+- **Central list:** `DEPRECATIONS.md` at the **web** package root.
+- **Component docs:** `README.md` under **web** SCSS for that component (`src/scss/components/<Name>/`).
+
+Use **`isDevelopment()`** for web JS deprecations so `NODE_ENV` values other than `development` (including `testing`, as used in this repository's unit tests per `ENVIRONMENTS.TESTING`) do not show deprecation warnings in the console — parity with web-react, where `useDeprecationMessage` runs only in development.
+
+## Web-React: Deprecate a Whole Component
+
+1. Add one runtime warning in the component root:
+   - use `useDeprecationMessage`
+   - prefer `method: 'custom'` for complex migrations
+   - `trigger: true` for whole-component deprecation
+   - explain replacement and migration direction in `customText`
+   - message must clearly state removal in next major
+
+```tsx
+useDeprecationMessage({
+  method: 'custom',
+  trigger: true,
+  componentName: 'MyComponent',
+  customText: `The component will be removed in the next major version. Use UNSTABLE_MyComponent instead. …`,
+});
+```
+
+2. Add a dedicated subsection to package `DEPRECATIONS.md`:
+   - short statement that the component is deprecated
+   - what replaces it
+   - one-sentence migration direction
+
+3. Add **DEPRECATION NOTICE** near the top of component `README.md`:
+   - removal timeline (next major)
+   - replacement API
+   - migration note for common use case
+   - link/reference to package-level deprecations explanation
+
+If a convenience wrapper renders the root component internally, attach the hook **only on the root** to avoid duplicate console warnings.
+
+### Migration Guide Requirement for Component Deprecations
+
+When deprecating a component, do not stop at notice-only text. Add explicit migration guidance:
+
+1. Add `#### Migration Guide` in package `DEPRECATIONS.md` entry.
+2. Add a short `### Migration Guide` section in the component README deprecation block.
+3. Include concrete steps (replace old composition, move logic ownership, update validation flow).
+4. Include at least one before/after snippet for non-trivial migrations.
+
+Template:
+
+```md
+#### Migration Guide
+
+1. Replace `<OldComponent>` composition with `<ReplacementA>` + `<ReplacementB>`.
+2. Move queue/validation/state handling from component internals to app state.
+3. Keep only visual state props in new components.
+```
+
+### Web-React: Deprecate a Prop or Value
+
+Decide warning style by migration type:
+
+- **Rename prop**: `method: 'property'`, `deprecatedName` + `newName`.
+- **Remove prop without replacement**: `method: 'property'`, `deprecatedName` + `delete: true`.
+- **Rename prop value**: `method: 'property'`, `propertyName`, `deprecatedValue`, `newValue`.
+- **Complex guidance** (layout/behavior migration): `method: 'custom'`.
+
+Trigger strategy:
+
+- `trigger: !!oldProp` for optional prop removals.
+- `trigger: oldProp === 'deprecatedValue'` for value migration.
+- `trigger: !requiredProp` for "currently optional, future required" contracts.
+
+Documentation updates for prop deprecations:
+
+1. Mention prop deprecation in package deprecations list.
+2. Mark/update API tables and narrative in component README.
+3. Align demos/stories toward the new approach.
+4. If deprecation changes composition ergonomics (e.g. `isBlock` replacements), explain alternatives with examples.
+
+Migration-guide expectations for prop deprecations:
+
+- For simple rename/remove: a concise one-liner can be enough (`oldProp` → `newProp`).
+- For behavior change: add before/after examples and explain side effects.
+- If no direct replacement exists, document the recommended pattern, not only removal.
+
+Always inspect current `useDeprecationMessage` implementation before coding; message format can evolve.
+
+## Web: Deprecate Markup + JS Plugin
+
+1. **web** package `DEPRECATIONS.md` — new subsection describing HTML/CSS/JS impact and replacement.
+
+2. That component's **web** SCSS `README.md` — same **DEPRECATION NOTICE** pattern as other deprecated vanilla components (search `DEPRECATION NOTICE` under `packages/web/src/scss/components`).
+
+3. Optional **constructor** warning in the relevant JS plugin module:
+
+```ts
+import { isDevelopment } from './common/constants/environments';
+import { warning } from './common/utilities';
+
+if (isDevelopment()) {
+  warning(false, 'Deprecation warning (MyPlugin): …');
+}
+```
+
+For deprecated data attributes on DOM, use shared helper pattern (`deprecatedDataAttribute` style) to keep wording consistent.
+
+### Migration Guide Requirement in Web
+
+For component deprecations in `web`, mirror the same migration quality:
+
+1. Add `#### Migration Guide` under the component in `DEPRECATIONS.md`.
+2. Add migration steps in component README deprecation block.
+3. Show HTML before/after for markup migrations.
+4. If JS plugin is deprecated, state what replaces `data-spirit-toggle` usage and where behavior should live.
+
+## Removing Deprecations (next Major)
+
+Reverse the above in **both** packages when the API is removed or renamed:
+
+1. Remove runtime warnings (`useDeprecationMessage`, JS `warning` blocks).
+2. Remove sections from package deprecations lists.
+3. Remove deprecation notices and stale migration text from READMEs.
+4. Remove old aliases/deprecated exports and any `@deprecated` markers.
+5. Update stories/demos/tests to final API only.
+6. Add a concise migration guide in the breaking-change commit/PR text.
+
+Before merge, verify no stale references remain by searching for:
+
+- deprecated component/prop names
+- `DEPRECATION NOTICE` sections that still mention removed APIs
+- warning messages referring to already removed functionality
+
+## Commits
+
+The repo **commitlint** config allows one **scope** per commit. Touching **web** and **web-react** usually means **two commits** (e.g. `feat(web-react): deprecate \`MyComponent\` component #DS-XXXX`and`feat(web): deprecate \`MyComponent\` component #DS-XXXX`).
+
+For major removals, use breaking-change style commits/scopes consistent with current repository conventions.
+
+## Verification
+
+Minimum verification after adding deprecations:
+
+1. Lint changed packages.
+2. Run focused unit tests for affected components/hooks/plugins.
+3. Validate docs render and links in changed READMEs.
+4. Smoke-test warning behavior:
+   - warning appears in development
+   - warning does not spam test/prod flows unexpectedly.

--- a/packages/web-react/DEPRECATIONS.md
+++ b/packages/web-react/DEPRECATIONS.md
@@ -34,6 +34,48 @@ We are providing a [codemod][codemod-flex] to assist with this change.
 
 The `Header` component is deprecated, please use the `UNSTABLE_Header` component instead.
 
+### FileUploader
+
+The `FileUploader` component and its subcomponents are deprecated. Use `UNSTABLE_FileUpload` and `UNSTABLE_File` instead. `UNSTABLE_FileUpload` is visual-first; you own queue handling, validation, and form integration.
+
+For details, see [UNSTABLE_FileUpload][unstable-file-upload] and [UNSTABLE_File][unstable-file] documentation.
+
+#### Migration Guide
+
+1. Replace `FileUploader` composition (`FileUploader`, `FileUploaderInput`, `FileUploaderList`, `FileUploaderAttachment`) with `UNSTABLE_FileUpload` + `UNSTABLE_File`.
+2. Move queue handling (`addToQueue`, `onDismiss`, duplicate checks, limits) from component internals to your application state.
+3. Keep validation in your app and pass only visual validation props to `UNSTABLE_FileUpload`.
+
+```tsx
+// before
+<FileUploader id="file-uploader" fileQueue={fileQueue} addToQueue={addToQueue} onDismiss={onDismiss} clearQueue={clearQueue}>
+  <FileUploaderInput id="file-uploader-input" name="attachments" label="Label" linkText="Upload your file(s)" />
+  <FileUploaderList
+    id="file-uploader-list"
+    inputName="attachments"
+    label="Attachments"
+    attachmentComponent={(props) => <FileUploaderAttachment key={props.id} {...props} />}
+  />
+</FileUploader>
+
+// after
+<Stack hasSpacing>
+  <UNSTABLE_FileUpload
+    id="file-upload"
+    name="attachments"
+    label="Label"
+    linkText="Upload your file(s)"
+    labelText="or drag and drop here"
+    onFilesSelected={onFilesSelected}
+  />
+  <Stack elementType="ul" aria-label="Uploaded files" hasSpacing>
+    {items.map((item) => (
+      <UNSTABLE_File key={item.id} id={item.id} label={item.label} onDismiss={() => onDismiss(item.id)} />
+    ))}
+  </Stack>
+</Stack>
+```
+
 ### Stack
 
 If you are using the `Stack` component with dividers, you must wrap each item inside the `Stack` component with a `StackItem` component.
@@ -67,3 +109,5 @@ For more information, see documentation for [Button][button] and [ButtonLink][bu
 [codemod-collapse]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/codemods/src/transforms/v4/web-react/README.md#v4web-reactcollapse-isdisposable-prop--uncontrolledcollapse-hideoncollapse-to-isdisposable-prop-change
 [codemod-flex]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/codemods/src/transforms/v4/web-react/README.md#v4web-reactflex-direction-values---flex-direction-prop-values-row-to-horizontal-and-column-to-vertical
 [readme-deprecations]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/README.md#deprecations
+[unstable-file]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/UNSTABLE_File/README.md
+[unstable-file-upload]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/UNSTABLE_FileUpload/README.md

--- a/packages/web-react/src/components/FileUploader/FileUploader.tsx
+++ b/packages/web-react/src/components/FileUploader/FileUploader.tsx
@@ -2,7 +2,7 @@
 
 import classNames from 'classnames';
 import React from 'react';
-import { useStyleProps } from '../../hooks';
+import { useDeprecationMessage, useStyleProps } from '../../hooks';
 import { type SpiritFileUploaderProps } from '../../types';
 import {
   DEFAULT_ERROR_MESSAGE_MAX_FILE_SIZE,
@@ -30,6 +30,13 @@ const FileUploader = (props: SpiritFileUploaderProps) => {
 
   const { classProps } = useFileUploaderStyleProps({ isFluid });
   const { styleProps, props: transferProps } = useStyleProps(restProps);
+
+  useDeprecationMessage({
+    method: 'custom',
+    trigger: true,
+    componentName: 'FileUploader',
+    customText: 'See the UNSTABLE_FileUpload and UNSTABLE_File component documentation.',
+  });
 
   const contextValue = {
     addToQueue,

--- a/packages/web-react/src/components/FileUploader/README.md
+++ b/packages/web-react/src/components/FileUploader/README.md
@@ -3,6 +3,23 @@
 The FileUploader implementation is used to select files either by selecting files from the device itself,
 or by drag and drop if the device supports it. React package extends [web package][file-uploader].
 
+## ⚠️ DEPRECATION NOTICE
+
+The component and its subcomponents will be removed in the next major version. Use `UNSTABLE_FileUpload` and `UNSTABLE_File` instead.
+`UNSTABLE_FileUpload` is visual-first: queue handling, validation, and form integration are the consumer's responsibility.
+
+Please see [UNSTABLE_FileUpload][unstable-file-upload-component] and [UNSTABLE_File][unstable-file-component] component documentation.
+
+[What are deprecations?][readme-deprecations]
+
+### Migration Guide
+
+Migrate from `FileUploader` composition to `UNSTABLE_FileUpload` + `UNSTABLE_File`:
+
+1. Replace `FileUploader` / `FileUploaderInput` / `FileUploaderList` / `FileUploaderAttachment` with `UNSTABLE_*` components.
+2. Move queue logic (`addToQueue`, `findInQueue`, `onDismiss`, queue limits, duplicate checks) to your own state.
+3. Keep validation logic in your app and pass only visual validation props to `UNSTABLE_FileUpload`.
+
 ## Usage
 
 ### Basic
@@ -579,7 +596,10 @@ please refer to the [Icon component documentation][web-react-icon-documentation]
 [list-item-element-docs]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li
 [next-js-body-size-limit]: https://nextjs.org/docs/app/api-reference/config/next-config-js/serverActions#bodysizelimit
 [readme-additional-attributes]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/README.md#additional-attributes
+[readme-deprecations]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/README.md#deprecations
 [readme-escape-hatches]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/README.md#escape-hatches
 [readme-style-props]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/README.md#style-props
+[unstable-file-component]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/UNSTABLE_File/README.md
+[unstable-file-upload-component]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/UNSTABLE_FileUpload/README.md
 [web-react-icon-documentation]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/Icon/README.md#-usage
 [wiki-binary-prefixes]: https://en.wikipedia.org/wiki/Binary_prefix

--- a/packages/web/DEPRECATIONS.md
+++ b/packages/web/DEPRECATIONS.md
@@ -41,6 +41,34 @@ Form fields now support the `size` property. Ensure that a size is set for all f
 - `<div class="TextArea"><!-- … --></div>` → `<div class="TextArea TextArea--medium"><!-- … --></div>`
 - `<div class="TextField"><!-- … --></div>` → `<div class="TextField TextField--medium"><!-- … --></div>`
 
+### FileUploader
+
+The `FileUploader` composition (HTML/CSS classes and the `fileUploader` JavaScript plugin) is deprecated and will be removed in the next major version. Use `UNSTABLE_FileUpload` and `UNSTABLE_File` instead. The new API is visual- and composition-first; queue handling and validation are the consumer's responsibility.
+
+See [UNSTABLE_FileUpload][unstable-file-upload-web] and [UNSTABLE_File][unstable-file-web] documentation.
+
+#### Migration Guide
+
+1. Replace `FileUploader`/`FileUploaderInput`/`FileUploaderList`/`FileUploaderAttachment` markup with `UNSTABLE_FileUpload` and `UNSTABLE_File`.
+2. Remove dependency on the `fileUploader` plugin (`data-spirit-toggle="fileUploader"` and related behavior).
+3. Move queue and validation logic to your own JavaScript and keep the new components visual-first.
+
+```html
+<!-- before -->
+<div class="FileUploader" data-spirit-toggle="fileUploader">
+  <div class="FileUploaderInput" data-spirit-element="wrapper"><!-- … --></div>
+  <ul class="FileUploaderList" data-spirit-element="list">
+    <!-- … -->
+  </ul>
+</div>
+
+<!-- after -->
+<div class="UNSTABLE_FileUpload"><!-- upload input/dropzone --></div>
+<ul class="Stack" aria-label="Uploaded files">
+  <li class="UNSTABLE_File"><!-- file row --></li>
+</ul>
+```
+
 ### Header
 
 The `Header` component was removed, please use `UNSTABLE_Header` component instead.
@@ -95,3 +123,5 @@ For more information, see documentation of the [TextField][text-field] component
 [button]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/Button/README.md
 [readme-deprecations]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/README.md#deprecations
 [text-field]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/TextField/README.md
+[unstable-file-upload-web]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/UNSTABLE_FileUpload/README.md
+[unstable-file-web]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/UNSTABLE_File/README.md

--- a/packages/web/src/js/FileUploader.ts
+++ b/packages/web/src/js/FileUploader.ts
@@ -1,4 +1,5 @@
 import BaseComponent from './BaseComponent';
+import { isDevelopment } from './common/constants/environments';
 import { info, warning } from './common/utilities';
 import { EventHandler, SelectorEngine } from './dom';
 import { SpiritConfig, enableToggleAutoloader, image2Base64Preview } from './utils';
@@ -96,6 +97,13 @@ class FileUploader extends BaseComponent {
     this.fileQueue = new Map();
     this.instanceUid = FileUploader.getUid();
     this.isDisabled = this.inputElement?.disabled || false;
+
+    if (isDevelopment()) {
+      warning(
+        false,
+        'Deprecation warning (FileUploader): The FileUploader composition and its JavaScript plugin will be removed in the next major version. Use UNSTABLE_FileUpload and UNSTABLE_File instead.',
+      );
+    }
 
     this.init();
   }

--- a/packages/web/src/js/__tests__/FileUploader.test.ts
+++ b/packages/web/src/js/__tests__/FileUploader.test.ts
@@ -77,6 +77,21 @@ describe('FileUploader', () => {
   });
 
   describe('constructor', () => {
+    it('should warn about deprecation in development', () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+
+      const consoleWarnMock = jest.spyOn(global.console, 'warn').mockImplementation();
+
+      const fileUploader = new FileUploader(container);
+
+      expect(fileUploader).toBeInstanceOf(FileUploader);
+      expect(consoleWarnMock).toHaveBeenCalledWith(expect.stringContaining('Deprecation warning (FileUploader)'));
+
+      consoleWarnMock.mockRestore();
+      process.env.NODE_ENV = originalNodeEnv;
+    });
+
     it('should take care of element passed as a CSS selector', () => {
       fixtureEl.innerHTML = `
         <div class="FileUploader" data-spirit-toggle="fileUploader">

--- a/packages/web/src/scss/components/FileUploader/README.md
+++ b/packages/web/src/scss/components/FileUploader/README.md
@@ -4,6 +4,23 @@ FileUploader allows users to pick one or more files to upload.
 
 > FileUploader itself actually does not upload anything to the server.
 
+## ⚠️ DEPRECATION NOTICE
+
+The `FileUploader` composition and its JavaScript plugin will be removed in the next major version. Use `UNSTABLE_FileUpload` and `UNSTABLE_File` instead.
+The new API is visual- and composition-first; queue handling and validation are the consumer's responsibility.
+
+Please see [UNSTABLE_FileUpload][unstable-file-upload-component] and [UNSTABLE_File][unstable-file-component] component documentation.
+
+[What are deprecations?][readme-deprecations]
+
+### Migration Guide
+
+Migrate from `FileUploader` to `UNSTABLE_FileUpload` + `UNSTABLE_File`:
+
+1. Replace legacy FileUploader markup/subcomponents with `UNSTABLE_*` components.
+2. Remove usage of the `fileUploader` JavaScript plugin (`data-spirit-toggle="fileUploader"`).
+3. Keep queue handling and validation in your own JavaScript and treat `UNSTABLE_*` as visual components.
+
 FileUploader is a composition of a few subcomponents:
 
 - [FileUploader](#fileuploader-1)
@@ -654,6 +671,9 @@ Example: So if you set `name="attachments"` to the default input element, the at
 
 [dictionary-validation]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation
 [learn-about-file-sizes]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/FileUploader/README.md#understanding-file-size-in-bytes
+[readme-deprecations]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/README.md#deprecations
+[unstable-file-component]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/UNSTABLE_File/README.md
+[unstable-file-upload-component]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/UNSTABLE_FileUpload/README.md
 [mdn-accept]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept
 [mdn-input-file]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file
 [mdn-multiple]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#multiple


### PR DESCRIPTION
## Description

Deprecates FileUploader in web-react and web ahead of the next major: dev-time warnings, updates to both DEPRECATIONS.md, deprecation notices in component READMEs, and explicit Migration Guide sections (React + HTML) pointing teams to UNSTABLE_FileUpload and UNSTABLE_File, including ownership of queue/validation logic.

### Additional context

Adds .agents/skills/component-deprecation (SKILL + README) documenting the deprecation workflow, props deprecations, and migration-guide expectations.

### Issue reference

[Deprecate FileUploader](https://jira.almacareer.tech/browse/DS-2444)
