### PR TITLE
docs(release-notes): refine 2026-05-15 release notes

### DIFF
--- a/.agents/skills/release-notes/README.md
+++ b/.agents/skills/release-notes/README.md
@@ -1,6 +1,6 @@
 # Release Notes Skill
 
-Generates a Slack Canvas–ready release notes document after each lerna publish. Reads CHANGELOG.md files, synthesizes a human-readable summary, pulls upcoming work from Jira, and writes the result to `.release-notes/`.
+Generates a Slack Canvas–ready release notes document after each lerna publish. Reads CHANGELOG.md files, synthesizes a human-readable summary, pulls upcoming work from Jira, and writes the result to `docs/release-notes/`.
 
 ## Usage
 
@@ -12,7 +12,7 @@ Run after a successful `yarn release` / lerna publish. No arguments needed — t
 
 ## Output
 
-The skill writes to `.release-notes/release-notes-YYYY-MM-DD.md` (gitignored). The file uses standard Markdown with:
+The skill writes to `docs/release-notes/YYYY-MM-DD.md` (version-controlled; see [docs/release-notes on GitHub](https://github.com/alma-oss/spirit-design-system/tree/main/docs/release-notes)). The file uses standard Markdown with:
 
 - `#` / `##` / `###` headers for document structure
 - `**bold**` for package names, What's Next headings, and prop names
@@ -62,7 +62,7 @@ The file will be parsed into native Canvas blocks with proper formatting.
 | 5    | Synthesizes a multi-paragraph General Changes summary in the team's tone of voice                         |
 | 6    | Fetches upcoming work from the active and next Jira sprint (project: DS)                                  |
 | 7    | Assembles the full document                                                                               |
-| 8    | Writes to `.release-notes/release-notes-YYYY-MM-DD.md`                                                    |
+| 8    | Writes to `docs/release-notes/YYYY-MM-DD.md`                                                              |
 
 ## Symlink Setup
 

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -193,10 +193,11 @@ Thank you for staying with us!
 
 ### Step 8 — Write the Output File
 
-1. Ensure `.release-notes/` directory exists (create it if not).
-2. Write the document to `.release-notes/release-notes-{YYYY-MM-DD}.md`.
+1. Ensure `docs/release-notes/` directory exists (create it if not).
+2. Write the document to `docs/release-notes/{YYYY-MM-DD}.md` (same date as the document title; see `docs/release-notes/2026-04-13.md` for naming).
 3. Print the full file path to the terminal.
 4. Remind the user to review the ⚠️ warnings (if any) before pasting into Slack Canvas.
+5. Commit the file to the repository so it is published under [docs/release-notes](https://github.com/alma-oss/spirit-design-system/tree/main/docs/release-notes).
 
 ---
 

--- a/docs/release-notes/2026-05-15.md
+++ b/docs/release-notes/2026-05-15.md
@@ -1,0 +1,77 @@
+# 2026-05-15 Spirit Design System Release Notes
+
+📢 🚀 🎉 Ahoy, we have a new release with features and improvements. Here we go.
+
+## General Changes
+
+We've rolled out a **rem-based sizing foundation** across design tokens, `@alma-oss/spirit-web`, and `@alma-oss/spirit-web-react`, so spacing and dimensions scale more naturally with user font settings. If you consume tokens or component styles directly, review layouts after upgrading — values that were expressed in `px` now use `rem`.
+
+We've added **`I18nProvider`** in Web React so you can supply merged translations for localized component copy. **`UNSTABLE_Picker`** gets richer examples, and we fixed **`ToastContext`** export.
+
+We've **deprecated `FileUploader`** in both `@alma-oss/spirit-web` and `@alma-oss/spirit-web-react` — migrate to `UNSTABLE_FileUpload` instead. See the migration guide in [Web React DEPRECATIONS](https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/DEPRECATIONS.md#fileuploader) and [Web DEPRECATIONS](https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/DEPRECATIONS.md#fileuploader).
+
+## News in Packages
+
+📦 **Web React _4.7.0_** `@alma-oss/spirit-web-react`
+
+### Features
+
+- Add `I18nProvider` and translations #DS-2210 ([7a8d1fe](https://github.com/alma-oss/spirit-design-system/commit/7a8d1fe9c14f4c4338dd4eaf0337c7973a02d592))
+- Introduce unstable `Table` component ([2be3ceb](https://github.com/alma-oss/spirit-design-system/commit/2be3ceb47b3ded6f061bcec0c820cb5cadf2d558))
+- Replace px with rem #DS-2392 ([ecd927e](https://github.com/alma-oss/spirit-design-system/commit/ecd927e9c5c6fc6ba54540453b2701c55bba682b))
+- Deprecate `FileUploader` component and subcomponents #DS-2444 ([9b91bf5](https://github.com/alma-oss/spirit-design-system/commit/9b91bf589e49c0d0c274ea90b811e5e1a5653c15))
+
+### Bug Fixes
+
+- Fix type for **containerProps** #DS-2561 ([99c34aa](https://github.com/alma-oss/spirit-design-system/commit/99c34aa1306645b049266667766dd0ea003ee128))
+- Fix subpath type declarations not resolving for package exports #DS-2561 ([b2d6aaf](https://github.com/alma-oss/spirit-design-system/commit/b2d6aaf4b99d9a2cefeaea18dc16aaad9fb61601))
+- Add disabled class for `ControlButton` when `UNSTABLE_File` is disabled ([a535c53](https://github.com/alma-oss/spirit-design-system/commit/a535c534ed7462fc33387b5982cd3fbf8a2c2f8c))
+- Export `ToastContext` ([d061e48](https://github.com/alma-oss/spirit-design-system/commit/d061e48e5069f877c561cddb38ac48b43c961911))
+- Switch specificity of style utilities and escape hatches #DS-2234 ([5d4da74](https://github.com/alma-oss/spirit-design-system/commit/5d4da74cb4eebf781d5dcadb83a5135e635e86f7))
+
+[Full changelog](https://github.com/alma-oss/spirit-design-system/compare/@alma-oss/spirit-web-react@4.5.0...@alma-oss/spirit-web-react@4.7.0)
+
+📦 **Web _4.6.0_** `@alma-oss/spirit-web`
+
+### Features
+
+- Introduce unstable `Table` component ([bf13df1](https://github.com/alma-oss/spirit-design-system/commit/bf13df1da1594897786203f058c43fade40a57de))
+- Replace px with rem #DS-2392 ([4fb76e8](https://github.com/alma-oss/spirit-design-system/commit/4fb76e868ae68740dab2338c9fb8293f87092bd8))
+- Deprecate `FileUploader` component and subcomponents #DS-2444 ([7086646](https://github.com/alma-oss/spirit-design-system/commit/7086646502f3742987352538165166a7446292f9))
+
+### Bug Fixes
+
+- Fix icon in File upload success validation text ([ca9fb28](https://github.com/alma-oss/spirit-design-system/commit/ca9fb28068410fefe656419b7f281f4feb73a6b3))
+
+[Full changelog](https://github.com/alma-oss/spirit-design-system/compare/@alma-oss/spirit-web@4.4.0...@alma-oss/spirit-web@4.6.0)
+
+📦 **Design Tokens _4.2.0_** `@alma-oss/spirit-design-tokens`
+
+### Features
+
+- Update tokens to rem #DS-2392 ([cb72cc3](https://github.com/alma-oss/spirit-design-system/commit/cb72cc39b51caa8f8a4ff207f299741bfee30ac6))
+
+[Full changelog](https://github.com/alma-oss/spirit-design-system/compare/@alma-oss/spirit-design-tokens@4.1.2...@alma-oss/spirit-design-tokens@4.2.0)
+
+## What's Next 🔮
+
+The release of the new major version is slowly but surely approaching, and we are currently preparing the following features:
+
+- **UNSTABLE_Combobox**
+  New multi-select combobox with allowing users to filter a list of options (e.g. job positions or locations) by typing
+
+- **TextField addons (React)**
+  `TextField` will support `startAddon` / `endAddon` so icons, buttons, and other addons can sit inside the field, aligned with the web `InputAddon` API.
+
+- **Form fields — outline variant**
+  Box fields (`TextField`, `TextArea`, `Select`, `FileUploader`, `UNSTABLE_Picker`) will get a border-only **outline** variant alongside the default filled style.
+
+🎯 You can see more of our [quarterly targets outlook in Notion](https://www.notion.so/almacareer/Spirit-DS-team-Quarterly-Goals-878e92d5b74543039e513c0160fb9117).
+
+## We'd Love to Hear Your Feedback
+
+💬 If you have any idea, suggestion or request regarding the newly introduced unstable components, or if you just need help or want to report a bug or wrong behavior, please get in touch with us on our Slack channel: [#spirit-design-system-support_cs_en](https://slack.com/archives/C068XPSDWQN).
+
+🐙 Everything is available in our [repository on GitHub](https://github.com/alma-oss/spirit-design-system/).
+
+Thank you for staying with us!


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Adds Slack Canvas–ready release notes for the 2026-05-15 publish:

@alma-oss/spirit-web-react 4.7.0
@alma-oss/spirit-web 4.6.0
@alma-oss/spirit-design-tokens 4.2.0

### Additional context

- Intended for copy-paste into the [Spirit Release Notes Slack Canvas template](https://almamedia.slack.com/docs/T0325RBAD/F08D6U6EAKH).
- Reviewers: skim General Changes and What's Next for tone/accuracy; confirm package versions and changelog links match the published tags.
- No code or package changes — documentation only.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
