### PR TITLE
test(web-react): simplify `colorSchemePropsTest` — one prop per test

### DIFF
--- a/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
+++ b/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
@@ -4,14 +4,12 @@ import React from 'react';
 import {
   ariaAttributesTest,
   classNamePrefixProviderTest,
-  colorSchemePropsTest,
   elementTypePropsTest,
   emotionColorPropsTest,
   restPropsTest,
   stylePropsTest,
   validHtmlAttributesTest,
 } from '@local/tests';
-import { EmotionColors } from '../../../constants';
 import { getColorSchemeClassName } from '../../../utils';
 import Alert from '../Alert';
 
@@ -23,11 +21,6 @@ describe('Alert', () => {
   stylePropsTest(Alert);
 
   emotionColorPropsTest(Alert, 'Alert--');
-
-  colorSchemePropsTest(Alert, Object.values(EmotionColors), {
-    isSubtle: true,
-    hasSubtleProp: false,
-  });
 
   restPropsTest(Alert, 'div');
 

--- a/packages/web-react/src/components/Button/__tests__/Button.test.tsx
+++ b/packages/web-react/src/components/Button/__tests__/Button.test.tsx
@@ -41,10 +41,7 @@ describe('Button', () => {
 
   elementTypePropsTest(Button);
 
-  colorSchemePropsTest(Button, Object.values(EmotionColors), {
-    isSubtle: false,
-    hasSubtleProp: false,
-  });
+  colorSchemePropsTest(Button, Object.values(EmotionColors));
 
   it('should have default classname', () => {
     render(<Button />);

--- a/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
+++ b/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
@@ -41,10 +41,7 @@ describe('ButtonLink', () => {
 
   elementTypePropsTest(ButtonLink);
 
-  colorSchemePropsTest(ButtonLink, Object.values(EmotionColors), {
-    isSubtle: false,
-    hasSubtleProp: false,
-  });
+  colorSchemePropsTest(ButtonLink, Object.values(EmotionColors));
 
   it('should have default classname', () => {
     render(<ButtonLink />);

--- a/packages/web-react/src/components/Pill/__tests__/Pill.test.tsx
+++ b/packages/web-react/src/components/Pill/__tests__/Pill.test.tsx
@@ -7,6 +7,7 @@ import {
   colorSchemePropsTest,
   elementTypePropsTest,
   emotionColorPropsTest,
+  isSubtlePropsTest,
   restPropsTest,
   stylePropsTest,
   validHtmlAttributesTest,
@@ -22,9 +23,7 @@ describe('Pill', () => {
 
   colorSchemePropsTest(Pill, [...Object.values(PillColorsExtended), ...Object.values(EmotionColors)]);
 
-  colorSchemePropsTest(Pill, [...Object.values(PillColorsExtended), ...Object.values(EmotionColors)], {
-    isSubtle: true,
-  });
+  isSubtlePropsTest(Pill, 'success');
 
   stylePropsTest(Pill);
 

--- a/packages/web-react/src/components/Tooltip/__tests__/TooltipPopover.test.tsx
+++ b/packages/web-react/src/components/Tooltip/__tests__/TooltipPopover.test.tsx
@@ -23,10 +23,7 @@ describe('TooltipPopover', () => {
 
   ariaAttributesTest(TooltipPopover);
 
-  colorSchemePropsTest(TooltipPopover, [DEFAULT_TOOLTIP_COLOR], {
-    isSubtle: false,
-    hasSubtleProp: false,
-  });
+  colorSchemePropsTest(TooltipPopover, [DEFAULT_TOOLTIP_COLOR]);
 
   it('should render tooltip popover', () => {
     const popoverText = 'TooltipPopover';

--- a/packages/web-react/tests/providerTests/index.ts
+++ b/packages/web-react/tests/providerTests/index.ts
@@ -4,6 +4,7 @@ export * from './colorSchemePropsTest';
 export * from './dictionaryPropsTest';
 export * from './elementTypePropsTest';
 export * from './formFieldContextPropsTest';
+export * from './isSubtlePropsTest';
 export * from './itemPropsTest';
 export * from './loadingPropsTest';
 export * from './requiredPropsTest';

--- a/packages/web-react/tests/providerTests/isSubtlePropsTest.tsx
+++ b/packages/web-react/tests/providerTests/isSubtlePropsTest.tsx
@@ -8,19 +8,19 @@ type ColorSchemeComponentProps<C extends string> = {
   isSubtle?: boolean;
 };
 
-export function colorSchemePropsTest<C extends string, P extends object = ColorSchemeComponentProps<C>>(
+export function isSubtlePropsTest<C extends string, P extends object = ColorSchemeComponentProps<C>>(
   Component: ComponentType<P>,
-  colors: readonly C[],
+  color: C,
   testId?: string,
 ): void {
-  it.each(colors)('should render color scheme class for %s', async (color) => {
-    const props = { color } as P;
+  it('should render subtle color scheme class', async () => {
+    const props = { color, isSubtle: true } as P;
     const dom = render(<Component {...props} />);
 
     await waitFor(() => {
       const element = getElement(dom, testId);
 
-      expect(element).toHaveClass(getColorSchemeClassName({ color, isSubtle: false }));
+      expect(element).toHaveClass(getColorSchemeClassName({ color, isSubtle: true }));
     });
   });
 }


### PR DESCRIPTION
## Description

`colorSchemePropsTest` bundled two separate concerns — iterating over `color` values and handling the `isSubtle` state via a `hasSubtleProp` flag — breaking the project's convention of testing one prop in isolation per helper. The flag forced four of six call sites to pass explicit defaults, and `Alert` needed `isSubtle: true` even though its hook unit test already verifies the full color+subtle class for all colors.

The helper is split into `colorSchemePropsTest` (tests `color` only, always expects the non-subtle class) and a new `isSubtlePropsTest` (tests the `isSubtle` prop with a single representative color). Alert's now-redundant `colorSchemePropsTest` call is removed; Button, ButtonLink, and TooltipPopover drop the noisy options object.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->