### PR TITLE
docs(web-react): document `rem` usage in components #DS-2393

### DIFF
--- a/docs/contribution/units.md
+++ b/docs/contribution/units.md
@@ -1,0 +1,128 @@
+# Units
+
+Spirit generally prefers `rem` for layout-related sizing (spacing, typography, radii, shadows).
+This document explains how units are used across Spirit, how the `px`-to-`rem` conversion works,
+and which utilities to reach for when contributing to Spirit. Note that some values intentionally
+stay in `px` — border widths, base font-size tokens, and visually-hidden utility techniques, for
+example — because they must not scale with the user's root font-size.
+
+## Why `rem`?
+
+`rem` is relative to the `<html>` element's font size. Using it means:
+
+- Sizes respect the user's browser or OS font-size preference — essential for accessibility.
+- Visual proportions stay consistent with surrounding typography.
+- All Spirit values (spacing, typography, sizing) share the same scale, so the system remains coherent.
+
+⚠️ Fixed `px` values ignore the user's root font-size setting, so it breaks consistency and violates [accessibility rule][wcag-resize-text].
+
+## Base Font Size
+
+The default base is **16 px**, matching the browser default. It is defined in three places to keep all
+converters in sync:
+
+| Layer         | Identifier                                                                  | Default |
+| ------------- | --------------------------------------------------------------------------- | ------- |
+| Design tokens | `fontSizeBaseMobile`, `fontSizeBaseTablet`, `fontSizeBaseDesktop`           | `16px`  |
+| SCSS          | `$font-size-base-fallback` in `packages/web/src/scss/settings/_units.scss`  | `16px`  |
+| JS/TS         | `FALLBACK_BASE_FONT_SIZE_PX` in `packages/web-react/src/constants/units.ts` | `16`    |
+
+The design-token values exported from Supernova are the source of truth. When Supernova exports tokens,
+it divides each pixel value by the relevant device base to produce the `rem` strings in
+`packages/design-tokens/src`. All three converters listed below fall back to the same value, so the
+arithmetic is consistent throughout the system.
+
+## Utilities
+
+### SCSS — `px-to-rem()` (`packages/web`)
+
+```scss
+// Path is relative to the component file, e.g. packages/web/src/scss/components/*/
+@use '../../tools/units';
+
+.MyComponent {
+  padding: units.px-to-rem(16px); // → 1rem
+  font-size: units.px-to-rem(14px); // → 0.875rem
+}
+```
+
+Signature:
+
+```scss
+px-to-rem($value-px, $base-font-size: $fallback-base-font-size, $decimals: 4)
+```
+
+| Parameter         | Type                    | Default                            | Notes                                                             |
+| ----------------- | ----------------------- | ---------------------------------- | ----------------------------------------------------------------- |
+| `$value-px`       | `px` or unitless number | —                                  | Unitless values are treated as px.                                |
+| `$base-font-size` | `px` or unitless number | `$fallback-base-font-size` (16 px) | Falls back to `$font-size-base-fallback` when omitted or invalid. |
+| `$decimals`       | integer 0–100           | `4`                                | Invalid values silently fall back to `4`.                         |
+
+## Mixed-Unit Arithmetic
+
+Because some Spirit tokens stay in `px` (e.g. border widths) while layout tokens use `rem`,
+you cannot add them together directly. CSS requires `calc()` whenever operands have different units.
+
+```scss
+// ❌ Invalid — px and rem cannot be added without calc()
+padding: $border-width-100 + spacing.$space-400;
+
+// ✅ Correct — use calc() to mix units
+padding: calc(#{$border-width-100} + #{spacing.$space-400});
+```
+
+### JavaScript/TypeScript — `pxToRem()` (`packages/web-react`)
+
+```ts
+import { pxToRem } from '@alma-oss/spirit-web-react/utils';
+
+pxToRem(24); // → '1.5rem'
+pxToRem('16px'); // → '1rem'
+pxToRem(14, { baseFontSize: 16, decimals: 2 }); // → '0.88rem'
+```
+
+Signature:
+
+```ts
+pxToRem(valuePx: string | number, options?: PxToRemOptions): string
+
+type PxToRemOptions = {
+  baseFontSize?: number | string; // defaults to fontSizeBaseMobile token value (16)
+  decimals?: number;              // defaults to 4
+};
+```
+
+### JavaScript/TypeScript — `cssLengthToPixels()` (`packages/common`)
+
+> **Internal only** — `@alma-oss/spirit-common` is not published to npm.
+
+Converts a CSS length string back to a pixel number. Useful when computing pixel dimensions from
+`rem` token values at runtime (e.g. when positioning an overlay or popover in JS).
+
+```ts
+import { cssLengthToPixels, getRootFontSizePx } from '@alma-oss/spirit-common/utilities';
+
+cssLengthToPixels('1rem'); // → 16 (uses the current root font size at runtime)
+cssLengthToPixels('24px'); // → 24
+cssLengthToPixels('auto'); // → undefined
+
+getRootFontSizePx(); // → current <html> font-size in px; falls back to 16
+```
+
+In SSR and test environments without a DOM, `getRootFontSizePx` returns the fallback value of `16`.
+
+## Decimal Precision
+
+All three converters default to **4 decimal places** and strip trailing zeros:
+
+| Input  | Output                   |
+| ------ | ------------------------ |
+| `14px` | `0.875rem`               |
+| `16px` | `1rem` (not `1.0000rem`) |
+| `15px` | `0.9375rem`              |
+| `10px` | `0.625rem`               |
+
+The token exporter uses the same precision, so the values in `packages/design-tokens/src` match
+what these utilities produce.
+
+[wcag-resize-text]: https://www.w3.org/WAI/WCAG21/Understanding/resize-text

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -14,6 +14,23 @@
 import { environments } from '@alma-oss/spirit-common/constants/environments';
 ```
 
+### `cssLengthToPixels()`
+
+Converts a CSS length string (`'1rem'`, `'24px'`) to a pixel number at runtime. Falls back to
+`16` in SSR / DOM-less environments.
+
+```ts
+import { cssLengthToPixels } from '@alma-oss/spirit-common/utilities';
+
+cssLengthToPixels('1rem'); // → 16
+cssLengthToPixels('24px'); // → 24
+cssLengthToPixels('auto'); // → undefined
+```
+
+👉 See the [units guide][units-guide] for full context.
+
 ## License
 
 See the [LICENSE](LICENSE.md) file for information.
+
+[units-guide]: https://github.com/alma-oss/spirit-design-system/tree/main/docs/contribution/units.md

--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -14,10 +14,11 @@
 4. [Basic Usage](#basic-usage)
    1. [In Sass](#in-sass)
    2. [In JavaScript](#in-javascript)
-5. [Rebranding Spirit](#rebranding-spirit)
+5. [Units — `rem`](#units--rem)
+6. [Rebranding Spirit](#rebranding-spirit)
    1. [Using Your Design Tokens with TypeScript](#using-your-design-tokens-with-typescript)
-6. [FAQ](#faq)
-7. [License](#license)
+7. [FAQ](#faq)
+8. [License](#license)
 
 ## Available Design Tokens
 
@@ -228,6 +229,34 @@ const desktopBreakpoint = SpiritDesignTokens.breakpoints.desktop;
 
 The structure is the same as in Sass.
 
+## Units — `rem`
+
+All numeric Spirit design tokens (spacing, typography, radii, shadows) are expressed in `rem` units
+relative to the root font size, which defaults to **16 px**.
+
+```js
+import { space700, space1000 } from '@alma-oss/spirit-design-tokens';
+
+console.log(space700); // → '1rem'  (= 16 px at default root size)
+console.log(space1000); // → '2rem'  (= 32 px at default root size)
+```
+
+```scss
+@use '@tokens' as tokens;
+
+.MyComponent {
+  margin-bottom: tokens.$space-700; // → 1rem
+}
+```
+
+The base font size used during token export is defined per device in `fontSizeBaseMobile`,
+`fontSizeBaseTablet`, and `fontSizeBaseDesktop` (all `16px` by default). If you change your
+project's root font size, all `rem` token values will scale accordingly — this is intentional
+and keeps the layout proportional to the user's font-size preference.
+
+For a full explanation of how the conversion works and what utilities are available in Spirit
+packages, see the [units guide][units-guide].
+
 ## Rebranding Spirit
 
 The system is designed to be easily rebranded. To do so, you need to provide
@@ -428,8 +457,9 @@ values. This way, you can switch between themes without changing your components
 
 See the [LICENSE](LICENSE.md) file for information.
 
+[units-guide]: https://github.com/alma-oss/spirit-design-system/tree/main/docs/contribution/units.md
+[sass-embedded]: https://sass-lang.com/documentation/breaking-changes/legacy-js-api/#bundlers
 [spirit-figma]: https://www.figma.com/design/w9Ca4hvkuYLshsrHu1bYwT/
 [spirit-supernova]: https://spirit.design/
 [supernova]: https://spirit.supernova-docs.io
 [web-docs]: https://github.com/alma-oss/spirit-design-system/tree/main/packages/web#readme
-[sass-embedded]: https://sass-lang.com/documentation/breaking-changes/legacy-js-api/#bundlers

--- a/packages/web-react/README.md
+++ b/packages/web-react/README.md
@@ -15,6 +15,7 @@
 - [Testing](#testing)
 - [Styling](#styling)
 - [Types Generated From Design Tokens](#types-generated-from-design-tokens)
+- [Utilities](#utilities)
 - [Controlled vs Uncontrolled Components](#controlled-vs-uncontrolled-components)
 - [Deprecations](#deprecations)
 - [Examples](#examples)
@@ -365,6 +366,24 @@ are doing so at your own risk.
 
 Please consult additional styling with [web package documentation][web-pkg-rebrand].
 
+## Utilities
+
+### `pxToRem()`
+
+`pxToRem` converts a pixel value to a `rem` string. It uses the Spirit base font size (16 px by
+default) and trims trailing decimal zeros.
+
+```ts
+import { pxToRem } from '@alma-oss/spirit-web-react/utils';
+
+pxToRem(24); // → '1.5rem'
+pxToRem('16px'); // → '1rem'
+pxToRem(14, { baseFontSize: 16, decimals: 2 }); // → '0.88rem'
+```
+
+👉 See the [units guide][units-guide] for full details, including the SCSS
+equivalent and how base font sizes relate to design tokens.
+
 ## Controlled vs Uncontrolled Components
 
 - A [Controlled Component][react-controlled] is one that takes its current
@@ -476,6 +495,7 @@ See the [LICENSE][license] file for information.
 [figma-skill]: https://skills.sh/alma-oss/spirit-design-system/figma-to-spirit
 [license]: LICENSE.md
 [next-pages-router-push]: https://nextjs.org/docs/pages/api-reference/functions/use-router#routerpush
+[units-guide]: https://github.com/alma-oss/spirit-design-system/tree/main/docs/contribution/units.md
 [react-controlled]: https://reactjs.org/docs/forms.html#controlled-components
 [react-uncontrolled]: https://reactjs.org/docs/uncontrolled-components.html
 [skills-docs]: https://skills.sh/docs

--- a/packages/web-react/src/components/Icon/README.md
+++ b/packages/web-react/src/components/Icon/README.md
@@ -76,14 +76,28 @@ import icons from '@alma-oss/spirit-icons/icons';
 </IconsProvider>;
 ```
 
