### PR TITLE
chore(repo): introduce shared agent's permissions #DS-2569

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,45 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "defaultMode": "plan",
+    "allow": [
+      "Bash(git *)",
+      "Bash(gh pr:*)",
+      "Bash(gh repo:*)",
+      "Bash(gh api:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(echo:*)",
+      "Bash(pwd)",
+      "Bash(which:*)",
+      "Bash(find:*)",
+      "Bash(grep:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(wc:*)",
+      "Bash(diff:*)",
+      "Bash(stat:*)",
+      "Bash(jq:*)",
+      "Bash(yarn *)",
+      "Bash(make *)"
+    ],
+    "ask": [
+      "Bash(git branch -D:*)",
+      "Bash(git push --force:*)"
+    ],
+    "deny": [
+      "Bash(git reset --hard:*)",
+      "Bash(git clean -fd:*)",
+      "Bash(git filter-branch:*)",
+      "Bash(git gc:*)",
+      "Bash(make version)",
+      "Bash(rm -rf *)",
+      "Bash(* publish:*)",
+      "Read(~/.ssh/*)",
+      "Read(.env*)",
+      "Write(.env*)"
+    ]
+  },
   "attribution": {
     "commit": "",
     "pr": ""

--- a/.cursor/cli.json
+++ b/.cursor/cli.json
@@ -1,0 +1,38 @@
+{
+  "permissions": {
+    "allow": [
+      "Shell(git)",
+      "Shell(gh:pr)",
+      "Shell(gh:repo)",
+      "Shell(gh:api)",
+      "Shell(ls)",
+      "Shell(cat)",
+      "Shell(echo)",
+      "Shell(pwd)",
+      "Shell(which)",
+      "Shell(find)",
+      "Shell(grep)",
+      "Shell(head)",
+      "Shell(tail)",
+      "Shell(wc)",
+      "Shell(diff)",
+      "Shell(stat)",
+      "Shell(jq)",
+      "Shell(yarn)",
+      "Shell(make)"
+    ],
+    "ask": ["Shell(git branch -D)", "Shell(git push --force)"],
+    "deny": [
+      "Shell(git reset --hard)",
+      "Shell(git clean -fd)",
+      "Shell(git:filter-branch)",
+      "Shell(git:gc)",
+      "Shell(make version)",
+      "Shell(rm -rf *)",
+      "Shell(* publish:*)",
+      "Read(~/.ssh/*)",
+      "Read(.env*)",
+      "Write(.env*)"
+    ]
+  }
+}


### PR DESCRIPTION
## What

Adds shared AI agent permissions for Claude Code (`.claude/settings.json`) and Cursor (`.cursor/cli.json`).

## Why

Follows up on #2577 — permissions were extracted into a separate PR per DS-2555/DS-2569 to keep the MCP config PR focused.

## Changes

- `defaultMode: plan` — agents start in plan mode by default
- **allow**: broad `git *`, `gh pr/repo/api`, standard read-only shell commands, `yarn *`, `make *`
- **ask**: `git push --force`, `git branch -D` — prompts for confirmation instead of blocking
- **deny**: destructive commands (`git reset --hard`, `git clean -fd`, `rm -rf *`), publishing commands, access to `.env*` and `~/.ssh/*`