### PR TITLE
chore(repo): ignore playwright mcp debug artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ packages/*/build
 /test-results/
 /playwright-report/
 /playwright/.cache/
+.playwright-mcp/
 
 # Narwall Nx
 # Use `nc-cloud.env ` to store the `NX_CLOUD_ACCESS_TOKEN` for connection to the Nx Cloud.


### PR DESCRIPTION
## Description

This PR adds `.playwright-mcp/` to `.gitignore` so local Playwright MCP debug artifacts are not accidentally committed.

Playwright MCP is useful for interactive diagnostics of visual, interaction, accessibility, and page-rendering issues. It lets us inspect the actual rendered component demos in the browser, interact with them, capture screenshots, read accessibility snapshots, and check console or DOM state before deciding whether a fix belongs in the component, demo, or test.

Example local MCP setup from `mcp.json`:

```json
"playwright": {
  "command": "npx",
  "args": ["-y", "@playwright/mcp@latest", "--browser=chrome"]
}
```

Running this can create local `.playwright-mcp/` artifacts, similar to other Playwright outputs already ignored by the repository.

### Additional context

I am currently testing custom rules to enforce the correct usage of Playwright MCP in combination with the Docker-based Make targets, so interactive debugging stays aligned with the repository’s e2e workflow.

Playwright MCP should be used for diagnostics and interactive debugging. It does not replace the existing Docker-based Make targets such as `make test-e2e` and `make test-e2e-update`, which remain the canonical way to run and update e2e tests.

No tests were run because this is a `.gitignore`-only change.

### Issue reference

No issue.