### PR TITLE
refactor(web-react): use Grid and Stack in `UNSTABLE_FileUpload` demos

### DIFF
--- a/packages/web-react/src/components/UNSTABLE_FileUpload/demo/FileUploadDraggingNotAvailable.tsx
+++ b/packages/web-react/src/components/UNSTABLE_FileUpload/demo/FileUploadDraggingNotAvailable.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { Grid } from '../../Grid';
 import { UNSTABLE_FileUpload } from '..';
 
 const FileUploadDraggingNotAvailable = () => (
   // ⚠️ VISUAL EXAMPLE ONLY – shows how the input looks when drag-and-drop is not supported. No files are added.
-  <div className="Grid Grid--alignmentXStretch Grid--alignmentYStretch Grid--tablet--cols-2 Grid--cols-1">
+  <Grid cols={{ mobile: 1, tablet: 2 }}>
     <UNSTABLE_FileUpload
       rootId="example-no-drag-standard"
       id="file-uploader-no-drag-standard"
@@ -25,7 +26,7 @@ const FileUploadDraggingNotAvailable = () => (
       linkText="Upload your file"
       name="attachment-no-drag-compact"
     />
-  </div>
+  </Grid>
 );
 
 export default FileUploadDraggingNotAvailable;

--- a/packages/web-react/src/components/UNSTABLE_FileUpload/demo/FileUploadInputDisabled.tsx
+++ b/packages/web-react/src/components/UNSTABLE_FileUpload/demo/FileUploadInputDisabled.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { Grid } from '../../Grid';
 import { UNSTABLE_FileUpload } from '..';
 
 const FileUploadInputDisabled = () => (
-  <div className="Grid Grid--alignmentXStretch Grid--alignmentYStretch Grid--tablet--cols-2 Grid--cols-1">
+  <Grid cols={{ mobile: 1, tablet: 2 }}>
     <UNSTABLE_FileUpload
       rootId="example-disabled-standard"
       id="file-uploader-disabled-standard"
@@ -26,7 +27,7 @@ const FileUploadInputDisabled = () => (
       isDisabled
       isRequired
     />
-  </div>
+  </Grid>
 );
 
 export default FileUploadInputDisabled;

--- a/packages/web-react/src/components/UNSTABLE_FileUpload/demo/FileUploadInputValidationStates.tsx
+++ b/packages/web-react/src/components/UNSTABLE_FileUpload/demo/FileUploadInputValidationStates.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ValidationStates } from '../../../constants';
+import { Grid } from '../../Grid';
 import { UNSTABLE_FileUpload } from '..';
 
 const states = Object.values(ValidationStates);
@@ -7,10 +8,7 @@ const states = Object.values(ValidationStates);
 const FileUploadInputValidationStates = () => (
   <>
     {states.map((state) => (
-      <div
-        key={state}
-        className="Grid Grid--alignmentXStretch Grid--alignmentYStretch Grid--tablet--cols-2 Grid--cols-1"
-      >
+      <Grid key={state} cols={{ mobile: 1, tablet: 2 }}>
         <UNSTABLE_FileUpload
           rootId={`example-validation-standard-${state}`}
           id={`file-uploader-standard-${state}`}
@@ -42,7 +40,7 @@ const FileUploadInputValidationStates = () => (
           }
           validationState={state}
         />
-      </div>
+      </Grid>
     ))}
   </>
 );

--- a/packages/web-react/src/components/UNSTABLE_FileUpload/demo/FileUploadInputValidationWithIcon.tsx
+++ b/packages/web-react/src/components/UNSTABLE_FileUpload/demo/FileUploadInputValidationWithIcon.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ValidationStates } from '../../../constants';
+import { Grid } from '../../Grid';
 import { UNSTABLE_FileUpload } from '..';
 
 const FileUploadInputValidationWithIcon = () => {
@@ -8,10 +9,7 @@ const FileUploadInputValidationWithIcon = () => {
   return (
     <>
       {states.map((state) => (
-        <div
-          key={`file-uploader-${state}-validation-icon`}
-          className="Grid Grid--alignmentXStretch Grid--alignmentYStretch Grid--tablet--cols-2 Grid--cols-1"
-        >
+        <Grid key={`file-uploader-${state}-validation-icon`} cols={{ mobile: 1, tablet: 2 }}>
           <UNSTABLE_FileUpload
             rootId={`example-validation-icon-standard-${state}`}
             id={`file-uploader-icon-standard-${state}`}
@@ -39,7 +37,7 @@ const FileUploadInputValidationWithIcon = () => {
             hasValidationIcon
             isRequired
           />
-        </div>
+        </Grid>
       ))}
     </>
   );

--- a/packages/web-react/src/components/UNSTABLE_FileUpload/demo/FileUploadInputWithAttachment.tsx
+++ b/packages/web-react/src/components/UNSTABLE_FileUpload/demo/FileUploadInputWithAttachment.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Stack } from '../..';
 import { Icon } from '../../Icon';
+import { Stack } from '../../Stack';
 import { UNSTABLE_File, UNSTABLE_FileImagePreview } from '../../UNSTABLE_File';
 import { UNSTABLE_FileUpload } from '..';
 import { visualOnlyNoopOnDismiss } from './visualOnlyContext';
 
 const FileUploadInputWithAttachment = () => (
-  <div className="docs-Stack docs-Stack--stretch">
+  <Stack hasSpacing>
     <UNSTABLE_FileUpload
       rootId="example-with-file-list"
       id="file-uploader-with-list"
@@ -57,7 +57,7 @@ const FileUploadInputWithAttachment = () => (
         onDismiss={visualOnlyNoopOnDismiss}
       />
     </Stack>
-  </div>
+  </Stack>
 );
 
 export default FileUploadInputWithAttachment;

--- a/packages/web-react/src/components/UNSTABLE_FileUpload/demo/FileUploadSimple.tsx
+++ b/packages/web-react/src/components/UNSTABLE_FileUpload/demo/FileUploadSimple.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React from 'react';
-import { Stack } from '../..';
+import { Grid } from '../../Grid';
+import { Stack } from '../../Stack';
 import { UNSTABLE_File, UNSTABLE_FileImagePreview } from '../../UNSTABLE_File';
 import { UNSTABLE_FileUpload } from '..';
 import { useFileQueue } from './useFileQueue';
@@ -72,7 +73,7 @@ const SimpleUploadColumn = ({ title, inputId, isCompact, name, rootId }: SimpleU
 };
 
 const FileUploadSimple = () => (
-  <div className="Grid Grid--alignmentXStretch Grid--alignmentYStretch Grid--tablet--cols-2 Grid--cols-1">
+  <Grid cols={{ mobile: 1, tablet: 2 }}>
     <div>
       <SimpleUploadColumn
         title="Default"
@@ -90,7 +91,7 @@ const FileUploadSimple = () => (
         isCompact
       />
     </div>
-  </div>
+  </Grid>
 );
 
 export default FileUploadSimple;


### PR DESCRIPTION
## Summary

- Replace manual `div` elements with `Grid` CSS classes in `UNSTABLE_FileUpload` demo examples
- Replace `docs-Stack` wrapper with the `Stack` component in `FileUploadInputWithAttachment`
- Align demo layout code with Spirit React components used elsewhere in the design system

## Test plan

- [ ] Open `UNSTABLE_FileUpload` demos in Storybook / docsite and verify layout is unchanged
- [ ] Check responsive two-column layout on tablet+ breakpoints
- [ ] Verify `FileUploadInputWithAttachment` vertical spacing between uploader and file list