### PR TITLE
docs(web-react): update missing prop on PickerItem

### DIFF
--- a/packages/web-react/src/components/UNSTABLE_Picker/README.md
+++ b/packages/web-react/src/components/UNSTABLE_Picker/README.md
@@ -413,11 +413,12 @@ UNSTABLE_PickerItem is one option row in the popover (picker context is required
 
 ### API
 
-| Name       | Type        | Default | Required | Description                            |
-| ---------- | ----------- | ------- | -------- | -------------------------------------- |
-| `children` | `ReactNode` | —       | ✓        | Label shown next to the radio/checkbox |
-| `value`    | `string`    | —       | ✓        | Key used in `selectedKeys`             |
-| `name`     | `string`    | —       | ✕        | Native input `name`                    |
+| Name         | Type        | Default | Required | Description                            |
+| ------------ | ----------- | ------- | -------- | -------------------------------------- |
+| `children`   | `ReactNode` | —       | ✓        | Label shown next to the radio/checkbox |
+| `value`      | `string`    | —       | ✓        | Key used in `selectedKeys`             |
+| `name`       | `string`    | —       | ✕        | Native input `name`                    |
+| `helperText` | `ReactNode` | —       | ✕        | Helper text below the radio/checkbox   |
 
 On top of the API options, the components accept [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Adds the missing helperText prop to the UNSTABLE_PickerItem API table.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
