### PR TITLE
fix(web): add missing space before self-closing tag in SVG elements

### DIFF
--- a/packages/web/src/scss/components/Spinner/preview.html
+++ b/packages/web/src/scss/components/Spinner/preview.html
@@ -11,7 +11,7 @@
         height="24"
         class="animation-spin-clockwise"
       >
-        <use href="/assets/icons/svg/sprite.svg#spinner"/>
+        <use href="/assets/icons/svg/sprite.svg#spinner" />
       </svg>
 
     </div>
@@ -33,7 +33,7 @@
         height="24"
         class="animation-spin-clockwise"
       >
-        <use href="/assets/icons/svg/sprite.svg#spinner"/>
+        <use href="/assets/icons/svg/sprite.svg#spinner" />
       </svg>
 
       <svg
@@ -41,7 +41,7 @@
         height="24"
         class="text-primary animation-spin-clockwise"
       >
-        <use href="/assets/icons/svg/sprite.svg#spinner"/>
+        <use href="/assets/icons/svg/sprite.svg#spinner" />
       </svg>
 
       <svg
@@ -49,7 +49,7 @@
         height="24"
         class="text-secondary animation-spin-clockwise"
       >
-        <use href="/assets/icons/svg/sprite.svg#spinner"/>
+        <use href="/assets/icons/svg/sprite.svg#spinner" />
       </svg>
 
       <svg
@@ -57,7 +57,7 @@
         height="24"
         class="text-tertiary animation-spin-clockwise"
       >
-        <use href="/assets/icons/svg/sprite.svg#spinner"/>
+        <use href="/assets/icons/svg/sprite.svg#spinner" />
       </svg>
 
     </div>
@@ -79,7 +79,7 @@
         height="36"
         class="animation-spin-clockwise"
       >
-        <use href="/assets/icons/svg/sprite.svg#spinner"/>
+        <use href="/assets/icons/svg/sprite.svg#spinner" />
       </svg>
 
       <svg
@@ -87,7 +87,7 @@
         height="24"
         class="animation-spin-clockwise"
       >
-        <use href="/assets/icons/svg/sprite.svg#spinner"/>
+        <use href="/assets/icons/svg/sprite.svg#spinner" />
         <title>Spinner title</title>
       </svg>
 

--- a/packages/web/src/scss/components/Toast/index.html
+++ b/packages/web/src/scss/components/Toast/index.html
@@ -65,7 +65,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use href="/assets/icons/svg/sprite.svg#close"/>
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
                 <span class="accessibility-hidden">Close</span>
               </button>
@@ -289,7 +289,7 @@
                     height="20"
                     aria-hidden="true"
                   >
-                    <use href="/assets/icons/svg/sprite.svg#chevron-down"/>
+                    <use href="/assets/icons/svg/sprite.svg#chevron-down" />
                   </svg>
                 </div>
               </div>
@@ -485,7 +485,7 @@
                     aria-hidden="true"
                     data-spirit-populate-field="icon"
                   >
-                    <use href="/assets/icons/svg/sprite.svg#info"/>
+                    <use href="/assets/icons/svg/sprite.svg#info" />
                   </svg>
                   <div class="ToastBar__content">
                     <div
@@ -511,7 +511,7 @@
                     height="24"
                     aria-hidden="true"
                   >
-                    <use href="/assets/icons/svg/sprite.svg#close"/>
+                    <use href="/assets/icons/svg/sprite.svg#close" />
                   </svg>
                   <span class="accessibility-hidden">Close</span>
                 </button>
@@ -531,7 +531,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use href="/assets/icons/svg/sprite.svg#check-plain"/>
+                  <use href="/assets/icons/svg/sprite.svg#check-plain" />
                 </svg>
                 <div class="ToastBar__content">
                   <div class="text-truncate-multiline">I was first!</div>
@@ -555,7 +555,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use href="/assets/icons/svg/sprite.svg#close"/>
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
                 <span class="accessibility-hidden">Close</span>
               </button>
@@ -574,7 +574,7 @@
                   height="20"
                   aria-hidden="true"
                 >
-                  <use href="/assets/icons/svg/sprite.svg#info"/>
+                  <use href="/assets/icons/svg/sprite.svg#info" />
                 </svg>
                 <div class="ToastBar__content">
                   <div class="text-truncate-multiline">I appeared later. This toast has a long message that wraps
