### PR TITLE
fix(web-react): fix type for containerProps #DS-2561

### DIFF
--- a/packages/web-react/src/components/Section/__tests__/Section.test.tsx
+++ b/packages/web-react/src/components/Section/__tests__/Section.test.tsx
@@ -82,6 +82,16 @@ describe('Section', () => {
     expect(screen.getByTestId('container')).toBeInTheDocument();
   });
 
+  it('should pass Container size prop', () => {
+    render(
+      <Section data-testid="section" containerProps={{ size: 'large', 'data-testid': 'container' }}>
+        Content
+      </Section>,
+    );
+
+    expect(screen.getByTestId('container')).toHaveClass('Container--large');
+  });
+
   it('should render with padding', () => {
     render(
       <Section paddingY="space-200" data-testid="section">

--- a/packages/web-react/src/components/Section/stories/Section.stories.tsx
+++ b/packages/web-react/src/components/Section/stories/Section.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta<typeof Section> = {
       control: 'object',
       table: {
         type: {
-          summary: 'ContainerProps',
+          summary: 'SpiritContainerProps',
         },
       },
     },

--- a/packages/web-react/src/types/section.ts
+++ b/packages/web-react/src/types/section.ts
@@ -1,5 +1,5 @@
 import { type ElementType } from 'react';
-import { type ContainerProps } from './container';
+import { type SpiritContainerProps } from './container';
 import {
   type BackgroundColorsDictionaryType,
   type ChildrenProps,
@@ -11,13 +11,16 @@ import {
   type TextAlignmentType,
 } from './shared';
 
+/** Props forwarded to the inner `Container` (excluding `children`, which `Section` supplies). */
+export type SectionContainerProps = Omit<SpiritContainerProps, 'children'>;
+
 /** ===== BASE API ===== */
 export interface SectionBaseProps extends ChildrenProps, StyleProps {}
 
 /** ===== STYLE API ===== */
 export interface SectionStyleProps<S = void> extends SectionBaseProps {
   /** Container props to pass to the container component. */
-  containerProps?: ContainerProps;
+  containerProps?: SectionContainerProps;
   /** Whether the section should have a container. */
   hasContainer?: boolean;
   /** The background color of the section. */


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Container is implemented with `SpiritContainerProps`, which extends `ContainerProps` with `size` and `isFluid`. Section spreads containerProps onto <Container />, so the prop type had to match. ContainerProps alone omits size, which caused the error on containerProps={{ size: 'large' }}.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