+## Box Size Units
+
+The `boxSize` prop accepts values **in px** (as a plain number, without the unit suffix).
+The component converts them to `rem` internally using the Spirit base font size (16 px by default),
+so the icon scales with the user's root font-size preference.
+
+```tsx
+// 24 px → '1.5rem' at the default 16 px base
+<Icon name="info" boxSize={24} />
+
+// Responsive: 20 px mobile, 30 px tablet, 40 px desktop
+<Icon name="info" boxSize={{ mobile: 20, tablet: 30, desktop: 40 }} />
+```
+
 ## API
 
-| Name      | Type                                                                                                                                                 | Default      | Required | Description                                                                                           |
-| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | -------- | ----------------------------------------------------------------------------------------------------- |
-| `boxSize` | \[`number` \| `Responsive<number>`]                                                                                                                  | 24           | ✕        | Size of the icon, use object to set responsive values, e.g. `{ mobile: 20, tablet: 30, desktop: 40 }` |
-| `color`   | \[[AccentColorNamesType][readme-generated-types] \| [EmotionColorNamesType][readme-generated-types] \| [TextColorNamesType][readme-generated-types]] | `primary` \* | ✕        | Color of the dualtone icon                                                                            |
-| `name`    | `string`                                                                                                                                             | —            | ✓        | Name of the icon                                                                                      |
-| `title`   | `string`                                                                                                                                             | —            | ✕        | Title of the icon                                                                                     |
+| Name      | Type                                                                                                                                                 | Default      | Required | Description                                                                                                                                        |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `boxSize` | \[`number` \| `Responsive<number>`]                                                                                                                  | 24           | ✕        | Size of the icon **in px** — converted to `rem` internally. Use an object to set responsive values, e.g. `{ mobile: 20, tablet: 30, desktop: 40 }` |
+| `color`   | \[[AccentColorNamesType][readme-generated-types] \| [EmotionColorNamesType][readme-generated-types] \| [TextColorNamesType][readme-generated-types]] | `primary` \* | ✕        | Color of the dualtone icon                                                                                                                         |
+| `name`    | `string`                                                                                                                                             | —            | ✓        | Name of the icon                                                                                                                                   |
+| `title`   | `string`                                                                                                                                             | —            | ✕        | Title of the icon                                                                                                                                  |
 
 (\*) The default color "Primary" is used only for dualtone icons. For single-tone icons, the default color is inherited from the parent element.
 