@@ -600,7 +600,7 @@
                   height="24"
                   aria-hidden="true"
                 >
-                  <use href="/assets/icons/svg/sprite.svg#close"/>
+                  <use href="/assets/icons/svg/sprite.svg#close" />
                 </svg>
                 <span class="accessibility-hidden">Close</span>
               </button>
@@ -674,7 +674,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use href="/assets/icons/svg/sprite.svg#info"/>
+              <use href="/assets/icons/svg/sprite.svg#info" />
             </svg>
             <div class="ToastBar__content">
               <div class="text-truncate-multiline">Message with icon and action</div>
@@ -710,7 +710,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use href="/assets/icons/svg/sprite.svg#close"/>
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -729,7 +729,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use href="/assets/icons/svg/sprite.svg#download"/>
+              <use href="/assets/icons/svg/sprite.svg#download" />
             </svg>
             <div class="ToastBar__content">
               <div class="text-truncate-multiline">Dismissible message with custom icon and action</div>
@@ -752,7 +752,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use href="/assets/icons/svg/sprite.svg#close"/>
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -785,7 +785,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use href="/assets/icons/svg/sprite.svg#info"/>
+              <use href="/assets/icons/svg/sprite.svg#info" />
             </svg>
             <div class="ToastBar__content">
               <div class="text-truncate-multiline">Neutral</div>
@@ -808,7 +808,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use href="/assets/icons/svg/sprite.svg#close"/>
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -827,7 +827,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use href="/assets/icons/svg/sprite.svg#info"/>
+              <use href="/assets/icons/svg/sprite.svg#info" />
             </svg>
             <div class="ToastBar__content">
               <div class="text-truncate-multiline">Informative</div>
@@ -850,7 +850,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use href="/assets/icons/svg/sprite.svg#close"/>
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -869,7 +869,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use href="/assets/icons/svg/sprite.svg#check-plain"/>
+              <use href="/assets/icons/svg/sprite.svg#check-plain" />
             </svg>
             <div class="ToastBar__content">
               <div class="text-truncate-multiline">Success</div>
@@ -892,7 +892,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use href="/assets/icons/svg/sprite.svg#close"/>
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -911,7 +911,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use href="/assets/icons/svg/sprite.svg#warning"/>
+              <use href="/assets/icons/svg/sprite.svg#warning" />
             </svg>
             <div class="ToastBar__content">
               <div class="text-truncate-multiline">Warning</div>
@@ -934,7 +934,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use href="/assets/icons/svg/sprite.svg#close"/>
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
@@ -953,7 +953,7 @@
               height="20"
               aria-hidden="true"
             >
-              <use href="/assets/icons/svg/sprite.svg#danger"/>
+              <use href="/assets/icons/svg/sprite.svg#danger" />
             </svg>
             <div class="ToastBar__content">
               <div class="text-truncate-multiline">Danger</div>
@@ -976,7 +976,7 @@
               height="24"
               aria-hidden="true"
             >
-              <use href="/assets/icons/svg/sprite.svg#close"/>
+              <use href="/assets/icons/svg/sprite.svg#close" />
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>

--- a/packages/web/src/scss/components/UNSTABLE_Header/index.html
+++ b/packages/web/src/scss/components/UNSTABLE_Header/index.html
@@ -176,7 +176,7 @@
                       height="20"
                       aria-hidden="true"
                     >
-                      <use href="/assets/icons/svg/sprite.svg#profile"/>
+                      <use href="/assets/icons/svg/sprite.svg#profile" />
                     </svg>
                   </span>
                   <span class="typography-body-small-semibold">My Account</span>
@@ -370,7 +370,7 @@
                       height="20"
                       aria-hidden="true"
                     >
-                      <use href="/assets/icons/svg/sprite.svg#profile"/>
+                      <use href="/assets/icons/svg/sprite.svg#profile" />
                     </svg>
                   </span>
                   <span class="typography-body-small-semibold">My Account</span>

--- a/packages/web/src/scss/helpers/animations/index.html
+++ b/packages/web/src/scss/helpers/animations/index.html
@@ -13,7 +13,7 @@
         width="24"
         height="24"
       >
-        <use href="/assets/icons/svg/sprite.svg#reload"/>
+        <use href="/assets/icons/svg/sprite.svg#reload" />
       </svg>
 
     </div>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
