### PR TITLE
feat(demo): persist theme switcher selection across navigation

### DIFF
--- a/apps/demo/netlify.toml
+++ b/apps/demo/netlify.toml
@@ -31,6 +31,7 @@ ignore = "node scripts/ignoreNetlifyBuilds.js"
 ignore = """\
     git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF \
     ./packages/web-react/ \
+    ./apps/demo/ \
     ./packages/web/ \
     ./.github/workflows/ \
     """

--- a/apps/demo/partials/layout/base.hbs
+++ b/apps/demo/partials/layout/base.hbs
@@ -37,15 +37,71 @@
         themes.push('{{theme.id}}');
       {{/each}}
 
-      const switchTheme = (event) => {
-        const targetElement = document.body;
-        const theme = event.target.value;
+      const THEME_STORAGE_KEY = 'spirit-demo-theme';
 
-        themes.forEach((theme) => {
-          targetElement.classList.remove(`theme-${theme}`);
-        });
-        targetElement.classList.add(`theme-${theme}`);
+      const readStoredTheme = () => {
+        try {
+          return localStorage.getItem(THEME_STORAGE_KEY);
+        } catch (error) {
+          console.error('Failed to read theme from localStorage', error);
+          return null;
+        }
       };
+
+      const storeTheme = (theme) => {
+        try {
+          localStorage.setItem(THEME_STORAGE_KEY, theme);
+        } catch (error) {
+          console.error('Failed to store theme in localStorage', error);
+        }
+      };
+
+      const isThemeAvailable = (theme, availableThemes) => availableThemes.includes(theme);
+
+      let appliedTheme = null;
+
+      const applyTheme = (theme, availableThemes) => {
+        if (!isThemeAvailable(theme, availableThemes)) {
+          return;
+        }
+        // Apply on <html> so the theme is in effect before <body> is parsed (prevents FOUC).
+        const targetElement = document.documentElement;
+        if (appliedTheme) {
+          targetElement.classList.remove(`theme-${appliedTheme}`);
+        }
+        targetElement.classList.add(`theme-${theme}`);
+        appliedTheme = theme;
+      };
+
+      const syncSelects = (theme) => {
+        document.querySelectorAll('[data-theme-switcher]').forEach((select) => {
+          select.value = theme;
+        });
+      };
+
+      const switchTheme = (event) => {
+        const theme = event.currentTarget.value;
+        if (!isThemeAvailable(theme, themes)) {
+          return;
+        }
+        applyTheme(theme, themes);
+        storeTheme(theme);
+        syncSelects(theme);
+      };
+
+      // Apply the persisted theme synchronously, before the browser paints the body.
+      const storedTheme = readStoredTheme();
+      if (storedTheme) {
+        applyTheme(storedTheme, themes);
+      }
+
+      document.addEventListener('DOMContentLoaded', () => {
+        const currentTheme = readStoredTheme();
+        if (!currentTheme || !isThemeAvailable(currentTheme, themes)) {
+          return;
+        }
+        syncSelects(currentTheme);
+      });
 
       const allowedOriginPattern = /^https:\/\/([a-zA-Z0-9-]+\.)*supernova-docs\.io$/;
 

--- a/apps/demo/partials/themeSwitcher.hbs
+++ b/apps/demo/partials/themeSwitcher.hbs
@@ -1,7 +1,7 @@
 <div class="Select Select--medium Select--fluid">
   <label for="{{id}}" class="Select__label {{#if isLabelHidden }}Select__label--hidden{{/if}}">Theme</label>
   <div class="Select__inputContainer">
-    <select id="{{id}}" name="theme" class="Select__input" onchange="switchTheme(event)" autocomplete="off">
+    <select id="{{id}}" name="theme" class="Select__input" onchange="switchTheme(event)" autocomplete="off" data-theme-switcher>
       {{#each @themes as |theme|}}
         <option value="{{theme.id}}">{{theme.name}}</option>
       {{/each}}


### PR DESCRIPTION
## Description

The theme switcher reset to the default on every page navigation, so users had to re-pick the theme on each new page. Applying the saved theme later (e.g. on `DOMContentLoaded`) also caused a visible flash, so the selection is now persisted in `localStorage` and re-applied synchronously to `<html>` from the head script — before the browser paints. Targeting `<html>` instead of `<body>` is intentional: SCSS theme rules use class-only selectors, so the visual result is identical, but the class can be set before body parsing.

### Additional context

- Try switching the theme in the header and clicking around between Web / Web React / component pages — the selection now sticks and there is no flicker.
- `localStorage` access is wrapped in `try/catch` to stay safe when the API is unavailable (e.g. privacy mode).
- The head `<script>` must remain blocking (no `defer`/`async`) and run before stylesheet links for the no-flicker behavior to hold — already how it is wired today.

### Issue reference

_None._