### PR TITLE
chore(repo): track .claude/skills symlink to share agent skills

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,8 @@ nx-cloud.env
 !.idea/
 .idea/*
 !.idea/runConfigurations/
+
+# Claude Code — override global ignore; track only explicitly committed bits
+!.claude/
+.claude/*
+!.claude/skills


### PR DESCRIPTION
## Description

Adds a `.claude/skills` → `../.agents/skills` symlink so Claude Code automatically discovers the repo's shared agent skills (the ones already living in `.agents/skills/`). No content is duplicated — git tracks the symlink itself (mode `120000`), pointing at the canonical `.agents/skills/` directory.

Also updates `.gitignore` to:

- Override a common global ignore of `.claude/` (many developers ignore it personally) so this repo can track specific entries.
- Re-ignore everything inside `.claude/` by default.
- Explicitly un-ignore `.claude/skills`.

This sets up a pattern: future shared Claude Code config (e.g. `.claude/commands/`, `.claude/agents/`) can be added with one more `!.claude/<name>` line. Personal files (`settings.local.json`, `worktrees/`, scheduled task locks, local plans) stay ignored.

### Additional context

- Symlink portability: tracked symlinks work on macOS/Linux out of the box. Windows users would need `core.symlinks=true` and developer mode — not a concern for this team today, but worth keeping in mind if that changes.
- No behavior change for anyone who doesn't use Claude Code. The skills directory is already in the repo at `.agents/skills/`.

### Issue reference

No Jira issue — repo-level tooling tweak.