### PR TITLE
fix(web-react): fix subpath type declarations not resolving

### DIFF
--- a/packages/web-react/scripts/verifyBuild.ts
+++ b/packages/web-react/scripts/verifyBuild.ts
@@ -82,6 +82,34 @@ for (const exportCheck of exportsToCheck) {
   }
 }
 
+// Check all exports[*].types paths from package.json
+log('\n🗂  Verifying exports subpath type declarations...');
+const exportsMap: Record<string, Record<string, string> | string> = packageJson.exports ?? {};
+const missingTypePaths: string[] = [];
+let checkedCount = 0;
+
+for (const [exportKey, exportValue] of Object.entries(exportsMap)) {
+  if (typeof exportValue === 'object' && exportValue.types) {
+    checkedCount += 1;
+    const typesPath = exportValue.types.replace(/^\.\//, '');
+    const fullTypesPath = join(DIST_DIR, '..', typesPath);
+
+    if (!existsSync(fullTypesPath)) {
+      missingTypePaths.push(`${exportKey} → ${exportValue.types}`);
+    }
+  }
+}
+
+if (missingTypePaths.length === 0) {
+  logInfo(`✓ All ${checkedCount} subpath type declarations present`);
+} else {
+  logError(`✕ ${missingTypePaths.length} of ${checkedCount} subpath type declarations missing:`);
+  for (const missing of missingTypePaths) {
+    logError(`  ✕ ${missing}`);
+  }
+  errors += missingTypePaths.length;
+}
+
 // Summary
 log(`\n${'='.repeat(50)}`);
 if (errors === 0) {

--- a/packages/web-react/vite.config.ts
+++ b/packages/web-react/vite.config.ts
@@ -23,6 +23,7 @@ const dtsPlugin = dts({
   tsconfigPath: './config/tsconfig.prod.json',
   include: ['src/**/*'],
   exclude: ['**/__tests__/**', '**/stories/**', '**/demo/', '**/figma/'],
+  entryRoot: 'src',
   compilerOptions: {
     preserveConstEnums: true,
   },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Consumers of `@alma-oss/spirit-web-react` subpaths (e.g. `/components`, `/hooks`) were getting no TypeScript types because `vite-plugin-dts` was outputting declaration files under `dist/src/` while `package.json` exports declared them at `dist/components/index.d.ts` — paths that did not exist. This forced downstream repos to add manual `.d.ts` shims as a workaround.

Adding `entryRoot: 'src'` to the `dts()` plugin config strips the `src/` prefix from output paths, mirroring what rollup already does via `preserveModulesRoot: 'src'` for JS files. All subpath type entries in `package.json` exports now resolve correctly.

### Additional context

The mismatch was caught via [platform-frontends#2257](https://github.com/almacareer/platform-frontends/pull/2257), which added shim files to work around the missing types. Those shims can be removed once this fix is published.

### Issue reference

https://jira.almacareer.tech/browse/DS-2561