### PR TITLE
refactor(web-react): rename formFieldVariant to formFieldMode across components

### DIFF
--- a/packages/web-react/src/components/CharacterCounter/CharacterCounter.tsx
+++ b/packages/web-react/src/components/CharacterCounter/CharacterCounter.tsx
@@ -14,7 +14,7 @@ const CharacterCounter = (props: SpiritCharacterCounterProps) => {
   const propsWithDefaults = {
     isDisabled: contextProps.isDisabled,
     validationState: contextProps.validationState,
-    formFieldVariant: contextProps.formFieldVariant,
+    formFieldMode: contextProps.formFieldMode,
     ...props,
   };
   const { classProps, props: restProps } = useCharacterCounterStyleProps(propsWithDefaults);

--- a/packages/web-react/src/components/CharacterCounter/stories/CharacterCounter.stories.tsx
+++ b/packages/web-react/src/components/CharacterCounter/stories/CharacterCounter.stories.tsx
@@ -2,7 +2,7 @@ import { Markdown } from '@storybook/addon-docs/blocks';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 import { ValidationStates } from '../../../constants';
-import { FormFieldVariants } from '../../../types';
+import { FormFieldModes } from '../../../types';
 import ReadMe from '../README.md?raw';
 import { CharacterCounter } from '..';
 
@@ -21,9 +21,9 @@ const meta: Meta<typeof CharacterCounter> = {
     currentLength: {
       control: 'number',
     },
-    formFieldVariant: {
+    formFieldMode: {
       control: 'select',
-      options: [undefined, ...Object.values(FormFieldVariants)],
+      options: [undefined, ...Object.values(FormFieldModes)],
     },
     hasCounter: {
       control: 'boolean',

--- a/packages/web-react/src/components/CharacterCounter/types.ts
+++ b/packages/web-react/src/components/CharacterCounter/types.ts
@@ -1,4 +1,4 @@
-import type { FormFieldVariant, RegisterType, StyleProps, ValidationState } from '../../types/shared';
+import type { FormFieldMode, RegisterType, StyleProps, ValidationState } from '../../types/shared';
 
 export interface CharacterCounterProps extends StyleProps {
   /** Character threshold shown after the slash in the counter (e.g. `5/200`); implicitly enables the counter */
@@ -12,8 +12,8 @@ export interface CharacterCounterProps extends StyleProps {
 export interface SpiritCharacterCounterProps extends CharacterCounterProps {
   /** ID of the associated textarea, used to generate the screen reader message element ID */
   id: string;
-  /** Variant from form field context (inline / item layouts) */
-  formFieldVariant?: FormFieldVariant;
+  /** Mode from form field context (inline / item) */
+  formFieldMode?: FormFieldMode;
   /** Whether the character counter is disabled */
   isDisabled?: boolean;
   /** Callback to register/unregister aria-describedBy IDs */

--- a/packages/web-react/src/components/CharacterCounter/useCharacterCounterStyleProps.ts
+++ b/packages/web-react/src/components/CharacterCounter/useCharacterCounterStyleProps.ts
@@ -1,15 +1,15 @@
 import classNames from 'classnames';
 import { useClassNamePrefix } from '../../hooks';
-import { FormFieldVariants } from '../../types';
+import { FormFieldModes } from '../../types';
 import { type SpiritCharacterCounterProps } from './types';
 
 export interface CharacterCounterStyles {
   classProps: string;
-  props: Omit<SpiritCharacterCounterProps, 'formFieldVariant' | 'isDisabled' | 'validationState'>;
+  props: Omit<SpiritCharacterCounterProps, 'formFieldMode' | 'isDisabled' | 'validationState'>;
 }
 
 export function useCharacterCounterStyleProps(props: SpiritCharacterCounterProps): CharacterCounterStyles {
-  const { formFieldVariant, isDisabled, validationState, ...restProps } = props;
+  const { formFieldMode, isDisabled, validationState, ...restProps } = props;
   const characterCounterClass = useClassNamePrefix('CharacterCounter');
   const characterCounterDisabledClass = `${characterCounterClass}--disabled`;
   const characterCounterValidationClass = `${characterCounterClass}--${validationState}`;
@@ -18,8 +18,8 @@ export function useCharacterCounterStyleProps(props: SpiritCharacterCounterProps
 
   return {
     classProps: classNames(characterCounterClass, {
-      [inlineClass]: formFieldVariant === FormFieldVariants.INLINE,
-      [itemClass]: formFieldVariant === FormFieldVariants.ITEM,
+      [inlineClass]: formFieldMode === FormFieldModes.INLINE,
+      [itemClass]: formFieldMode === FormFieldModes.ITEM,
       [characterCounterDisabledClass]: isDisabled,
       [characterCounterValidationClass]: validationState,
     }),

--- a/packages/web-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/web-react/src/components/Checkbox/Checkbox.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import React, { type ForwardedRef, forwardRef } from 'react';
 import { PropsProvider } from '../../context';
 import { useAriaDescribedBy, useAriaDetails, useStyleProps } from '../../hooks';
-import { FormFieldVariants, type ForwardRefComponent, type SpiritCheckboxProps } from '../../types';
+import { FormFieldModes, type ForwardRefComponent, type SpiritCheckboxProps } from '../../types';
 import { HelperText } from '../HelperText';
 import { InputDetails } from '../InputDetails';
 import { Label } from '../Label';
@@ -42,7 +42,7 @@ const _Checkbox = (props: SpiritCheckboxProps, ref: ForwardedRef<HTMLInputElemen
   return (
     <PropsProvider
       value={{
-        formFieldVariant: isItem ? FormFieldVariants.ITEM : FormFieldVariants.INLINE,
+        formFieldMode: isItem ? FormFieldModes.ITEM : FormFieldModes.INLINE,
         isDisabled,
         isLabelHidden,
         isRequired,

--- a/packages/web-react/src/components/Checkbox/README.md
+++ b/packages/web-react/src/components/Checkbox/README.md
@@ -186,7 +186,7 @@ const CustomCheckbox = (props: SpiritCheckboxProps): JSX.Element => {
   return (
     <PropsProvider
       value={{
-        formFieldVariant: isItem ? FormFieldVariants.ITEM : FormFieldVariants.INLINE,
+        formFieldMode: isItem ? FormFieldModes.ITEM : FormFieldModes.INLINE,
         isDisabled,
         isLabelHidden,
         isRequired,

--- a/packages/web-react/src/components/HelperText/HelperText.tsx
+++ b/packages/web-react/src/components/HelperText/HelperText.tsx
@@ -19,7 +19,7 @@ const HelperText = <E extends ElementType = 'div'>(props: SpiritHelperTextProps<
   const propsWithDefaults = {
     ...defaultProps,
     isDisabled: contextProps.isDisabled,
-    formFieldVariant: contextProps.formFieldVariant,
+    formFieldMode: contextProps.formFieldMode,
     ...props,
   };
   const {
@@ -27,12 +27,12 @@ const HelperText = <E extends ElementType = 'div'>(props: SpiritHelperTextProps<
     elementType: Component = defaultProps.elementType as ElementType,
     id,
     isDisabled,
-    formFieldVariant,
+    formFieldMode,
     registerAria,
     ...restProps
   } = propsWithDefaults;
 
-  const { classProps } = useHelperTextStyleProps({ isDisabled, formFieldVariant });
+  const { classProps } = useHelperTextStyleProps({ isDisabled, formFieldMode });
   const { styleProps, props: transferProps } = useStyleProps(restProps);
   const mergedStyleProps = mergeStyleProps(Component, { classProps, styleProps, transferProps });
 

--- a/packages/web-react/src/components/HelperText/README.md
+++ b/packages/web-react/src/components/HelperText/README.md
@@ -19,28 +19,28 @@ When used inside form field components such as [Checkbox][readme-checkbox], [Rad
 You can override context by passing props directly:
 
 ```tsx
-<HelperText id="my-helper-text" helperText="Helper text" elementType="span" isDisabled formFieldVariant="inline" />
+<HelperText id="my-helper-text" helperText="Helper text" elementType="span" isDisabled formFieldMode="inline" />
 ```
 
 ### API
 
-| Name               | Type                                                   | Default | Required | Description                                                                                                                               |
-| ------------------ | ------------------------------------------------------ | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `elementType`      | `ElementType`                                          | `div`   | ✕        | Type of element used as main wrapper                                                                                                      |
-| `formFieldVariant` | `FormFieldVariant`                                     | —       | ✕        | Explicit visual variant (`inline`, `item`); omit for the default layout used by box form field components, or take it from parent context |
-| `helperText`       | `ReactNode`                                            | —       | ✓        | Content to display                                                                                                                        |
-| `id`               | `string`                                               | —       | ✕        | Element id (e.g. for `aria-describedby`)                                                                                                  |
-| `isDisabled`       | `bool`                                                 | `false` | ✕        | Disabled state; when omitted, taken from parent context                                                                                   |
-| `registerAria`     | `(payload: { add?: string; remove?: string }) => void` | —       | ✕        | Callback to register this element's id for `aria-describedby`                                                                             |
+| Name            | Type                                                   | Default | Required | Description                                                                                                                     |
+| --------------- | ------------------------------------------------------ | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `elementType`   | `ElementType`                                          | `div`   | ✕        | Type of element used as main wrapper                                                                                            |
+| `formFieldMode` | `FormFieldMode`                                        | —       | ✕        | Explicit mode (`inline`, `item`); omit for the default layout used by box form field components, or take it from parent context |
+| `helperText`    | `ReactNode`                                            | —       | ✓        | Content to display                                                                                                              |
+| `id`            | `string`                                               | —       | ✕        | Element id (e.g. for `aria-describedby`)                                                                                        |
+| `isDisabled`    | `bool`                                                 | `false` | ✕        | Disabled state; when omitted, taken from parent context                                                                         |
+| `registerAria`  | `(payload: { add?: string; remove?: string }) => void` | —       | ✕        | Callback to register this element's id for `aria-describedby`                                                                   |
 
 On top of the API options, the component accepts [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]
 and [escape hatches][readme-escape-hatches].
 
-## Variants
+## Modes
 
 - **inline**: Used by Checkbox, Radio, and Toggle (non-item). Keeps helper text above the label and selectable.
-- **item**: Used by Item and by Checkbox or Radio in item variant.
+- **item**: Used by Item and by Checkbox or Radio in item mode.
 
 [readme-additional-attributes]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/README.md#additional-attributes
 [readme-checkbox]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/Checkbox/README.md

--- a/packages/web-react/src/components/HelperText/__tests__/useHelperTextStyleProps.test.ts
+++ b/packages/web-react/src/components/HelperText/__tests__/useHelperTextStyleProps.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { FormFieldVariants } from '../../../types';
+import { FormFieldModes } from '../../../types';
 import { useHelperTextStyleProps } from '../useHelperTextStyleProps';
 
 describe('useHelperTextStyleProps', () => {
@@ -15,21 +15,21 @@ describe('useHelperTextStyleProps', () => {
     expect(result.current.classProps).toBe('HelperText HelperText--disabled');
   });
 
-  it('should return inline class when formFieldVariant is inline', () => {
-    const { result } = renderHook(() => useHelperTextStyleProps({ formFieldVariant: FormFieldVariants.INLINE }));
+  it('should return inline class when formFieldMode is inline', () => {
+    const { result } = renderHook(() => useHelperTextStyleProps({ formFieldMode: FormFieldModes.INLINE }));
 
     expect(result.current.classProps).toBe('HelperText HelperText--inline');
   });
 
-  it('should return item class when formFieldVariant is item', () => {
-    const { result } = renderHook(() => useHelperTextStyleProps({ formFieldVariant: FormFieldVariants.ITEM }));
+  it('should return item class when formFieldMode is item', () => {
+    const { result } = renderHook(() => useHelperTextStyleProps({ formFieldMode: FormFieldModes.ITEM }));
 
     expect(result.current.classProps).toBe('HelperText HelperText--item');
   });
 
   it('should return disabled and inline classes when both are set', () => {
     const { result } = renderHook(() =>
-      useHelperTextStyleProps({ isDisabled: true, formFieldVariant: FormFieldVariants.INLINE }),
+      useHelperTextStyleProps({ isDisabled: true, formFieldMode: FormFieldModes.INLINE }),
     );
 
     expect(result.current.classProps).toContain('HelperText');
@@ -39,7 +39,7 @@ describe('useHelperTextStyleProps', () => {
 
   it('should return disabled and item classes when both are set', () => {
     const { result } = renderHook(() =>
-      useHelperTextStyleProps({ isDisabled: true, formFieldVariant: FormFieldVariants.ITEM }),
+      useHelperTextStyleProps({ isDisabled: true, formFieldMode: FormFieldModes.ITEM }),
     );
 
     expect(result.current.classProps).toContain('HelperText');

--- a/packages/web-react/src/components/HelperText/stories/HelperText.stories.tsx
+++ b/packages/web-react/src/components/HelperText/stories/HelperText.stories.tsx
@@ -1,7 +1,7 @@
 import { Markdown } from '@storybook/addon-docs/blocks';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
-import { FormFieldVariants } from '../../../types';
+import { FormFieldModes } from '../../../types';
 import ReadMe from '../README.md?raw';
 import { HelperText } from '..';
 
@@ -24,9 +24,9 @@ const meta: Meta<typeof HelperText> = {
     helperText: {
       control: 'text',
     },
-    formFieldVariant: {
+    formFieldMode: {
       control: 'select',
-      options: Object.values(FormFieldVariants),
+      options: Object.values(FormFieldModes),
     },
   },
   args: {

--- a/packages/web-react/src/components/HelperText/useHelperTextStyleProps.ts
+++ b/packages/web-react/src/components/HelperText/useHelperTextStyleProps.ts
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { useClassNamePrefix } from '../../hooks';
-import { type FormFieldContextValue, FormFieldVariants } from '../../types';
+import { type FormFieldContextValue, FormFieldModes } from '../../types';
 
 export interface HelperTextStyles {
   /** className for the root element */
@@ -8,7 +8,7 @@ export interface HelperTextStyles {
 }
 
 export function useHelperTextStyleProps(props: FormFieldContextValue): HelperTextStyles {
-  const { formFieldVariant, isDisabled } = props;
+  const { formFieldMode, isDisabled } = props;
 
   const prefix = useClassNamePrefix('HelperText');
   const inlineClass = `${prefix}--inline`;
@@ -16,8 +16,8 @@ export function useHelperTextStyleProps(props: FormFieldContextValue): HelperTex
   const disabledClass = `${prefix}--disabled`;
 
   const classProps = classNames(prefix, {
-    [inlineClass]: formFieldVariant === FormFieldVariants.INLINE,
-    [itemClass]: formFieldVariant === FormFieldVariants.ITEM,
+    [inlineClass]: formFieldMode === FormFieldModes.INLINE,
+    [itemClass]: formFieldMode === FormFieldModes.ITEM,
     [disabledClass]: isDisabled,
   });
 

--- a/packages/web-react/src/components/InputDetails/__tests__/InputDetails.test.tsx
+++ b/packages/web-react/src/components/InputDetails/__tests__/InputDetails.test.tsx
@@ -23,8 +23,8 @@ describe('InputDetails', () => {
     renderComponent: (props) => <InputDetails {...props}>Content</InputDetails>,
     text: 'Content',
     classNamePrefix: 'InputDetails',
-    includeInlineVariant: false,
-    includeItemVariant: false,
+    includeInlineMode: false,
+    includeItemMode: false,
   });
 
   it('should render children content', () => {

--- a/packages/web-react/src/components/Item/Item.tsx
+++ b/packages/web-react/src/components/Item/Item.tsx
@@ -5,7 +5,7 @@ import React, { type ElementType } from 'react';
 import { PropsProvider } from '../../context';
 import { useStyleProps } from '../../hooks';
 import {
-  FormFieldVariants,
+  FormFieldModes,
   ITEM_SELECTION_DECORATOR_BOTH,
   ITEM_SELECTION_DECORATOR_ICON,
   type SpiritItemProps,
@@ -40,7 +40,7 @@ const Item = <E extends ElementType = 'button'>(props: SpiritItemProps<E>): JSX.
     (selectionDecorator === ITEM_SELECTION_DECORATOR_ICON || selectionDecorator === ITEM_SELECTION_DECORATOR_BOTH);
 
   return (
-    <PropsProvider value={{ formFieldVariant: FormFieldVariants.ITEM, isDisabled }}>
+    <PropsProvider value={{ formFieldMode: FormFieldModes.ITEM, isDisabled }}>
       <Component {...otherProps} {...mergedStyleProps} disabled={!!isDisabled && Component === 'button'}>
         {iconName && (
           <span className={classNames(classProps.icon.root, classProps.icon.start)}>

--- a/packages/web-react/src/components/Label/Label.tsx
+++ b/packages/web-react/src/components/Label/Label.tsx
@@ -18,7 +18,7 @@ const Label = <E extends ElementType = 'label'>(props: SpiritLabelProps<E>): JSX
   const contextProps = useContextProps<Partial<FormFieldContextValue>>();
   const propsWithDefaults = {
     ...defaultProps,
-    formFieldVariant: contextProps.formFieldVariant,
+    formFieldMode: contextProps.formFieldMode,
     isDisabled: contextProps.isDisabled,
     isLabelHidden: contextProps.isLabelHidden,
     isRequired: contextProps.isRequired,
@@ -28,7 +28,7 @@ const Label = <E extends ElementType = 'label'>(props: SpiritLabelProps<E>): JSX
     children,
     elementType: ElementTag = 'label' as ElementType,
     for: labelFor,
-    formFieldVariant,
+    formFieldMode,
     htmlFor,
     isDisabled,
     isLabelHidden,
@@ -37,7 +37,7 @@ const Label = <E extends ElementType = 'label'>(props: SpiritLabelProps<E>): JSX
   } = propsWithDefaults;
 
   const { classProps } = useLabelStyleProps({
-    formFieldVariant,
+    formFieldMode,
     isDisabled,
     isLabelHidden,
     isRequired,

--- a/packages/web-react/src/components/Label/README.md
+++ b/packages/web-react/src/components/Label/README.md
@@ -19,28 +19,28 @@ When used inside form field components such as [Checkbox][readme-checkbox], [Rad
 You can override context by passing props directly:
 
 ```tsx
-<Label htmlFor="my-input" formFieldVariant="inline" isRequired isDisabled={false} isLabelHidden={false}>
+<Label htmlFor="my-input" formFieldMode="inline" isRequired isDisabled={false} isLabelHidden={false}>
   Label text
 </Label>
 ```
 
 ### API
 
-| Name               | Type               | Default | Required | Description                                                                                                                               |
-| ------------------ | ------------------ | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `children`         | `ReactNode`        | —       | ✕        | Label content                                                                                                                             |
-| `elementType`      | `ElementType`      | `label` | ✕        | Type of element used as root (e.g. `label`, `span`)                                                                                       |
-| `formFieldVariant` | `FormFieldVariant` | —       | ✕        | Explicit visual variant (`inline`, `item`); omit for the default layout used by box form field components, or take it from parent context |
-| `for` / `htmlFor`  | `string`           | —       | ✕        | ID of the associated form control (for `elementType="label"`)                                                                             |
-| `isDisabled`       | `bool`             | `false` | ✕        | Disabled state; when not set, taken from parent context                                                                                   |
-| `isLabelHidden`    | `bool`             | `false` | ✕        | Visually hide label while keeping it accessible; from parent context                                                                      |
-| `isRequired`       | `bool`             | `false` | ✕        | Shows required indicator; when not set, taken from parent context                                                                         |
+| Name              | Type            | Default | Required | Description                                                                                                                     |
+| ----------------- | --------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `children`        | `ReactNode`     | —       | ✕        | Label content                                                                                                                   |
+| `elementType`     | `ElementType`   | `label` | ✕        | Type of element used as root (e.g. `label`, `span`)                                                                             |
+| `formFieldMode`   | `FormFieldMode` | —       | ✕        | Explicit mode (`inline`, `item`); omit for the default layout used by box form field components, or take it from parent context |
+| `for` / `htmlFor` | `string`        | —       | ✕        | ID of the associated form control (for `elementType="label"`)                                                                   |
+| `isDisabled`      | `bool`          | `false` | ✕        | Disabled state; when not set, taken from parent context                                                                         |
+| `isLabelHidden`   | `bool`          | `false` | ✕        | Visually hide label while keeping it accessible; from parent context                                                            |
+| `isRequired`      | `bool`          | `false` | ✕        | Shows required indicator; when not set, taken from parent context                                                               |
 
 On top of the API options, the component accepts [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]
 and [escape hatches][readme-escape-hatches].
 
-## Variants
+## Modes
 
 The default layout is used by box form field components.
 

--- a/packages/web-react/src/components/Label/__tests__/useLabelStyleProps.test.ts
+++ b/packages/web-react/src/components/Label/__tests__/useLabelStyleProps.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { FormFieldVariants } from '../../../types';
+import { FormFieldModes } from '../../../types';
 import { useLabelStyleProps } from '../useLabelStyleProps';
 
 describe('useLabelStyleProps', () => {
@@ -15,14 +15,14 @@ describe('useLabelStyleProps', () => {
     expect(result.current.classProps).toContain('Label--disabled');
   });
 
-  it('should return inline class when formFieldVariant is inline', () => {
-    const { result } = renderHook(() => useLabelStyleProps({ formFieldVariant: FormFieldVariants.INLINE }));
+  it('should return inline class when formFieldMode is inline', () => {
+    const { result } = renderHook(() => useLabelStyleProps({ formFieldMode: FormFieldModes.INLINE }));
 
     expect(result.current.classProps).toContain('Label--inline');
   });
 
-  it('should return item class when formFieldVariant is item', () => {
-    const { result } = renderHook(() => useLabelStyleProps({ formFieldVariant: FormFieldVariants.ITEM }));
+  it('should return item class when formFieldMode is item', () => {
+    const { result } = renderHook(() => useLabelStyleProps({ formFieldMode: FormFieldModes.ITEM }));
 
     expect(result.current.classProps).toContain('Label--item');
   });

--- a/packages/web-react/src/components/Label/stories/Label.stories.tsx
+++ b/packages/web-react/src/components/Label/stories/Label.stories.tsx
@@ -1,7 +1,7 @@
 import { Markdown } from '@storybook/addon-docs/blocks';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
-import { FormFieldVariants } from '../../../types';
+import { FormFieldModes } from '../../../types';
 import ReadMe from '../README.md?raw';
 import { Label } from '..';
 
@@ -23,9 +23,9 @@ const meta: Meta<typeof Label> = {
         defaultValue: { summary: 'label' },
       },
     },
-    formFieldVariant: {
+    formFieldMode: {
       control: 'select',
-      options: Object.values(FormFieldVariants),
+      options: Object.values(FormFieldModes),
     },
     htmlFor: {
       control: 'text',

--- a/packages/web-react/src/components/Label/useLabelStyleProps.ts
+++ b/packages/web-react/src/components/Label/useLabelStyleProps.ts
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { useClassNamePrefix } from '../../hooks';
-import { type FormFieldContextValue, FormFieldVariants } from '../../types';
+import { type FormFieldContextValue, FormFieldModes } from '../../types';
 
 export interface LabelStyles {
   /** className for the root element */
@@ -8,7 +8,7 @@ export interface LabelStyles {
 }
 
 export function useLabelStyleProps(props: FormFieldContextValue): LabelStyles {
-  const { formFieldVariant, isDisabled, isRequired, isLabelHidden } = props;
+  const { formFieldMode, isDisabled, isRequired, isLabelHidden } = props;
 
   const prefix = useClassNamePrefix('Label');
   const inlineClass = `${prefix}--inline`;
@@ -18,8 +18,8 @@ export function useLabelStyleProps(props: FormFieldContextValue): LabelStyles {
   const hiddenClass = useClassNamePrefix('accessibility-hidden');
 
   const classProps = classNames(prefix, {
-    [inlineClass]: formFieldVariant === FormFieldVariants.INLINE,
-    [itemClass]: formFieldVariant === FormFieldVariants.ITEM,
+    [inlineClass]: formFieldMode === FormFieldModes.INLINE,
+    [itemClass]: formFieldMode === FormFieldModes.ITEM,
     [requiredClass]: isRequired,
     [disabledClass]: isDisabled,
     [hiddenClass]: isLabelHidden,

--- a/packages/web-react/src/components/Radio/README.md
+++ b/packages/web-react/src/components/Radio/README.md
@@ -88,7 +88,7 @@ const CustomRadio = (props: SpiritRadioProps): JSX.Element => {
   return (
     <PropsProvider
       value={{
-        formFieldVariant: isItem ? FormFieldVariants.ITEM : FormFieldVariants.INLINE,
+        formFieldMode: isItem ? FormFieldModes.ITEM : FormFieldModes.INLINE,
         isDisabled,
         isLabelHidden,
       }}

--- a/packages/web-react/src/components/Radio/Radio.tsx
+++ b/packages/web-react/src/components/Radio/Radio.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import React, { type ForwardedRef, forwardRef } from 'react';
 import { PropsProvider } from '../../context';
 import { useAriaDescribedBy, useStyleProps } from '../../hooks';
-import { FormFieldVariants, type ForwardRefComponent, type SpiritRadioProps } from '../../types';
+import { FormFieldModes, type ForwardRefComponent, type SpiritRadioProps } from '../../types';
 import { HelperText } from '../HelperText';
 import { Label } from '../Label';
 import { useRadioStyleProps } from './useRadioStyleProps';
@@ -32,7 +32,7 @@ const _Radio = (props: SpiritRadioProps, ref: ForwardedRef<HTMLInputElement>): J
   return (
     <PropsProvider
       value={{
-        formFieldVariant: isItem ? FormFieldVariants.ITEM : FormFieldVariants.INLINE,
+        formFieldMode: isItem ? FormFieldModes.ITEM : FormFieldModes.INLINE,
         isDisabled,
         isLabelHidden,
         validationState,

--- a/packages/web-react/src/components/Toggle/Toggle.tsx
+++ b/packages/web-react/src/components/Toggle/Toggle.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import React, { type ChangeEvent, type ForwardedRef, forwardRef, useState } from 'react';
 import { PropsProvider } from '../../context';
 import { useAriaDescribedBy, useAriaDetails, useStyleProps } from '../../hooks';
-import { FormFieldVariants, type ForwardRefComponent, type SpiritToggleProps } from '../../types';
+import { FormFieldModes, type ForwardRefComponent, type SpiritToggleProps } from '../../types';
 import { HelperText } from '../HelperText';
 import { InputDetails } from '../InputDetails';
 import { Label } from '../Label';
@@ -47,7 +47,7 @@ const _Toggle = (props: SpiritToggleProps, ref: ForwardedRef<HTMLInputElement>) 
   return (
     <PropsProvider
       value={{
-        formFieldVariant: FormFieldVariants.INLINE,
+        formFieldMode: FormFieldModes.INLINE,
         isDisabled,
         isLabelHidden,
         isRequired,

--- a/packages/web-react/src/components/ValidationText/README.md
+++ b/packages/web-react/src/components/ValidationText/README.md
@@ -25,7 +25,7 @@ You can override context by passing props directly:
   elementType="span"
   hasValidationStateIcon="danger"
   isDisabled={false}
-  formFieldVariant="inline"
+  formFieldMode="inline"
 />
 ```
 
@@ -35,25 +35,25 @@ When displaying validation text dynamically, set [`role="alert"`][aria-alert-rol
 
 ### API
 
-| Name                     | Type                                                   | Default | Required | Description                                                                                                                               |
-| ------------------------ | ------------------------------------------------------ | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `elementType`            | `ElementType`                                          | `div`   | ✕        | Element used as main wrapper. When `validationText` is an array, the component renders a `ul` inside the wrapper                          |
-| `formFieldVariant`       | `FormFieldVariant`                                     | —       | ✕        | Explicit visual variant (`inline`, `item`); omit for the default layout used by box form field components, or take it from parent context |
-| `hasValidationStateIcon` | [Validation dictionary][dictionary-validation]         | —       | ✕        | When set, shows validation icon and applies state styling (e.g. `danger`)                                                                 |
-| `id`                     | `string`                                               | —       | ✕        | Element id (e.g. for `aria-describedby`)                                                                                                  |
-| `isDisabled`             | `bool`                                                 | `false` | ✕        | Disabled state; when omitted, taken from parent context                                                                                   |
-| `registerAria`           | `(payload: { add?: string; remove?: string }) => void` | —       | ✕        | Callback to register this element's id for `aria-describedby`                                                                             |
-| `role`                   | `AriaRole`                                             | —       | ✕        | ARIA role (e.g. `alert` for dynamic validation)                                                                                           |
-| `validationText`         | `ReactNode` \| `ReactNode[]`                           | —       | ✕        | Validation message or messages to display                                                                                                 |
+| Name                     | Type                                                   | Default | Required | Description                                                                                                                     |
+| ------------------------ | ------------------------------------------------------ | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `elementType`            | `ElementType`                                          | `div`   | ✕        | Element used as main wrapper. When `validationText` is an array, the component renders a `ul` inside the wrapper                |
+| `formFieldMode`          | `FormFieldMode`                                        | —       | ✕        | Explicit mode (`inline`, `item`); omit for the default layout used by box form field components, or take it from parent context |
+| `hasValidationStateIcon` | [Validation dictionary][dictionary-validation]         | —       | ✕        | When set, shows validation icon and applies state styling (e.g. `danger`)                                                       |
+| `id`                     | `string`                                               | —       | ✕        | Element id (e.g. for `aria-describedby`)                                                                                        |
+| `isDisabled`             | `bool`                                                 | `false` | ✕        | Disabled state; when omitted, taken from parent context                                                                         |
+| `registerAria`           | `(payload: { add?: string; remove?: string }) => void` | —       | ✕        | Callback to register this element's id for `aria-describedby`                                                                   |
+| `role`                   | `AriaRole`                                             | —       | ✕        | ARIA role (e.g. `alert` for dynamic validation)                                                                                 |
+| `validationText`         | `ReactNode` \| `ReactNode[]`                           | —       | ✕        | Validation message or messages to display                                                                                       |
 
 On top of the API options, the component accepts [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]
 and [escape hatches][readme-escape-hatches].
 
-## Variants
+## Modes
 
 - **inline**: Used by Checkbox, Radio, and Toggle (non-item).
-- **item**: Used by Checkbox or Radio in item variant, or when `formFieldVariant="item"` is passed directly.
+- **item**: Used by Checkbox or Radio in item mode, or when `formFieldMode="item"` is passed directly.
 
 [aria-alert-role]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
 [dictionary-validation]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation

--- a/packages/web-react/src/components/ValidationText/ValidationText.tsx
+++ b/packages/web-react/src/components/ValidationText/ValidationText.tsx
@@ -20,7 +20,7 @@ const ValidationText = <E extends ElementType = 'div'>(props: SpiritValidationTe
   const contextProps = useContextProps<Partial<FormFieldContextValue>>();
   const propsWithDefaults = {
     ...defaultProps,
-    formFieldVariant: contextProps.formFieldVariant,
+    formFieldMode: contextProps.formFieldMode,
     isDisabled: contextProps.isDisabled,
     ...props,
   };
@@ -31,7 +31,7 @@ const ValidationText = <E extends ElementType = 'div'>(props: SpiritValidationTe
     registerAria,
     role,
     validationText,
-    formFieldVariant,
+    formFieldMode,
     isDisabled,
     ...restProps
   } = propsWithDefaults;
@@ -39,7 +39,7 @@ const ValidationText = <E extends ElementType = 'div'>(props: SpiritValidationTe
   const validationIconName = useValidationIcon({ hasValidationStateIcon });
   const validationStateForStyles = hasValidationStateIcon ?? contextProps.validationState;
   const { classProps } = useValidationTextStyleProps({
-    formFieldVariant,
+    formFieldMode,
     hasValidationStateIcon: validationStateForStyles,
     isDisabled,
   });

--- a/packages/web-react/src/components/ValidationText/__tests__/useValidationTextStyleProps.test.ts
+++ b/packages/web-react/src/components/ValidationText/__tests__/useValidationTextStyleProps.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { FormFieldVariants } from '../../../types';
+import { FormFieldModes } from '../../../types';
 import { useValidationTextStyleProps } from '../useValidationTextStyleProps';
 
 describe('useValidationTextStyleProps', () => {
@@ -34,20 +34,20 @@ describe('useValidationTextStyleProps', () => {
     expect(result.current.classProps).toContain('ValidationText--disabled');
   });
 
-  it('should return inline class when formFieldVariant is inline', () => {
+  it('should return inline class when formFieldMode is inline', () => {
     const { result } = renderHook(() =>
       useValidationTextStyleProps({
-        formFieldVariant: FormFieldVariants.INLINE,
+        formFieldMode: FormFieldModes.INLINE,
       }),
     );
 
     expect(result.current.classProps).toContain('ValidationText--inline');
   });
 
-  it('should return item class when formFieldVariant is item', () => {
+  it('should return item class when formFieldMode is item', () => {
     const { result } = renderHook(() =>
       useValidationTextStyleProps({
-        formFieldVariant: FormFieldVariants.ITEM,
+        formFieldMode: FormFieldModes.ITEM,
       }),
     );
 

--- a/packages/web-react/src/components/ValidationText/demo/ValidationTextItemType.tsx
+++ b/packages/web-react/src/components/ValidationText/demo/ValidationTextItemType.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Checkbox } from '../../Checkbox';
 
-const ValidationTextItemVariant = () => {
+const ValidationTextItemType = () => {
   const [isChecked, setIsChecked] = useState(false);
 
   return (
@@ -11,11 +11,11 @@ const ValidationTextItemVariant = () => {
       label="Checkbox Label"
       isItem
       validationState="danger"
-      validationText="Item variant validation text"
+      validationText="Item mode validation text"
       isChecked={isChecked}
       onChange={() => setIsChecked(!isChecked)}
     />
   );
 };
 
-export default ValidationTextItemVariant;
+export default ValidationTextItemType;

--- a/packages/web-react/src/components/ValidationText/demo/index.tsx
+++ b/packages/web-react/src/components/ValidationText/demo/index.tsx
@@ -7,7 +7,7 @@ import { IconsProvider } from '../../../context';
 import ValidationTextAsList from './ValidationTextAsList';
 import ValidationTextDisabled from './ValidationTextDisabled';
 import ValidationTextInlineCheckbox from './ValidationTextInlineCheckbox';
-import ValidationTextItemVariant from './ValidationTextItemVariant';
+import ValidationTextItemType from './ValidationTextItemType';
 import ValidationTextValidationStates from './ValidationTextValidationStates';
 import ValidationTextWithIcon from './ValidationTextWithIcon';
 
@@ -29,8 +29,8 @@ createRoot(document.getElementById('root') as HTMLElement).render(
       <DocsSection title="Inline Field (Checkbox)">
         <ValidationTextInlineCheckbox />
       </DocsSection>
-      <DocsSection title="Item Variant (Checkbox Item)">
-        <ValidationTextItemVariant />
+      <DocsSection title="Item Mode (Checkbox Item)">
+        <ValidationTextItemType />
       </DocsSection>
     </IconsProvider>
   </StrictMode>,

--- a/packages/web-react/src/components/ValidationText/stories/ValidationText.stories.tsx
+++ b/packages/web-react/src/components/ValidationText/stories/ValidationText.stories.tsx
@@ -2,7 +2,7 @@ import { Markdown } from '@storybook/addon-docs/blocks';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 import { ValidationStates } from '../../../constants';
-import { FormFieldVariants } from '../../../types';
+import { FormFieldModes } from '../../../types';
 import ReadMe from '../README.md?raw';
 import { ValidationText } from '..';
 
@@ -21,9 +21,9 @@ const meta: Meta<typeof ValidationText> = {
         defaultValue: { summary: 'div' },
       },
     },
-    formFieldVariant: {
+    formFieldMode: {
       control: 'select',
-      options: Object.values(FormFieldVariants),
+      options: Object.values(FormFieldModes),
     },
     hasValidationStateIcon: {
       control: 'select',

--- a/packages/web-react/src/components/ValidationText/useValidationTextStyleProps.ts
+++ b/packages/web-react/src/components/ValidationText/useValidationTextStyleProps.ts
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { useClassNamePrefix } from '../../hooks';
-import { type FormFieldContextValue, FormFieldVariants, type ValidationState } from '../../types';
+import { type FormFieldContextValue, FormFieldModes, type ValidationState } from '../../types';
 
 export interface ValidationTextStyles {
   /** className for the root element */
@@ -12,7 +12,7 @@ export interface UseValidationTextStylePropsProps extends FormFieldContextValue 
 }
 
 export function useValidationTextStyleProps(props: UseValidationTextStylePropsProps): ValidationTextStyles {
-  const { formFieldVariant, hasValidationStateIcon, isDisabled } = props;
+  const { formFieldMode, hasValidationStateIcon, isDisabled } = props;
 
   const prefix = useClassNamePrefix('ValidationText');
   const dangerClass = `${prefix}--danger`;
@@ -27,8 +27,8 @@ export function useValidationTextStyleProps(props: UseValidationTextStylePropsPr
     [warningClass]: hasValidationStateIcon === 'warning',
     [successClass]: hasValidationStateIcon === 'success',
     [disabledClass]: isDisabled,
-    [inlineClass]: formFieldVariant === FormFieldVariants.INLINE,
-    [itemClass]: formFieldVariant === FormFieldVariants.ITEM,
+    [inlineClass]: formFieldMode === FormFieldModes.INLINE,
+    [itemClass]: formFieldMode === FormFieldModes.ITEM,
   });
 
   return {

--- a/packages/web-react/src/constants/inputs.ts
+++ b/packages/web-react/src/constants/inputs.ts
@@ -1,4 +1,4 @@
-export const FormFieldVariants = {
+export const FormFieldModes = {
   INLINE: 'inline',
   ITEM: 'item',
 } as const;

--- a/packages/web-react/src/types/shared/inputs.ts
+++ b/packages/web-react/src/types/shared/inputs.ts
@@ -1,13 +1,13 @@
 import type { AriaRole, ElementType, ReactNode } from 'react';
-import { FormFieldVariants, type InputPositions } from '../../constants';
+import { FormFieldModes, type InputPositions } from '../../constants';
 import { type SizesDictionaryType, type ValidationStatesDictionaryType } from './dictionaries';
 
 export type ValidationState = ValidationStatesDictionaryType;
 
 export type ValidationTextType = ReactNode | ReactNode[];
 
-export { FormFieldVariants };
-export type FormFieldVariant = (typeof FormFieldVariants)[keyof typeof FormFieldVariants];
+export { FormFieldModes };
+export type FormFieldMode = (typeof FormFieldModes)[keyof typeof FormFieldModes];
 
 export type RegisterParams = { add?: string; remove?: string };
 
@@ -28,8 +28,8 @@ export interface FormFieldProps<E extends ElementType = 'div'> extends FormField
 }
 
 export interface FormFieldContextValue {
-  /** Visual variant (box, inline, item) for Label and HelperText styling. */
-  formFieldVariant?: FormFieldVariant;
+  /** Mode (inline, item) for Label and HelperText styling. */
+  formFieldMode?: FormFieldMode;
   /** Whether the field is disabled; affects Label and HelperText styling. */
   isDisabled?: boolean;
   /** Whether the field is an item (Checkbox or Radio in item mode). */
@@ -44,7 +44,7 @@ export interface FormFieldContextValue {
   validationState?: ValidationState;
 }
 
-export type FormFieldStyleProps = Pick<FormFieldContextValue, 'formFieldVariant' | 'isDisabled'>;
+export type FormFieldStyleProps = Pick<FormFieldContextValue, 'formFieldMode' | 'isDisabled'>;
 
 export type LabelStyleProps = FormFieldStyleProps &
   Pick<FormFieldContextValue, 'isLabelHidden' | 'isRequired' | 'isItem'>;

--- a/packages/web-react/tests/providerTests/formFieldContextPropsTest.tsx
+++ b/packages/web-react/tests/providerTests/formFieldContextPropsTest.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React, { type ReactElement } from 'react';
 import { PropsProvider } from '../../src/context';
-import { FormFieldVariants } from '../../src/types';
+import { FormFieldModes } from '../../src/types';
 
 type TestProps = Record<string, unknown>;
 type RenderComponent = (props?: TestProps) => ReactElement;
@@ -12,8 +12,8 @@ interface BaseFormFieldTestConfig {
 
 interface FormFieldContextPropsTestConfig extends BaseFormFieldTestConfig {
   classNamePrefix: string;
-  includeInlineVariant?: boolean;
-  includeItemVariant?: boolean;
+  includeInlineMode?: boolean;
+  includeItemMode?: boolean;
   text?: string;
 }
 
@@ -36,14 +36,14 @@ interface FormFieldLabelContextPropsTestConfig extends BaseFormFieldTestConfig {
   requiredProps?: TestProps;
 }
 
-interface VariantContextProps {
+interface TypeContextProps {
   disabledProps?: TestProps;
   inlineProps?: TestProps;
   itemProps?: TestProps;
 }
 
-interface FormFieldHelperTextContextPropsTestConfig extends BaseFormFieldTestConfig, VariantContextProps {
-  /** When false, skip inline class test (parents without `formFieldVariant` in context). @default false */
+interface FormFieldHelperTextContextPropsTestConfig extends BaseFormFieldTestConfig, TypeContextProps {
+  /** When false, skip inline class test (parents without `formFieldMode` in context). @default false */
   includeInline?: boolean;
   /** When false, skip item class test. @default false */
   includeItem?: boolean;
@@ -53,10 +53,10 @@ interface FormFieldHelperTextContextPropsTestConfig extends BaseFormFieldTestCon
   labelText?: string;
 }
 
-interface FormFieldValidationTextContextPropsTestConfig extends BaseFormFieldTestConfig, VariantContextProps {
+interface FormFieldValidationTextContextPropsTestConfig extends BaseFormFieldTestConfig, TypeContextProps {
   /** When false, skip disabled validation text test. @default true */
   includeDisabled?: boolean;
-  /** When false, skip inline class test (parents without `formFieldVariant` in context). @default false */
+  /** When false, skip inline class test (parents without `formFieldMode` in context). @default false */
   includeInline?: boolean;
   /** When false, skip item class test. @default false */
   includeItem?: boolean;
@@ -106,44 +106,42 @@ const expectClassForProps = ({
 
 export const formFieldContextPropsTest = ({
   classNamePrefix,
-  includeInlineVariant = true,
-  includeItemVariant = true,
+  includeInlineMode = true,
+  includeItemMode = true,
   renderComponent,
   text = DEFAULT_LABEL_TEXT,
 }: FormFieldContextPropsTestConfig) => {
   describe('prop priority (1. direct props, 2. context, 3. defaultProps)', () => {
-    if (includeInlineVariant || includeItemVariant) {
-      it('should use default formFieldVariant when no context and no direct prop', () => {
+    if (includeInlineMode || includeItemMode) {
+      it('should use default formFieldMode when no context and no direct prop', () => {
         renderFieldComponent(renderComponent);
         const element = screen.getByText(text);
 
         expect(element.className).toMatch(new RegExp(`^${classNamePrefix}\\b`));
 
-        if (includeInlineVariant) {
+        if (includeInlineMode) {
           expect(element.className).not.toContain(`${classNamePrefix}--inline`);
         }
-        if (includeItemVariant) {
+        if (includeItemMode) {
           expect(element.className).not.toContain(`${classNamePrefix}--item`);
         }
       });
     }
 
-    if (includeInlineVariant) {
-      it('should use context formFieldVariant when context provides it and no direct prop', () => {
-        render(
-          <PropsProvider value={{ formFieldVariant: FormFieldVariants.INLINE }}>{renderComponent()}</PropsProvider>,
-        );
+    if (includeInlineMode) {
+      it('should use context formFieldMode when context provides it and no direct prop', () => {
+        render(<PropsProvider value={{ formFieldMode: FormFieldModes.INLINE }}>{renderComponent()}</PropsProvider>);
         const element = screen.getByText(text);
 
         expect(element.className).toContain(`${classNamePrefix}--inline`);
       });
     }
 
-    if (includeInlineVariant && includeItemVariant) {
-      it('should use direct formFieldVariant over context (direct props override context)', () => {
+    if (includeInlineMode && includeItemMode) {
+      it('should use direct formFieldMode over context (direct props override context)', () => {
         render(
-          <PropsProvider value={{ formFieldVariant: FormFieldVariants.ITEM }}>
-            {renderComponent({ formFieldVariant: FormFieldVariants.INLINE })}
+          <PropsProvider value={{ formFieldMode: FormFieldModes.ITEM }}>
+            {renderComponent({ formFieldMode: FormFieldModes.INLINE })}
           </PropsProvider>,
         );
         const element = screen.getByText(text);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

You are right, I forgot to add it.

We want to introduce the `variant` prop to support the `outline` and `fill` variants. The same we have on SegmentedControl already.

But this would be confusing with formFieldVariant, as we want to pass this to the props context as well. So I propose this change, but I am open to any other name change; however, we should avoid variants.

The `formFieldVariant`/`formFieldVariant` is actually an internal prop.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
