### PR TITLE
chore(repo): enable `spirit/no-xlink-href` lint rule for HTML files

### DIFF
--- a/configs/eslint-config-spirit/rules/__tests__/no-xlink-href.test.js
+++ b/configs/eslint-config-spirit/rules/__tests__/no-xlink-href.test.js
@@ -2,6 +2,7 @@
 
 const { describe, it } = require('node:test');
 const { RuleTester } = require('eslint');
+const htmlParser = require('@html-eslint/parser');
 const rule = require('../no-xlink-href');
 
 RuleTester.describe = describe;
@@ -13,6 +14,12 @@ const tester = new RuleTester({
     parserOptions: {
       ecmaFeatures: { jsx: true },
     },
+  },
+});
+
+const htmlTester = new RuleTester({
+  languageOptions: {
+    parser: htmlParser,
   },
 });
 
@@ -76,6 +83,26 @@ tester.run('no-xlink-href', rule, {
     {
       code: "const svg = `<image xlink:href=\"${src}\" />`",
       errors: [{ messageId: 'stringLiteral' }],
+    },
+  ],
+});
+
+htmlTester.run('no-xlink-href (html)', rule, {
+  valid: [
+    { code: `<svg><use href="#icon"></use></svg>` },
+    { code: `<a href="/somewhere">link</a>` },
+  ],
+
+  invalid: [
+    {
+      code: `<svg><use xlink:href="#icon"></use></svg>`,
+      errors: [{ messageId: 'htmlNamespacedAttr' }],
+      output: `<svg><use href="#icon"></use></svg>`,
+    },
+    {
+      code: `<svg><image xlink:href="photo.png" /></svg>`,
+      errors: [{ messageId: 'htmlNamespacedAttr' }],
+      output: `<svg><image href="photo.png" /></svg>`,
     },
   ],
 });

--- a/configs/eslint-config-spirit/rules/no-xlink-href.js
+++ b/configs/eslint-config-spirit/rules/no-xlink-href.js
@@ -4,6 +4,7 @@
  * The xlink:href attribute was deprecated in SVG 2.0 in favor of plain `href`.
  * This rule detects its usage across:
  *   - JSX attributes (xlink:href="..." or xlinkHref="...")
+ *   - HTML attributes (xlink:href="...") via @html-eslint/parser
  *   - String/template literals containing xlink:href (e.g. in dangerouslySetInnerHTML or raw HTML)
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href
@@ -28,6 +29,8 @@ const rule = {
         "Deprecated SVG attribute 'xlink:href' found. Use 'href' instead.",
       jsxCamelCaseAttr:
         "Deprecated SVG attribute 'xlinkHref' (camelCase form of xlink:href) found. Use 'href' instead.",
+      htmlNamespacedAttr:
+        "Deprecated SVG attribute 'xlink:href' found. Use 'href' instead.",
       stringLiteral:
         "Deprecated SVG attribute 'xlink:href' found in string. Use 'href' instead.",
     },
@@ -113,6 +116,24 @@ const rule = {
       TemplateLiteral(node) {
         for (const quasi of node.quasis) {
           checkStringForXlinkHref(node, quasi.value.raw);
+        }
+      },
+
+      // ── HTML (via @html-eslint/parser) ───────────────
+      Attribute(node) {
+        const key = node && node.key;
+        if (
+          key &&
+          typeof key.value === "string" &&
+          key.value.toLowerCase() === "xlink:href"
+        ) {
+          context.report({
+            node,
+            messageId: "htmlNamespacedAttr",
+            fix(fixer) {
+              return fixer.replaceText(key, "href");
+            },
+          });
         }
       },
     };


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Linter didn't work for `.html` files.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
