### PR TITLE
fix(tests): handle Netlify verification interstitials and improve visual test reliability

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Wait for Netlify Deploy
         uses: mmazzarolo/wait-for-netlify-action@8a7a8d8cf5b313c916d805b76cc498380062d268
         id: get-netlify-preview-url
-        continue-on-error: true
         with:
           site_id: ${{ secrets.NETLIFY_SITE_SPIRIT_DESIGN_SYSTEM }}
           max_timeout: 1
@@ -61,26 +60,29 @@ jobs:
       # The Netlify preview URL is now available
       # as `steps.get-netlify-preview-url.outputs.url`
 
-      - name: Get Site URL
-        id: get-site-url
-        env:
-          # fallback to main url if the main branch is deployed
-          NETLIFY_DEPLOYED_URL: ${{ env.PR_NUMBER && env.NETLIFY_DEPLOY_PREVIEW_URL || env.NETLIFY_MAIN_URL }}
-        run: echo "site_url=${{ env.NETLIFY_DEPLOYED_URL }}" >> "$GITHUB_OUTPUT"
-
       - name: Get Playwright Version
         id: playwright-version
         run: |
           PW_VERSION=$(yq '.catalogs.test["@playwright/test"]' .yarnrc.yml)
           echo "version=$PW_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Validate Netlify URL
+        run: |
+          if [ -z "${{ steps.get-netlify-preview-url.outputs.url }}" ]; then
+            echo "Missing Netlify deploy URL output from wait-for-netlify-action."
+            exit 1
+          fi
+
       - name: Run Playwright tests
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/work \
             -w /work \
+            -e CI="true" \
             -e NODE_ENV="${{ env.NODE_ENV }}" \
-            -e WEBSITE_URL="${{ steps.get-netlify-preview-url.outcome == 'success' && steps.get-netlify-preview-url.outputs.url || steps.get-site-url.outputs.site_url }}" \
+            -e PW_WORKERS="${{ vars.PW_WORKERS || '1' }}" \
+            -e PW_PAGE_RETRIES="${{ vars.PW_PAGE_RETRIES || '5' }}" \
+            -e WEBSITE_URL="${{ steps.get-netlify-preview-url.outputs.url }}" \
             mcr.microsoft.com/playwright:v${{ steps.playwright-version.outputs.version }}-noble \
             sh -c "corepack install && corepack enable && yarn test:e2e"
 

--- a/tests/helpers/constants.ts
+++ b/tests/helpers/constants.ts
@@ -2,3 +2,8 @@ import { getServerUrl } from './getServerUrl';
 
 export const WEB_REACT_SERVER_URL = getServerUrl('web-react');
 export const WEB_REACT_COMPONENTS_URI = 'src/components';
+
+export const VERIFICATION_INTERSTITIAL_TEXT = 'We are verifying your connection';
+export const VERIFICATION_INTERSTITIAL_TIMEOUT_MS = 2000;
+export const NETWORK_ERROR_BASE_BACKOFF_MS = 1000;
+export const VERIFICATION_INTERSTITIAL_BASE_BACKOFF_MS = 2000;

--- a/tests/helpers/errors.ts
+++ b/tests/helpers/errors.ts
@@ -26,3 +26,15 @@ export class TimeoutError extends Error {
     this.name = 'TimeoutError';
   }
 }
+
+/**
+ * Represents a transient bot-protection/interstitial page returned by hosting.
+ * This page is not the target demo and must be retried or treated as infra issue.
+ */
+export class VerificationChallengeError extends Error {
+  constructor(message: string) {
+    super(message);
+
+    this.name = 'VerificationChallengeError';
+  }
+}

--- a/tests/helpers/hideFromVisualTests.ts
+++ b/tests/helpers/hideFromVisualTests.ts
@@ -12,4 +12,11 @@ export const hideFromVisualTests = async (page: Page): Promise<void> => {
   }, css);
   // Apply to the current page immediately
   await page.addStyleTag({ content: css });
+
+  // Verify computed style is actually applied on the current document.
+  await page.waitForFunction(() => {
+    const elements = Array.from(document.querySelectorAll('.hide-from-visual-tests'));
+
+    return elements.every((element) => getComputedStyle(element).display === 'none');
+  });
 };

--- a/tests/helpers/retryPageGoto.ts
+++ b/tests/helpers/retryPageGoto.ts
@@ -1,6 +1,12 @@
 /* eslint-disable no-console -- we need to log retry attempts for debugging */
 import { type Page, errors } from '@playwright/test';
