### PR TITLE
refactor: replace deprecated SVG xlink:href with href

### DIFF
--- a/apps/demo/partials/cover.hbs
+++ b/apps/demo/partials/cover.hbs
@@ -17,14 +17,14 @@
         <li class="d-flex">
           <a href="/" class="link-primary link-underlined">Spirit</a>
           <svg class="Icon" width="24" height="24" aria-hidden="true">
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         {{#if package}}
           <li class="d-flex">
             <a href="{{packageUrl}}" class="link-primary link-underlined">{{package}}</a>
             <svg class="Icon" width="24" height="24" aria-hidden="true">
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-right" />
             </svg>
           </li>
         {{/if}}
@@ -34,7 +34,7 @@
               {{parentPageName}}
             </a>
             <svg class="Icon" width="24" height="24" aria-hidden="true">
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-right" />
             </svg>
           </li>
         {{/if}}

--- a/apps/demo/partials/header.hbs
+++ b/apps/demo/partials/header.hbs
@@ -46,7 +46,7 @@
             aria-expanded="false"
           >
             <svg class="Icon" width="24" height="24" aria-hidden="true">
-              <use xlink:href="/assets/icons/svg/sprite.svg#hamburger" />
+              <use href="/assets/icons/svg/sprite.svg#hamburger" />
             </svg>
             <span class="accessibility-hidden">Menu</span>
           </button>
@@ -76,7 +76,7 @@
         aria-expanded="false"
       >
         <svg class="Icon" width="24" height="24" aria-hidden="true">
-          <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+          <use href="/assets/icons/svg/sprite.svg#close" />
         </svg>
         <span class="accessibility-hidden">Close</span>
       </button>

--- a/apps/demo/partials/themeSwitcher.hbs
+++ b/apps/demo/partials/themeSwitcher.hbs
@@ -8,9 +8,8 @@
     </select>
     <div class="InputAddon">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </div>
   </div>
 </div>
-

--- a/apps/demo/partials/web/icons.hbs
+++ b/apps/demo/partials/web/icons.hbs
@@ -7,7 +7,7 @@
       {{#each @icons as |icon|}}
         <li class="mb-700">
           <svg class="Icon" width="24" height="24" aria-hidden="true">
-            <use xlink:href="/assets/icons/svg/sprite.svg#{{icon}}"/>
+            <use href="/assets/icons/svg/sprite.svg#{{icon}}"/>
           </svg>
           <p class="typography-body-medium-bold mt-600">{{icon}}</p>
         </li>

--- a/apps/docsite/next.config.ts
+++ b/apps/docsite/next.config.ts
@@ -42,7 +42,7 @@ const nextConfig: NextConfig = {
   turbopack: {
     rules: {
       // html-loader without sources processing — serializable options for Turbopack.
-      // The filter function in the webpack html-loader rule is only for SVG sprite xlink:href,
+      // The filter function in the webpack html-loader rule is only for SVG sprite href,
       // not needed for preview HTML files imported in web-preview/page.tsx.
       '*.html': {
         loaders: [
@@ -87,7 +87,7 @@ const nextConfig: NextConfig = {
               list: [
                 {
                   tag: 'use',
-                  attribute: 'xlink:href',
+                  attribute: 'href',
                   type: 'src',
                   filter: (tag: unknown, attribute: string | number, attributes: { [x: string]: string }) => {
                     // Ensure the attribute value exists before calling startsWith

--- a/configs/eslint-config-spirit/index.js
+++ b/configs/eslint-config-spirit/index.js
@@ -26,7 +26,6 @@ module.exports = {
   plugins: ['jest-formatting', 'promise', 'react', '@typescript-eslint', /* 'react-refresh' */],
 
   rules: {
-
     /**
      * Set sorting of imports
      *

--- a/configs/eslint-config-spirit/package.json
+++ b/configs/eslint-config-spirit/package.json
@@ -6,6 +6,7 @@
   "type": "commonjs",
   "exports": {
     ".": "./index.js",
+    "./rules": "./rules.js",
     "./prettier": "./prettier.js",
     "./style": "./style.js",
     "./html": "./html.js"

--- a/configs/eslint-config-spirit/package.json
+++ b/configs/eslint-config-spirit/package.json
@@ -24,7 +24,7 @@
     "system"
   ],
   "scripts": {
-    "test": "node --test __tests__/html.test.cjs"
+    "test": "node --test"
   },
   "peerDependencies": {
     "eslint": "^8.0.0 || ^9.0.0"

--- a/configs/eslint-config-spirit/rules.js
+++ b/configs/eslint-config-spirit/rules.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const noXlinkHref = require('./rules/no-xlink-href');
+
+module.exports = [
+  {
+    plugins: {
+      spirit: {
+        rules: { 'no-xlink-href': noXlinkHref },
+      },
+    },
+    rules: {
+      'spirit/no-xlink-href': 'error',
+    },
+  },
+];

--- a/configs/eslint-config-spirit/rules/__tests__/no-xlink-href.test.js
+++ b/configs/eslint-config-spirit/rules/__tests__/no-xlink-href.test.js
@@ -1,0 +1,81 @@
+"use strict";
+
+const { describe, it } = require('node:test');
+const { RuleTester } = require('eslint');
+const rule = require('../no-xlink-href');
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+tester.run('no-xlink-href', rule, {
+  valid: [
+    // Plain href is fine
+    { code: `<use href="#icon" />` },
+    { code: `<image href="photo.png" />` },
+    // Unrelated attributes
+    { code: `<a xlink:show="new" />` },
+    // String without xlink:href
+    { code: `const s = "just a string with href"` },
+    { code: "const t = `template with href`" },
+  ],
+
+  invalid: [
+    // ── JSX namespaced ────────────────────────────────────────────────────
+    {
+      code: `<use xlink:href="#icon" />`,
+      errors: [{ messageId: 'jsxNamespacedAttr' }],
+      output: `<use href="#icon" />`,
+    },
+    {
+      code: `<image xlink:href="photo.png" />`,
+      errors: [{ messageId: 'jsxNamespacedAttr' }],
+      output: `<image href="photo.png" />`,
+    },
+    {
+      code: `<use xlink:href={iconRef} />`,
+      errors: [{ messageId: 'jsxNamespacedAttr' }],
+      output: `<use href={iconRef} />`,
+    },
+
+    // ── JSX camelCase (React) ─────────────────────────────────────────────
+    {
+      code: `<use xlinkHref="#icon" />`,
+      errors: [{ messageId: 'jsxCamelCaseAttr' }],
+      output: `<use href="#icon" />`,
+    },
+    {
+      code: `<use xlinkHref={ref} />`,
+      errors: [{ messageId: 'jsxCamelCaseAttr' }],
+      output: `<use href={ref} />`,
+    },
+
+    // ── String literals ───────────────────────────────────────────────────
+    {
+      code: `const s = '<use xlink:href="#icon" />'`,
+      errors: [{ messageId: 'stringLiteral' }],
+    },
+    {
+      code: `const html = '<use xlink:href="#id" />'`,
+      errors: [{ messageId: 'stringLiteral' }],
+    },
+
+    // ── Template literals ─────────────────────────────────────────────────
+    {
+      code: "const svg = `<use xlink:href=\"#icon\" />`",
+      errors: [{ messageId: 'stringLiteral' }],
+    },
+    {
+      code: "const svg = `<image xlink:href=\"${src}\" />`",
+      errors: [{ messageId: 'stringLiteral' }],
+    },
+  ],
+});

--- a/configs/eslint-config-spirit/rules/no-xlink-href.js
+++ b/configs/eslint-config-spirit/rules/no-xlink-href.js
@@ -1,0 +1,122 @@
+/**
+ * @fileoverview ESLint rule to disallow deprecated xlink:href attribute.
+ *
+ * The xlink:href attribute was deprecated in SVG 2.0 in favor of plain `href`.
+ * This rule detects its usage across:
+ *   - JSX attributes (xlink:href="..." or xlinkHref="...")
+ *   - String/template literals containing xlink:href (e.g. in dangerouslySetInnerHTML or raw HTML)
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href
+ */
+
+"use strict";
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow deprecated xlink:href attribute in favor of href",
+      category: "Best Practices",
+      recommended: true,
+      url: "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href",
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      jsxNamespacedAttr:
+        "Deprecated SVG attribute 'xlink:href' found. Use 'href' instead.",
+      jsxCamelCaseAttr:
+        "Deprecated SVG attribute 'xlinkHref' (camelCase form of xlink:href) found. Use 'href' instead.",
+      stringLiteral:
+        "Deprecated SVG attribute 'xlink:href' found in string. Use 'href' instead.",
+    },
+  },
+
+  create(context) {
+    /**
+     * Checks a string value for xlink:href occurrences and reports them.
+     * @param {import('eslint').Rule.Node} node
+     * @param {string} value
+     */
+    function checkStringForXlinkHref(node, value) {
+      if (/xlink:href/i.test(value)) {
+        context.report({
+          node,
+          messageId: "stringLiteral",
+        });
+      }
+    }
+
+    return {
+      // ── JSX: xlink:href="..." ──────────────────────────────────────────────
+      JSXAttribute(node) {
+        const { name } = node;
+
+        // Namespaced attribute: xlink:href
+        if (
+          name.type === "JSXNamespacedName" &&
+          name.namespace.name === "xlink" &&
+          name.name.name === "href"
+        ) {
+          context.report({
+            node,
+            messageId: "jsxNamespacedAttr",
+            fix(fixer) {
+              // Replace the whole attribute name (xlink:href) with href.
+              // Preserve the value expression as-is.
+              const value = node.value;
+              const valueSource = value
+                ? context.getSourceCode().getText(value)
+                : null;
+
+              return fixer.replaceText(
+                node,
+                valueSource ? `href=${valueSource}` : "href"
+              );
+            },
+          });
+          return;
+        }
+
+        // camelCase form used in React: xlinkHref
+        if (
+          name.type === "JSXIdentifier" &&
+          name.name === "xlinkHref"
+        ) {
+          context.report({
+            node,
+            messageId: "jsxCamelCaseAttr",
+            fix(fixer) {
+              const value = node.value;
+              const valueSource = value
+                ? context.getSourceCode().getText(value)
+                : null;
+
+              return fixer.replaceText(
+                node,
+                valueSource ? `href=${valueSource}` : "href"
+              );
+            },
+          });
+        }
+      },
+
+      // ── String literals ────────────────────────────────────────────────────
+      Literal(node) {
+        if (typeof node.value === "string") {
+          checkStringForXlinkHref(node, node.value);
+        }
+      },
+
+      // ── Template literals ──────────────────────────────────────────────────
+      TemplateLiteral(node) {
+        for (const quasi of node.quasis) {
+          checkStringForXlinkHref(node, quasi.value.raw);
+        }
+      },
+    };
+  },
+};
+
+module.exports = rule;

--- a/packages/web-react/eslint.config.mjs
+++ b/packages/web-react/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { fixupConfigRules, fixupPluginRules } from '@eslint/compat';
 import { FlatCompat } from '@eslint/eslintrc';
 import spiritHtml from 'eslint-config-spirit/html';
+import spiritRules from 'eslint-config-spirit/rules';
 import reactRefresh from 'eslint-plugin-react-refresh';
 
 const compat = new FlatCompat({
@@ -44,6 +45,7 @@ export default [
     ),
   ),
   ...spiritHtml,
+  ...spiritRules,
   {
     plugins: {
       'react-refresh': fixupPluginRules(reactRefresh),

--- a/packages/web-react/src/components/Avatar/README.md
+++ b/packages/web-react/src/components/Avatar/README.md
@@ -47,7 +47,7 @@ You can set different avatar sizes for different [breakpoints][dictionary-breakp
 ```tsx
 <Avatar size={{ mobile: 'xsmall', tablet: 'medium', desktop: 'xlarge' }} aria-label="Profile of Jiří Bárta">
   <svg class="Icon" width="24" height="24" aria-hidden="true">
-    <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+    <use href="/assets/icons/svg/sprite.svg#profile" />
   </svg>
 </Avatar>
 ```

--- a/packages/web-react/src/components/Card/README.md
+++ b/packages/web-react/src/components/Card/README.md
@@ -137,7 +137,7 @@ CardArtwork is an optional subcomponent that displays a small image or icon.
 ```tsx
 <CardArtwork>
   <svg class="Icon" width="24" height="24" aria-hidden="true">
-    <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+    <use href="/assets/icons/svg/sprite.svg#file" />
   </svg>
 </CardArtwork>
 ```
@@ -155,7 +155,7 @@ To align the artwork, use `alignmentX` prop:
 ```tsx
 <CardArtwork alignmentX="center">
   <svg class="Icon" width="24" height="24" aria-hidden="true">
-    <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+    <use href="/assets/icons/svg/sprite.svg#file" />
   </svg>
 </CardArtwork>
 ```

--- a/packages/web-react/tests/providerTests/validHtmlAttributesTest.tsx
+++ b/packages/web-react/tests/providerTests/validHtmlAttributesTest.tsx
@@ -7,7 +7,7 @@ const globalAttributes = [...htmlElementAttributes['*'], 'role'];
 
 // Custom attributes for specific tags which are not present in html-element-attributes library
 const customTagAttributes: Record<string, string[]> = {
-  svg: ['viewBox', 'fill', 'xmlns', 'xmlns:xlink', 'width', 'height'],
+  svg: ['viewBox', 'fill', 'xmlns', 'width', 'height'],
 };
 
 const validateHTMLAttributes = (element: HTMLElement) => {

--- a/packages/web/eslint.config.mjs
+++ b/packages/web/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { fixupConfigRules } from '@eslint/compat';
 import { FlatCompat } from '@eslint/eslintrc';
 import spiritHtml from 'eslint-config-spirit/html';
+import spiritRules from 'eslint-config-spirit/rules';
 
 const compat = new FlatCompat({
   baseDirectory: import.meta.dirname,
@@ -40,6 +41,7 @@ export default [
     compat.extends('eslint-config-spirit', '@lmc-eu/eslint-config-typescript', 'eslint-config-spirit/prettier'),
   ),
   ...spiritHtml,
+  ...spiritRules,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/web/src/icons/README.md
+++ b/packages/web/src/icons/README.md
@@ -7,6 +7,6 @@ The preferred way to display an icon from Spirit icon set is to use the `<svg>` 
 
 ```html
 <svg class="Icon" width="24" height="24" aria-hidden="true">
-  <use xlink:href="/icons/svg/sprite.svg#warning" />
+  <use href="/icons/svg/sprite.svg#warning" />
 </svg>
 ```

--- a/packages/web/src/js/Toast.ts
+++ b/packages/web/src/js/Toast.ts
@@ -197,11 +197,13 @@ class Toast extends BaseComponent {
     const { hasIcon, iconName, color } = this.config as Config;
 
     const iconUseElement = iconElement.querySelector('use') as SVGUseElement;
-    const originalIconPath = iconUseElement!.getAttribute('xlink:href') as string;
+    const originalIconPath = (iconUseElement!.getAttribute('href') ??
+      // eslint-disable-next-line spirit/no-xlink-href -- fallback for consumers still using xlink:href in their Toast template
+      iconUseElement!.getAttribute('xlink:href')) as string;
     const iconPath = originalIconPath.substring(0, originalIconPath.indexOf('#'));
 
     if (hasIcon) {
-      iconUseElement!.setAttribute('xlink:href', `${iconPath}#${iconName || COLOR_ICON_MAP[color]}`);
+      iconUseElement!.setAttribute('href', `${iconPath}#${iconName || COLOR_ICON_MAP[color]}`);
     } else {
       iconElement!.remove();
     }

--- a/packages/web/src/js/__tests__/Collapse.test.ts
+++ b/packages/web/src/js/__tests__/Collapse.test.ts
@@ -151,7 +151,7 @@ describe('Collapse', () => {
                 </span>
                 <span class="Accordion__itemIcon">
                   <svg width="24" height="24" aria-hidden="true">
-                    <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+                    <use href="/icons/svg/sprite.svg#chevron-down" />
                   </svg>
                 </span>
               </span>
@@ -190,7 +190,7 @@ describe('Collapse', () => {
                 </span>
                 <span class="Accordion__itemIcon">
                   <svg width="24" height="24" aria-hidden="true">
-                    <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+                    <use href="/icons/svg/sprite.svg#chevron-down" />
                   </svg>
                 </span>
               </span>

--- a/packages/web/src/js/__tests__/Dropdown.test.ts
+++ b/packages/web/src/js/__tests__/Dropdown.test.ts
@@ -4,7 +4,7 @@ import Dropdown, { CLASSNAME_EXPANDED, CLASSNAME_OPEN } from '../Dropdown';
 const childrenHtml = `
   <a href="#" class="d-flex mb-400">
     <svg width="24" height="24" aria-hidden="true" class="mr-400">
-      <use xlink:href="/icons/svg/sprite.svg#info" />
+      <use href="/icons/svg/sprite.svg#info" />
     </svg>
     <span>Information</span>
   </a>

--- a/packages/web/src/scss/components/Accordion/README.md
+++ b/packages/web/src/scss/components/Accordion/README.md
@@ -84,7 +84,7 @@ Minimum header with a heading and an arrow icon:
   <span class="Accordion__itemSide">
     <span class="Accordion__itemIcon">
       <svg class="Icon" width="24" height="24" aria-hidden="true">
-        <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+        <use href="/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </span>
   </span>
@@ -107,7 +107,7 @@ Optionally add a slot into the `Accordion__itemSide` element:
   </span>
   <span class="Accordion__itemIcon">
     <svg class="Icon" width="24" height="24" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+      <use href="/icons/svg/sprite.svg#chevron-down" />
     </svg>
   </span>
 </span>
@@ -172,7 +172,7 @@ When you put it all together:
         </span>
         <span class="Accordion__itemIcon">
           <svg class="Icon" width="24" height="24" aria-hidden="true">
-            <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+            <use href="/icons/svg/sprite.svg#chevron-down" />
           </svg>
         </span>
       </span>

--- a/packages/web/src/scss/components/Accordion/preview.html
+++ b/packages/web/src/scss/components/Accordion/preview.html
@@ -29,7 +29,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                 </svg>
               </span>
             </span>
@@ -88,7 +88,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                 </svg>
               </span>
             </span>
@@ -138,7 +138,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                 </svg>
               </span>
             </span>
@@ -198,7 +198,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                 </svg>
               </span>
             </span>
@@ -271,7 +271,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                 </svg>
               </span>
             </span>
@@ -323,7 +323,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                 </svg>
               </span>
             </span>
@@ -374,7 +374,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                 </svg>
               </span>
             </span>

--- a/packages/web/src/scss/components/Alert/README.md
+++ b/packages/web/src/scss/components/Alert/README.md
@@ -7,14 +7,14 @@ Variants:
 ```html
 <div class="Alert Alert--success color-scheme-on-emotion-success-subtle">
   <svg class="Icon" width="24" height="24">
-    <use xlink:href="/icons/svg/sprite.svg#info" />
+    <use href="/icons/svg/sprite.svg#info" />
   </svg>
   <div>We sent you an activation link to email <strong>spirit@lmc.eu</strong>.</div>
 </div>
 
 <div class="Alert Alert--informative color-scheme-on-emotion-informative-subtle">
   <svg class="Icon" width="24" height="24">
-    <use xlink:href="/icons/svg/sprite.svg#info" />
+    <use href="/icons/svg/sprite.svg#info" />
   </svg>
   <div>
     Data update failed due to missing internet connection Data update failed due to missing internet connection Data
@@ -25,28 +25,28 @@ Variants:
 
 <div class="Alert Alert--warning color-scheme-on-emotion-warning-subtle">
   <svg class="Icon" width="24" height="24">
-    <use xlink:href="/icons/svg/sprite.svg#warning" />
+    <use href="/icons/svg/sprite.svg#warning" />
   </svg>
   <div><strong>Warning!</strong> Data update failed due to missing internet connection</div>
 </div>
 
 <div class="Alert Alert--danger color-scheme-on-emotion-danger-subtle">
   <svg class="Icon" width="24" height="24">
-    <use xlink:href="/icons/svg/sprite.svg#close" />
+    <use href="/icons/svg/sprite.svg#close" />
   </svg>
   <div>Data update failed due to missing internet connection</div>
 </div>
 
 <div class="Alert Alert--success Alert--center color-scheme-on-emotion-success-subtle">
   <svg class="Icon" width="24" height="24">
-    <use xlink:href="/icons/svg/sprite.svg#info" />
+    <use href="/icons/svg/sprite.svg#info" />
   </svg>
   <div>We sent you an activation link to email <strong>spirit@lmc.eu</strong>.</div>
 </div>
 
 <div class="Alert Alert--informative Alert--center color-scheme-on-emotion-informative-subtle">
   <svg class="Icon" width="24" height="24">
-    <use xlink:href="/icons/svg/sprite.svg#info" />
+    <use href="/icons/svg/sprite.svg#info" />
   </svg>
   <div>
     Data update failed due to missing internet connection Data update failed due to missing internet connection Data
@@ -57,14 +57,14 @@ Variants:
 
 <div class="Alert Alert--warning Alert--center color-scheme-on-emotion-warning-subtle">
   <svg class="Icon" width="24" height="24">
-    <use xlink:href="/icons/svg/sprite.svg#warning" />
+    <use href="/icons/svg/sprite.svg#warning" />
   </svg>
   <div><strong>Warning!</strong> Data update failed due to missing internet connection</div>
 </div>
 
 <div class="Alert Alert--danger Alert--center color-scheme-on-emotion-danger-subtle">
   <svg class="Icon" width="24" height="24">
-    <use xlink:href="/icons/svg/sprite.svg#close" />
+    <use href="/icons/svg/sprite.svg#close" />
   </svg>
   <div>Data update failed due to missing internet connection</div>
 </div>

--- a/packages/web/src/scss/components/Alert/preview.html
+++ b/packages/web/src/scss/components/Alert/preview.html
@@ -8,7 +8,7 @@
 
       <div class="Alert Alert--success color-scheme-on-emotion-success-subtle">
         <svg width="24" height="24">
-          <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+          <use href="/assets/icons/svg/sprite.svg#check-plain" />
         </svg>
         <div>
           We sent you an activation link to email <strong>spirit@lmc.eu</strong>.
@@ -18,7 +18,7 @@
 
       <div class="Alert Alert--informative color-scheme-on-emotion-informative-subtle">
         <svg width="24" height="24">
-          <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+          <use href="/assets/icons/svg/sprite.svg#info" />
         </svg>
         <div>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
@@ -29,7 +29,7 @@
 
       <div class="Alert Alert--warning color-scheme-on-emotion-warning-subtle">
         <svg width="24" height="24">
-          <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
+          <use href="/assets/icons/svg/sprite.svg#warning" />
         </svg>
         <div>
           <strong>Warning!</strong> Data update failed due to missing internet connection.
@@ -39,7 +39,7 @@
 
       <div class="Alert Alert--danger color-scheme-on-emotion-danger-subtle">
         <svg width="24" height="24">
-          <use xlink:href="/assets/icons/svg/sprite.svg#danger" />
+          <use href="/assets/icons/svg/sprite.svg#danger" />
         </svg>
         <div>
           Data update failed due to missing internet connection.
@@ -62,7 +62,7 @@
 
       <div class="Alert Alert--success Alert--center color-scheme-on-emotion-success-subtle">
         <svg width="24" height="24">
-          <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+          <use href="/assets/icons/svg/sprite.svg#check-plain" />
         </svg>
         <div>
           We sent you an activation link to email <strong>spirit@lmc.eu</strong>.
@@ -72,7 +72,7 @@
 
       <div class="Alert Alert--informative Alert--center color-scheme-on-emotion-informative-subtle">
         <svg width="24" height="24">
-          <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+          <use href="/assets/icons/svg/sprite.svg#info" />
         </svg>
         <div>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
@@ -84,7 +84,7 @@
 
       <div class="Alert Alert--warning Alert--center color-scheme-on-emotion-warning-subtle">
         <svg width="24" height="24">
-          <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
+          <use href="/assets/icons/svg/sprite.svg#warning" />
         </svg>
         <div>
           <strong>Warning!</strong> Data update failed due to missing internet connection.
@@ -94,7 +94,7 @@
 
       <div class="Alert Alert--danger Alert--center color-scheme-on-emotion-danger-subtle">
         <svg width="24" height="24">
-          <use xlink:href="/assets/icons/svg/sprite.svg#danger" />
+          <use href="/assets/icons/svg/sprite.svg#danger" />
         </svg>
         <div>
           Data update failed due to missing internet connection.
@@ -118,7 +118,7 @@
 
       <div class="Alert Alert--success color-scheme-on-emotion-success-subtle">
         <svg width="24" height="24">
-          <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+          <use href="/assets/icons/svg/sprite.svg#profile" />
         </svg>
         <div>
           We sent you an activation link to email <strong>spirit@lmc.eu</strong>.
@@ -128,7 +128,7 @@
 
       <div class="Alert Alert--informative color-scheme-on-emotion-informative-subtle">
         <svg width="24" height="24">
-          <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+          <use href="/assets/icons/svg/sprite.svg#info" />
         </svg>
         <div>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam at excepturi laudantium magnam mollitia
@@ -139,7 +139,7 @@
 
       <div class="Alert Alert--warning color-scheme-on-emotion-warning-subtle">
         <svg width="24" height="24">
-          <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
+          <use href="/assets/icons/svg/sprite.svg#warning" />
         </svg>
         <div>
           <strong>Warning!</strong> Data update failed due to missing internet connection.
@@ -149,7 +149,7 @@
 
       <div class="Alert Alert--danger color-scheme-on-emotion-danger-subtle">
         <svg width="24" height="24">
-          <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+          <use href="/assets/icons/svg/sprite.svg#close" />
         </svg>
         <div>
           Data update failed due to missing internet connection.

--- a/packages/web/src/scss/components/Avatar/README.md
+++ b/packages/web/src/scss/components/Avatar/README.md
@@ -61,7 +61,7 @@ You can set different avatar sizes for different [breakpoints][dictionary-breakp
   aria-label="Profile of Jiří Bárta"
 >
   <svg class="Icon" width="24" height="24" aria-hidden="true">
-    <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+    <use href="/assets/icons/svg/sprite.svg#profile" />
   </svg>
 </a>
 ```
@@ -75,7 +75,7 @@ The content of the `Avatar` component can be an image, an icon, or a text string
 ```html
 <div class="Avatar Avatar--medium" aria-label="Profile of Jiří Bárta">
   <svg class="Icon" width="24" height="24" aria-hidden="true">
-    <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+    <use href="/assets/icons/svg/sprite.svg#profile" />
   </svg>
 </div>
 ```

--- a/packages/web/src/scss/components/Avatar/preview.html
+++ b/packages/web/src/scss/components/Avatar/preview.html
@@ -23,7 +23,7 @@
             height="24"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+            <use href="/assets/icons/svg/sprite.svg#profile" />
           </svg>
         </a>
 
@@ -41,7 +41,7 @@
             height="24"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+            <use href="/assets/icons/svg/sprite.svg#profile" />
           </svg>
         </div>
 
@@ -161,7 +161,7 @@
             height="24"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+            <use href="/assets/icons/svg/sprite.svg#profile" />
           </svg>
         </a>
 
@@ -196,7 +196,7 @@
             height="24"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+            <use href="/assets/icons/svg/sprite.svg#profile" />
           </svg>
         </a>
 

--- a/packages/web/src/scss/components/Breadcrumbs/README.md
+++ b/packages/web/src/scss/components/Breadcrumbs/README.md
@@ -10,25 +10,25 @@ Shows where the user is within the app hierarchy.
     <li class="d-none d-tablet-flex">
       <a href="#rootUrl" class="link-primary link-underlined">Root</a>
       <svg class="Icon" width="24" height="24">
-        <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
+        <use href="/icons/svg/sprite.svg#chevron-right" />
       </svg>
     </li>
     <li class="d-none d-tablet-flex">
       <a href="#categoryUrl" class="link-primary link-underlined">Category</a>
       <svg class="Icon" width="24" height="24">
-        <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
+        <use href="/icons/svg/sprite.svg#chevron-right" />
       </svg>
     </li>
     <li class="d-tablet-none">
       <svg class="Icon" width="24" height="24">
-        <use xlink:href="/icons/svg/sprite.svg#chevron-left" />
+        <use href="/icons/svg/sprite.svg#chevron-left" />
       </svg>
       <a href="#subcategoryUrl" class="link-primary link-underlined">Back</a>
     </li>
     <li class="d-none d-tablet-flex">
       <a href="#subcategoryUrl" class="link-primary link-underlined">Subcategory</a>
       <svg class="Icon" width="24" height="24">
-        <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
+        <use href="/icons/svg/sprite.svg#chevron-right" />
       </svg>
     </li>
     <li class="d-none d-tablet-flex">
@@ -51,7 +51,7 @@ For comprehensive guidance on handling text truncation, translations, and multip
     This is a very long title of the current page
   </a>
   <svg class="Icon" width="24" height="24">
-    <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
+    <use href="/icons/svg/sprite.svg#chevron-right" />
   </svg>
 </li>
 <!-- … --->

--- a/packages/web/src/scss/components/Breadcrumbs/preview.html
+++ b/packages/web/src/scss/components/Breadcrumbs/preview.html
@@ -10,25 +10,25 @@
         <li class="d-none d-tablet-flex">
           <a href="#rootUrl" class="link-primary link-underlined">Root</a>
           <svg width="24" height="24">
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         <li class="d-none d-tablet-flex">
           <a href="#categoryUrl" class="link-primary link-underlined">Category</a>
           <svg width="24" height="24">
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         <li class="d-tablet-none">
           <svg width="24" height="24">
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-left" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-left" />
           </svg>
           <a href="#subcategoryUrl" class="link-primary link-underlined">Back</a>
         </li>
         <li class="d-none d-tablet-flex">
           <a href="#subcategoryUrl" class="link-primary link-underlined">Subcategory</a>
           <svg width="24" height="24">
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         <li class="d-none d-tablet-flex">
@@ -60,25 +60,25 @@
         <li class="d-none d-tablet-flex">
           <a href="#rootUrl" class="link-primary link-underlined">Root</a>
           <svg width="24" height="24">
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         <li class="d-none d-tablet-flex">
           <a href="#categoryUrl" class="link-primary link-underlined">Category</a>
           <svg width="24" height="24">
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         <li class="d-tablet-none">
           <svg width="24" height="24">
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-left" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-left" />
           </svg>
           <a href="#subcategoryUrl" class="link-primary link-underlined">Back</a>
         </li>
         <li class="d-none d-tablet-flex">
           <a href="#subcategoryUrl" class="link-primary link-underlined">Subcategory</a>
           <svg width="24" height="24">
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         <li class="d-none d-tablet-flex">
@@ -106,25 +106,25 @@
         <li class="d-none d-tablet-flex">
           <a href="#rootUrl" class="link-primary link-underlined">Root</a>
           <svg width="24" height="24">
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         <li class="d-none d-tablet-flex">
           <a href="#categoryUrl" class="link-primary link-underlined">Category</a>
           <svg width="24" height="24">
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         <li class="d-tablet-none">
           <svg width="24" height="24">
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-left" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-left" />
           </svg>
           <a href="#subcategoryUrl" class="link-primary link-underlined">Back</a>
         </li>
         <li class="d-none d-tablet-flex">
           <a href="#subcategoryUrl" class="link-primary link-underlined">Subcategory</a>
           <svg width="24" height="24">
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         <li class="d-none d-tablet-flex">

--- a/packages/web/src/scss/components/Button/README.md
+++ b/packages/web/src/scss/components/Button/README.md
@@ -52,7 +52,7 @@ To insert an icon into a button, use the [Icon][readme-icon] component. Spacing 
 ```html
 <button type="button" class="Button Button--primary Button--medium">
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
   Menu
 </button>
@@ -65,7 +65,7 @@ Use the `Button--symmetrical` modifier when you only need a compact, icon-only b
 ```html
 <button type="button" class="Button Button--primary Button--medium Button--symmetrical">
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
   <span class="accessibility-hidden">Menu</span>
 </button>
@@ -104,7 +104,7 @@ Icon on mobile, text label from tablet onwards:
 ```html
 <button type="button" class="Button Button--primary Button--medium Button--symmetrical Button--tablet--asymmetrical">
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
   <span class="accessibility-hidden">Menu</span>
   <span class="d-none d-tablet-inline" aria-hidden="true">Menu</span>
@@ -116,7 +116,7 @@ Text label on mobile, icon from tablet onwards:
 ```html
 <button type="button" class="Button Button--primary Button--medium Button--tablet--symmetrical">
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
   <span class="accessibility-hidden">Menu</span>
   <span class="d-tablet-none" aria-hidden="true">Menu</span>
@@ -128,7 +128,7 @@ Text label on mobile, icon from desktop onwards:
 ```html
 <button type="button" class="Button Button--primary Button--medium Button--desktop--symmetrical">
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
   <span class="accessibility-hidden">Menu</span>
   <span class="d-desktop-none" aria-hidden="true">Menu</span>
@@ -140,7 +140,7 @@ Icon on mobile and tablet, text label on desktop:
 ```html
 <button type="button" class="Button Button--primary Button--medium Button--symmetrical Button--desktop--asymmetrical">
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
   <span class="accessibility-hidden">Menu</span>
   <span class="d-none d-desktop-inline" aria-hidden="true">Menu</span>
@@ -155,7 +155,7 @@ Icon on tablet only:
   class="Button Button--primary Button--medium Button--tablet--symmetrical Button--desktop--asymmetrical"
 >
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
   <span class="accessibility-hidden">Menu</span>
   <span class="d-tablet-none d-desktop-inline" aria-hidden="true">Menu</span>
@@ -219,7 +219,7 @@ Loading button with a text label:
 <a href="#" class="Button Button--primary Button--medium Button--loading Button--disabled">
   Button primary
   <svg class="Icon animation-spin-clockwise" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#spinner" />
+    <use href="/icons/svg/sprite.svg#spinner" />
   </svg>
 </a>
 ```
@@ -229,11 +229,11 @@ Loading button with an icon and a text label:
 ```html
 <button type="button" class="Button Button--primary Button--medium Button--loading" disabled>
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
   Menu
   <svg class="Icon animation-spin-clockwise" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#spinner" />
+    <use href="/icons/svg/sprite.svg#spinner" />
   </svg>
 </button>
 ```
@@ -244,10 +244,10 @@ Loading button with an icon and a text label:
 <button type="button" class="Button Button--primary Button--medium Button--symmetrical Button--loading" disabled>
   <span class="accessibility-hidden">Menu</span>
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
   <svg class="Icon animation-spin-clockwise" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#spinner" />
+    <use href="/icons/svg/sprite.svg#spinner" />
   </svg>
 </button>
 ```
@@ -269,7 +269,7 @@ For example, add the `aria-label` attribute to the Button:
 ```html
 <button type="button" class="Button Button--primary Button--medium Button--symmetrical" aria-label="Menu">
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
 </button>
 ```
@@ -281,7 +281,7 @@ Alternatively, use the `accessibility-hidden` class:
 ```html
 <button type="button" class="Button Button--primary Button--medium Button--symmetrical">
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
   <span class="accessibility-hidden">Menu</span>
 </button>
@@ -302,7 +302,7 @@ In other cases, consider displaying the button label in a [Tooltip][readme-toolt
     aria-describedby="my-tooltip"
   >
     <svg class="Icon" width="20" height="20" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#info" />
+      <use href="/icons/svg/sprite.svg#info" />
     </svg>
     <span class="accessibility-hidden">I have a tooltip!</span>
   </button>
@@ -326,7 +326,7 @@ Custom spacing:
 ```html
 <button type="button" class="Button Button--primary Button--medium" style="--button-spacing: var(--spirit-space-600)">
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
   Menu
 </button>
@@ -351,7 +351,7 @@ Custom spacing from tablet up:
   style="--button-spacing-tablet: var(--spirit-space-800)"
 >
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
   Menu
 </button>
@@ -366,7 +366,7 @@ Custom spacing for each breakpoint:
   style="--button-spacing: var(--spirit-space-400); --button-spacing-tablet: var(--spirit-space-600); --button-spacing-desktop: var(--spirit-space-800)"
 >
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
   Menu
 </button>

--- a/packages/web/src/scss/components/Card/README.md
+++ b/packages/web/src/scss/components/Card/README.md
@@ -127,7 +127,7 @@ CardArtwork is an optional subcomponent that displays a small image or icon.
 ```html
 <div class="CardArtwork CardArtwork--alignmentXLeft">
   <svg class="Icon" width="24" height="24" aria-hidden="true">
-    <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+    <use href="/assets/icons/svg/sprite.svg#file" />
   </svg>
 </div>
 ```

--- a/packages/web/src/scss/components/Card/index.html
+++ b/packages/web/src/scss/components/Card/index.html
@@ -238,7 +238,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <!-- End user content -->
           </div>
@@ -557,7 +557,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <!-- End user content -->
           </div>
@@ -589,7 +589,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <!-- End user content -->
           </div>
@@ -713,7 +713,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <!-- End user content -->
           </div>
@@ -745,7 +745,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <!-- End user content -->
           </div>
@@ -895,7 +895,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+                <use href="/assets/icons/svg/sprite.svg#file" />
               </svg>
             </div>
             <!-- End IconBox -->
@@ -924,7 +924,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+                <use href="/assets/icons/svg/sprite.svg#file" />
               </svg>
             </div>
             <!-- End IconBox -->
@@ -953,7 +953,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+                <use href="/assets/icons/svg/sprite.svg#file" />
               </svg>
             </div>
             <!-- End IconBox -->
@@ -1862,7 +1862,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#add" />
+                <use href="/assets/icons/svg/sprite.svg#add" />
               </svg>
             </button>
             <button
@@ -1876,7 +1876,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#edit" />
+                <use href="/assets/icons/svg/sprite.svg#edit" />
               </svg>
             </button>
             <button
@@ -1890,7 +1890,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#help" />
+                <use href="/assets/icons/svg/sprite.svg#help" />
               </svg>
             </button>
           </footer>

--- a/packages/web/src/scss/components/CharacterCounter/index.html
+++ b/packages/web/src/scss/components/CharacterCounter/index.html
@@ -150,7 +150,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#danger" />
+                <use href="/assets/icons/svg/sprite.svg#danger" />
               </svg>
               <div>You have entered too many characters</div>
             </div>

--- a/packages/web/src/scss/components/Checkbox/README.md
+++ b/packages/web/src/scss/components/Checkbox/README.md
@@ -77,7 +77,7 @@ See Validation state [dictionary][dictionary-validation].
     <label class="Label Label--inline" for="checkbox-warning">Checkbox Label</label>
     <div class="ValidationText ValidationText--warning ValidationText--inline" id="checkbox-warning-helper-text">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
+        <use href="/assets/icons/svg/sprite.svg#warning" />
       </svg>
       <span>Warning validation text with icon</span>
     </div>

--- a/packages/web/src/scss/components/Checkbox/index.html
+++ b/packages/web/src/scss/components/Checkbox/index.html
@@ -317,9 +317,9 @@
               aria-hidden="true"
             >
               {{#if (eq state "success")}}
-              <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+              <use href="/assets/icons/svg/sprite.svg#check-plain" />
               {{else}}
-              <use xlink:href="/assets/icons/svg/sprite.svg#{{ state }}" />
+              <use href="/assets/icons/svg/sprite.svg#{{ state }}" />
               {{/if}}
             </svg>
             <span>This is {{ state }} validation text.</span>
@@ -583,7 +583,7 @@
           height="24"
           aria-hidden="true"
         >
-          <use xlink:href="/icons/svg/sprite.svg#close" />
+          <use href="/icons/svg/sprite.svg#close" />
         </svg>
         <span class="accessibility-hidden">Close</span>
       </button>
@@ -616,7 +616,7 @@
           height="24"
           aria-hidden="true"
         >
-          <use xlink:href="/icons/svg/sprite.svg#close" />
+          <use href="/icons/svg/sprite.svg#close" />
         </svg>
         <span class="accessibility-hidden">Close</span>
       </button>

--- a/packages/web/src/scss/components/ControlButton/README.md
+++ b/packages/web/src/scss/components/ControlButton/README.md
@@ -25,7 +25,7 @@ ControlButtons are composed using component styles and helper classes:
   aria-label="Close"
 >
   <svg class="Icon" width="16" height="16" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#close" />
+    <use href="/icons/svg/sprite.svg#close" />
   </svg>
 </button>
 ```
@@ -56,7 +56,7 @@ parent element:
     aria-label="Close"
   >
     <svg class="Icon" width="16" height="16" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#close" />
+      <use href="/icons/svg/sprite.svg#close" />
     </svg>
   </button>
 </div>
@@ -80,7 +80,7 @@ the background visible in the default state. The modifier class reads the
   aria-label="Close"
 >
   <svg class="Icon" width="16" height="16" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#close" />
+    <use href="/icons/svg/sprite.svg#close" />
   </svg>
 </button>
 ```
@@ -99,7 +99,7 @@ visible. The border color will adapt to the background color:
   aria-label="Close"
 >
   <svg class="Icon" width="16" height="16" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#close" />
+    <use href="/icons/svg/sprite.svg#close" />
   </svg>
 </button>
 ```
@@ -137,7 +137,7 @@ while mapping the existing sizes up:
     aria-label="Close"
   >
     <svg class="Icon" width="16" height="16" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#close" />
+      <use href="/icons/svg/sprite.svg#close" />
     </svg>
   </button>
 </div>
@@ -154,7 +154,7 @@ A symmetrical control button has equal width and height, typically used with ico
   aria-label="Close"
 >
   <svg class="Icon" width="16" height="16" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#close" />
+    <use href="/icons/svg/sprite.svg#close" />
   </svg>
 </button>
 ```
@@ -172,7 +172,7 @@ Symmetrical from tablet breakpoint and up:
   aria-label="Close"
 >
   <svg class="Icon" width="16" height="16" aria-hidden="true">
-    <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+    <use href="/assets/icons/svg/sprite.svg#close" />
   </svg>
 </button>
 ```
@@ -186,7 +186,7 @@ Symmetrical from desktop breakpoint and up:
   aria-label="Close"
 >
   <svg class="Icon" width="16" height="16" aria-hidden="true">
-    <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+    <use href="/assets/icons/svg/sprite.svg#close" />
   </svg>
 </button>
 ```
@@ -200,7 +200,7 @@ Symmetrical on mobile, not on tablet and up (use modifier class with suffix `--a
   aria-label="Close"
 >
   <svg class="Icon" width="16" height="16" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#close" />
+    <use href="/icons/svg/sprite.svg#close" />
   </svg>
 </button>
 ```
@@ -214,7 +214,7 @@ Symmetrical on mobile and tablet, not on desktop (combine breakpoint-specific cl
   aria-label="Close"
 >
   <svg class="Icon" width="16" height="16" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#close" />
+    <use href="/icons/svg/sprite.svg#close" />
   </svg>
 </button>
 ```
@@ -237,7 +237,7 @@ To achieve proper styles, use `color-scheme-on-disabled` class on the parent ele
     disabled
   >
     <svg class="Icon" width="16" height="16" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#chevron-left" />
+      <use href="/icons/svg/sprite.svg#chevron-left" />
     </svg>
   </button>
   <span>Disabled content</span>
@@ -248,7 +248,7 @@ To achieve proper styles, use `color-scheme-on-disabled` class on the parent ele
     disabled
   >
     <svg class="Icon" width="16" height="16" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
+      <use href="/icons/svg/sprite.svg#chevron-right" />
     </svg>
   </button>
 </div>
@@ -264,7 +264,7 @@ To achieve proper styles, use `color-scheme-on-disabled` class on the parent ele
   disabled
 >
   <svg class="Icon" width="16" height="16" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#close" />
+    <use href="/icons/svg/sprite.svg#close" />
   </svg>
 </button>
 ```
@@ -285,7 +285,7 @@ Custom spacing:
   aria-label="Close"
 >
   <svg class="Icon" width="16" height="16" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#close" />
+    <use href="/icons/svg/sprite.svg#close" />
   </svg>
   Close
 </button>
@@ -311,7 +311,7 @@ Custom spacing from tablet up:
   aria-label="Close"
 >
   <svg class="Icon" width="16" height="16" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#close" />
+    <use href="/icons/svg/sprite.svg#close" />
   </svg>
   Close
 </button>
@@ -327,7 +327,7 @@ Custom spacing for each breakpoint:
   aria-label="Close"
 >
   <svg class="Icon" width="16" height="16" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#close" />
+    <use href="/icons/svg/sprite.svg#close" />
   </svg>
   Close
 </button>

--- a/packages/web/src/scss/components/ControlButton/index.html
+++ b/packages/web/src/scss/components/ControlButton/index.html
@@ -38,7 +38,7 @@
                 height="{{#if (eq size "large")}}20{{else}}16{{/if}}"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
             {{/each}}
@@ -54,7 +54,7 @@
                 height="{{#if (eq size "large")}}20{{else}}16{{/if}}"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
             {{/each}}
@@ -77,7 +77,7 @@
                 height="{{#if (eq size "large")}}20{{else}}16{{/if}}"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
             {{/each}}
@@ -93,7 +93,7 @@
                 height="{{#if (eq size "large")}}20{{else}}16{{/if}}"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
             {{/each}}
@@ -113,7 +113,7 @@
                 height="{{#if (eq size "large")}}20{{else}}16{{/if}}"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
             {{/each}}
@@ -129,7 +129,7 @@
                 height="{{#if (eq size "large")}}20{{else}}16{{/if}}"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
             {{/each}}
@@ -157,7 +157,7 @@
                 height="{{#if (eq size "large")}}20{{else}}16{{/if}}"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
             {{/each}}
@@ -173,7 +173,7 @@
                 height="{{#if (eq size "large")}}20{{else}}16{{/if}}"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
             {{/each}}
@@ -193,7 +193,7 @@
                 height="{{#if (eq size "large")}}20{{else}}16{{/if}}"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
             {{/each}}
@@ -209,7 +209,7 @@
                 height="{{#if (eq size "large")}}20{{else}}16{{/if}}"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
             {{/each}}
@@ -237,7 +237,7 @@
                 height="{{#if (eq size "large")}}20{{else}}16{{/if}}"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
             {{/each}}
@@ -253,7 +253,7 @@
                 height="{{#if (eq size "large")}}20{{else}}16{{/if}}"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
             {{/each}}
@@ -273,7 +273,7 @@
                 height="{{#if (eq size "large")}}20{{else}}16{{/if}}"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
             {{/each}}
@@ -289,7 +289,7 @@
                 height="{{#if (eq size "large")}}20{{else}}16{{/if}}"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
             {{/each}}
@@ -326,7 +326,7 @@
               height="{{#if (eq size "xlarge")}}20{{else}}16{{/if}}"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
           </button>
           {{/each}}
@@ -342,7 +342,7 @@
               height="{{#if (eq size "xlarge")}}20{{else}}16{{/if}}"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
           </button>
           {{/each}}
@@ -373,7 +373,7 @@
           height="16"
           aria-hidden="true"
         >
-          <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+          <use href="/assets/icons/svg/sprite.svg#close" />
         </svg>
       </button>
 
@@ -388,7 +388,7 @@
           height="16"
           aria-hidden="true"
         >
-          <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+          <use href="/assets/icons/svg/sprite.svg#close" />
         </svg>
       </button>
 
@@ -403,7 +403,7 @@
           height="16"
           aria-hidden="true"
         >
-          <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+          <use href="/assets/icons/svg/sprite.svg#close" />
         </svg>
       </button>
 
@@ -418,7 +418,7 @@
           height="16"
           aria-hidden="true"
         >
-          <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+          <use href="/assets/icons/svg/sprite.svg#close" />
         </svg>
       </button>
 
@@ -433,7 +433,7 @@
           height="16"
           aria-hidden="true"
         >
-          <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+          <use href="/assets/icons/svg/sprite.svg#close" />
         </svg>
       </button>
 
@@ -448,7 +448,7 @@
           height="16"
           aria-hidden="true"
         >
-          <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+          <use href="/assets/icons/svg/sprite.svg#close" />
         </svg>
       </button>
 
@@ -477,7 +477,7 @@
             height="16"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-left" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-left" />
           </svg>
         </button>
 
@@ -495,7 +495,7 @@
             height="16"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </button>
       </div>
@@ -515,7 +515,7 @@
             height="16"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+            <use href="/assets/icons/svg/sprite.svg#close" />
           </svg>
         </button>
 
@@ -531,7 +531,7 @@
             height="16"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+            <use href="/assets/icons/svg/sprite.svg#close" />
           </svg>
         </button>
       </div>

--- a/packages/web/src/scss/components/Drawer/README.md
+++ b/packages/web/src/scss/components/Drawer/README.md
@@ -43,7 +43,7 @@ The `DrawerCloseButton` component is a button that closes the drawer when clicke
   aria-expanded="false"
 >
   <svg class="Icon" width="24" height="24" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#close" />
+    <use href="/icons/svg/sprite.svg#close" />
   </svg>
   <span class="accessibility-hidden">Close</span>
 </button>
@@ -76,7 +76,7 @@ The `DrawerPanel` component is a container for the content that will be displaye
         aria-controls="drawer-example"
       >
         <svg class="Icon" width="24" height="24" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#close" />
+          <use href="/icons/svg/sprite.svg#close" />
         </svg>
         <span class="accessibility-hidden">Close</span>
       </button>

--- a/packages/web/src/scss/components/Drawer/index.html
+++ b/packages/web/src/scss/components/Drawer/index.html
@@ -185,7 +185,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
               <span class="accessibility-hidden">Close</span>
             </button>

--- a/packages/web/src/scss/components/Dropdown/README.md
+++ b/packages/web/src/scss/components/Dropdown/README.md
@@ -16,25 +16,25 @@
   <div class="DropdownPopover placement-bottom-start" data-spirit-placement="bottom-start" id="dropdown-default">
     <a href="#" class="d-flex mb-400">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#info" />
+        <use href="/icons/svg/sprite.svg#info" />
       </svg>
       <span>Information</span>
     </a>
     <a href="#" class="d-flex mb-400">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#link" />
+        <use href="/icons/svg/sprite.svg#link" />
       </svg>
       <span>Bibendum aliquam, fusce integer sit amet congue non nulla aliquet enim</span>
     </a>
     <a href="#" class="d-flex mb-400">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#profile" />
+        <use href="/icons/svg/sprite.svg#profile" />
       </svg>
       <span>Profile</span>
     </a>
     <a href="#" class="d-flex">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#help" />
+        <use href="/icons/svg/sprite.svg#help" />
       </svg>
       <span>Help</span>
     </a>
@@ -58,25 +58,25 @@
   <div class="DropdownPopover placement-top-end" data-spirit-placement="top-end" id="dropdown-top-end">
     <a href="#" class="d-flex mb-400">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#info" />
+        <use href="/icons/svg/sprite.svg#info" />
       </svg>
       <span>Information</span>
     </a>
     <a href="#" class="d-flex mb-400">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#link" />
+        <use href="/icons/svg/sprite.svg#link" />
       </svg>
       <span>Bibendum aliquam, fusce integer sit amet congue non nulla aliquet enim</span>
     </a>
     <a href="#" class="d-flex mb-400">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#profile" />
+        <use href="/icons/svg/sprite.svg#profile" />
       </svg>
       <span>Profile</span>
     </a>
     <a href="#" class="d-flex">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#help" />
+        <use href="/icons/svg/sprite.svg#help" />
       </svg>
       <span>Help</span>
     </a>
@@ -105,25 +105,25 @@
   >
     <a href="#" class="d-flex mb-400">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#info" />
+        <use href="/icons/svg/sprite.svg#info" />
       </svg>
       <span>Information</span>
     </a>
     <a href="#" class="d-flex mb-400">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#link" />
+        <use href="/icons/svg/sprite.svg#link" />
       </svg>
       <span>Bibendum aliquam, fusce integer sit amet congue non nulla aliquet enim</span>
     </a>
     <a href="#" class="d-flex mb-400">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#profile" />
+        <use href="/icons/svg/sprite.svg#profile" />
       </svg>
       <span>Profile</span>
     </a>
     <a href="#" class="d-flex">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#help" />
+        <use href="/icons/svg/sprite.svg#help" />
       </svg>
       <span>Help</span>
     </a>
@@ -152,25 +152,25 @@
   >
     <a href="#" class="d-flex mb-400">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#info" />
+        <use href="/icons/svg/sprite.svg#info" />
       </svg>
       <span>Information</span>
     </a>
     <a href="#" class="d-flex mb-400">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#link" />
+        <use href="/icons/svg/sprite.svg#link" />
       </svg>
       <span>Bibendum aliquam, fusce integer sit amet congue non nulla aliquet enim</span>
     </a>
     <a href="#" class="d-flex mb-400">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#profile" />
+        <use href="/icons/svg/sprite.svg#profile" />
       </svg>
       <span>Profile</span>
     </a>
     <a href="#" class="d-flex">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#help" />
+        <use href="/icons/svg/sprite.svg#help" />
       </svg>
       <span>Help</span>
     </a>
@@ -199,25 +199,25 @@
   >
     <a href="#" class="d-flex mb-400">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#info" />
+        <use href="/icons/svg/sprite.svg#info" />
       </svg>
       <span>Information</span>
     </a>
     <a href="#" class="d-flex mb-400">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#link" />
+        <use href="/icons/svg/sprite.svg#link" />
       </svg>
       <span>Bibendum aliquam, fusce integer sit amet congue non nulla aliquet enim</span>
     </a>
     <a href="#" class="d-flex mb-400">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#profile" />
+        <use href="/icons/svg/sprite.svg#profile" />
       </svg>
       <span>Profile</span>
     </a>
     <a href="#" class="d-flex">
       <svg width="24" height="24" aria-hidden="true" class="Icon mr-400">
-        <use xlink:href="/icons/svg/sprite.svg#help" />
+        <use href="/icons/svg/sprite.svg#help" />
       </svg>
       <span>Help</span>
     </a>
@@ -244,7 +244,7 @@ See the [Item][item] component for more information.
     <a href="#" class="Item">
       <span class="Item__icon Item__icon--start">
         <svg class="Icon" width="24" height="24" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#info" />
+          <use href="/icons/svg/sprite.svg#info" />
         </svg>
       </span>
       <span class="Item__label">Information</span>

--- a/packages/web/src/scss/components/Dropdown/index.html
+++ b/packages/web/src/scss/components/Dropdown/index.html
@@ -333,7 +333,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                <use href="/assets/icons/svg/sprite.svg#info" />
               </svg>
             </span>
             <span class="Item__label">Item with icon</span>
@@ -403,7 +403,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                <use href="/assets/icons/svg/sprite.svg#info" />
               </svg>
             </span>
             <span class="Item__label">Information</span>
@@ -416,7 +416,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#link" />
+                <use href="/assets/icons/svg/sprite.svg#link" />
               </svg>
             </span>
             <span class="Item__label">Bibendum aliquam, fusce integer sit amet congue non nulla aliquet enim</span>
@@ -429,7 +429,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                <use href="/assets/icons/svg/sprite.svg#profile" />
               </svg>
             </span>
             <span class="Item__label">Profile</span>
@@ -442,7 +442,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#help" />
+                <use href="/assets/icons/svg/sprite.svg#help" />
               </svg>
             </span>
             <span class="Item__label">Help</span>
@@ -488,7 +488,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                <use href="/assets/icons/svg/sprite.svg#info" />
               </svg>
             </span>
             <span class="Item__label">Bibendum aliquam, fusce integer sit amet congue non nulla aliquet enim</span>
@@ -501,7 +501,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#link" />
+                <use href="/assets/icons/svg/sprite.svg#link" />
               </svg>
             </span>
             <span class="Item__label">Nulla condimentum, purus commodo cursus non nulla rhoncus</span>
@@ -514,7 +514,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                <use href="/assets/icons/svg/sprite.svg#profile" />
               </svg>
             </span>
             <span class="Item__label">Mauris nunc, elementum enim in lacinia vitae quam placerat sem, euismod accumsan</span>
@@ -527,7 +527,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#help" />
+                <use href="/assets/icons/svg/sprite.svg#help" />
               </svg>
             </span>
             <span class="Item__label">Donec dui, nunc dui vel varius libero molestie nibh nunc</span>
@@ -574,7 +574,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                <use href="/assets/icons/svg/sprite.svg#info" />
               </svg>
             </span>
             <span class="Item__label">Information</span>
@@ -587,7 +587,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#link" />
+                <use href="/assets/icons/svg/sprite.svg#link" />
               </svg>
             </span>
             <span class="Item__label">Bibendum aliquam, fusce integer sit amet congue non nulla aliquet enim</span>
@@ -600,7 +600,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                <use href="/assets/icons/svg/sprite.svg#profile" />
               </svg>
             </span>
             <span class="Item__label">Profile</span>
@@ -613,7 +613,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#help" />
+                <use href="/assets/icons/svg/sprite.svg#help" />
               </svg>
             </span>
             <span class="Item__label">Help</span>
@@ -659,7 +659,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                <use href="/assets/icons/svg/sprite.svg#info" />
               </svg>
             </span>
             <span class="Item__label">Information</span>
@@ -672,7 +672,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#link" />
+                <use href="/assets/icons/svg/sprite.svg#link" />
               </svg>
             </span>
             <span class="Item__label">Bibendum aliquam, fusce integer sit amet congue non nulla aliquet enim</span>
@@ -685,7 +685,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                <use href="/assets/icons/svg/sprite.svg#profile" />
               </svg>
             </span>
             <span class="Item__label">Profile</span>
@@ -698,7 +698,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#help" />
+                <use href="/assets/icons/svg/sprite.svg#help" />
               </svg>
             </span>
             <span class="Item__label">Help</span>

--- a/packages/web/src/scss/components/FieldGroup/README.md
+++ b/packages/web/src/scss/components/FieldGroup/README.md
@@ -149,7 +149,7 @@ See Validation state [dictionary][dictionary-validation] and [ValidationText][re
 
 <div id="field-group-danger-validation-text" class="ValidationText ValidationText--danger">
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
+    <use href="/assets/icons/svg/sprite.svg#warning" />
   </svg>
   <div>Warning validation text with icon</div>
 </div>

--- a/packages/web/src/scss/components/FieldGroup/index.html
+++ b/packages/web/src/scss/components/FieldGroup/index.html
@@ -271,9 +271,9 @@
             aria-hidden="true"
           >
             {{#if (eq state "success")}}
-            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+            <use href="/assets/icons/svg/sprite.svg#check-plain" />
             {{else}}
-            <use xlink:href="/assets/icons/svg/sprite.svg#{{state}}" />
+            <use href="/assets/icons/svg/sprite.svg#{{state}}" />
             {{/if}}
           </svg>
           <div>This is {{state}} validation text with icon.</div>

--- a/packages/web/src/scss/components/FileUploader/README.md
+++ b/packages/web/src/scss/components/FileUploader/README.md
@@ -82,7 +82,7 @@ To add helper text, use the [HelperText][readme-helper-text] component:
   />
   <div class="FileUploaderInput__dropZone" data-spirit-element="dropZone">
     <svg class="Icon" width="24" height="24" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#upload" />
+      <use href="/icons/svg/sprite.svg#upload" />
     </svg>
     <label for="file-uploader" class="FileUploaderInput__dropZoneLabel">
       <span class="FileUploaderInput__link link-primary link-underlined">Upload your file</span>
@@ -244,7 +244,7 @@ When validated on server:
   <!-- Drop zone with input -->
   <div class="ValidationText ValidationText--warning">
     <svg class="Icon" width="20" height="20" aria-hidden="true">
-      <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
+      <use href="/assets/icons/svg/sprite.svg#warning" />
     </svg>
     <div>Warning validation text with icon</div>
   </div>
@@ -338,7 +338,7 @@ truncated.
 <li class="FileUploaderAttachment">
   <!-- File icon: -->
   <svg class="Icon" width="24" height="24" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#file" />
+    <use href="/icons/svg/sprite.svg#file" />
   </svg>
   <!-- File name: -->
   <span class="FileUploaderAttachment__name">
@@ -348,7 +348,7 @@ truncated.
   <button type="button" class="FileUploaderAttachment__action">
     <span class="accessibility-hidden">Remove</span>
     <svg class="Icon" width="24" height="24" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#close" />
+      <use href="/icons/svg/sprite.svg#close" />
     </svg>
   </button>
 </li>
@@ -364,7 +364,7 @@ pick up the template and apply it on any attachments the user wants to upload.
   <template data-spirit-snippet="item">
     <li class="FileUploaderAttachment" data-spirit-populate-field="item">
       <svg class="Icon" width="24" height="24" aria-hidden="true">
-        <use xlink:href="/icons/svg/sprite.svg#file" />
+        <use href="/icons/svg/sprite.svg#file" />
       </svg>
       <span class="FileUploaderAttachment__name">
         <span class="text-truncate" data-spirit-populate-field="name">File name</span>
@@ -372,7 +372,7 @@ pick up the template and apply it on any attachments the user wants to upload.
       <button type="button" class="FileUploaderAttachment__action" data-spirit-populate-field="button">
         <span class="accessibility-hidden">Remove</span>
         <svg class="Icon" width="24" height="24" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#close" />
+          <use href="/icons/svg/sprite.svg#close" />
         </svg>
       </button>
     </li>
@@ -414,7 +414,7 @@ Full example:
   <button type="button" class="FileUploaderAttachment__action">
     <span class="accessibility-hidden">Remove</span>
     <svg class="Icon" width="24" height="24" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#close" />
+      <use href="/icons/svg/sprite.svg#close" />
     </svg>
   </button>
 </li>
@@ -430,7 +430,7 @@ You can add custom actions to the FileUploaderAttachment.
   <button type="button" class="FileUploaderAttachment__action">
     <span class="accessibility-hidden">Edit</span>
     <svg class="Icon" width="24" height="24" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#edit" />
+      <use href="/icons/svg/sprite.svg#edit" />
     </svg>
   </button>
   <!-- Custom action: end -->
@@ -442,7 +442,7 @@ Full example:
 ```html
 <li class="FileUploaderAttachment">
   <svg class="Icon" width="24" height="24" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#file" />
+    <use href="/icons/svg/sprite.svg#file" />
   </svg>
   <span class="FileUploaderAttachment__name">
     <span class="text-truncate">My resume.docx</span>
@@ -452,7 +452,7 @@ Full example:
     <button type="button" class="FileUploaderAttachment__action">
       <span class="accessibility-hidden">Edit</span>
       <svg class="Icon" width="24" height="24" aria-hidden="true">
-        <use xlink:href="/icons/svg/sprite.svg#edit" />
+        <use href="/icons/svg/sprite.svg#edit" />
       </svg>
     </button>
     <!-- Custom action: end -->
@@ -460,7 +460,7 @@ Full example:
   <button type="button" class="FileUploaderAttachment__action">
     <span class="accessibility-hidden">Remove</span>
     <svg class="Icon" width="24" height="24" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#close" />
+      <use href="/icons/svg/sprite.svg#close" />
     </svg>
   </button>
 </li>
@@ -560,7 +560,7 @@ This is how all subcomponents build up the complete FileUploader:
   <template data-spirit-snippet="item">
     <li class="FileUploaderAttachment" data-spirit-populate-field="item">
       <svg class="Icon" width="24" height="24" aria-hidden="true">
-        <use xlink:href="/icons/svg/sprite.svg#file" />
+        <use href="/icons/svg/sprite.svg#file" />
       </svg>
       <span class="FileUploaderAttachment__name">
         <span class="text-truncate" data-spirit-populate-field="name">File name</span>
@@ -568,7 +568,7 @@ This is how all subcomponents build up the complete FileUploader:
       <button type="button" class="FileUploaderAttachment__action" data-spirit-populate-field="button">
         <span class="accessibility-hidden">Remove</span>
         <svg class="Icon" width="24" height="24" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#close" />
+          <use href="/icons/svg/sprite.svg#close" />
         </svg>
       </button>
     </li>
@@ -587,7 +587,7 @@ This is how all subcomponents build up the complete FileUploader:
     />
     <div class="FileUploaderInput__dropZone" data-spirit-element="dropZone">
       <svg class="Icon" width="24" height="24" aria-hidden="true">
-        <use xlink:href="/icons/svg/sprite.svg#upload" />
+        <use href="/icons/svg/sprite.svg#upload" />
       </svg>
       <label for="file-uploader-with-attachments" class="FileUploaderInput__dropZoneLabel">
         <span class="FileUploaderInput__link link-primary link-underlined">Upload your file</span>
@@ -604,7 +604,7 @@ This is how all subcomponents build up the complete FileUploader:
     <!-- FileUploaderAttachment INSERTED BY THE JS PLUGIN: start -->
     <li class="FileUploaderAttachment">
       <svg class="Icon" width="24" height="24" aria-hidden="true">
-        <use xlink:href="/icons/svg/sprite.svg#file" />
+        <use href="/icons/svg/sprite.svg#file" />
       </svg>
       <span class="FileUploaderAttachment__name">
         <span class="text-truncate">My resume.docx</span>
@@ -612,7 +612,7 @@ This is how all subcomponents build up the complete FileUploader:
       <button type="button" class="FileUploaderAttachment__action">
         <span class="accessibility-hidden">Remove</span>
         <svg class="Icon" width="24" height="24" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#close" />
+          <use href="/icons/svg/sprite.svg#close" />
         </svg>
       </button>
     </li>

--- a/packages/web/src/scss/components/FileUploader/index.html
+++ b/packages/web/src/scss/components/FileUploader/index.html
@@ -25,7 +25,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span
@@ -45,7 +45,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -80,7 +80,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <label
               for="file-uploader"
@@ -139,7 +139,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span
@@ -159,7 +159,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -193,7 +193,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <label
               for="file-uploader-multiple"
@@ -251,7 +251,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span
@@ -271,7 +271,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -306,7 +306,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <label
               for="file-uploader-multiple-with-accept"
@@ -366,7 +366,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span
@@ -386,7 +386,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -422,7 +422,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <label
               for="file-uploader-with-dismissible"
@@ -479,7 +479,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span
@@ -499,7 +499,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -532,7 +532,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <label
               for="file-uploader-success"
@@ -578,7 +578,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span
@@ -598,7 +598,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -631,7 +631,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <label
               for="file-uploader-warning"
@@ -677,7 +677,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span
@@ -697,7 +697,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -730,7 +730,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <label
               for="file-uploader-danger"
@@ -795,7 +795,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span
@@ -815,7 +815,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -848,7 +848,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <label
               for="file-uploader-{{state}}-validation-icon"
@@ -867,9 +867,9 @@
               aria-hidden="true"
             >
               {{#if (eq state "success")}}
-              <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+              <use href="/assets/icons/svg/sprite.svg#check-plain" />
               {{else}}
-              <use xlink:href="/assets/icons/svg/sprite.svg#{{state}}" />
+              <use href="/assets/icons/svg/sprite.svg#{{state}}" />
               {{/if}}
             </svg>
             <div>This is {{state}} validation text. Long validation text to show how it wraps.</div>
@@ -921,7 +921,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span
@@ -941,7 +941,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -975,7 +975,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <label
               for="file-uploader-disabled"
@@ -1040,7 +1040,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span class="text-truncate">Document.pdf</span>
@@ -1056,7 +1056,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -1088,7 +1088,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#edit" />
+                  <use href="/assets/icons/svg/sprite.svg#edit" />
                 </svg>
               </button>
               <!-- Slot content: end -->
@@ -1104,7 +1104,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -1136,7 +1136,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -1231,7 +1231,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span
@@ -1253,7 +1253,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#edit" />
+                  <use href="/assets/icons/svg/sprite.svg#edit" />
                 </svg>
               </button>
               <!-- Slot content: end -->
@@ -1270,7 +1270,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -1304,7 +1304,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <label
               for="file-uploader-with-image-preview"
@@ -1409,7 +1409,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span
@@ -1431,7 +1431,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#edit" />
+                  <use href="/assets/icons/svg/sprite.svg#edit" />
                 </svg>
               </button>
               <!-- Slot content: end -->
@@ -1448,7 +1448,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -1482,7 +1482,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <label
               for="file-uploader-with-custom-attachment-actions"
@@ -1605,7 +1605,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span
@@ -1627,7 +1627,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#edit" />
+                  <use href="/assets/icons/svg/sprite.svg#edit" />
                 </svg>
               </button>
               <!-- Slot content: end -->
@@ -1644,7 +1644,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -1679,7 +1679,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <label
               for="file-uploader-with-meta-data"
@@ -1866,7 +1866,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <label
               for="file-uploader-with-attachments"
@@ -1898,7 +1898,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span class="text-truncate">My resume.docx</span>
@@ -1914,7 +1914,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -1954,7 +1954,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <label
               for="file-uploader-with-attachments-and-validation"
@@ -1987,7 +1987,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span class="text-truncate">My resume.docx</span>
@@ -2003,7 +2003,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -2017,7 +2017,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="FileUploaderAttachment__name">
               <span class="text-truncate">
@@ -2035,7 +2035,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </li>
@@ -2090,7 +2090,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <label
               for="file-uploader-not-draggable"
@@ -2148,7 +2148,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+                <use href="/assets/icons/svg/sprite.svg#file" />
               </svg>
               <span class="FileUploaderAttachment__name">
                 <span
@@ -2168,7 +2168,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
               </button>
             </li>
@@ -2203,7 +2203,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+                <use href="/assets/icons/svg/sprite.svg#upload" />
               </svg>
               <label
                 for="file-upload-in-form"

--- a/packages/web/src/scss/components/Footer/README.md
+++ b/packages/web/src/scss/components/Footer/README.md
@@ -99,7 +99,7 @@ Use the secondary [Button][button] component to create social media links inside
     <a href="https://www.example.com" class="Button Button--secondary Button--medium Button--symmetrical">
       <span class="accessibility-hidden">Facebook</span>
       <svg class="Icon" width="24" height="24" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#logo-facebook" />
+        <use href="/assets/icons/svg/sprite.svg#logo-facebook" />
       </svg>
     </a>
   </li>
@@ -222,7 +222,7 @@ Responsive values can be defined using the `tablet` and `desktop` infixes.
           <a href="https://www.example.com" class="Button Button--secondary Button--medium Button--symmetrical">
             <span class="accessibility-hidden">Facebook</span>
             <svg class="Icon" width="24" height="24" aria-hidden="true">
-              <use xlink:href="/assets/icons/svg/sprite.svg#logo-facebook" />
+              <use href="/assets/icons/svg/sprite.svg#logo-facebook" />
             </svg>
           </a>
         </li>
@@ -230,7 +230,7 @@ Responsive values can be defined using the `tablet` and `desktop` infixes.
           <a href="https://www.example.com" class="Button Button--secondary Button--medium Button--symmetrical">
             <span class="accessibility-hidden">X</span>
             <svg class="Icon" width="24" height="24" aria-hidden="true">
-              <use xlink:href="/assets/icons/svg/sprite.svg#logo-x" />
+              <use href="/assets/icons/svg/sprite.svg#logo-x" />
             </svg>
           </a>
         </li>
@@ -238,7 +238,7 @@ Responsive values can be defined using the `tablet` and `desktop` infixes.
           <a href="https://www.example.com" class="Button Button--secondary Button--medium Button--symmetrical">
             <span class="accessibility-hidden">YouTube</span>
             <svg class="Icon" width="24" height="24" aria-hidden="true">
-              <use xlink:href="/assets/icons/svg/sprite.svg#logo-youtube" />
+              <use href="/assets/icons/svg/sprite.svg#logo-youtube" />
             </svg>
           </a>
         </li>
@@ -254,7 +254,7 @@ Responsive values can be defined using the `tablet` and `desktop` infixes.
             </select>
             <div class="InputAddon">
               <svg class="Icon" width="20" height="20" aria-hidden="true">
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </div>
           </div>

--- a/packages/web/src/scss/components/Footer/index.html
+++ b/packages/web/src/scss/components/Footer/index.html
@@ -231,7 +231,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#logo-facebook" />
+                  <use href="/assets/icons/svg/sprite.svg#logo-facebook" />
                 </svg>
               </a>
             </li>
@@ -247,7 +247,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#logo-x" />
+                  <use href="/assets/icons/svg/sprite.svg#logo-x" />
                 </svg>
               </a>
             </li>
@@ -263,7 +263,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#logo-youtube" />
+                  <use href="/assets/icons/svg/sprite.svg#logo-youtube" />
                 </svg>
               </a>
             </li>
@@ -279,7 +279,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#logo-google" />
+                  <use href="/assets/icons/svg/sprite.svg#logo-google" />
                 </svg>
               </a>
             </li>
@@ -295,7 +295,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#logo-linkedin" />
+                  <use href="/assets/icons/svg/sprite.svg#logo-linkedin" />
                 </svg>
               </a>
             </li>
@@ -323,7 +323,7 @@
                     height="20"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                    <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                   </svg>
                 </div>
               </div>
@@ -737,7 +737,7 @@
                     height="20"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                    <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                   </svg>
                 </div>
               </div>

--- a/packages/web/src/scss/components/Header/README.md
+++ b/packages/web/src/scss/components/Header/README.md
@@ -154,7 +154,7 @@ and `aria-controls` attributes.
   aria-expanded="false"
 >
   <svg class="Icon" width="24" height="24" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
   <span class="accessibility-hidden">Menu</span>
 </button>
@@ -268,7 +268,7 @@ Close button closes the Header Dialog using our Off-canvas JavaScript plugin.
   aria-expanded="false"
 >
   <svg class="Icon" width="24" height="24" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#close" />
+    <use href="/icons/svg/sprite.svg#close" />
   </svg>
   <span class="accessibility-hidden">Close</span>
 </button>
@@ -383,7 +383,7 @@ And the complete Header Dialog:
       aria-expanded="false"
     >
       <svg class="Icon" width="24" height="24" aria-hidden="true">
-        <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+        <use href="/icons/svg/sprite.svg#hamburger" />
       </svg>
       <span class="accessibility-hidden">Menu</span>
     </button>
@@ -437,7 +437,7 @@ And the complete Header Dialog:
         aria-expanded="false"
       >
         <svg class="Icon" width="24" height="24" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#close" />
+          <use href="/icons/svg/sprite.svg#close" />
         </svg>
         <span class="accessibility-hidden">Close</span>
       </button>

--- a/packages/web/src/scss/components/Header/index.html
+++ b/packages/web/src/scss/components/Header/index.html
@@ -52,7 +52,7 @@
             height="24"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#hamburger" />
+            <use href="/assets/icons/svg/sprite.svg#hamburger" />
           </svg>
           <span class="accessibility-hidden">Menu</span>
         </button>
@@ -123,7 +123,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -207,7 +207,7 @@
             height="24"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#hamburger" />
+            <use href="/assets/icons/svg/sprite.svg#hamburger" />
           </svg>
           <span class="accessibility-hidden">Menu</span>
         </button>
@@ -265,7 +265,7 @@
             height="24"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#search" />
+            <use href="/assets/icons/svg/sprite.svg#search" />
           </svg>
           <span class="accessibility-hidden">Search</span>
         </button>
@@ -301,7 +301,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -395,7 +395,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>

--- a/packages/web/src/scss/components/HelperText/index.html
+++ b/packages/web/src/scss/components/HelperText/index.html
@@ -148,7 +148,7 @@
             height="24"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+            <use href="/assets/icons/svg/sprite.svg#check-plain" />
           </svg>
         </span>
       </button>

--- a/packages/web/src/scss/components/Icon/README.md
+++ b/packages/web/src/scss/components/Icon/README.md
@@ -4,7 +4,7 @@
 
 ```html
 <svg class="Icon" width="24" height="24" style="--spirit-icon-size: 1.5rem;">
-  <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+  <use href="/assets/icons/svg/sprite.svg#info" />
 </svg>
 ```
 
@@ -24,7 +24,7 @@ Available colors include `text`, `emotion`, and `accent` colors.
 
 ```html
 <svg class="Icon Icon--success" width="24" height="24">
-  <use xlink:href="/assets/icons/svg/sprite.svg#shield-dualtone" />
+  <use href="/assets/icons/svg/sprite.svg#shield-dualtone" />
 </svg>
 ```
 
@@ -48,7 +48,7 @@ For a single (non-responsive) size, use inline style with `--spirit-icon-size`.
 
 ```html
 <svg class="Icon" width="24" height="24" style="--spirit-icon-size: 1.5rem;">
-  <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+  <use href="/assets/icons/svg/sprite.svg#info" />
 </svg>
 ```
 
@@ -71,6 +71,6 @@ If only tablet or desktop is set, width and height is used for smaller breakpoin
     --spirit-icon-size-desktop: 2.5rem;
   "
 >
-  <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+  <use href="/assets/icons/svg/sprite.svg#info" />
 </svg>
 ```

--- a/packages/web/src/scss/components/Icon/preview.html
+++ b/packages/web/src/scss/components/Icon/preview.html
@@ -15,7 +15,7 @@
         height="24"
         style="--spirit-icon-size: 1.5rem;"
       >
-        <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+        <use href="/assets/icons/svg/sprite.svg#info" />
       </svg>
 
     </div>
@@ -41,7 +41,7 @@
              --spirit-icon-size-desktop: 2.5rem;
           "
       >
-        <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+        <use href="/assets/icons/svg/sprite.svg#info" />
       </svg>
 
     </div>
@@ -66,7 +66,7 @@
             height="24"
             style="--spirit-icon-size: 1.5rem;"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+            <use href="/assets/icons/svg/sprite.svg#file" />
           </svg>
           {{color}}
         </div>
@@ -82,7 +82,7 @@
             height="24"
             style="--spirit-icon-size: 1.5rem;"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+            <use href="/assets/icons/svg/sprite.svg#file" />
           </svg>
           {{color}}
         </div>
@@ -98,7 +98,7 @@
             height="24"
             style="--spirit-icon-size: 1.5rem;"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+            <use href="/assets/icons/svg/sprite.svg#file" />
           </svg>
           {{color}}
         </div>
@@ -125,7 +125,7 @@
             height="24"
             style="--spirit-icon-size: 1.5rem;"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#folder-dualtone" />
+            <use href="/assets/icons/svg/sprite.svg#folder-dualtone" />
           </svg>
           {{color}}
         </div>
@@ -141,7 +141,7 @@
             height="24"
             style="--spirit-icon-size: 1.5rem;"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#folder-dualtone" />
+            <use href="/assets/icons/svg/sprite.svg#folder-dualtone" />
           </svg>
           {{color}}
         </div>
@@ -157,7 +157,7 @@
             height="24"
             style="--spirit-icon-size: 1.5rem;"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#folder-dualtone" />
+            <use href="/assets/icons/svg/sprite.svg#folder-dualtone" />
           </svg>
           {{color}}
         </div>

--- a/packages/web/src/scss/components/InputAddon/index.html
+++ b/packages/web/src/scss/components/InputAddon/index.html
@@ -36,7 +36,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#visibility-on" />
+                  <use href="/assets/icons/svg/sprite.svg#visibility-on" />
                 </svg>
               </span>
               <span class="accessibility-checked">
@@ -46,7 +46,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#visibility-off" />
+                  <use href="/assets/icons/svg/sprite.svg#visibility-off" />
                 </svg>
               </span>
             </button>
@@ -87,7 +87,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#search" />
+              <use href="/assets/icons/svg/sprite.svg#search" />
             </svg>
             <span class="accessibility-hidden">Use search to find jobs for you</span>
           </label>
@@ -207,7 +207,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#link" />
+              <use href="/assets/icons/svg/sprite.svg#link" />
             </svg>
             <span class="accessibility-hidden">Profile URL</span>
           </label>
@@ -233,7 +233,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </div>
@@ -284,7 +284,7 @@
                     height="16"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#visibility-on" />
+                    <use href="/assets/icons/svg/sprite.svg#visibility-on" />
                   </svg>
                 </span>
                 <span class="accessibility-checked">
@@ -294,7 +294,7 @@
                     height="16"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#visibility-off" />
+                    <use href="/assets/icons/svg/sprite.svg#visibility-off" />
                   </svg>
                 </span>
               </button>
@@ -335,7 +335,7 @@
                     height="20"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#visibility-on" />
+                    <use href="/assets/icons/svg/sprite.svg#visibility-on" />
                   </svg>
                 </span>
                 <span class="accessibility-checked">
@@ -345,7 +345,7 @@
                     height="20"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#visibility-off" />
+                    <use href="/assets/icons/svg/sprite.svg#visibility-off" />
                   </svg>
                 </span>
               </button>
@@ -386,7 +386,7 @@
                     height="20"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#visibility-on" />
+                    <use href="/assets/icons/svg/sprite.svg#visibility-on" />
                   </svg>
                 </span>
                 <span class="accessibility-checked">
@@ -396,7 +396,7 @@
                     height="20"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#visibility-off" />
+                    <use href="/assets/icons/svg/sprite.svg#visibility-off" />
                   </svg>
                 </span>
               </button>

--- a/packages/web/src/scss/components/InputDetails/index.html
+++ b/packages/web/src/scss/components/InputDetails/index.html
@@ -220,7 +220,7 @@
           height="24"
           aria-hidden="true"
         >
-          <use xlink:href="/icons/svg/sprite.svg#close" />
+          <use href="/icons/svg/sprite.svg#close" />
         </svg>
         <span class="accessibility-hidden">Close</span>
       </button>
@@ -253,7 +253,7 @@
           height="24"
           aria-hidden="true"
         >
-          <use xlink:href="/icons/svg/sprite.svg#close" />
+          <use href="/icons/svg/sprite.svg#close" />
         </svg>
         <span class="accessibility-hidden">Close</span>
       </button>

--- a/packages/web/src/scss/components/Item/README.md
+++ b/packages/web/src/scss/components/Item/README.md
@@ -18,7 +18,7 @@ Item with icon example:
 <button type="button" class="Item">
   <span class="Item__icon Item__icon--start">
     <svg class="Icon" width="24" height="24" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#search" />
+      <use href="/icons/svg/sprite.svg#search" />
     </svg>
   </span>
   <span class="Label Label--item">Item</span>
@@ -34,7 +34,7 @@ Selected with icon only:
   <span class="Item__label">Item</span>
   <span class="Item__icon Item__icon--end">
     <svg class="Icon" width="24" height="24" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#check-plain" />
+      <use href="/icons/svg/sprite.svg#check-plain" />
     </svg>
   </span>
 </button>
@@ -55,7 +55,7 @@ Selected with background and icon:
   <span class="Label Label--item">Item</span>
   <span class="Item__icon Item__icon--end">
     <svg class="Icon" width="24" height="24" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#check-plain" />
+      <use href="/icons/svg/sprite.svg#check-plain" />
     </svg>
   </span>
 </button>
@@ -86,14 +86,14 @@ Item with icon and helper text in selected state example:
 <button type="button" class="Item Item--selected">
   <span class="Item__icon Item__icon--start">
     <svg class="Icon" width="24" height="24" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#search" />
+      <use href="/icons/svg/sprite.svg#search" />
     </svg>
   </span>
   <span class="Label Label--item">Item</span>
   <span class="HelperText HelperText--item">Helper text</span>
   <span class="Item__icon Item__icon--end">
     <svg class="Icon" width="24" height="24" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#check-plain" />
+      <use href="/icons/svg/sprite.svg#check-plain" />
     </svg>
   </span>
 </button>
@@ -148,7 +148,7 @@ Usage in [Dropdown][dropdown] component:
     <a href="#" class="Item">
       <span class="Item__icon Item__icon--start">
         <svg class="Icon" width="24" height="24" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#info" />
+          <use href="/icons/svg/sprite.svg#info" />
         </svg>
       </span>
       <span class="Label Label--item">Information</span>

--- a/packages/web/src/scss/components/Item/index.html
+++ b/packages/web/src/scss/components/Item/index.html
@@ -56,7 +56,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+              <use href="/assets/icons/svg/sprite.svg#check-plain" />
             </svg>
           </span>
         </button>
@@ -92,7 +92,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+              <use href="/assets/icons/svg/sprite.svg#check-plain" />
             </svg>
           </span>
         </button>
@@ -132,7 +132,7 @@
             height="24"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+            <use href="/assets/icons/svg/sprite.svg#check-plain" />
           </svg>
         </span>
       </button>
@@ -172,7 +172,7 @@
             height="24"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+            <use href="/assets/icons/svg/sprite.svg#check-plain" />
           </svg>
         </span>
       </button>
@@ -198,7 +198,7 @@
             height="24"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+            <use href="/assets/icons/svg/sprite.svg#check-plain" />
           </svg>
         </span>
       </button>
@@ -227,7 +227,7 @@
             height="24"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#search" />
+            <use href="/assets/icons/svg/sprite.svg#search" />
           </svg>
         </span>
         <span class="Label Label--item">Item label</span>
@@ -244,7 +244,7 @@
             height="24"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#search" />
+            <use href="/assets/icons/svg/sprite.svg#search" />
           </svg>
         </span>
         <span class="Label Label--item">Item label</span>
@@ -255,7 +255,7 @@
             height="24"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+            <use href="/assets/icons/svg/sprite.svg#check-plain" />
           </svg>
         </span>
       </button>

--- a/packages/web/src/scss/components/Label/index.html
+++ b/packages/web/src/scss/components/Label/index.html
@@ -170,7 +170,7 @@
             height="24"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+            <use href="/assets/icons/svg/sprite.svg#check-plain" />
           </svg>
         </span>
       </button>

--- a/packages/web/src/scss/components/Modal/README.md
+++ b/packages/web/src/scss/components/Modal/README.md
@@ -112,7 +112,7 @@ and allows users to easily close it.
     aria-expanded="false"
   >
     <svg class="Icon" width="24" height="24" aria-hidden="true">
-      <use xlink:href="/icons/svg/sprite.svg#close" />
+      <use href="/icons/svg/sprite.svg#close" />
     </svg>
     <span class="accessibility-hidden">Close</span>
   </button>
@@ -377,7 +377,7 @@ When you put it all together:
         aria-expanded="false"
       >
         <svg class="Icon" width="24" height="24" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#close" />
+          <use href="/icons/svg/sprite.svg#close" />
         </svg>
         <span class="accessibility-hidden">Close</span>
       </button>

--- a/packages/web/src/scss/components/Modal/index.html
+++ b/packages/web/src/scss/components/Modal/index.html
@@ -92,7 +92,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
               <span class="accessibility-hidden">Close</span>
             </button>
@@ -356,7 +356,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
               <span class="accessibility-hidden">Close</span>
             </button>
@@ -455,7 +455,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
               <span class="accessibility-hidden">Close</span>
             </button>
@@ -601,7 +601,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
               <span class="accessibility-hidden">Close</span>
             </button>
@@ -699,7 +699,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
               <span class="accessibility-hidden">Close</span>
             </button>
@@ -806,7 +806,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
               <span class="accessibility-hidden">Close</span>
             </button>
@@ -973,7 +973,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
               <span class="accessibility-hidden">Close</span>
             </button>
@@ -1378,7 +1378,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
               <span class="accessibility-hidden">Close</span>
             </button>
@@ -1449,7 +1449,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
               <span class="accessibility-hidden">Close</span>
             </button>
@@ -1558,7 +1558,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
               <span class="accessibility-hidden">Close</span>
             </button>

--- a/packages/web/src/scss/components/Navigation/README.md
+++ b/packages/web/src/scss/components/Navigation/README.md
@@ -105,7 +105,7 @@ The `NavigationAvatar` is a component that is styled to be used as a navigation 
 <a href="#" class="NavigationAvatar">
   <span class="Avatar Avatar--small" aria-label="Profile of Jiří Bárta">
     <svg class="Icon" width="20" height="20" aria-hidden="true">
-      <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+      <use href="/assets/icons/svg/sprite.svg#profile" />
     </svg>
   </span>
   <span class="typography-body-small-semibold">My Account</span>
@@ -118,7 +118,7 @@ If you want the avatar to be square, don't forget to add the `NavigationAvatar--
 <a href="#" class="NavigationAvatar NavigationAvatar--square">
   <span class="Avatar Avatar--square Avatar--small" aria-label="Profile of Jiří Bárta">
     <svg class="Icon" width="20" height="20" aria-hidden="true">
-      <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+      <use href="/assets/icons/svg/sprite.svg#profile" />
     </svg>
   </span>
   <span class="typography-body-small-semibold">My Account</span>
@@ -137,7 +137,7 @@ Available sizes: `xsmall`, `small`, `medium`, `large`, `xlarge`.
 <a href="#" class="NavigationAvatar">
   <span class="Avatar Avatar--xsmall" aria-label="Profile of Jiří Bárta">
     <svg class="Icon" width="16" height="16" aria-hidden="true">
-      <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+      <use href="/assets/icons/svg/sprite.svg#profile" />
     </svg>
   </span>
   <span class="typography-body-small-semibold">My Account</span>
@@ -150,7 +150,7 @@ You can also use responsive sizes with breakpoint-specific classes, e.g. `Avatar
 <a href="#" class="NavigationAvatar">
   <span class="Avatar Avatar--small Avatar--tablet--medium Avatar--desktop--large" aria-label="Profile of Jiří Bárta">
     <svg class="Icon" width="20" height="20" aria-hidden="true">
-      <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+      <use href="/assets/icons/svg/sprite.svg#profile" />
     </svg>
   </span>
   <span class="typography-body-small-semibold">My Account</span>
@@ -179,7 +179,7 @@ With NavigationAction and NavigationAvatar components:
       <a href="#" class="NavigationAvatar">
         <span class="Avatar Avatar--small" aria-label="Profile of Jiří Bárta">
           <svg class="Icon" width="20" height="20" aria-hidden="true">
-            <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+            <use href="/assets/icons/svg/sprite.svg#profile" />
           </svg>
         </span>
         <span class="typography-body-small-semibold">My Account</span>
@@ -204,7 +204,7 @@ With Buttons and NavigationAvatar:
       <a href="#" class="NavigationAvatar">
         <span class="Avatar Avatar--small" aria-label="Profile of Jiří Bárta">
           <svg class="Icon" width="20" height="20" aria-hidden="true">
-            <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+            <use href="/assets/icons/svg/sprite.svg#profile" />
           </svg>
         </span>
         <span class="typography-body-small-semibold">My Account</span>

--- a/packages/web/src/scss/components/Navigation/index.html
+++ b/packages/web/src/scss/components/Navigation/index.html
@@ -201,7 +201,7 @@
                   aria-hidden="true"
                   class="Icon accessibility-open"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-up" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-up" />
                 </svg>
                 <svg
                   width="20"
@@ -209,7 +209,7 @@
                   aria-hidden="true"
                   class="Icon accessibility-closed"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                 </svg>
               </button>
               <div
@@ -274,7 +274,7 @@
                 aria-hidden="true"
                 class="Icon accessibility-open"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-up" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-up" />
               </svg>
               <svg
                 width="20"
@@ -282,7 +282,7 @@
                 aria-hidden="true"
                 class="Icon accessibility-closed"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
             <div id="collapse-navigation" class="Collapse is-open">
@@ -396,7 +396,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                  <use href="/assets/icons/svg/sprite.svg#profile" />
                 </svg>
               </span>
               <span class="typography-body-small-semibold">My Account</span>
@@ -411,7 +411,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                  <use href="/assets/icons/svg/sprite.svg#profile" />
                 </svg>
               </span>
               <span class="typography-body-small-semibold">My Account</span>
@@ -445,7 +445,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                  <use href="/assets/icons/svg/sprite.svg#profile" />
                 </svg>
               </span>
               <span class="typography-body-small-semibold">My Account</span>
@@ -460,7 +460,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                  <use href="/assets/icons/svg/sprite.svg#profile" />
                 </svg>
               </span>
               <span class="typography-body-small-semibold">My Account</span>
@@ -503,7 +503,7 @@
                     height="20"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                    <use href="/assets/icons/svg/sprite.svg#profile" />
                   </svg>
                 </span>
                 <span class="typography-body-small-semibold">My Account</span>
@@ -513,7 +513,7 @@
                   aria-hidden="true"
                   class="Icon accessibility-open"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-up" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-up" />
                 </svg>
                 <svg
                   width="20"
@@ -521,7 +521,7 @@
                   aria-hidden="true"
                   class="Icon accessibility-closed"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                 </svg>
               </button>
               <div
@@ -567,7 +567,7 @@
                     height="20"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                    <use href="/assets/icons/svg/sprite.svg#profile" />
                   </svg>
                 </span>
                 <span class="typography-body-small-semibold">My Account</span>
@@ -577,7 +577,7 @@
                   aria-hidden="true"
                   class="Icon accessibility-open"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-up" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-up" />
                 </svg>
                 <svg
                   width="20"
@@ -585,7 +585,7 @@
                   aria-hidden="true"
                   class="Icon accessibility-closed"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                 </svg>
               </button>
               <div

--- a/packages/web/src/scss/components/Offcanvas/README.md
+++ b/packages/web/src/scss/components/Offcanvas/README.md
@@ -29,7 +29,7 @@ The `data-spirit-target` attribute accepts a CSS selector to apply the Offcanvas
   aria-expanded="false"
 >
   <svg class="Icon" width="24" height="24" aria-hidden="true">
-    <use xlink:href="/icons/svg/sprite.svg#hamburger" />
+    <use href="/icons/svg/sprite.svg#hamburger" />
   </svg>
   <span class="accessibility-hidden">Menu</span>
 </button>

--- a/packages/web/src/scss/components/Pagination/README.md
+++ b/packages/web/src/scss/components/Pagination/README.md
@@ -38,7 +38,7 @@ First item selected:
     <li class="Pagination__item">
       <a href="#" class="Button Button--secondary Button--symmetrical">
         <svg class="Icon" width="24" height="24" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
+          <use href="/icons/svg/sprite.svg#chevron-right" />
         </svg>
         <span class="accessibility-hidden">Next</span>
       </a>
@@ -55,7 +55,7 @@ Middle item selected:
     <li class="Pagination__item">
       <a href="#" class="Button Button--secondary Button--symmetrical">
         <svg class="Icon" width="24" height="24" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#chevron-left" />
+          <use href="/icons/svg/sprite.svg#chevron-left" />
         </svg>
         <span class="accessibility-hidden">Previous</span>
       </a>
@@ -93,7 +93,7 @@ Middle item selected:
     <li class="Pagination__item">
       <a href="#" class="Button Button--secondary Button--symmetrical">
         <svg class="Icon" width="24" height="24" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#chevron-right" />
+          <use href="/icons/svg/sprite.svg#chevron-right" />
         </svg>
         <span class="accessibility-hidden">Next</span>
       </a>
@@ -110,7 +110,7 @@ Last item selected:
     <li class="Pagination__item">
       <a href="#" class="Button Button--secondary Button--symmetrical">
         <svg class="Icon" width="24" height="24" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#chevron-left" />
+          <use href="/icons/svg/sprite.svg#chevron-left" />
         </svg>
         <span class="accessibility-hidden">Previous</span>
       </a>

--- a/packages/web/src/scss/components/Pagination/preview.html
+++ b/packages/web/src/scss/components/Pagination/preview.html
@@ -72,7 +72,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-right" />
               </svg>
               <span class="accessibility-hidden">Next</span>
             </a>
@@ -110,7 +110,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-left" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-left" />
               </svg>
               <span class="accessibility-hidden">Previous</span>
             </a>
@@ -176,7 +176,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-right" />
               </svg>
               <span class="accessibility-hidden">Next</span>
             </a>
@@ -214,7 +214,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-left" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-left" />
               </svg>
               <span class="accessibility-hidden">Previous</span>
             </a>
@@ -353,7 +353,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-right" />
               </svg>
               <span class="accessibility-hidden">Next</span>
             </a>

--- a/packages/web/src/scss/components/PricingPlan/README.md
+++ b/packages/web/src/scss/components/PricingPlan/README.md
@@ -119,7 +119,7 @@ description.
     <li class="PricingPlanBody__featureItem">
       <div class="PricingPlanBody__featureTitle">
         <svg class="Icon" width="16" height="16" aria-hidden="true">
-          <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+          <use href="/assets/icons/svg/sprite.svg#check-plain" />
         </svg>
         <div class="PricingPlanBody__featureTitleText">Feature name</div>
       </div>
@@ -170,7 +170,7 @@ The footer is optional and can contain additional information or disclaimers.
         <li class="PricingPlanBody__featureItem">
           <div class="PricingPlanBody__featureTitle">
             <svg class="Icon" width="16" height="16" aria-hidden="true">
-              <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+              <use href="/assets/icons/svg/sprite.svg#check-plain" />
             </svg>
             <div class="PricingPlanBody__featureTitleText">Feature name</div>
           </div>

--- a/packages/web/src/scss/components/PricingPlan/index.html
+++ b/packages/web/src/scss/components/PricingPlan/index.html
@@ -37,7 +37,7 @@
                     height="16"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                    <use href="/assets/icons/svg/sprite.svg#check-plain" />
                   </svg>
                   <div class="PricingPlanBody__featureTitleText">
                     Feature name
@@ -94,7 +94,7 @@
                     height="16"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                    <use href="/assets/icons/svg/sprite.svg#check-plain" />
                   </svg>
                   <div class="Tooltip" data-spirit-element="tooltip">
                     <button
@@ -127,7 +127,7 @@
                           height="24"
                           aria-hidden="true"
                         >
-                          <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                          <use href="/assets/icons/svg/sprite.svg#close" />
                         </svg>
                         <span class="accessibility-hidden">Close</span>
                       </button>
@@ -186,7 +186,7 @@
                     height="16"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                    <use href="/assets/icons/svg/sprite.svg#check-plain" />
                   </svg>
 
                   <button
@@ -227,7 +227,7 @@
                             height="24"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                            <use href="/assets/icons/svg/sprite.svg#close" />
                           </svg>
                           <span class="accessibility-hidden">Close</span>
                         </button>
@@ -315,7 +315,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
 
                           <button
@@ -356,7 +356,7 @@
                                     height="24"
                                     aria-hidden="true"
                                   >
-                                    <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                                    <use href="/assets/icons/svg/sprite.svg#close" />
                                   </svg>
                                   <span class="accessibility-hidden">Close</span>
                                 </button>
@@ -385,7 +385,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -403,7 +403,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -454,7 +454,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -472,7 +472,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -490,7 +490,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -536,7 +536,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -554,7 +554,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name with a very long name that should wrap to the next line
@@ -573,7 +573,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -591,7 +591,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -732,7 +732,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -750,7 +750,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -768,7 +768,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -826,7 +826,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -844,7 +844,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -862,7 +862,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -915,7 +915,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -933,7 +933,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name with a very long name that should wrap to the next line
@@ -952,7 +952,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name
@@ -970,7 +970,7 @@
                             height="16"
                             aria-hidden="true"
                           >
-                            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                            <use href="/assets/icons/svg/sprite.svg#check-plain" />
                           </svg>
                           <div class="PricingPlanBody__featureTitleText">
                             Feature name

--- a/packages/web/src/scss/components/ScrollView/README.md
+++ b/packages/web/src/scss/components/ScrollView/README.md
@@ -173,7 +173,7 @@ Notes:
       aria-label="Scroll up"
     >
       <svg class="Icon" width="16" height="16" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-up" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-up" />
       </svg>
     </button>
     <button
@@ -182,7 +182,7 @@ Notes:
       aria-label="Scroll down"
     >
       <svg class="Icon" width="16" height="16" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </button>
   </div>
@@ -206,7 +206,7 @@ Notes:
       aria-label="Scroll left"
     >
       <svg class="Icon" width="16" height="16" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-left" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-left" />
       </svg>
     </button>
     <button
@@ -215,7 +215,7 @@ Notes:
       aria-label="Scroll right"
     >
       <svg class="Icon" width="16" height="16" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-right" />
       </svg>
     </button>
   </div>

--- a/packages/web/src/scss/components/ScrollView/preview.html
+++ b/packages/web/src/scss/components/ScrollView/preview.html
@@ -378,7 +378,7 @@
               height="16"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-left" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-left" />
             </svg>
           </button>
           <button
@@ -392,7 +392,7 @@
               height="16"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-right" />
             </svg>
           </button>
         </div>
@@ -443,7 +443,7 @@
               height="16"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-left" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-left" />
             </svg>
           </button>
           <button
@@ -457,7 +457,7 @@
               height="16"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-right" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-right" />
             </svg>
           </button>
         </div>
@@ -510,7 +510,7 @@
                 height="16"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-up" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-up" />
               </svg>
             </button>
             <button
@@ -524,7 +524,7 @@
                 height="16"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
           </div>

--- a/packages/web/src/scss/components/SegmentedControl/README.md
+++ b/packages/web/src/scss/components/SegmentedControl/README.md
@@ -77,7 +77,7 @@ Consider using a `Tooltip` to provide additional context for the icons.
 <input type="radio" id="segmented-control-label" name="segmented" value="value" class="SegmentedControlItem__input" />
 <label for="segmented-control-label" class="SegmentedControlItem__label">
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/assets/icons/svg/sprite.svg#file"></use>
+    <use href="/assets/icons/svg/sprite.svg#file"></use>
   </svg>
   <span class="accessibility-hidden">Label</span>
 </label>
@@ -103,7 +103,7 @@ Consider using a `Tooltip` to provide additional context for the icons.
   />
   <label for="segmented-control-tooltip" class="SegmentedControlItem__label">
     <svg class="Icon" width="20" height="20" aria-hidden="true">
-      <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+      <use href="/assets/icons/svg/sprite.svg#file" />
     </svg>
     <span
       id="tooltip-label"
@@ -141,7 +141,7 @@ For detailed guidance on handling text truncation, translations, and multiple st
 <input type="radio" id="segmented-control-label" name="segmented" value="value" class="SegmentedControlItem__input" />
 <label for="segmented-control-label" class="SegmentedControlItem__label">
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/assets/icons/svg/sprite.svg#file"></use>
+    <use href="/assets/icons/svg/sprite.svg#file"></use>
   </svg>
   <span class="text-truncate">Label</span>
 </label>

--- a/packages/web/src/scss/components/SegmentedControl/index.html
+++ b/packages/web/src/scss/components/SegmentedControl/index.html
@@ -88,7 +88,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+                  <use href="/assets/icons/svg/sprite.svg#file" />
                 </svg>
                 <span class="accessibility-hidden">Label</span>
                 {{/if}}
@@ -99,7 +99,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+                  <use href="/assets/icons/svg/sprite.svg#file" />
                 </svg>
                 Label
                 {{/if}}
@@ -227,7 +227,7 @@
             height="20"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+            <use href="/assets/icons/svg/sprite.svg#file" />
           </svg>
           <span class="text-truncate">Label {{item }} {{#if (eq item "2")}} - this label will be truncated{{/if}}</span>
         </label>
@@ -276,7 +276,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span
               id="tooltip-label-{{item}}"
@@ -338,7 +338,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
             <span class="accessibility-hidden">Label</span>
             <span

--- a/packages/web/src/scss/components/Select/README.md
+++ b/packages/web/src/scss/components/Select/README.md
@@ -12,7 +12,7 @@ Basic usage:
     </select>
     <div class="InputAddon">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </div>
   </div>
@@ -31,7 +31,7 @@ Sizes (please note the icon size):
     </select>
     <div class="InputAddon">
       <svg class="Icon" width="16" height="16" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </div>
   </div>
@@ -45,7 +45,7 @@ Sizes (please note the icon size):
       </select>
       <div class="InputAddon">
         <svg class="Icon" width="20" height="20" aria-hidden="true">
-          <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+          <use href="/assets/icons/svg/sprite.svg#chevron-down" />
         </svg>
       </div>
     </div>
@@ -59,7 +59,7 @@ Sizes (please note the icon size):
         </select>
         <div class="InputAddon">
           <svg class="Icon" width="20" height="20" aria-hidden="true">
-            <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+            <use href="/assets/icons/svg/sprite.svg#chevron-down" />
           </svg>
         </div>
       </div>
@@ -81,7 +81,7 @@ Required select (requires a placeholder option):
     </select>
     <div class="InputAddon">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </div>
   </div>
@@ -100,7 +100,7 @@ Hidden label:
     </select>
     <div class="InputAddon">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </div>
   </div>
@@ -128,7 +128,7 @@ sure users give all needed details before sending the form.
     </select>
     <div class="InputAddon">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </div>
   </div>
@@ -144,7 +144,7 @@ sure users give all needed details before sending the form.
     </select>
     <div class="InputAddon">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </div>
   </div>
@@ -170,7 +170,7 @@ To add helper text, use the [HelperText][readme-helper-text] component:
     </select>
     <div class="InputAddon">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </div>
   </div>
@@ -198,7 +198,7 @@ or by adding a JS interaction class when controlled by JavaScript (`has-success`
     </select>
     <div class="InputAddon">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </div>
   </div>
@@ -213,7 +213,7 @@ or by adding a JS interaction class when controlled by JavaScript (`has-success`
     </select>
     <div class="InputAddon">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </div>
   </div>
@@ -229,7 +229,7 @@ or by adding a JS interaction class when controlled by JavaScript (`has-success`
     </select>
     <div class="InputAddon">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </div>
   </div>
@@ -250,13 +250,13 @@ or by adding a JS interaction class when controlled by JavaScript (`has-success`
     </select>
     <div class="InputAddon">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </div>
   </div>
   <div class="ValidationText ValidationText--warning" id="select-warning-icon-validation-text">
     <svg class="Icon" width="20" height="20" aria-hidden="true">
-      <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
+      <use href="/assets/icons/svg/sprite.svg#warning" />
     </svg>
     <div>Validation text with icon</div>
   </div>
@@ -280,7 +280,7 @@ class when controlled by JavaScript:
     </select>
     <div class="InputAddon">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </div>
   </div>
@@ -295,7 +295,7 @@ class when controlled by JavaScript:
     </select>
     <div class="InputAddon">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </div>
   </div>

--- a/packages/web/src/scss/components/Select/index.html
+++ b/packages/web/src/scss/components/Select/index.html
@@ -28,7 +28,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-down" />
             </svg>
           </div>
         </div>
@@ -70,7 +70,7 @@
                 height="16"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </div>
           </div>
@@ -101,7 +101,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </div>
           </div>
@@ -132,7 +132,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </div>
           </div>
@@ -182,7 +182,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-down" />
             </svg>
           </div>
         </div>
@@ -222,7 +222,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-down" />
             </svg>
           </div>
         </div>
@@ -266,7 +266,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-down" />
             </svg>
           </div>
         </div>
@@ -298,7 +298,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-down" />
             </svg>
           </div>
         </div>
@@ -339,7 +339,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-down" />
             </svg>
           </div>
         </div>
@@ -384,7 +384,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-down" />
             </svg>
           </div>
         </div>
@@ -424,7 +424,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-down" />
             </svg>
           </div>
         </div>
@@ -451,7 +451,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-down" />
             </svg>
           </div>
         </div>
@@ -482,7 +482,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-down" />
             </svg>
           </div>
         </div>
@@ -532,7 +532,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+              <use href="/assets/icons/svg/sprite.svg#chevron-down" />
             </svg>
           </div>
         </div>
@@ -547,9 +547,9 @@
             aria-hidden="true"
           >
             {{#if (eq state "success")}}
-            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+            <use href="/assets/icons/svg/sprite.svg#check-plain" />
             {{else}}
-            <use xlink:href="/assets/icons/svg/sprite.svg#{{state}}" />
+            <use href="/assets/icons/svg/sprite.svg#{{state}}" />
             {{/if}}
           </svg>
           <div>This is {{state}} validation text. Long validation text to show how it wraps.</div>

--- a/packages/web/src/scss/components/Slider/README.md
+++ b/packages/web/src/scss/components/Slider/README.md
@@ -172,7 +172,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
   />
   <div id="slider-warning-validation-text" class="ValidationText ValidationText--warning">
     <svg class="Icon" width="20" height="20" aria-hidden="true">
-      <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
+      <use href="/assets/icons/svg/sprite.svg#warning" />
     </svg>
     <div>Validation text with icon</div>
   </div>

--- a/packages/web/src/scss/components/Slider/index.html
+++ b/packages/web/src/scss/components/Slider/index.html
@@ -280,9 +280,9 @@
             aria-hidden="true"
           >
             {{#if (eq state "success")}}
-            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+            <use href="/assets/icons/svg/sprite.svg#check-plain" />
             {{else}}
-            <use xlink:href="/assets/icons/svg/sprite.svg#{{state}}" />
+            <use href="/assets/icons/svg/sprite.svg#{{state}}" />
             {{/if}}
           </svg>
           <div>This is {{state}} validation text. Long validation text to show how it wraps.</div>

--- a/packages/web/src/scss/components/Spinner/README.md
+++ b/packages/web/src/scss/components/Spinner/README.md
@@ -5,15 +5,15 @@ It is just a combination of the Icon component and the utility classes.
 
 ```html
 <svg width="24" height="24" class="Icon animation-spin-clockwise">
-  <use xlink:href="/icons/svg/sprite.svg#spinner" />
+  <use href="/icons/svg/sprite.svg#spinner" />
 </svg>
 <svg width="24" height="24" class="Icon text-primary animation-spin-clockwise">
-  <use xlink:href="/icons/svg/sprite.svg#spinner" />
+  <use href="/icons/svg/sprite.svg#spinner" />
 </svg>
 <svg width="24" height="24" class="Icon text-secondary animation-spin-clockwise">
-  <use xlink:href="/icons/svg/sprite.svg#spinner" />
+  <use href="/icons/svg/sprite.svg#spinner" />
 </svg>
 <svg width="24" height="24" class="Icon text-tertiary animation-spin-clockwise">
-  <use xlink:href="/icons/svg/sprite.svg#spinner" />
+  <use href="/icons/svg/sprite.svg#spinner" />
 </svg>
 ```

--- a/packages/web/src/scss/components/Spinner/preview.html
+++ b/packages/web/src/scss/components/Spinner/preview.html
@@ -11,7 +11,7 @@
         height="24"
         class="animation-spin-clockwise"
       >
-        <use xlink:href="/assets/icons/svg/sprite.svg#spinner"/>
+        <use href="/assets/icons/svg/sprite.svg#spinner"/>
       </svg>
 
     </div>
@@ -33,7 +33,7 @@
         height="24"
         class="animation-spin-clockwise"
       >
-        <use xlink:href="/assets/icons/svg/sprite.svg#spinner"/>
+        <use href="/assets/icons/svg/sprite.svg#spinner"/>
       </svg>
 
       <svg
@@ -41,7 +41,7 @@
         height="24"
         class="text-primary animation-spin-clockwise"
       >
-        <use xlink:href="/assets/icons/svg/sprite.svg#spinner"/>
+        <use href="/assets/icons/svg/sprite.svg#spinner"/>
       </svg>
 
       <svg
@@ -49,7 +49,7 @@
         height="24"
         class="text-secondary animation-spin-clockwise"
       >
-        <use xlink:href="/assets/icons/svg/sprite.svg#spinner"/>
+        <use href="/assets/icons/svg/sprite.svg#spinner"/>
       </svg>
 
       <svg
@@ -57,7 +57,7 @@
         height="24"
         class="text-tertiary animation-spin-clockwise"
       >
-        <use xlink:href="/assets/icons/svg/sprite.svg#spinner"/>
+        <use href="/assets/icons/svg/sprite.svg#spinner"/>
       </svg>
 
     </div>
@@ -79,7 +79,7 @@
         height="36"
         class="animation-spin-clockwise"
       >
-        <use xlink:href="/assets/icons/svg/sprite.svg#spinner"/>
+        <use href="/assets/icons/svg/sprite.svg#spinner"/>
       </svg>
 
       <svg
@@ -87,7 +87,7 @@
         height="24"
         class="animation-spin-clockwise"
       >
-        <use xlink:href="/assets/icons/svg/sprite.svg#spinner"/>
+        <use href="/assets/icons/svg/sprite.svg#spinner"/>
         <title>Spinner title</title>
       </svg>
 

--- a/packages/web/src/scss/components/SplitButton/README.md
+++ b/packages/web/src/scss/components/SplitButton/README.md
@@ -36,7 +36,7 @@ Learn more about the [Dropdown][readme-dropdown] component in its documentation.
     >
       More
       <svg class="Icon" width="24" height="24" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+        <use href="/assets/icons/svg/sprite.svg#chevron-down" />
       </svg>
     </button>
     <div class="DropdownPopover placement-bottom-start" data-spirit-placement="bottom-start" id="dropdown-1">
@@ -64,7 +64,7 @@ Learn more about the [Tooltip][readme-tooltip] component in its documentation.
       aria-labelledby="tooltip-1"
     >
       <svg class="Icon" width="24" height="24" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#download" />
+        <use href="/assets/icons/svg/sprite.svg#download" />
       </svg>
     </button>
     <div

--- a/packages/web/src/scss/components/SplitButton/index.html
+++ b/packages/web/src/scss/components/SplitButton/index.html
@@ -21,7 +21,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                  <use href="/assets/icons/svg/sprite.svg#check-plain" />
                 </svg>
                 Button
               </button>
@@ -42,7 +42,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                    <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                   </svg>
                 </button>
                 <div
@@ -58,7 +58,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                        <use href="/assets/icons/svg/sprite.svg#info" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Information</span>
@@ -71,7 +71,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                        <use href="/assets/icons/svg/sprite.svg#profile" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Profile</span>
@@ -84,7 +84,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#help" />
+                        <use href="/assets/icons/svg/sprite.svg#help" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Help</span>
@@ -101,7 +101,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                  <use href="/assets/icons/svg/sprite.svg#check-plain" />
                 </svg>
                 Button
               </button>
@@ -123,7 +123,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                    <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                   </svg>
                 </button>
                 <div
@@ -139,7 +139,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                        <use href="/assets/icons/svg/sprite.svg#info" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Information</span>
@@ -152,7 +152,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                        <use href="/assets/icons/svg/sprite.svg#profile" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Profile</span>
@@ -165,7 +165,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#help" />
+                        <use href="/assets/icons/svg/sprite.svg#help" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Help</span>
@@ -182,7 +182,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                  <use href="/assets/icons/svg/sprite.svg#check-plain" />
                 </svg>
                 Button
               </button>
@@ -203,7 +203,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                    <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                   </svg>
                 </button>
                 <div
@@ -219,7 +219,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                        <use href="/assets/icons/svg/sprite.svg#info" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Information</span>
@@ -232,7 +232,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                        <use href="/assets/icons/svg/sprite.svg#profile" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Profile</span>
@@ -245,7 +245,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#help" />
+                        <use href="/assets/icons/svg/sprite.svg#help" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Help</span>
@@ -263,7 +263,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#download" />
+                  <use href="/assets/icons/svg/sprite.svg#download" />
                 </svg>
               </button>
               <button type="button" class="Button Button--{{ size }} Button--{{ color }}">
@@ -274,7 +274,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#edit" />
+                  <use href="/assets/icons/svg/sprite.svg#edit" />
                 </svg>
               </button>
               <button type="button" class="Button Button--{{ size }} Button--{{ color }}">
@@ -285,7 +285,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#link" />
+                  <use href="/assets/icons/svg/sprite.svg#link" />
                 </svg>
               </button>
             </div>
@@ -305,7 +305,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#download" />
+                    <use href="/assets/icons/svg/sprite.svg#download" />
                   </svg>
                 </button>
                 <div
@@ -333,7 +333,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#link" />
+                    <use href="/assets/icons/svg/sprite.svg#link" />
                   </svg>
                 </button>
                 <div
@@ -379,7 +379,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                  <use href="/assets/icons/svg/sprite.svg#check-plain" />
                 </svg>
                 Button
               </button>
@@ -401,7 +401,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                    <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                   </svg>
                 </button>
                 <div
@@ -417,7 +417,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                        <use href="/assets/icons/svg/sprite.svg#info" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Information</span>
@@ -430,7 +430,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                        <use href="/assets/icons/svg/sprite.svg#profile" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Profile</span>
@@ -443,7 +443,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#help" />
+                        <use href="/assets/icons/svg/sprite.svg#help" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Help</span>
@@ -464,7 +464,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                  <use href="/assets/icons/svg/sprite.svg#check-plain" />
                 </svg>
                 Button
               </button>
@@ -491,7 +491,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                    <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                   </svg>
                 </button>
                 <div
@@ -507,7 +507,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                        <use href="/assets/icons/svg/sprite.svg#info" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Information</span>
@@ -520,7 +520,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                        <use href="/assets/icons/svg/sprite.svg#profile" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Profile</span>
@@ -533,7 +533,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#help" />
+                        <use href="/assets/icons/svg/sprite.svg#help" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Help</span>
@@ -554,7 +554,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                  <use href="/assets/icons/svg/sprite.svg#check-plain" />
                 </svg>
                 Button
               </button>
@@ -576,7 +576,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                    <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                   </svg>
                 </button>
                 <div
@@ -592,7 +592,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                        <use href="/assets/icons/svg/sprite.svg#info" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Information</span>
@@ -605,7 +605,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                        <use href="/assets/icons/svg/sprite.svg#profile" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Profile</span>
@@ -618,7 +618,7 @@
                         height="24"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#help" />
+                        <use href="/assets/icons/svg/sprite.svg#help" />
                       </svg>
                     </span>
                     <span class="Label Label--item">Help</span>
@@ -640,7 +640,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#download" />
+                  <use href="/assets/icons/svg/sprite.svg#download" />
                 </svg>
               </button>
               <button
@@ -655,7 +655,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#edit" />
+                  <use href="/assets/icons/svg/sprite.svg#edit" />
                 </svg>
               </button>
               <button
@@ -670,7 +670,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#link" />
+                  <use href="/assets/icons/svg/sprite.svg#link" />
                 </svg>
               </button>
             </div>
@@ -691,7 +691,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#download" />
+                    <use href="/assets/icons/svg/sprite.svg#download" />
                   </svg>
                 </button>
                 <div
@@ -720,7 +720,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#link" />
+                    <use href="/assets/icons/svg/sprite.svg#link" />
                   </svg>
                 </button>
                 <div

--- a/packages/web/src/scss/components/Tag/README.md
+++ b/packages/web/src/scss/components/Tag/README.md
@@ -74,7 +74,7 @@ Tag comes in five available sizes: xsmall, small, medium, large, and xlarge.
       aria-label="Remove Tag label"
     >
       <svg class="Icon" width="16" height="16" aria-hidden="true">
-        <use xlink:href="/icons/svg/sprite.svg#close" />
+        <use href="/icons/svg/sprite.svg#close" />
       </svg>
     </button>
   </div>
@@ -119,7 +119,7 @@ Disabled Tag with `ControlButton`:
       disabled
     >
       <svg class="Icon" width="16" height="16" aria-hidden="true">
-        <use xlink:href="/icons/svg/sprite.svg#close" />
+        <use href="/icons/svg/sprite.svg#close" />
       </svg>
     </button>
   </div>

--- a/packages/web/src/scss/components/Tag/preview.html
+++ b/packages/web/src/scss/components/Tag/preview.html
@@ -70,7 +70,7 @@
                   height="16"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
               </button>
             </div>
@@ -87,7 +87,7 @@
                   height="16"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
               </button>
             </div>
@@ -183,7 +183,7 @@
             height="16"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+            <use href="/assets/icons/svg/sprite.svg#close" />
           </svg>
         </button>
       </div>
@@ -201,7 +201,7 @@
             height="16"
             aria-hidden="true"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+            <use href="/assets/icons/svg/sprite.svg#close" />
           </svg>
         </button>
       </div>

--- a/packages/web/src/scss/components/TextArea/README.md
+++ b/packages/web/src/scss/components/TextArea/README.md
@@ -155,7 +155,7 @@ Filled</textarea
   </div>
   <div id="text-area-danger-with-icon-validation-text" class="ValidationText ValidationText--danger">
     <svg class="Icon" width="20" height="20" aria-hidden="true">
-      <use xlink:href="/assets/icons/svg/sprite.svg#danger" />
+      <use href="/assets/icons/svg/sprite.svg#danger" />
     </svg>
     <div>Validation text with icon</div>
   </div>

--- a/packages/web/src/scss/components/TextArea/index.html
+++ b/packages/web/src/scss/components/TextArea/index.html
@@ -378,9 +378,9 @@
             aria-hidden="true"
           >
             {{#if (eq state "success")}}
-            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+            <use href="/assets/icons/svg/sprite.svg#check-plain" />
             {{else}}
-            <use xlink:href="/assets/icons/svg/sprite.svg#{{state}}" />
+            <use href="/assets/icons/svg/sprite.svg#{{state}}" />
             {{/if}}
           </svg>
           <div>This is {{state}} validation text. Long validation text to show how it wraps.</div>
@@ -554,7 +554,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#danger" />
+                <use href="/assets/icons/svg/sprite.svg#danger" />
               </svg>
               <div>You have entered too many characters</div>
             </div>

--- a/packages/web/src/scss/components/Timeline/README.md
+++ b/packages/web/src/scss/components/Timeline/README.md
@@ -127,7 +127,7 @@ Add `TimelineMarker--icon` modifier to control the size of marker icon.
 ```html
 <div aria-hidden="true" class="TimelineMarker TimelineMarker--icon">
   <svg class="Icon Icon--secondary" width="24" height="24">
-    <use xlink:href="/assets/icons/svg/sprite.svg#search"></use>
+    <use href="/assets/icons/svg/sprite.svg#search"></use>
   </svg>
 </div>
 ```

--- a/packages/web/src/scss/components/Timeline/preview.html
+++ b/packages/web/src/scss/components/Timeline/preview.html
@@ -132,7 +132,7 @@
               width="24"
               height="24"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#search"></use>
+              <use href="/assets/icons/svg/sprite.svg#search"></use>
             </svg>
           </div>
           <div class="TimelineHeading">
@@ -149,7 +149,7 @@
               width="24"
               height="24"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file"></use>
+              <use href="/assets/icons/svg/sprite.svg#file"></use>
             </svg>
           </div>
           <div class="TimelineHeading">
@@ -262,7 +262,7 @@
               width="24"
               height="24"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file"></use>
+              <use href="/assets/icons/svg/sprite.svg#file"></use>
             </svg>
           </div>
           <div class="TimelineHeading"><h3 class="typography-heading-small-semibold">Small Icon Marker</h3></div>
@@ -278,7 +278,7 @@
               width="24"
               height="24"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file"></use>
+              <use href="/assets/icons/svg/sprite.svg#file"></use>
             </svg>
           </div>
           <div class="TimelineHeading"><h3 class="typography-heading-small-semibold">Medium Icon Marker</h3></div>
@@ -294,7 +294,7 @@
               width="24"
               height="24"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file"></use>
+              <use href="/assets/icons/svg/sprite.svg#file"></use>
             </svg>
           </div>
           <div class="TimelineHeading"><h3 class="typography-heading-small-semibold">Large Icon Marker</h3></div>
@@ -346,7 +346,7 @@
               width="24"
               height="24"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file"></use>
+              <use href="/assets/icons/svg/sprite.svg#file"></use>
             </svg>
           </div>
           <div class="TimelineHeading">

--- a/packages/web/src/scss/components/Toast/README.md
+++ b/packages/web/src/scss/components/Toast/README.md
@@ -184,7 +184,7 @@ An icon can be added to the ToastBar component:
   <div class="ToastBar__box">
     <div class="ToastBar__container">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/icons/svg/sprite.svg#info" />
+        <use href="/icons/svg/sprite.svg#info" />
       </svg>
       <div class="ToastBar__content">
         <div class="text-truncate-multiline" data-spirit-populate-field="message">Message with icon</div>
@@ -302,7 +302,7 @@ button:
       aria-expanded="true"
     >
       <svg class="Icon" width="24" height="24" aria-hidden="true">
-        <use xlink:href="/icons/svg/sprite.svg#close" />
+        <use href="/icons/svg/sprite.svg#close" />
       </svg>
       <span class="accessibility-hidden">Close</span>
     </button>
@@ -335,7 +335,7 @@ button:
       <div class="ToastBar__box">
         <div class="ToastBar__container">
           <svg class="Icon" width="20" height="20" aria-hidden="true">
-            <use xlink:href="/icons/svg/sprite.svg#info" />
+            <use href="/icons/svg/sprite.svg#info" />
           </svg>
           <div class="ToastBar__content">
             <div class="text-truncate-multiline">Toast message</div>
@@ -350,7 +350,7 @@ button:
           aria-expanded="true"
         >
           <svg class="Icon" width="24" height="24" aria-hidden="true">
-            <use xlink:href="/icons/svg/sprite.svg#close" />
+            <use href="/icons/svg/sprite.svg#close" />
           </svg>
           <span class="accessibility-hidden">Close</span>
         </button>
@@ -378,7 +378,7 @@ the template and apply it on any toasts to be shown to the user, using the confi
         <div class="ToastBar__box">
           <div class="ToastBar__container">
             <svg class="Icon" width="20" height="20" aria-hidden="true" data-spirit-populate-field="icon">
-              <use xlink:href="/icons/svg/sprite.svg#info" />
+              <use href="/icons/svg/sprite.svg#info" />
             </svg>
             <div class="ToastBar__content">
               <div class="text-truncate-multiline" data-spirit-populate-field="message"></div>
@@ -393,7 +393,7 @@ the template and apply it on any toasts to be shown to the user, using the confi
             aria-expanded="true"
           >
             <svg class="Icon" width="24" height="24" aria-hidden="true">
-              <use xlink:href="/icons/svg/sprite.svg#close" />
+              <use href="/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>

--- a/packages/web/src/scss/components/Toast/index.html
+++ b/packages/web/src/scss/components/Toast/index.html
@@ -45,7 +45,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
+                  <use href="/assets/icons/svg/sprite.svg#warning" />
                 </svg>
                 <div class="ToastBar__content">
                   <div class="text-truncate-multiline">I was hidden and you exposed me!</div>
@@ -65,7 +65,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close"/>
                 </svg>
                 <span class="accessibility-hidden">Close</span>
               </button>
@@ -289,7 +289,7 @@
                     height="20"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                    <use href="/assets/icons/svg/sprite.svg#chevron-down"/>
                   </svg>
                 </div>
               </div>
@@ -485,7 +485,7 @@
                     aria-hidden="true"
                     data-spirit-populate-field="icon"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                    <use href="/assets/icons/svg/sprite.svg#info"/>
                   </svg>
                   <div class="ToastBar__content">
                     <div
@@ -511,7 +511,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                    <use href="/assets/icons/svg/sprite.svg#close"/>
                   </svg>
                   <span class="accessibility-hidden">Close</span>
                 </button>
@@ -531,7 +531,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                  <use href="/assets/icons/svg/sprite.svg#check-plain"/>
                 </svg>
                 <div class="ToastBar__content">
                   <div class="text-truncate-multiline">I was first!</div>
@@ -555,7 +555,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close"/>
                 </svg>
                 <span class="accessibility-hidden">Close</span>
               </button>
@@ -574,7 +574,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                  <use href="/assets/icons/svg/sprite.svg#info"/>
                 </svg>
                 <div class="ToastBar__content">
                   <div class="text-truncate-multiline">I appeared later. This toast has a long message that wraps
@@ -600,7 +600,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close"/>
                 </svg>
                 <span class="accessibility-hidden">Close</span>
               </button>
@@ -674,7 +674,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+              <use href="/assets/icons/svg/sprite.svg#info"/>
             </svg>
             <div class="ToastBar__content">
               <div class="text-truncate-multiline">Message with icon and action</div>
@@ -710,7 +710,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close"/>
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -729,7 +729,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#download" />
+              <use href="/assets/icons/svg/sprite.svg#download"/>
             </svg>
             <div class="ToastBar__content">
               <div class="text-truncate-multiline">Dismissible message with custom icon and action</div>
@@ -752,7 +752,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close"/>
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -785,7 +785,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+              <use href="/assets/icons/svg/sprite.svg#info"/>
             </svg>
             <div class="ToastBar__content">
               <div class="text-truncate-multiline">Neutral</div>
@@ -808,7 +808,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close"/>
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -827,7 +827,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+              <use href="/assets/icons/svg/sprite.svg#info"/>
             </svg>
             <div class="ToastBar__content">
               <div class="text-truncate-multiline">Informative</div>
@@ -850,7 +850,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close"/>
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -869,7 +869,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+              <use href="/assets/icons/svg/sprite.svg#check-plain"/>
             </svg>
             <div class="ToastBar__content">
               <div class="text-truncate-multiline">Success</div>
@@ -892,7 +892,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close"/>
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -911,7 +911,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
+              <use href="/assets/icons/svg/sprite.svg#warning"/>
             </svg>
             <div class="ToastBar__content">
               <div class="text-truncate-multiline">Warning</div>
@@ -934,7 +934,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close"/>
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -953,7 +953,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#danger" />
+              <use href="/assets/icons/svg/sprite.svg#danger"/>
             </svg>
             <div class="ToastBar__content">
               <div class="text-truncate-multiline">Danger</div>
@@ -976,7 +976,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close"/>
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>

--- a/packages/web/src/scss/components/Toggle/README.md
+++ b/packages/web/src/scss/components/Toggle/README.md
@@ -137,7 +137,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
     <label class="Label Label--inline" for="toggle-warning">Toggle Label</label>
     <div class="ValidationText ValidationText--warning ValidationText--inline" id="toggle-warning-validation-text">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
+        <use href="/assets/icons/svg/sprite.svg#warning" />
       </svg>
       <span>Validation text with icon</span>
     </div>

--- a/packages/web/src/scss/components/Toggle/index.html
+++ b/packages/web/src/scss/components/Toggle/index.html
@@ -455,9 +455,9 @@
               aria-hidden="true"
             >
               {{#if (eq state "success")}}
-              <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+              <use href="/assets/icons/svg/sprite.svg#check-plain" />
               {{else}}
-              <use xlink:href="/assets/icons/svg/sprite.svg#{{state}}" />
+              <use href="/assets/icons/svg/sprite.svg#{{state}}" />
               {{/if}}
             </svg>
             <span>This is {{state}} validation text. Long validation text to show how it wraps.</span>
@@ -650,7 +650,7 @@
           height="24"
           aria-hidden="true"
         >
-          <use xlink:href="/icons/svg/sprite.svg#close" />
+          <use href="/icons/svg/sprite.svg#close" />
         </svg>
         <span class="accessibility-hidden">Close</span>
       </button>
@@ -683,7 +683,7 @@
           height="24"
           aria-hidden="true"
         >
-          <use xlink:href="/icons/svg/sprite.svg#close" />
+          <use href="/icons/svg/sprite.svg#close" />
         </svg>
         <span class="accessibility-hidden">Close</span>
       </button>

--- a/packages/web/src/scss/components/Tooltip/README.md
+++ b/packages/web/src/scss/components/Tooltip/README.md
@@ -100,7 +100,7 @@ Tooltip can be made dismissible by following these steps:
       aria-expanded="true"
     >
       <svg class="Icon" width="24" height="24" aria-hidden="true">
-        <use xlink:href="/icons/svg/sprite.svg#close" />
+        <use href="/icons/svg/sprite.svg#close" />
       </svg>
       <span class="accessibility-hidden">Close</span>
     </button>

--- a/packages/web/src/scss/components/Tooltip/index.html
+++ b/packages/web/src/scss/components/Tooltip/index.html
@@ -81,7 +81,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -147,7 +147,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -379,7 +379,7 @@
             data-spirit-toggle="tooltip"
             data-spirit-target="#tooltip-example-with-icon"
           >
-            <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+            <use href="/assets/icons/svg/sprite.svg#info" />
           </svg>
           <div
             id="tooltip-example-with-icon"
@@ -405,7 +405,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
               <span class="accessibility-hidden">Close</span>
             </button>
@@ -842,7 +842,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </div>
           </div>
@@ -874,7 +874,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </div>
           </div>
@@ -930,7 +930,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
                 <span class="accessibility-hidden">Close</span>
               </button>

--- a/packages/web/src/scss/components/UNSTABLE_File/README.md
+++ b/packages/web/src/scss/components/UNSTABLE_File/README.md
@@ -12,7 +12,7 @@ It is a standalone component, but most often it is used in combination with the 
   <li class="UNSTABLE_File">
     <div class="UNSTABLE_File__preview">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+        <use href="/assets/icons/svg/sprite.svg#file" />
       </svg>
     </div>
     <div class="UNSTABLE_File__content">
@@ -33,7 +33,7 @@ It is a standalone component, but most often it is used in combination with the 
         aria-label="Edit file name Document.pdf"
       >
         <svg class="Icon" width="16" height="16" aria-hidden="true">
-          <use xlink:href="/assets/icons/svg/sprite.svg#edit" />
+          <use href="/assets/icons/svg/sprite.svg#edit" />
         </svg>
       </button>
       <button
@@ -42,7 +42,7 @@ It is a standalone component, but most often it is used in combination with the 
         aria-label="Remove file Document.pdf from list"
       >
         <svg class="Icon" width="16" height="16" aria-hidden="true">
-          <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+          <use href="/assets/icons/svg/sprite.svg#close" />
         </svg>
       </button>
     </div>
@@ -108,7 +108,7 @@ Add the appropriate validation class (`has-success`, `has-warning`, or `has-dang
   <!-- … preview, name … -->
   <div class="ValidationText ValidationText--success">
     <svg class="Icon" width="20" height="20" aria-hidden="true">
-      <use xlink:href="/assets/icons/svg/sprite.svg#success" />
+      <use href="/assets/icons/svg/sprite.svg#success" />
     </svg>
     <div>File uploaded successfully</div>
   </div>
@@ -131,7 +131,7 @@ Show upload progress using `HelperText` component:
       <div class="HelperText">
         <div>
           <svg class="Icon animation-spin-clockwise" width="16" height="16" aria-hidden="true">
-            <use xlink:href="/assets/icons/svg/sprite.svg#spinner" />
+            <use href="/assets/icons/svg/sprite.svg#spinner" />
           </svg>
           <span>Uploading your file…</span>
         </div>
@@ -148,7 +148,7 @@ Show upload progress using `HelperText` component:
 <li class="UNSTABLE_File UNSTABLE_File--disabled">
   <div class="UNSTABLE_File__preview">
     <svg class="Icon" width="20" height="20" aria-hidden="true">
-      <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+      <use href="/assets/icons/svg/sprite.svg#file" />
     </svg>
   </div>
   <div class="UNSTABLE_File__content">
@@ -166,7 +166,7 @@ Show upload progress using `HelperText` component:
     disabled
   >
     <svg class="Icon" width="16" height="16" aria-hidden="true">
-      <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+      <use href="/assets/icons/svg/sprite.svg#close" />
     </svg>
   </button>
 </li>

--- a/packages/web/src/scss/components/UNSTABLE_File/index.html
+++ b/packages/web/src/scss/components/UNSTABLE_File/index.html
@@ -20,7 +20,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+                  <use href="/assets/icons/svg/sprite.svg#file" />
                 </svg>
               </div>
               <div class="UNSTABLE_File__content">
@@ -46,7 +46,7 @@
                     height="16"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#edit" />
+                    <use href="/assets/icons/svg/sprite.svg#edit" />
                   </svg>
                 </button>
                 <button
@@ -60,7 +60,7 @@
                     height="16"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                    <use href="/assets/icons/svg/sprite.svg#close" />
                   </svg>
                 </button>
               </div>
@@ -79,7 +79,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+                  <use href="/assets/icons/svg/sprite.svg#file" />
                 </svg>
               </div>
               <div class="UNSTABLE_File__content">
@@ -95,7 +95,7 @@
                         height="16"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#spinner" />
+                        <use href="/assets/icons/svg/sprite.svg#spinner" />
                       </svg>
                       <span>Uploading your file…</span>
                     </div>
@@ -113,7 +113,7 @@
                   height="16"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
               </button>
             </li>
@@ -131,7 +131,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+                  <use href="/assets/icons/svg/sprite.svg#file" />
                 </svg>
               </div>
               <div class="UNSTABLE_File__content">
@@ -154,7 +154,7 @@
                   height="16"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
               </button>
             </li>
@@ -172,7 +172,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+                  <use href="/assets/icons/svg/sprite.svg#file" />
                 </svg>
               </div>
               <div class="UNSTABLE_File__content">
@@ -187,7 +187,7 @@
                       height="20"
                       aria-hidden="true"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                      <use href="/assets/icons/svg/sprite.svg#check-plain" />
                     </svg>
                     <div>File uploaded successfully</div>
                   </div>
@@ -204,7 +204,7 @@
                   height="16"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
               </button>
             </li>
@@ -222,7 +222,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+                  <use href="/assets/icons/svg/sprite.svg#file" />
                 </svg>
               </div>
               <div class="UNSTABLE_File__content">
@@ -237,7 +237,7 @@
                       height="20"
                       aria-hidden="true"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
+                      <use href="/assets/icons/svg/sprite.svg#warning" />
                     </svg>
                     <div>Large file – may take time</div>
                   </div>
@@ -254,7 +254,7 @@
                   height="16"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
               </button>
             </li>
@@ -272,7 +272,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+                  <use href="/assets/icons/svg/sprite.svg#file" />
                 </svg>
               </div>
               <div class="UNSTABLE_File__content">
@@ -287,7 +287,7 @@
                       height="20"
                       aria-hidden="true"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#danger" />
+                      <use href="/assets/icons/svg/sprite.svg#danger" />
                     </svg>
                     <div>File upload error – please retry</div>
                   </div>
@@ -304,7 +304,7 @@
                   height="16"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
               </button>
             </li>
@@ -322,7 +322,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+                  <use href="/assets/icons/svg/sprite.svg#file" />
                 </svg>
               </div>
               <div class="UNSTABLE_File__content">
@@ -385,7 +385,7 @@
                     height="16"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#edit" />
+                    <use href="/assets/icons/svg/sprite.svg#edit" />
                   </svg>
                 </button>
                 <button
@@ -399,7 +399,7 @@
                     height="16"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                    <use href="/assets/icons/svg/sprite.svg#close" />
                   </svg>
                 </button>
               </div>
@@ -432,7 +432,7 @@
                         height="16"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#spinner" />
+                        <use href="/assets/icons/svg/sprite.svg#spinner" />
                       </svg>
                       <span>Uploading your file…</span>
                     </div>
@@ -450,7 +450,7 @@
                   height="16"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
               </button>
             </li>
@@ -489,7 +489,7 @@
                   height="16"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
               </button>
             </li>
@@ -520,7 +520,7 @@
                       height="20"
                       aria-hidden="true"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                      <use href="/assets/icons/svg/sprite.svg#check-plain" />
                     </svg>
                     <div>File uploaded successfully</div>
                   </div>
@@ -537,7 +537,7 @@
                   height="16"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
               </button>
             </li>
@@ -568,7 +568,7 @@
                       height="20"
                       aria-hidden="true"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
+                      <use href="/assets/icons/svg/sprite.svg#warning" />
                     </svg>
                     <div>Large file – may take time</div>
                   </div>
@@ -585,7 +585,7 @@
                   height="16"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
               </button>
             </li>
@@ -616,7 +616,7 @@
                       height="20"
                       aria-hidden="true"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#danger" />
+                      <use href="/assets/icons/svg/sprite.svg#danger" />
                     </svg>
                     <div>File upload error – please retry</div>
                   </div>
@@ -633,7 +633,7 @@
                   height="16"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
               </button>
             </li>

--- a/packages/web/src/scss/components/UNSTABLE_FileUpload/README.md
+++ b/packages/web/src/scss/components/UNSTABLE_FileUpload/README.md
@@ -42,7 +42,7 @@ The class controls appearance only: dashed border and visibility of the “or dr
     />
     <div class="UNSTABLE_FileUploadInput__dropZone">
       <svg class="Icon" width="28" height="28" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+        <use href="/assets/icons/svg/sprite.svg#upload" />
       </svg>
       <div class="UNSTABLE_FileUploadInput__dropZoneContent">
         <label for="file-uploader" class="UNSTABLE_FileUploadInput__dropZoneLabel">
@@ -163,7 +163,7 @@ If you need a vertical spacing, you can use `Stack` with `Stack--hasSpacing` on 
   <li class="UNSTABLE_File">
     <div class="UNSTABLE_File__preview">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+        <use href="/assets/icons/svg/sprite.svg#file" />
       </svg>
     </div>
     <div class="UNSTABLE_File__content">
@@ -184,7 +184,7 @@ If you need a vertical spacing, you can use `Stack` with `Stack--hasSpacing` on 
         aria-label="Edit file name Document.pdf"
       >
         <svg class="Icon" width="16" height="16" aria-hidden="true">
-          <use xlink:href="/assets/icons/svg/sprite.svg#edit" />
+          <use href="/assets/icons/svg/sprite.svg#edit" />
         </svg>
       </button>
       <button
@@ -193,7 +193,7 @@ If you need a vertical spacing, you can use `Stack` with `Stack--hasSpacing` on 
         aria-label="Remove file Document.pdf from list"
       >
         <svg class="Icon" width="16" height="16" aria-hidden="true">
-          <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+          <use href="/assets/icons/svg/sprite.svg#close" />
         </svg>
       </button>
     </div>
@@ -212,7 +212,7 @@ If you need a vertical spacing, you can use `Stack` with `Stack--hasSpacing` on 
         <div class="HelperText">
           <div>
             <svg class="Icon animation-spin-clockwise" width="16" height="16" aria-hidden="true">
-              <use xlink:href="/assets/icons/svg/sprite.svg#spinner" />
+              <use href="/assets/icons/svg/sprite.svg#spinner" />
             </svg>
             <span>Uploading your file…</span>
           </div>
@@ -225,7 +225,7 @@ If you need a vertical spacing, you can use `Stack` with `Stack--hasSpacing` on 
       aria-label="Remove file vacation-photo.jpg from list"
     >
       <svg class="Icon" width="16" height="16" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+        <use href="/assets/icons/svg/sprite.svg#close" />
       </svg>
     </button>
   </li>
@@ -234,7 +234,7 @@ If you need a vertical spacing, you can use `Stack` with `Stack--hasSpacing` on 
   <li class="UNSTABLE_File has-success">
     <div class="UNSTABLE_File__preview">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+        <use href="/assets/icons/svg/sprite.svg#file" />
       </svg>
     </div>
     <div class="UNSTABLE_File__content">
@@ -244,7 +244,7 @@ If you need a vertical spacing, you can use `Stack` with `Stack--hasSpacing` on 
         </span>
         <div class="ValidationText ValidationText--success">
           <svg class="Icon" width="20" height="20" aria-hidden="true">
-            <use xlink:href="/assets/icons/svg/sprite.svg#success" />
+            <use href="/assets/icons/svg/sprite.svg#success" />
           </svg>
           <div>File uploaded successfully</div>
         </div>
@@ -256,7 +256,7 @@ If you need a vertical spacing, you can use `Stack` with `Stack--hasSpacing` on 
       aria-label="Remove file report-2024.xlsx from list"
     >
       <svg class="Icon" width="16" height="16" aria-hidden="true">
-        <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+        <use href="/assets/icons/svg/sprite.svg#close" />
       </svg>
     </button>
   </li>

--- a/packages/web/src/scss/components/UNSTABLE_FileUpload/index.html
+++ b/packages/web/src/scss/components/UNSTABLE_FileUpload/index.html
@@ -43,7 +43,7 @@
                     height="28"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+                    <use href="/assets/icons/svg/sprite.svg#upload" />
                   </svg>
                   {{/if}}
                   <div class="UNSTABLE_FileUploadInput__dropZoneContent">
@@ -115,7 +115,7 @@
                   height="28"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+                  <use href="/assets/icons/svg/sprite.svg#upload" />
                 </svg>
                 {{/if}}
                 <div class="UNSTABLE_FileUploadInput__dropZoneContent">
@@ -197,7 +197,7 @@
                   height="28"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+                  <use href="/assets/icons/svg/sprite.svg#upload" />
                 </svg>
                 {{/if}}
                 <div class="UNSTABLE_FileUploadInput__dropZoneContent">
@@ -229,9 +229,9 @@
                   aria-hidden="true"
                 >
                   {{#if (eq state "success")}}
-                  <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+                  <use href="/assets/icons/svg/sprite.svg#check-plain" />
                   {{else}}
-                  <use xlink:href="/assets/icons/svg/sprite.svg#{{state}}" />
+                  <use href="/assets/icons/svg/sprite.svg#{{state}}" />
                   {{/if}}
                 </svg>
                 <div>This is {{state}} validation text. Long validation text to show how it wraps.</div>
@@ -287,7 +287,7 @@
                     height="28"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+                    <use href="/assets/icons/svg/sprite.svg#upload" />
                   </svg>
                   {{/if}}
                   <div class="UNSTABLE_FileUploadInput__dropZoneContent">
@@ -360,7 +360,7 @@
                     height="28"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+                    <use href="/assets/icons/svg/sprite.svg#upload" />
                   </svg>
                   {{/if}}
                   <div class="UNSTABLE_FileUploadInput__dropZoneContent">
@@ -416,7 +416,7 @@
               height="28"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#upload" />
+              <use href="/assets/icons/svg/sprite.svg#upload" />
             </svg>
             <div class="UNSTABLE_FileUploadInput__dropZoneContent">
               <label for="file-uploader-with-list" class="UNSTABLE_FileUploadInput__dropZoneLabel">
@@ -440,7 +440,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
           </div>
           <div class="UNSTABLE_File__content">
@@ -466,7 +466,7 @@
                 height="16"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#edit" />
+                <use href="/assets/icons/svg/sprite.svg#edit" />
               </svg>
             </button>
             <button
@@ -480,7 +480,7 @@
                 height="16"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </div>
@@ -508,7 +508,7 @@
                     height="16"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#spinner" />
+                    <use href="/assets/icons/svg/sprite.svg#spinner" />
                   </svg>
                   <span>Uploading your file…</span>
                 </div>
@@ -526,7 +526,7 @@
               height="16"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
           </button>
         </li>
@@ -539,7 +539,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
           </div>
           <div class="UNSTABLE_File__content">
@@ -554,7 +554,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#success" />
+                  <use href="/assets/icons/svg/sprite.svg#success" />
                 </svg>
                 <div>File uploaded successfully</div>
               </div>
@@ -571,7 +571,7 @@
               height="16"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
           </button>
         </li>
@@ -584,7 +584,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#file" />
+              <use href="/assets/icons/svg/sprite.svg#file" />
             </svg>
           </div>
           <div class="UNSTABLE_File__content">
@@ -599,7 +599,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#danger" />
+                  <use href="/assets/icons/svg/sprite.svg#danger" />
                 </svg>
                 <div>File upload error – please retry</div>
               </div>
@@ -616,7 +616,7 @@
               height="16"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
           </button>
         </li>

--- a/packages/web/src/scss/components/UNSTABLE_Header/README.md
+++ b/packages/web/src/scss/components/UNSTABLE_Header/README.md
@@ -163,7 +163,7 @@ Use the composition mentioned above to create the layout you need.
           <li>
             <button class="Button Button--tertiary Button--medium Button--symmetrical">
               <svg class="Icon" width="24" height="24" aria-hidden="true">
-                <use xlink:href="/assets/icons/svg/sprite.svg#search" />
+                <use href="/assets/icons/svg/sprite.svg#search" />
               </svg>
             </button>
           </li>

--- a/packages/web/src/scss/components/UNSTABLE_Header/index.html
+++ b/packages/web/src/scss/components/UNSTABLE_Header/index.html
@@ -162,7 +162,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#search" />
+                    <use href="/assets/icons/svg/sprite.svg#search" />
                   </svg>
                   <span class="accessibility-hidden">Search</span>
                 </button>
@@ -176,7 +176,7 @@
                       height="20"
                       aria-hidden="true"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#profile"/>
+                      <use href="/assets/icons/svg/sprite.svg#profile"/>
                     </svg>
                   </span>
                   <span class="typography-body-small-semibold">My Account</span>
@@ -205,7 +205,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#hamburger" />
+                    <use href="/assets/icons/svg/sprite.svg#hamburger" />
                   </svg>
                 </button>
               </li>
@@ -237,7 +237,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -254,7 +254,7 @@
                         height="20"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                        <use href="/assets/icons/svg/sprite.svg#profile" />
                       </svg>
                     </span>
                     <span class="typography-body-small-semibold">My Account</span>
@@ -356,7 +356,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#search" />
+                    <use href="/assets/icons/svg/sprite.svg#search" />
                   </svg>
                   <span class="accessibility-hidden">Search</span>
                 </button>
@@ -370,7 +370,7 @@
                       height="20"
                       aria-hidden="true"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#profile"/>
+                      <use href="/assets/icons/svg/sprite.svg#profile"/>
                     </svg>
                   </span>
                   <span class="typography-body-small-semibold">My Account</span>
@@ -399,7 +399,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#hamburger" />
+                    <use href="/assets/icons/svg/sprite.svg#hamburger" />
                   </svg>
                 </button>
               </li>
@@ -431,7 +431,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -448,7 +448,7 @@
                         height="20"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                        <use href="/assets/icons/svg/sprite.svg#profile" />
                       </svg>
                     </span>
                     <span class="typography-body-small-semibold">My Account</span>
@@ -548,7 +548,7 @@
                       aria-hidden="true"
                       class="Icon accessibility-open"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#chevron-up" />
+                      <use href="/assets/icons/svg/sprite.svg#chevron-up" />
                     </svg>
                     <svg
                       width="20"
@@ -556,7 +556,7 @@
                       aria-hidden="true"
                       class="Icon accessibility-closed"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                      <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                     </svg>
                   </button>
                   <div
@@ -600,7 +600,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#search" />
+                    <use href="/assets/icons/svg/sprite.svg#search" />
                   </svg>
                   <span class="accessibility-hidden">Search</span>
                 </button>
@@ -623,7 +623,7 @@
                         height="20"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                        <use href="/assets/icons/svg/sprite.svg#profile" />
                       </svg>
                     </span>
                     <span class="typography-body-small-semibold">My Account</span>
@@ -633,7 +633,7 @@
                       aria-hidden="true"
                       class="Icon accessibility-open"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#chevron-up" />
+                      <use href="/assets/icons/svg/sprite.svg#chevron-up" />
                     </svg>
                     <svg
                       width="20"
@@ -641,7 +641,7 @@
                       aria-hidden="true"
                       class="Icon accessibility-closed"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                      <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                     </svg>
                   </button>
                   <div
@@ -692,7 +692,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use xlink:href="/assets/icons/svg/sprite.svg#hamburger" />
+                    <use href="/assets/icons/svg/sprite.svg#hamburger" />
                   </svg>
                 </button>
               </li>
@@ -724,7 +724,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -741,7 +741,7 @@
                         height="20"
                         aria-hidden="true"
                       >
-                        <use xlink:href="/assets/icons/svg/sprite.svg#profile" />
+                        <use href="/assets/icons/svg/sprite.svg#profile" />
                       </svg>
                     </span>
                     <span class="typography-body-small-semibold">My Account</span>
@@ -777,7 +777,7 @@
                       aria-hidden="true"
                       class="Icon accessibility-open"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#chevron-up" />
+                      <use href="/assets/icons/svg/sprite.svg#chevron-up" />
                     </svg>
                     <svg
                       width="24"
@@ -785,7 +785,7 @@
                       aria-hidden="true"
                       class="Icon accessibility-closed"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                      <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                     </svg>
                   </button>
                   <div id="collapse-navigation" class="Collapse">

--- a/packages/web/src/scss/components/UNSTABLE_Picker/README.md
+++ b/packages/web/src/scss/components/UNSTABLE_Picker/README.md
@@ -60,7 +60,7 @@ overflow its scrollable container or get clipped.
       >
         <span class="accessibility-hidden">Add</span>
         <svg class="Icon" width="20" height="20" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+          <use href="/icons/svg/sprite.svg#chevron-down" />
         </svg>
       </button>
     </div>
@@ -118,7 +118,7 @@ Place a hidden `<span>` with a unique `id` anywhere in the `<body>` and referenc
         class="ControlButton ControlButton--small ControlButton--symmetrical"
       >
         <svg class="Icon" width="16" height="16" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#close" />
+          <use href="/icons/svg/sprite.svg#close" />
         </svg>
       </button>
     </div>
@@ -199,7 +199,7 @@ Each size expects a matching Tag and ControlButton size inside the selection are
               class="ControlButton ControlButton--medium ControlButton--symmetrical"
             >
               <svg class="Icon" width="16" height="16" aria-hidden="true">
-                <use xlink:href="/icons/svg/sprite.svg#close" />
+                <use href="/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </div>
@@ -293,7 +293,7 @@ inside the selection area (remove buttons) to disable the Picker.
               disabled
             >
               <svg class="Icon" width="16" height="16" aria-hidden="true">
-                <use xlink:href="/icons/svg/sprite.svg#close" />
+                <use href="/icons/svg/sprite.svg#close" />
               </svg>
             </button>
           </div>
@@ -310,7 +310,7 @@ inside the selection area (remove buttons) to disable the Picker.
       >
         <span class="accessibility-hidden">Add</span>
         <svg class="Icon" width="20" height="20" aria-hidden="true">
-          <use xlink:href="/icons/svg/sprite.svg#chevron-down" />
+          <use href="/icons/svg/sprite.svg#chevron-down" />
         </svg>
       </button>
     </div>

--- a/packages/web/src/scss/components/UNSTABLE_Picker/index.html
+++ b/packages/web/src/scss/components/UNSTABLE_Picker/index.html
@@ -62,7 +62,7 @@
           height="16"
           aria-hidden="true"
         >
-          <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+          <use href="/assets/icons/svg/sprite.svg#close" />
         </svg>
       </button>
     </div>
@@ -129,7 +129,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
           </div>
@@ -262,7 +262,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
           </div>
@@ -414,7 +414,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                 </svg>
               </button>
             </div>
@@ -541,7 +541,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                 </svg>
               </button>
             </div>
@@ -668,7 +668,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                  <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                 </svg>
               </button>
             </div>
@@ -809,7 +809,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
           </div>
@@ -956,7 +956,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
           </div>
@@ -1103,7 +1103,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
           </div>
@@ -1251,7 +1251,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
           </div>
@@ -1402,7 +1402,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
           </div>
@@ -1538,7 +1538,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
           </div>
@@ -1675,7 +1675,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
           </div>
@@ -1826,7 +1826,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
           </div>
@@ -1965,7 +1965,7 @@
                       height="16"
                       aria-hidden="true"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                      <use href="/assets/icons/svg/sprite.svg#close" />
                     </svg>
                   </button>
                 </div>
@@ -1997,7 +1997,7 @@
                       height="16"
                       aria-hidden="true"
                     >
-                      <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                      <use href="/assets/icons/svg/sprite.svg#close" />
                     </svg>
                   </button>
                 </div>
@@ -2020,7 +2020,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
           </div>
@@ -2168,7 +2168,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
           </div>
@@ -2325,7 +2325,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
           </div>
@@ -2482,7 +2482,7 @@
                 height="20"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#chevron-down" />
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
               </svg>
             </button>
           </div>

--- a/packages/web/src/scss/components/ValidationText/README.md
+++ b/packages/web/src/scss/components/ValidationText/README.md
@@ -23,7 +23,7 @@ To render validation text with an icon, add an `<svg>` icon as the first child.
 ```html
 <div class="ValidationText ValidationText--danger">
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/assets/icons/svg/sprite.svg#danger" />
+    <use href="/assets/icons/svg/sprite.svg#danger" />
   </svg>
   <div>Danger validation text with icon</div>
 </div>
@@ -49,7 +49,7 @@ You can combine an icon with a list of validation texts.
 ```html
 <div class="ValidationText ValidationText--danger">
   <svg class="Icon" width="20" height="20" aria-hidden="true">
-    <use xlink:href="/assets/icons/svg/sprite.svg#danger" />
+    <use href="/assets/icons/svg/sprite.svg#danger" />
   </svg>
   <ul>
     <li>First validation text</li>

--- a/packages/web/src/scss/components/ValidationText/index.html
+++ b/packages/web/src/scss/components/ValidationText/index.html
@@ -93,9 +93,9 @@
             aria-hidden="true"
           >
             {{#if (eq state "success")}}
-            <use xlink:href="/assets/icons/svg/sprite.svg#check-plain" />
+            <use href="/assets/icons/svg/sprite.svg#check-plain" />
             {{else}}
-            <use xlink:href="/assets/icons/svg/sprite.svg#{{state}}" />
+            <use href="/assets/icons/svg/sprite.svg#{{state}}" />
             {{/if}}
           </svg>
           <div>This is {{state}} validation text with icon.</div>
@@ -219,7 +219,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use xlink:href="/assets/icons/svg/sprite.svg#warning" />
+              <use href="/assets/icons/svg/sprite.svg#warning" />
             </svg>
             <span>Warning validation text with icon</span>
           </div>

--- a/packages/web/src/scss/helpers/accessibility/README.md
+++ b/packages/web/src/scss/helpers/accessibility/README.md
@@ -45,12 +45,12 @@ This helper conditionally displays content based on the `aria-checked` attribute
 <button type="button" role="switch" aria-checked="false" aria-label="Show password">
   <span class="accessibility-unchecked">
     <svg class="Icon" width="20" height="20" aria-hidden="true">
-      <use xlink:href="/icons/sprite.svg#visibility-on" />
+      <use href="/icons/sprite.svg#visibility-on" />
     </svg>
   </span>
   <span class="accessibility-checked">
     <svg class="Icon" width="20" height="20" aria-hidden="true">
-      <use xlink:href="/icons/sprite.svg#visibility-off" />
+      <use href="/icons/sprite.svg#visibility-off" />
     </svg>
   </span>
 </button>

--- a/packages/web/src/scss/helpers/accessibility/index.html
+++ b/packages/web/src/scss/helpers/accessibility/index.html
@@ -50,7 +50,7 @@
           height="16"
           aria-hidden="true"
         >
-          <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+          <use href="/assets/icons/svg/sprite.svg#close" />
         </svg>
       </button>
     </div>

--- a/packages/web/src/scss/helpers/animations/index.html
+++ b/packages/web/src/scss/helpers/animations/index.html
@@ -13,7 +13,7 @@
         width="24"
         height="24"
       >
-        <use xlink:href="/assets/icons/svg/sprite.svg#reload"/>
+        <use href="/assets/icons/svg/sprite.svg#reload"/>
       </svg>
 
     </div>

--- a/packages/web/src/scss/helpers/dynamic-color/index.html
+++ b/packages/web/src/scss/helpers/dynamic-color/index.html
@@ -42,7 +42,7 @@
                 height="24"
                 aria-hidden="true"
               >
-                <use xlink:href="/assets/icons/svg/sprite.svg#close" />
+                <use href="/assets/icons/svg/sprite.svg#close" />
               </svg>
               <span class="accessibility-hidden">Close</span>
             </button>
@@ -92,7 +92,7 @@
                                 height="14"
                                 aria-hidden="true"
                               >
-                                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                                <use href="/assets/icons/svg/sprite.svg#info" />
                               </svg>
                               <span class="accessibility-hidden">About lightness delta for hover</span>
                             </button>
@@ -161,7 +161,7 @@
                                 height="14"
                                 aria-hidden="true"
                               >
-                                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                                <use href="/assets/icons/svg/sprite.svg#info" />
                               </svg>
                               <span class="accessibility-hidden">About chroma scale for hover</span>
                             </button>
@@ -240,7 +240,7 @@
                                 height="14"
                                 aria-hidden="true"
                               >
-                                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                                <use href="/assets/icons/svg/sprite.svg#info" />
                               </svg>
                               <span class="accessibility-hidden">About lightness delta for active</span>
                             </button>
@@ -308,7 +308,7 @@
                                 height="14"
                                 aria-hidden="true"
                               >
-                                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                                <use href="/assets/icons/svg/sprite.svg#info" />
                               </svg>
                               <span class="accessibility-hidden">About chroma scale for active</span>
                             </button>
@@ -386,7 +386,7 @@
                                 height="14"
                                 aria-hidden="true"
                               >
-                                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                                <use href="/assets/icons/svg/sprite.svg#info" />
                               </svg>
                               <span class="accessibility-hidden">About lightness delta for selected</span>
                             </button>
@@ -454,7 +454,7 @@
                                 height="14"
                                 aria-hidden="true"
                               >
-                                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                                <use href="/assets/icons/svg/sprite.svg#info" />
                               </svg>
                               <span class="accessibility-hidden">About chroma scale for selected</span>
                             </button>
@@ -532,7 +532,7 @@
                                 height="14"
                                 aria-hidden="true"
                               >
-                                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                                <use href="/assets/icons/svg/sprite.svg#info" />
                               </svg>
                               <span class="accessibility-hidden">About lightness delta for border</span>
                             </button>
@@ -600,7 +600,7 @@
                                 height="14"
                                 aria-hidden="true"
                               >
-                                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                                <use href="/assets/icons/svg/sprite.svg#info" />
                               </svg>
                               <span class="accessibility-hidden">About chroma scale for border</span>
                             </button>
@@ -678,7 +678,7 @@
                                 height="14"
                                 aria-hidden="true"
                               >
-                                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                                <use href="/assets/icons/svg/sprite.svg#info" />
                               </svg>
                               <span class="accessibility-hidden">About lightness midpoint</span>
                             </button>
@@ -747,7 +747,7 @@
                                 height="14"
                                 aria-hidden="true"
                               >
-                                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                                <use href="/assets/icons/svg/sprite.svg#info" />
                               </svg>
                               <span class="accessibility-hidden">About chroma lightness midpoint</span>
                             </button>
@@ -816,7 +816,7 @@
                                 height="14"
                                 aria-hidden="true"
                               >
-                                <use xlink:href="/assets/icons/svg/sprite.svg#info" />
+                                <use href="/assets/icons/svg/sprite.svg#info" />
                               </svg>
                               <span class="accessibility-hidden">About chroma upper limit</span>
                             </button>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

SVG 2.0 deprecated the `xlink:href` attribute on `<use>` elements in favour of the plain `href` attribute, and all modern browsers support `href` directly. The codebase still used `xlink:href` throughout component demos, documentation, the `Toast` JS class (which read/wrote the attribute via DOM APIs), and test fixtures — meaning the output was technically invalid per current SVG spec. This refactor replaces every occurrence with `href` and removes the now-unnecessary `xmlns:xlink` namespace from the React attribute allowlist.

### Issue reference

https://jira.almacareer.tech/browse/DS-2487