--- a/packages/web-react/src/components/Modal/README.md
+++ b/packages/web-react/src/components/Modal/README.md
@@ -318,16 +318,29 @@ limit.
 You can set a custom preferred height of ModalDialog using the `height` prop.
 The prop accepts any valid CSS length value, either as a string or an object with breakpoints as keys.
 
+👉 We recommend using `rem` values so the modal height scales with the user's root font-size preference.
+`px` values are also accepted but ignore the user's font-size setting.
+
+If you only have a pixel value at hand, use the [`pxToRem` utility][pxtorem-utility] to convert it:
+
+```tsx
+import { pxToRem } from '@alma-oss/spirit-web-react/utils';
+
+<ModalDialog isScrollable height={pxToRem(500)}>
+  …
+</ModalDialog>;
+```
+
 The height property falls back to the previous breakpoint using the mobile-first approach. For example, if you set
-`height={{ tablet: '500px' }}` while not setting the `desktop` breakpoint, the value will be used for
+`height={{ tablet: '31.25rem' }}` while not setting the `desktop` breakpoint, the value will be used for
 both tablet and desktop screens. The single non-object value will be used for all breakpoints.
 This is useful for Modals with dynamic content, e.g. a list of items that can be added or removed, or a multistep wizard.
 
 ```tsx
-<ModalDialog isScrollable height="500px">
+<ModalDialog isScrollable height="31.25rem">
   …
 </ModalDialog>
-<ModalDialog isScrollable height={{ mobile: '300px', tablet: '500px', desktop: '600px' }}>
+<ModalDialog isScrollable height={{ mobile: '18.75rem', tablet: '31.25rem', desktop: '37.5rem' }}>
   …
 </ModalDialog>
 ```
