### PR TITLE
refactor(web): remove needless pseudo-element from interactive `Tag`

### DIFF
--- a/packages/web/src/scss/components/Tag/_Tag.scss
+++ b/packages/web/src/scss/components/Tag/_Tag.scss
@@ -4,7 +4,6 @@
 @use '../../tools/component-color-overrides';
 @use '../../tools/dictionaries';
 @use '../../tools/dynamic-colors';
-@use '../../tools/pseudo-element';
 @use '../../tools/reset';
 @use '../../tools/typography';
 @use 'theme';
@@ -63,15 +62,7 @@
 );
 
 .Tag:is(a, button) {
-    @include pseudo-element.stretch($set-root-relative: true, $z-index: -1);
-    @include dynamic-colors.background-interactive($target: '::before');
-
-    z-index: 0;
-
-    &::before {
-        border-radius: calc(#{theme.$border-radius} - #{theme.$border-width});
-        background-color: transparent;
-    }
+    @include dynamic-colors.background-interactive();
 }
 
 .Tag:is(a) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

The interactive `Tag` (`elementType="a"` / `"button"`) used a `::before` pseudo-element as the target for `background-interactive()`, operating under the assumption that the helper could not be called on the same element where the color scheme is defined. It turns out it can, so the overlay, its stacking context (`z-index: 0`), and the `pseudo-element` import are all removed.

### Issue reference

<!-- no issue -->