### PR TITLE
feat(web): add shake animation helper with demo controls

### DIFF
--- a/packages/web/src/scss/helpers/animations/_animations.scss
+++ b/packages/web/src/scss/helpers/animations/_animations.scss
@@ -1,5 +1,6 @@
 $_spin-duration: 1s;
 $_spin-easing: linear;
+$_shake-easing: ease-in-out;
 
 @keyframes spin {
     0% {
@@ -11,6 +12,29 @@ $_spin-easing: linear;
     }
 }
 
-.animation-spin-clockwise {
-    animation: spin $_spin-duration $_spin-easing infinite;
+@keyframes shake {
+    0%,
+    100% {
+        transform: translateX(0);
+    }
+
+    20%,
+    60% {
+        transform: translateX(calc(-1 * var(--animation-shake-distance, 2px)));
+    }
+
+    40%,
+    80% {
+        transform: translateX(var(--animation-shake-distance, 2px));
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .animation-spin-clockwise {
+        animation: spin $_spin-duration $_spin-easing infinite;
+    }
+
+    .animation-shake {
+        animation: shake var(--animation-shake-duration, 0.4s) $_shake-easing var(--animation-shake-iterations, 2);
+    }
 }

--- a/packages/web/src/scss/helpers/animations/index.html
+++ b/packages/web/src/scss/helpers/animations/index.html
@@ -1,20 +1,62 @@
 {{#> web/layout/default title="Animations" parentPageName="Helpers" }}
 
+<script>
+  const restartAnimation = (elementId, className) => {
+    const element = document.getElementById(elementId);
+
+    if (!element) {
+      return;
+    }
+
+    element.classList.remove(className);
+    void element.offsetWidth;
+    element.classList.add(className);
+  }
+</script>
+
 <section class="py-900 py-tablet-1000">
 
   <div class="Container">
 
-    <h2 class="docs-Heading">Animations</h2>
+    <h2 class="docs-Heading">Spin</h2>
 
     <div class="docs-Stack docs-Stack--start">
 
       <svg
-        class="animation-spin-clockwise"
+        class="Icon animation-spin-clockwise"
         width="24"
         height="24"
       >
-        <use xlink:href="/assets/icons/svg/sprite.svg#reload" />
+        <use href="/assets/icons/svg/sprite.svg#reload" />
       </svg>
+
+    </div>
+
+  </div>
+
+</section>
+
+<section class="py-900 py-tablet-1000">
+
+  <div class="Container">
+
+    <h2 class="docs-Heading">Shake</h2>
+
+    <div class="docs-Stack docs-Stack--start">
+
+      <p
+        id="shake-animation-example"
+        class="animation-shake"
+      >
+        Example text with a subtle shake animation.
+      </p>
+
+      <button
+        type="button"
+        onclick="restartAnimation('shake-animation-example', 'animation-shake')"
+      >
+        Restart shake animation
+      </button>
 
     </div>
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description
Validation text can require short visual emphasis without introducing a continuous motion effect. This update adds reusable `animation-shake` helper in `web`, both with reduced-motion handling and finite default iterations so the effect stays subtle by default. The animations demo now includes neutral examples and restart controls to verify replay behavior for finite animations.

## Additional info
- As we decided pulse animation is not implemented

### Demo
https://deploy-preview-2686--spirit-design-system.netlify.app/packages/web/src/scss/helpers/animations/

### Issue reference
https://jira.almacareer.tech/browse/DS-2564