@@ -339,22 +352,27 @@ the viewport height. See the [Custom Max Height](#custom-max-height) section for
 
 ### Custom Max Height
 
-The default maximum height of a scrollable ModalDialog is **600 px**, as long as it can fit the viewport.
+The default maximum height of a scrollable ModalDialog is **37.5rem (600 px at the default root font size)**,
+as long as it can fit the viewport.
 
 If the viewport is smaller, scrollable ModalDialog will shrink to fit the viewport. In such case, the ModalDialog height
 will calculate as "viewport height (`100dvh`) minus 1100 spacing".
 
 You can use the `maxHeight` prop to override the default maximum height limit.
 
+👉 We recommend using `rem` values so the modal height scales with the user's root font-size preference.
+`px` values are also accepted but ignore the user's font-size setting.
+If you only have a pixel value at hand, use the [`pxToRem` utility][pxtorem-utility] to convert it.
+
 The max height property falls back to the previous breakpoint using the mobile-first approach. For example, if you set
-`maxHeight={{ tablet: '500px' }}` while not setting the `desktop` breakpoint, the value will be used for
+`maxHeight={{ tablet: '31.25rem' }}` while not setting the `desktop` breakpoint, the value will be used for
 both tablet and desktop screens. The single non-object value will be used for all breakpoints.
 
 ```tsx
-<ModalDialog isScrollable maxHeight="700px">
+<ModalDialog isScrollable maxHeight="43.75rem">
   …
 </ModalDialog>
-<ModalDialog isScrollable maxHeight={{ mobile: '500px', tablet: '700px', desktop: '800px' }}>
+<ModalDialog isScrollable maxHeight={{ mobile: '31.25rem', tablet: '43.75rem', desktop: '50rem' }}>
   …
 </ModalDialog>
 ```
@@ -435,6 +453,7 @@ please refer to the [Icon component documentation][web-react-icon-documentation]
 [mdn-dialog]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
 [mdn-form]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
 [modal]: https://github.com/alma-oss/spirit-design-system/tree/main/packages/web/src/scss/components/Modal
+[pxtorem-utility]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/README.md#pxtorem
 [readme-additional-attributes]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/README.md#additional-attributes
 [readme-escape-hatches]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/README.md#escape-hatches
 [readme-style-props]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/README.md#style-props

--- a/packages/web-react/src/components/Skeleton/README.md
+++ b/packages/web-react/src/components/Skeleton/README.md
@@ -56,13 +56,24 @@ SkeletonShape defines a placeholder for loading the Shape component.
 <SkeletonShape width={100} height={100} borderRadius={{ mobile: '100', tablet: '400', desktop: '500' }}/>
 ```
 
+### Shape Size Units
+
+The `width` and `height` props accept values **in px** (as a plain number, without the unit suffix).
+The component converts them to `rem` internally using the Spirit base font size (16 px by default),
+so the shape scales with the user's root font-size preference.
+
+```tsx
+// 100 px → '6.25rem' at the default 16 px base
+<SkeletonShape width={100} height={100} />
+```
+
 ### API
 
 | Name           | Type                                        | Default | Required | Description                                                                                                       |
 | -------------- | ------------------------------------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
 | `borderRadius` | [Radius dictionary][radius-size] \ `object` | `400`   | ✕        | Border radius variant, use object to set responsive values, e.g. { mobile: '200', tablet: '300', desktop: '400' } |
-| `width`        | `number`                                    | ✕       | ✓        | Specifies the width of an shape                                                                                   |
-| `height`       | `number`                                    | ✕       | ✓        | Specifies the height of an shape                                                                                  |
+| `width`        | `number`                                    | ✕       | ✓        | Width of the shape **in px** (converted to `rem` internally)                                                      |
+| `height`       | `number`                                    | ✕       | ✓        | Height of the shape **in px** (converted to `rem` internally)                                                     |
 
 On top of the API options, the components accept [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]

--- a/packages/web-react/src/components/Skeleton/__tests__/SkeletonShape.test.tsx
+++ b/packages/web-react/src/components/Skeleton/__tests__/SkeletonShape.test.tsx
@@ -40,9 +40,9 @@ describe('SkeletonShape', () => {
     const { result } = renderHook(() => useSkeletonShapeStyleProps(props));
 
     expect(result.current.skeletonShapeStyleProps).toEqual({
-      '--spirit-skeleton-shape-height': '100px',
+      '--spirit-skeleton-shape-height': '6.25rem',
       '--spirit-skeleton-shape-radius': 'var(--spirit-radius-200)',
-      '--spirit-skeleton-shape-width': '100px',
+      '--spirit-skeleton-shape-width': '6.25rem',
     });
   });
 
@@ -56,11 +56,11 @@ describe('SkeletonShape', () => {
     const { result } = renderHook(() => useSkeletonShapeStyleProps(props));
 
     expect(result.current.skeletonShapeStyleProps).toEqual({
-      '--spirit-skeleton-shape-height': '100px',
+      '--spirit-skeleton-shape-height': '6.25rem',
       '--spirit-skeleton-shape-radius': 'var(--spirit-radius-100)',
       '--spirit-skeleton-shape-radius-tablet': 'var(--spirit-radius-400)',
       '--spirit-skeleton-shape-radius-desktop': 'var(--spirit-radius-500)',
-      '--spirit-skeleton-shape-width': '100px',
+      '--spirit-skeleton-shape-width': '6.25rem',
     });
   });
 });

--- a/packages/web-react/src/components/Skeleton/useSkeletonShapeStyleProps.ts
+++ b/packages/web-react/src/components/Skeleton/useSkeletonShapeStyleProps.ts
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { type CSSProperties } from 'react';
 import { useClassNamePrefix } from '../../hooks';
 import { type SkeletonShapeBaseProps } from '../../types';
+import { pxToRem } from '../../utils';
 
 interface CustomizedCSSProperties extends CSSProperties {
   [key: string]: string | undefined | number;
@@ -13,7 +14,7 @@ const setCustomDimension = (prefix: string, size: number | undefined): Customize
 
   const propName = `--${prefix}`;
 
-  return { [propName]: `${size?.toString()}px` } as CustomizedCSSProperties;
+  return { [propName]: pxToRem(size) } as CustomizedCSSProperties;
 };
 
 const setCustomBorderRadius = (

--- a/packages/web-react/src/components/TextArea/README.md
+++ b/packages/web-react/src/components/TextArea/README.md
@@ -103,7 +103,7 @@ an optimized experience:
 | Name                    | Type                                           | Default  | Required | Description                                                                     |
 | ----------------------- | ---------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------- |
 | `autoComplete`          | `string`                                       | -        | ✕        | [Automated assistance in filling][autocomplete-attr]                            |
-| `autoResizingMaxHeight` | `number`                                       | `400`    | ✕        | Maximum field height with automatic height control                              |
+| `autoResizingMaxHeight` | `number`                                       | `400`    | ✕        | Maximum field height **in px** with automatic height control. \*                |
 | `counterThreshold`      | `number`                                       | —        | ✕        | Character threshold; shows `current/threshold` counter                          |
 | `hasCounter`            | `bool`                                         | —        | ✕        | Show character counter (count only); auto `true` with `counterThreshold`        |
 | `maxLength`             | `number`                                       | —        | ✕        | Native textarea hard cap; with `counterThreshold`, prefer `>= counterThreshold` |
@@ -123,6 +123,9 @@ an optimized experience:
 | `validationState`       | [Validation dictionary][dictionary-validation] | —        | ✕        | Type of validation state                                                        |
 | `validationText`        | \[`ReactNode` \| `ReactNode[]`]                | —        | ✕        | Validation text                                                                 |
 | `value`                 | `string`                                       | —        | ✕        | Textarea value                                                                  |
+
+(\*) The value is compared against the browser's `scrollHeight` (a DOM pixel measurement),
+so `px` is intentional here and cannot be replaced with `rem`.
 
 On top of the API options, the components accept [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -227,6 +227,16 @@ Spirit Design System is also available on CDN:
 
 👉 Consider using a specific version instead of `latest` in production.
 
+## Units — `rem`
+
+Spirit primarily uses `rem` for layout-related sizing — spacing, typography, radii, and shadows
+are expressed in `rem` relative to a **16 px** root font size. Intentional `px` exceptions exist
+for values that must not scale with the root font size, such as border widths and
+visually-hidden utility techniques.
+
+👉 See the [units guide][units-guide] for full details, including the SCSS
+`px-to-rem()` function available internally and how the base font size relates to design tokens.
+
 ## Rebranding
 
 Design tokens enable quick and easy rebranding of Spirit Sass components and styles.
@@ -270,4 +280,5 @@ See the [LICENSE][license] file for information.
 [feature-flags-docs]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/contribution/feature-flags.md
 [license]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/LICENSE.md
 [postcss-prefix-selector]: https://www.npmjs.com/package/postcss-prefix-selector
+[units-guide]: https://github.com/alma-oss/spirit-design-system/tree/main/docs/contribution/units.md
 [vite]: https://vitejs.dev

--- a/packages/web/src/scss/components/Modal/README.md
+++ b/packages/web/src/scss/components/Modal/README.md
@@ -278,6 +278,9 @@ You can set a custom preferred height of ModalDialog using a custom property:
 - `--modal-dialog-height-tablet` for tablet screens and up.
 - `--modal-dialog-height-desktop` for desktop screens and up.
 
+👉 We recommend using `rem` values so the modal height scales with the user's root font-size preference.
+`px` values are also accepted but ignore the user's font-size setting.
+
 The custom properties fall back to the previous breakpoint using the mobile-first approach. For example, if you set
 `--modal-dialog-height-tablet` while leaving `--modal-dialog-height-desktop` unset, the value will be used for
 both tablet and desktop screens.
@@ -287,7 +290,7 @@ This is useful for Modals with dynamic content, e.g. a list of items that can be
 ```html
 <article
   class="ModalDialog ModalDialog--scrollable"
-  style="--modal-dialog-height: 400px; --modal-dialog-height-tablet: 500px; --modal-dialog-height-desktop: 600px;"
+  style="--modal-dialog-height: 25rem; --modal-dialog-height-tablet: 31.25rem; --modal-dialog-height-desktop: 37.5rem;"
 >
   <!-- … -->
 </article>
@@ -300,7 +303,7 @@ the viewport height. See the [Custom Max Height](#custom-max-height) section for
 
 ### Custom Max Height
 
-The default maximum height of a scrollable ModalDialog is **600 px**, as long as it can fit the viewport.
+The default maximum height of a scrollable ModalDialog is **37.5rem (600 px at the default root font size)**, as long as it can fit the viewport.
 
 If the viewport is smaller, scrollable ModalDialog will shrink to fit the viewport. In such case, the ModalDialog height
 will calculate as "viewport height (`100dvh`) minus 1100 spacing".
@@ -311,6 +314,9 @@ You can set a custom preferred height of ModalDialog using a custom property:
 - `--modal-dialog-max-height-tablet` for tablet screens and up.
 - `--modal-dialog-max-height-desktop` for desktop screens and up.
 
+👉 We recommend using `rem` values so the modal height scales with the user's root font-size preference.
+`px` values are also accepted but ignore the user's font-size setting.
+
 The custom properties fall back to the previous breakpoint using the mobile-first approach. For example, if you set
 `--modal-dialog-max-height-tablet` while leaving `--modal-dialog-max-height-desktop` unset, the value will be used for both tablet and
 desktop screens.
@@ -318,7 +324,7 @@ desktop screens.
 ```html
 <article
   class="ModalDialog ModalDialog--scrollable"
-  style="--modal-dialog-max-height: 300px; --modal-dialog-max-height-tablet: 400px; --modal-dialog-max-height-desktop: 500px;"
+  style="--modal-dialog-max-height: 18.75rem; --modal-dialog-max-height-tablet: 25rem; --modal-dialog-max-height-desktop: 31.25rem;"
 >
   <!-- … -->
 </article>

--- a/packages/web/src/scss/components/Skeleton/README.md
+++ b/packages/web/src/scss/components/Skeleton/README.md
@@ -49,23 +49,31 @@ Use CSS custom properties to define the width, height, and radius of the shape.
 
 - The default radius is `--spirit-radius-300`
 
-- `--spirit-skeleton-shape-width: number{px};`
-- `--spirit-skeleton-shape-height: number{px};`
+- `--spirit-skeleton-shape-width: number{rem};`
+- `--spirit-skeleton-shape-height: number{rem};`
 - `--spirit-skeleton-shape-radius: var(--spirit-radius-200);`
 - `--spirit-skeleton-shape-radius-tablet: var(--spirit-radius-300);`
 - `--spirit-skeleton-shape-radius-desktop: var(--spirit-radius-400);`
 
+Always express shape dimensions in `rem` (not `px`). `rem` is relative to the root font size, so shapes:
+
+- scale with the user's browser/OS font-size preference, which is essential for accessibility,
+- stay visually proportional to the surrounding typography,
+- follow the same scale as the rest of Spirit's design tokens (spacing, typography, sizing), which are all defined in `rem`.
+
+Fixed `px` values ignore the user's root font-size setting and break this consistency.
+
 ```html
 <div
   class="Skeleton Skeleton--shape"
-  style="--spirit-skeleton-shape-width: 100px; --spirit-skeleton-shape-height: 100px; --spirit-skeleton-shape-radius: var(--spirit-radius-400)"
+  style="--spirit-skeleton-shape-width: 6.25rem; --spirit-skeleton-shape-height: 6.25rem; --spirit-skeleton-shape-radius: var(--spirit-radius-400)"
 ></div>
 ```
 
 ```html
 <div
   class="Skeleton Skeleton--shape"
-  style="--spirit-skeleton-shape-width: 100px; --spirit-skeleton-shape-height: 100px"
+  style="--spirit-skeleton-shape-width: 6.25rem; --spirit-skeleton-shape-height: 6.25rem"
 ></div>
 ```
 

--- a/packages/web/src/scss/components/Skeleton/preview.html
+++ b/packages/web/src/scss/components/Skeleton/preview.html
@@ -64,8 +64,8 @@
             <div
               class="Skeleton Skeleton--shape"
               style="
-              --spirit-skeleton-shape-width: 100px;
-              --spirit-skeleton-shape-height: 100px
+              --spirit-skeleton-shape-width: 6.25rem;
+              --spirit-skeleton-shape-height: 6.25rem
               "
             >
             </div>
@@ -78,8 +78,8 @@
             <div
               class="Skeleton Skeleton--shape"
               style="
-              --spirit-skeleton-shape-width: 100px;
-              --spirit-skeleton-shape-height: 100px;
+              --spirit-skeleton-shape-width: 6.25rem;
+              --spirit-skeleton-shape-height: 6.25rem;
               --spirit-skeleton-shape-radius: var(--spirit-radius-full)
               "
             >
@@ -93,8 +93,8 @@
             <div
               class="Skeleton Skeleton--shape"
               style="
-              --spirit-skeleton-shape-width: 300px;
-              --spirit-skeleton-shape-height: 100px;
+              --spirit-skeleton-shape-width: 18.75rem;
+              --spirit-skeleton-shape-height: 6.25rem;
               --spirit-skeleton-shape-radius: var(--spirit-radius-400)
               "
             >
@@ -107,8 +107,8 @@
           <div class="docs-Stack docs-Stack--stretch">
             <div
               class="Skeleton Skeleton--shape" style="
-              --spirit-skeleton-shape-width: 300px;
-              --spirit-skeleton-shape-height: 100px;
+              --spirit-skeleton-shape-width: 18.75rem;
+              --spirit-skeleton-shape-height: 6.25rem;
               --spirit-skeleton-shape-radius: var(--spirit-radius-200);
               --spirit-skeleton-shape-radius-tablet: var(--spirit-radius-400);
               --spirit-skeleton-shape-radius-desktop: var(--spirit-radius-500);
@@ -139,8 +139,8 @@
               <div
                 class="Skeleton Skeleton--shape"
                 style="
-                --spirit-skeleton-shape-width: 100px;
-                --spirit-skeleton-shape-height: 100px;
+                --spirit-skeleton-shape-width: 6.25rem;
+                --spirit-skeleton-shape-height: 6.25rem;
                 --spirit-skeleton-shape-radius: var(--spirit-radius-full)
                 "
               >


### PR DESCRIPTION
## Description

Documents the `px` → `rem` unit convention used across Spirit's three implementation layers (design tokens, `web`, `web-react`) so that both Spirit contributors and consumers know when and how to use rem values.

**What this PR does:**

- Adds a new contributor guide `docs/contribution/px-to-rem.md` explaining _why_ rem is preferred, how the base font size is defined in each layer, and the full API of the SCSS/JS/TS conversion utilities with worked examples.
- Adds a "Units — `rem`" section to `packages/design-tokens/README.md`, `packages/web/README.md`, `packages/web-react/README.md`, and `packages/common/README.md`, each pointing to the guide.
- Documents px-input / rem-output behaviour for the affected React components: `Icon` (`boxSize`), `SkeletonShape` (`width`, `height`), `Modal` (custom height / max-height custom properties), and `TextArea` (`autoResizingMaxHeight` — intentional px, with rationale).
- Mirrors the same rem updates in the `web` package HTML docs and `preview.html` demo for `Skeleton` and `Modal`.
- **Code fix:** `SkeletonShape` was the only React component whose user-facing numeric size props (`width`, `height`) still produced raw `px` strings in CSS custom properties. The `useSkeletonShapeStyleProps` hook now passes both values through `pxToRem()`, and the test expectations are updated accordingly (`100px` → `6.25rem`). All other numeric-dimension props in the system already used `pxToRem`.

### Additional context

The code change in `useSkeletonShapeStyleProps.ts` is technically a **breaking change for `web` consumers** who set `--spirit-skeleton-shape-width` / `--spirit-skeleton-shape-height` directly in HTML (they must switch from `100px` to `6.25rem`). The React prop interface is unchanged — callers still pass `width={100}`.

Reviewers may want to pay attention to:
- The SCSS import path in `docs/contribution/px-to-rem.md` (`@use '../../tools/units'`) — it uses a relative path matching how Spirit components actually import the mixin, not a load-path alias.
- The `TextArea.autoResizingMaxHeight` footnote — this prop is compared against the browser's `scrollHeight` (a DOM pixel measurement), so `px` is intentional and cannot be replaced with `rem`.

### Issue reference

[DS-2393](https://jira.almacareer.tech/browse/DS-2393)