### PR TITLE
fix(e2e): declare pageRetries fixture with option: true for Playwright v1.60 compatibility

### DIFF
--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -1,5 +1,7 @@
 import { test as base } from '@playwright/test';
 
+const PAGE_RETRIES_FALLBACK = 3;
+
 /**
  * Custom fixture types for extended test functionality.
  */
@@ -26,12 +28,7 @@ interface CustomFixtures {
  * ```
  */
 export const test = base.extend<CustomFixtures>({
-  // Define the pageRetries fixture by reading from test configuration
-  pageRetries: async ({}, use, testInfo) => {
-    // Read pageRetries from the project configuration
-    const retries = (testInfo.project.use as any).pageRetries;
-    await use(retries);
-  },
+  pageRetries: [PAGE_RETRIES_FALLBACK, { option: true }],
 });
 
 // Re-export expect for convenience (so tests can import from this file)


### PR DESCRIPTION
## Description

Playwright v1.60 introduced a breaking change: fixtures cannot be set in the `use` config section unless they are registered with `{ option: true }`. The `pageRetries` fixture was defined without this flag, causing all 134 E2E tests to fail immediately with a fixture override error. Switching to the `[default, { option: true }]` declaration is the correct pattern and removes the previous workaround that read from `testInfo.project.use` directly.

### Additional context

The breakage was introduced by the `@playwright/test` bump to v1.60.0 in the latest dependency update PR. The `playwright.config.ts` `use` section is otherwise unchanged — `pageRetries` continues to be driven by `PW_PAGE_RETRIES` env var with a default of 3.

### Issue reference

<!-- No linked issue -->