### PR TITLE
feat(web,web-react)!: migrate `Tag` to color schemes #DS-2456

### DIFF
--- a/apps/demo/partials/cover.hbs
+++ b/apps/demo/partials/cover.hbs
@@ -8,7 +8,7 @@
       {{title}}
 
       {{#if isUnstable}}
-        <span class="Tag Tag--large Tag--warning">Unstable</span>
+        <span class="Tag Tag--large Tag--warning color-scheme-on-emotion-warning-basic">Unstable</span>
       {{/if}}
     </h1>
 

--- a/packages/web-react/src/components/Tag/__tests__/Tag.test.tsx
+++ b/packages/web-react/src/components/Tag/__tests__/Tag.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {
   ariaAttributesTest,
   classNamePrefixProviderTest,
+  colorSchemePropsTest,
   elementTypePropsTest,
   emotionColorPropsTest,
   restPropsTest,
@@ -11,12 +12,16 @@ import {
   stylePropsTest,
   validHtmlAttributesTest,
 } from '@local/tests';
+import { EmotionColors } from '../../../constants';
+import { TagColorsExtended } from '../constants';
 import Tag from '../Tag';
 
 describe('Tag', () => {
   classNamePrefixProviderTest(Tag, 'Tag');
 
   emotionColorPropsTest(Tag, 'Tag--');
+
+  colorSchemePropsTest(Tag, [...Object.values(TagColorsExtended), ...Object.values(EmotionColors)]);
 
   sizeExtendedPropsTest(Tag);
 

--- a/packages/web-react/src/components/Tag/__tests__/useTagStyleProps.test.ts
+++ b/packages/web-react/src/components/Tag/__tests__/useTagStyleProps.test.ts
@@ -11,17 +11,17 @@ describe('useTagStyleProps', () => {
   });
 
   it.each([
-    ['neutral', 'border-neutral-basic bg-neutral-basic text-neutral-subtle'],
-    ['success', 'border-emotion-success-basic bg-emotion-success-basic text-emotion-success-subtle'],
-    ['informative', 'border-emotion-informative-basic bg-emotion-informative-basic text-emotion-informative-subtle'],
-    ['warning', 'border-emotion-warning-basic bg-emotion-warning-basic text-emotion-warning-subtle'],
-    ['danger', 'border-emotion-danger-basic bg-emotion-danger-basic text-emotion-danger-subtle'],
-    ['selected', 'border-selected-basic bg-selected-basic text-selected-subtle'],
-  ])('should return color class %s', (color, colorClasses) => {
+    ['neutral', 'color-scheme-on-neutral-basic'],
+    ['success', 'color-scheme-on-emotion-success-basic'],
+    ['informative', 'color-scheme-on-emotion-informative-basic'],
+    ['warning', 'color-scheme-on-emotion-warning-basic'],
+    ['danger', 'color-scheme-on-emotion-danger-basic'],
+    ['selected', 'color-scheme-on-selected-basic'],
+  ])('should return color classes for %s', (color, colorSchemeClass) => {
     const props = { color } as SpiritTagProps;
     const { result } = renderHook(() => useTagStyleProps(props));
 
-    expect(result.current.classProps).toBe(`Tag Tag--${color} ${colorClasses}`);
+    expect(result.current.classProps).toBe(`Tag Tag--${color} ${colorSchemeClass}`);
   });
 
   it('should return small success subtle', () => {
@@ -33,11 +33,11 @@ describe('useTagStyleProps', () => {
     const { result } = renderHook(() => useTagStyleProps(props));
 
     expect(result.current.classProps).toBe(
-      'Tag Tag--success Tag--small Tag--subtle border-emotion-success-subtle bg-emotion-success-subtle text-emotion-success-basic',
+      'Tag Tag--success color-scheme-on-emotion-success-subtle Tag--small Tag--subtle',
     );
   });
 
-  it('should return disabled class', () => {
+  it('should return disabled class without color scheme', () => {
     const props = {
       color: 'neutral',
       isDisabled: true,

--- a/packages/web-react/src/components/Tag/useTagStyleProps.ts
+++ b/packages/web-react/src/components/Tag/useTagStyleProps.ts
@@ -1,8 +1,7 @@
 import classNames from 'classnames';
-import { Intensity } from '../../constants';
 import { useClassNamePrefix } from '../../hooks';
 import { type TagProps } from '../../types';
-import { createScopedColorTokenName } from '../../utils';
+import { getColorSchemeClassName } from '../../utils';
 
 export interface TagStyles {
   /** className props */
@@ -10,34 +9,6 @@ export interface TagStyles {
   /** props to be passed to the element */
   props: Partial<TagProps>;
 }
-
-const getColorClasses = (color: string | undefined, isSubtle: boolean | undefined) => {
-  if (!color) {
-    return {};
-  }
-
-  const borderIntensity = isSubtle ? Intensity.SUBTLE : Intensity.BASIC;
-  const backgroundIntensity = isSubtle ? Intensity.SUBTLE : Intensity.BASIC;
-  const textIntensity = isSubtle ? Intensity.BASIC : Intensity.SUBTLE;
-  const borderColor = createScopedColorTokenName({
-    color,
-    intensity: borderIntensity,
-  });
-  const backgroundColor = createScopedColorTokenName({
-    color,
-    intensity: backgroundIntensity,
-  });
-  const textColor = createScopedColorTokenName({
-    color,
-    intensity: textIntensity,
-  });
-
-  return {
-    [`border-${borderColor}`]: true,
-    [`bg-${backgroundColor}`]: true,
-    [`text-${textColor}`]: true,
-  };
-};
 
 export function useTagStyleProps<C = void, S = void>(props: TagProps<C, S>) {
   const { color, isDisabled, isSubtle, size, ...modifiedProps } = props;
@@ -47,16 +18,21 @@ export function useTagStyleProps<C = void, S = void>(props: TagProps<C, S>) {
   const tagDisabledClass = `${tagClass}--disabled`;
   const tagSizeClass = `${tagClass}--${size}`;
   const tagSubtleClass = `${tagClass}--subtle`;
-  const classProps = classNames(tagClass, {
-    [tagColorClass]: color,
-    [tagDisabledClass]: isDisabled,
-    [tagSizeClass]: size,
-    [tagSubtleClass]: isSubtle,
-    ...(!isDisabled && getColorClasses(color as string | undefined, isSubtle as boolean | undefined)),
-  });
+  const tagColorSchemeClass = color && !isDisabled ? getColorSchemeClassName({ color: color as string, isSubtle }) : '';
 
   return {
-    classProps,
+    classProps: classNames(
+      tagClass,
+      {
+        [tagColorClass]: color,
+      },
+      tagColorSchemeClass,
+      {
+        [tagDisabledClass]: isDisabled,
+        [tagSizeClass]: size,
+        [tagSubtleClass]: isSubtle,
+      },
+    ),
     props: modifiedProps,
   };
 }

--- a/packages/web-react/tests/providerTests/colorSchemePropsTest.tsx
+++ b/packages/web-react/tests/providerTests/colorSchemePropsTest.tsx
@@ -1,5 +1,5 @@
 import { render, waitFor } from '@testing-library/react';
-import React, { type ComponentType } from 'react';
+import React from 'react';
 import { getColorSchemeClassName } from '../../src';
 import getElement from '../testUtils/getElement';
 
@@ -8,8 +8,10 @@ type ColorSchemeComponentProps<C extends string> = {
   isSubtle?: boolean;
 };
 
-export function colorSchemePropsTest<C extends string, P extends object = ColorSchemeComponentProps<C>>(
-  Component: ComponentType<P>,
+type ColorSchemeTestComponent<C extends string> = (props: ColorSchemeComponentProps<C>) => JSX.Element;
+
+export function colorSchemePropsTest<C extends string>(
+  Component: ColorSchemeTestComponent<C>,
   colors: readonly C[],
   testId?: string,
 ): void {
@@ -20,8 +22,7 @@ export function colorSchemePropsTest<C extends string, P extends object = ColorS
       [color, false],
     ]),
   )('should render color scheme class for %s with isSubtle=%s', async (color, isSubtle) => {
-    const props = { color, isSubtle } as P;
-    const dom = render(<Component {...props} />);
+    const dom = render(<Component color={color} isSubtle={isSubtle} />);
 
     await waitFor(() => {
       const element = getElement(dom, testId);
@@ -31,14 +32,13 @@ export function colorSchemePropsTest<C extends string, P extends object = ColorS
   });
 }
 
-export function colorSchemeBasicTest<C extends string, P extends object = ColorSchemeComponentProps<C>>(
-  Component: ComponentType<P>,
+export function colorSchemeBasicTest<C extends string>(
+  Component: ColorSchemeTestComponent<C>,
   colors: readonly C[],
   testId?: string,
 ): void {
   it.each(colors)('should render color scheme class for %s', async (color) => {
-    const props = { color } as P;
-    const dom = render(<Component {...props} />);
+    const dom = render(<Component color={color} />);
 
     await waitFor(() => {
       const element = getElement(dom, testId);
@@ -48,14 +48,13 @@ export function colorSchemeBasicTest<C extends string, P extends object = ColorS
   });
 }
 
-export function colorSchemeSubtleTest<C extends string, P extends object = ColorSchemeComponentProps<C>>(
-  Component: ComponentType<P>,
+export function colorSchemeSubtleTest<C extends string>(
+  Component: ColorSchemeTestComponent<C>,
   colors: readonly C[],
   testId?: string,
 ): void {
   it.each(colors)('should render color scheme class for %s', async (color) => {
-    const props = { color } as P;
-    const dom = render(<Component {...props} />);
+    const dom = render(<Component color={color} />);
 
     await waitFor(() => {
       const element = getElement(dom, testId);

--- a/packages/web/src/scss/components/Card/index.html
+++ b/packages/web/src/scss/components/Card/index.html
@@ -2026,7 +2026,7 @@
             </a>
           </div>
           <div class="CardBody">
-            <span class="Tag Tag--neutral Tag--small Tag--subtle border-neutral-subtle bg-neutral-subtle text-neutral-basic">Tag</span>
+            <span class="Tag Tag--neutral Tag--small Tag--subtle color-scheme-on-neutral-subtle">Tag</span>
           </div>
         </li>
 
@@ -2042,7 +2042,7 @@
             </a>
           </div>
           <div class="CardBody">
-            <span class="Tag Tag--neutral Tag--small Tag--subtle border-neutral-subtle bg-neutral-subtle text-neutral-basic">Tag</span>
+            <span class="Tag Tag--neutral Tag--small Tag--subtle color-scheme-on-neutral-subtle">Tag</span>
           </div>
         </li>
 
@@ -2058,7 +2058,7 @@
             </a>
           </div>
           <div class="CardBody">
-            <span class="Tag Tag--neutral Tag--small Tag--subtle border-neutral-subtle bg-neutral-subtle text-neutral-basic">Tag</span>
+            <span class="Tag Tag--neutral Tag--small Tag--subtle color-scheme-on-neutral-subtle">Tag</span>
           </div>
         </li>
 
@@ -2074,7 +2074,7 @@
             </a>
           </div>
           <div class="CardBody">
-            <span class="Tag Tag--neutral Tag--small Tag--subtle border-neutral-subtle bg-neutral-subtle text-neutral-basic">Tag</span>
+            <span class="Tag Tag--neutral Tag--small Tag--subtle color-scheme-on-neutral-subtle">Tag</span>
           </div>
         </li>
 

--- a/packages/web/src/scss/components/Collapse/preview.html
+++ b/packages/web/src/scss/components/Collapse/preview.html
@@ -77,7 +77,7 @@
 
     <h2 class="docs-Heading">
       Destroy Collapsing on Tablet
-      <span class="Tag Tag--warning Tag--medium Tag--subtle border-emotion-warning-subtle bg-emotion-warning-subtle text-emotion-warning-basic">Resize your viewport to test</span>
+      <span class="Tag Tag--warning Tag--medium Tag--subtle color-scheme-on-emotion-warning-subtle">Resize your viewport to test</span>
     </h2>
 
     <div class="docs-Stack docs-Stack--start">
@@ -120,7 +120,7 @@
 
     <h2 class="docs-Heading">
       Destroy Collapsing on Desktop
-      <span class="Tag Tag--warning Tag--medium Tag--subtle border-emotion-warning-subtle bg-emotion-warning-subtle text-emotion-warning-basic">Resize your viewport to test</span>
+      <span class="Tag Tag--warning Tag--medium Tag--subtle color-scheme-on-emotion-warning-subtle">Resize your viewport to test</span>
     </h2>
 
     <div class="docs-Stack docs-Stack--start">

--- a/packages/web/src/scss/components/FileUploader/index.html
+++ b/packages/web/src/scss/components/FileUploader/index.html
@@ -1014,7 +1014,7 @@
 
     <h2 class="docs-Heading">
       Attachment
-      <span class="Tag Tag--warning Tag--medium Tag--subtle border-emotion-warning-subtle bg-emotion-warning-subtle text-emotion-warning-basic">Visual demo only</span>
+      <span class="Tag Tag--warning Tag--medium Tag--subtle color-scheme-on-emotion-warning-subtle">Visual demo only</span>
     </h2>
 
     <!-- ⚠️ VISUAL EXAMPLE ONLY, DO NOT COPY-PASTE -->
@@ -1832,7 +1832,7 @@
   <div class="Container">
     <h2 class="docs-Heading">
       Input with Attachment
-      <span class="Tag Tag--warning Tag--medium Tag--subtle border-emotion-warning-subtle bg-emotion-warning-subtle text-emotion-warning-basic">Visual demo only</span>
+      <span class="Tag Tag--warning Tag--medium Tag--subtle color-scheme-on-emotion-warning-subtle">Visual demo only</span>
     </h2>
 
     <!-- ⚠️ VISUAL EXAMPLE ONLY, DO NOT COPY-PASTE -->
@@ -2056,7 +2056,7 @@
 
     <h2 class="docs-Heading">
       Dragging not Available
-      <span class="Tag Tag--warning Tag--medium Tag--subtle border-emotion-warning-subtle bg-emotion-warning-subtle text-emotion-warning-basic">Visual demo only</span>
+      <span class="Tag Tag--warning Tag--medium Tag--subtle color-scheme-on-emotion-warning-subtle">Visual demo only</span>
     </h2>
 
     <!-- ⚠️ VISUAL EXAMPLE ONLY, DO NOT COPY-PASTE -->

--- a/packages/web/src/scss/components/Tag/README.md
+++ b/packages/web/src/scss/components/Tag/README.md
@@ -5,36 +5,37 @@ Tag is a visual label used to categorize, organize, or indicate the status of it
 ## Basic Usage
 
 ```html
-<span class="Tag Tag--neutral Tag--small">Tag</span>
+<span class="Tag Tag--neutral Tag--small color-scheme-on-neutral-basic">Tag</span>
 ```
 
 ## Color Variants
 
-⚠️ Color variant classes (`Tag--<color>`, `Tag--subtle`) are deprecated and will be removed in the next major version
-in favor of color schemes using utility classes (`border-*`, `bg-*`, `text-*`).
-See [DS-2269][ds-2269].
-
-There are several color variants of Tag to choose from: neutral, informative, success, warning, danger, and selected.
-
-Each variant also has a subtle version using the `Tag--subtle` modifier:
+`Tag` supports neutral, selected, and emotion color variants.
+Apply the matching `color-scheme-on-*` helper to each variant:
 
 ```html
-<span class="Tag Tag--neutral Tag--small">Neutral tag</span>
-<span class="Tag Tag--informative Tag--small">Informative tag</span>
-<span class="Tag Tag--success Tag--small">Success tag</span>
-<span class="Tag Tag--warning Tag--small">Warning tag</span>
-<span class="Tag Tag--danger Tag--small">Danger tag</span>
-<span class="Tag Tag--selected Tag--small">Selected tag</span>
+<span class="Tag Tag--neutral Tag--small color-scheme-on-neutral-basic">Neutral tag</span>
+<span class="Tag Tag--informative Tag--small color-scheme-on-emotion-informative-basic">Informative tag</span>
+<span class="Tag Tag--success Tag--small color-scheme-on-emotion-success-basic">Success tag</span>
+<span class="Tag Tag--warning Tag--small color-scheme-on-emotion-warning-basic">Warning tag</span>
+<span class="Tag Tag--danger Tag--small color-scheme-on-emotion-danger-basic">Danger tag</span>
+<span class="Tag Tag--selected Tag--small color-scheme-on-selected-basic">Selected tag</span>
 ```
 
-Subtle variants:
+The system allows you to override the default color scheme by configuring optional design tokens. Even though the `Tag--<color>` modifier is not used by default, it can be used to override the color scheme when needed. See [Component Color Overrides][component-color-overrides] for more information.
+
+### Subtle Variant
+
+Use the `*-subtle` color scheme class together with the `Tag--subtle` modifier when you need a softer color intensity:
 
 ```html
-<span class="Tag Tag--neutral Tag--subtle Tag--small">Neutral subtle tag</span>
-<span class="Tag Tag--informative Tag--subtle Tag--small">Informative subtle tag</span>
-<span class="Tag Tag--success Tag--subtle Tag--small">Success subtle tag</span>
-<span class="Tag Tag--warning Tag--subtle Tag--small">Warning subtle tag</span>
-<span class="Tag Tag--danger Tag--subtle Tag--small">Danger subtle tag</span>
+<span class="Tag Tag--neutral Tag--subtle Tag--small color-scheme-on-neutral-subtle">Neutral subtle tag</span>
+<span class="Tag Tag--informative Tag--subtle Tag--small color-scheme-on-emotion-informative-subtle"
+  >Informative subtle tag</span
+>
+<span class="Tag Tag--success Tag--subtle Tag--small color-scheme-on-emotion-success-subtle">Success subtle tag</span>
+<span class="Tag Tag--warning Tag--subtle Tag--small color-scheme-on-emotion-warning-subtle">Warning subtle tag</span>
+<span class="Tag Tag--danger Tag--subtle Tag--small color-scheme-on-emotion-danger-subtle">Danger subtle tag</span>
 ```
 
 ## Sizes
@@ -42,11 +43,11 @@ Subtle variants:
 Tag comes in five available sizes: xsmall, small, medium, large, and xlarge.
 
 ```html
-<span class="Tag Tag--neutral Tag--xsmall">XSmall tag</span>
-<span class="Tag Tag--neutral Tag--small">Small tag</span>
-<span class="Tag Tag--neutral Tag--medium">Medium tag</span>
-<span class="Tag Tag--neutral Tag--large">Large tag</span>
-<span class="Tag Tag--neutral Tag--xlarge">XLarge tag</span>
+<span class="Tag Tag--neutral Tag--xsmall color-scheme-on-neutral-basic">XSmall tag</span>
+<span class="Tag Tag--neutral Tag--small color-scheme-on-neutral-basic">Small tag</span>
+<span class="Tag Tag--neutral Tag--medium color-scheme-on-neutral-basic">Medium tag</span>
+<span class="Tag Tag--neutral Tag--large color-scheme-on-neutral-basic">Large tag</span>
+<span class="Tag Tag--neutral Tag--xlarge color-scheme-on-neutral-basic">XLarge tag</span>
 ```
 
 ## With ControlButton
@@ -65,7 +66,7 @@ Tag comes in five available sizes: xsmall, small, medium, large, and xlarge.
 
 ```html
 <div class="spirit-feature-enable-v5-control-button-expanded-size-scale">
-  <div class="Tag Tag--selected Tag--medium">
+  <div class="Tag Tag--selected Tag--medium color-scheme-on-selected-basic">
     <span>Tag label</span>
     <button
       type="button"
@@ -108,5 +109,5 @@ Disabled Tag with `ControlButton`:
 </div>
 ```
 
-[ds-2269]: https://jira.almacareer.tech/browse/DS-2269
+[component-color-overrides]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/design-tokens/README.md#component-color-overrides
 [expanded-size-scale]: https://github.com/lmc-eu/spirit-design-system/blob/main/packages/web/src/scss/components/ControlButton/README.md#expanded-size-scale

--- a/packages/web/src/scss/components/Tag/_Tag.scss
+++ b/packages/web/src/scss/components/Tag/_Tag.scss
@@ -1,9 +1,7 @@
-// 1. A design exception: visible border for x-small subtle Tags (the parent rule sets a
-//    transparent background via a local variable, so the border is the only visual cue).
-
-@use 'sass:map';
 @use '@tokens' as tokens;
 @use '../../settings/cursors';
+@use '../../tools/color-scheme';
+@use '../../tools/component-color-overrides';
 @use '../../tools/dictionaries';
 @use '../../tools/typography';
 @use 'theme';
@@ -18,58 +16,38 @@
     padding-inline: var(--#{tokens.$css-variable-prefix}tag-padding-x);
     padding-block: var(--#{tokens.$css-variable-prefix}tag-padding-y);
     text-align: center;
-    color: var(--#{tokens.$css-variable-prefix}tag-color);
+    color: color-scheme.color();
     border-width: theme.$border-width;
     border-style: theme.$border-style;
-    border-color: var(--#{tokens.$css-variable-prefix}tag-border-color);
+    border-color: color-scheme.border-color();
     border-radius: theme.$border-radius;
-    background-color: var(--#{tokens.$css-variable-prefix}tag-background-color);
+    background-color: color-scheme.background-color();
 }
 
-// @deprecated Color variant classes (`Tag--subtle`, `Tag--<color>`) are deprecated in favor of color schemes
-// (utility classes `border-*`, `bg-*`, `text-*`). They will be removed in the next major version.
-// @see https://jira.almacareer.tech/browse/DS-2269
-.Tag--subtle {
-    --#{tokens.$css-variable-prefix}local-background-color: oklch(
-        from var(--#{tokens.$css-variable-prefix}tag-subtle-background-color) l c h / 0%
-    );
-
-    color: var(--#{tokens.$css-variable-prefix}tag-subtle-color);
-    border-color: var(--#{tokens.$css-variable-prefix}tag-subtle-border-color);
-
-    // stylelint-disable-next-line declaration-no-important -- Override the bg-* utility class.
-    background-color: var(--#{tokens.$css-variable-prefix}local-background-color) !important;
-}
-
-// @deprecated See above.
-@include dictionaries.generate-colors(
-    $class-name: 'Tag',
-    $dictionary-values: theme.$color-dictionary,
-    $config: theme.$color-config
-);
 @include dictionaries.generate-sizes(
     $class-name: 'Tag',
     $dictionary-values: theme.$size-dictionary,
     $config: theme.$size-config
 );
 
-// 1.
-.Tag--subtle.Tag--xsmall {
-    border-color: var(--#{tokens.$css-variable-prefix}tag-subtle-border-color);
-}
-
-// stylelint-disable declaration-no-important -- Override the local override above.
 .Tag--disabled {
+    --#{tokens.$css-variable-prefix}local-color: #{theme.$color-disabled};
+    --#{tokens.$css-variable-prefix}local-border-color: transparent;
     --#{tokens.$css-variable-prefix}local-background-color: #{theme.$background-color-disabled};
 
-    color: theme.$color-disabled !important;
-    border-color: transparent;
-    background-color: theme.$background-color-disabled !important;
     pointer-events: none;
     cursor: cursors.$disabled;
 }
 
 .Tag--disabled.Tag--subtle {
-    border-color: theme.$border-color-disabled;
+    --#{tokens.$css-variable-prefix}local-border-color: #{theme.$border-color-disabled};
 }
-// stylelint-enable
+
+@include component-color-overrides.generate(
+    $class-name: 'Tag',
+    $property-map: (
+        content: color,
+        background: background-color,
+        border: border-color,
+    )
+);

--- a/packages/web/src/scss/components/Tag/_theme.scss
+++ b/packages/web/src/scss/components/Tag/_theme.scss
@@ -1,4 +1,3 @@
-@use 'sass:list';
 @use '@tokens' as tokens;
 @use '../../settings/dictionaries';
 @use '../../tools/units';
@@ -6,20 +5,6 @@
 $border-width: tokens.$border-width-100;
 $border-style: solid;
 $border-radius: tokens.$radius-300;
-
-$color-dictionary: (
-    emotion: dictionaries.$emotion-colors,
-    neutral: neutral,
-    selected: selected,
-);
-$color-config: (
-    color: 'content-subtle',
-    border-color: 'border-basic',
-    background-color: 'background-basic',
-    subtle-color: 'content-basic',
-    subtle-border-color: 'border-subtle',
-    subtle-background-color: 'background-subtle',
-);
 
 // Disabled
 $color-disabled: tokens.$disabled-content;

--- a/packages/web/src/scss/components/Tag/preview.html
+++ b/packages/web/src/scss/components/Tag/preview.html
@@ -20,8 +20,8 @@
             {{#if (eq color "warning")}}{{setVar "colorPrefix" "emotion-warning"}}{{/if}}
             {{#if (eq color "danger")}}{{setVar "colorPrefix" "emotion-danger"}}{{/if}}
             {{#if (eq color "selected")}}{{setVar "colorPrefix" "selected"}}{{/if}}
-            <span class="Tag Tag--{{color}} Tag--subtle Tag--{{size}} border-{{@root.colorPrefix}}-subtle bg-{{@root.colorPrefix}}-subtle text-{{@root.colorPrefix}}-basic">Tag {{color}}</span>
-            <span class="Tag Tag--{{color}} Tag--{{size}} border-{{@root.colorPrefix}}-basic bg-{{@root.colorPrefix}}-basic text-{{@root.colorPrefix}}-subtle">Tag {{color}}</span>
+            <span class="Tag Tag--{{color}} Tag--subtle Tag--{{size}} color-scheme-on-{{@root.colorPrefix}}-subtle">Tag {{color}}</span>
+            <span class="Tag Tag--{{color}} Tag--{{size}} color-scheme-on-{{@root.colorPrefix}}-basic">Tag {{color}}</span>
             {{/each}}
           </div>
         </section>
@@ -57,7 +57,7 @@
             {{#if (eq color "warning")}}{{setVar "colorPrefix" "emotion-warning"}}{{/if}}
             {{#if (eq color "danger")}}{{setVar "colorPrefix" "emotion-danger"}}{{/if}}
             {{#if (eq color "selected")}}{{setVar "colorPrefix" "selected"}}{{/if}}
-            <div class="Tag Tag--{{color}} Tag--subtle Tag--{{size}} border-{{@root.colorPrefix}}-subtle bg-{{@root.colorPrefix}}-subtle text-{{@root.colorPrefix}}-basic">
+            <div class="Tag Tag--{{color}} Tag--subtle Tag--{{size}} color-scheme-on-{{@root.colorPrefix}}-subtle">
               <span>Tag {{color}}</span>
               <button
                 type="button"
@@ -74,7 +74,7 @@
                 </svg>
               </button>
             </div>
-            <div class="Tag Tag--{{color}} Tag--{{size}} border-{{@root.colorPrefix}}-basic bg-{{@root.colorPrefix}}-basic text-{{@root.colorPrefix}}-subtle">
+            <div class="Tag Tag--{{color}} Tag--{{size}} color-scheme-on-{{@root.colorPrefix}}-basic">
               <span>Tag {{color}}</span>
               <button
                 type="button"

--- a/packages/web/src/scss/components/TextArea/index.html
+++ b/packages/web/src/scss/components/TextArea/index.html
@@ -460,7 +460,7 @@
 
   <div class="Container">
 
-    <h2 class="docs-Heading">Counter <span class="Tag Tag--medium Tag--subtle Tag--warning hide-from-visual-tests">Visual demo only</span></h2>
+    <h2 class="docs-Heading">Counter <span class="Tag Tag--medium Tag--subtle Tag--warning color-scheme-on-emotion-warning-subtle hide-from-visual-tests">Visual demo only</span></h2>
 
     <div class="docs-Stack docs-Stack--start">
 

--- a/packages/web/src/scss/components/UNSTABLE_Picker/README.md
+++ b/packages/web/src/scss/components/UNSTABLE_Picker/README.md
@@ -107,7 +107,7 @@ Place a hidden `<span>` with a unique `id` anywhere in the `<body>` and referenc
     tabindex="0"
     aria-label="Czech"
     aria-describedby="picker-tag-description"
-    class="Tag Tag--selected Tag--small"
+    class="Tag Tag--selected Tag--small color-scheme-on-selected-basic"
   >
     <!-- Tag content start -->
     <div role="gridcell" aria-colindex="1" class="d-contents">
@@ -185,7 +185,12 @@ Each size expects a matching Tag and ControlButton size inside the selection are
   <div class="Dropdown">
     <div role="group" aria-label="Languages" class="InputContainer InputContainer--large">
       <div role="grid" aria-label="Selected languages" class="UNSTABLE_PickerSelection">
-        <div role="row" tabindex="0" aria-label="Czech" class="Tag Tag--selected Tag--medium">
+        <div
+          role="row"
+          tabindex="0"
+          aria-label="Czech"
+          class="Tag Tag--selected Tag--medium color-scheme-on-selected-basic"
+        >
           <div role="gridcell" aria-colindex="1" class="d-contents">
             <span>Czech</span>
             <button

--- a/packages/web/src/scss/components/UNSTABLE_Picker/index.html
+++ b/packages/web/src/scss/components/UNSTABLE_Picker/index.html
@@ -42,7 +42,7 @@
     data-tag-row
     tabindex="0"
     aria-describedby="picker-tag-description"
-    class="Tag Tag--selected bg-selected-basic text-selected-subtle Tag--small"
+    class="Tag Tag--selected Tag--small color-scheme-on-selected-basic"
   >
     <div
       role="gridcell"


### PR DESCRIPTION
## Summary

Migrate `Tag` to the color-scheme pattern already used by `Pill` and `ToastBar`. Phase 1 of [DS-2456](https://jira.almacareer.tech/browse/DS-2456) — interactivity (the `:is(a, button)` overlay) will follow in a separate PR.

⚠️ **Breaking:** `.Tag--<color>` and `.Tag--subtle` CSS rules are no longer emitted. Consumers must apply a `color-scheme-on-*` class — the React component does this automatically.

ℹ️ ~~**Note:** Contains cherry-picked `UNSTABLE_Table` demos for visual tests to pass with ✅. The whole commit should disappear once the release branch is rebased on `main`.~~

ℹ️  ~~**UPDATE:** apparently the visual tests are broken more than I thought. Needs a rebase once the WIP fixes in `main` bubble up in the release branch.~~