-import { NetworkError } from './errors';
+import {
+  NETWORK_ERROR_BASE_BACKOFF_MS,
+  VERIFICATION_INTERSTITIAL_BASE_BACKOFF_MS,
+  VERIFICATION_INTERSTITIAL_TEXT,
+  VERIFICATION_INTERSTITIAL_TIMEOUT_MS,
+} from './constants';
+import { NetworkError, VerificationChallengeError } from './errors';
 
 /**
  * Network error patterns that should trigger a retry.
@@ -29,12 +35,35 @@ function isNetworkError(error: unknown): boolean {
 }
 
 /**
+ * Detects Netlify verification interstitial page.
+ * This is not the target demo page and should be retried like network flakiness.
+ */
+async function isVerificationInterstitial(page: Page): Promise<boolean> {
+  try {
+    const textContent = await page
+      .locator('body')
+      .innerText({ timeout: VERIFICATION_INTERSTITIAL_TIMEOUT_MS });
+
+    return textContent.includes(VERIFICATION_INTERSTITIAL_TEXT);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Calculates exponential backoff delay in milliseconds.
  * @param attemptNumber - The attempt number (1-based)
- * @returns Delay in milliseconds (1000, 2000, 4000, etc.)
+ * @param error - Error that triggered retry
+ * @returns Delay in milliseconds
  */
-function getBackoffDelay(attemptNumber: number): number {
-  return 1000 * Math.pow(2, attemptNumber - 1);
+function getBackoffDelay(attemptNumber: number, error: unknown): number {
+  // Verification interstitials tend to persist longer than transient TCP resets.
+  const baseDelay =
+    error instanceof VerificationChallengeError
+      ? VERIFICATION_INTERSTITIAL_BASE_BACKOFF_MS
+      : NETWORK_ERROR_BASE_BACKOFF_MS;
+
+  return baseDelay * Math.pow(2, attemptNumber - 1);
 }
 
 interface RetryPageGotoOptions {
@@ -96,6 +125,10 @@ export async function retryPageGoto(
 
       const response = await page.goto(url, gotoOptions);
 
+      if (await isVerificationInterstitial(page)) {
+        throw new VerificationChallengeError(`Verification interstitial detected for ${url}`);
+      }
+
       if (attempt > 1) {
         console.log(`✓ Successfully navigated to ${url} on attempt ${attempt}`);
       }
@@ -107,7 +140,8 @@ export async function retryPageGoto(
       // If it's not a network error or Timeout, rethrow immediately
       if (
         !isNetworkError(error) &&
-        !(error instanceof errors.TimeoutError)
+        !(error instanceof errors.TimeoutError) &&
+        !(error instanceof VerificationChallengeError)
       ) {
         throw error;
       }
@@ -122,7 +156,7 @@ export async function retryPageGoto(
       }
 
       // Calculate backoff and log retry
-      const backoffMs = getBackoffDelay(attempt);
+      const backoffMs = getBackoffDelay(attempt, error);
       console.warn(
         `⚠ Network error on attempt ${attempt}/${retries} for ${url}: ${error}. ` +
           `Retrying in ${backoffMs}ms...`,

--- a/tests/helpers/takeScreenshot.ts
+++ b/tests/helpers/takeScreenshot.ts
@@ -7,6 +7,8 @@ interface ExtendedScreenshotOptions extends PageAssertionsToHaveScreenshotOption
 const defaultOptions: ExtendedScreenshotOptions = {
   animations: 'disabled',
   fullPage: false,
+  // Apply deterministic visual-test overrides at screenshot time.
+  stylePath: 'tests/helpers/visualTestScreenshot.css',
   // Enable SSIM-CIE94 by default for better anti-aliasing handling
   // @see: { @link: https://github.com/microsoft/playwright/issues/38159 }
   _comparator: 'ssim-cie94',

--- a/tests/helpers/visualTestScreenshot.css
+++ b/tests/helpers/visualTestScreenshot.css
@@ -1,0 +1,3 @@
+.hide-from-visual-tests {
+  display: none !important;
+}

--- a/tests/helpers/waitForPageLoad.ts
+++ b/tests/helpers/waitForPageLoad.ts
@@ -1,6 +1,26 @@
 import { Page } from '@playwright/test';
+import { VERIFICATION_INTERSTITIAL_TEXT, VERIFICATION_INTERSTITIAL_TIMEOUT_MS } from './constants';
+import { VerificationChallengeError } from './errors';
+
+const waitForPageNavigationSettled = async (page: Page): Promise<void> => {
+  // `domcontentloaded` guarantees basic DOM availability, `load` stabilizes assets for snapshots.
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForLoadState('load');
+};
+
+const throwOnVerificationInterstitial = async (page: Page): Promise<void> => {
+  const text = await page.locator('body').innerText({ timeout: VERIFICATION_INTERSTITIAL_TIMEOUT_MS });
+  const isVerificationPage = text.includes(VERIFICATION_INTERSTITIAL_TEXT);
+
+  if (isVerificationPage) {
+    throw new VerificationChallengeError(`Verification interstitial detected on ${page.url()}`);
+  }
+};
 
 export const waitForPageLoad = async (page: Page): Promise<void> => {
+  await waitForPageNavigationSettled(page);
+  await throwOnVerificationInterstitial(page);
+
   // Wait for fonts to load
   await page.evaluate(() => document.fonts.ready);
 


### PR DESCRIPTION
## Description

Improve e2e visual test stability on Netlify previews by handling transient verification interstitials and hardening screenshot-time hiding.

### Additional context

- Detect and fail fast on Netlify verification interstitial pages (`We are verifying your connection`) so retries can recover instead of snapshotting the wrong page.
- Ensure `.hide-from-visual-tests` elements are reliably hidden during screenshot capture by applying deterministic screenshot CSS.

### Issue reference

N/A