### PR TITLE
refactor(web,web-react)!: remove inline modifier from `ValidationText` components

### DIFF
--- a/packages/web-react/src/components/ValidationText/README.md
+++ b/packages/web-react/src/components/ValidationText/README.md
@@ -20,9 +20,8 @@ You can override context by passing props directly:
 
 ```tsx
 <ValidationText
-  id="my-validation-text"
   elementType="span"
-  formFieldMode="inline"
+  id="my-validation-text"
   isDisabled={false}
   validationStateIcon="danger"
   validationText="Danger validation text"
@@ -35,24 +34,19 @@ When displaying validation text dynamically, set [`role="alert"`][aria-alert-rol
 
 ### API
 
-| Name                  | Type                                                   | Default | Required | Description                                                                                                                     |
-| --------------------- | ------------------------------------------------------ | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `elementType`         | `ElementType`                                          | `div`   | ✕        | Element used as main wrapper. When `validationText` is an array, the component renders a `ul` inside the wrapper                |
-| `formFieldMode`       | `FormFieldMode`                                        | —       | ✕        | Explicit mode (`inline`, `item`); omit for the default layout used by box form field components, or take it from parent context |
-| `id`                  | `string`                                               | —       | ✕        | Element id (e.g. for `aria-describedby`)                                                                                        |
-| `isDisabled`          | `bool`                                                 | `false` | ✕        | Disabled state; when omitted, taken from parent context                                                                         |
-| `registerAria`        | `(payload: { add?: string; remove?: string }) => void` | —       | ✕        | Callback to register this element's id for `aria-describedby`                                                                   |
-| `role`                | `AriaRole`                                             | —       | ✕        | ARIA role (e.g. `alert` for dynamic validation)                                                                                 |
-| `validationStateIcon` | [Validation dictionary][dictionary-validation]         | —       | ✕        | When set, shows validation icon and applies state styling (e.g. `danger`)                                                       |
-| `validationText`      | `ReactNode` \| `ReactNode[]`                           | —       | ✕        | Validation message or messages to display                                                                                       |
+| Name                  | Type                                                   | Default | Required | Description                                                                                                      |
+| --------------------- | ------------------------------------------------------ | ------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `elementType`         | `ElementType`                                          | `div`   | ✕        | Element used as main wrapper. When `validationText` is an array, the component renders a `ul` inside the wrapper |
+| `id`                  | `string`                                               | —       | ✕        | Element id (e.g. for `aria-describedby`)                                                                         |
+| `isDisabled`          | `bool`                                                 | `false` | ✕        | Disabled state; when omitted, taken from parent context                                                          |
+| `registerAria`        | `(payload: { add?: string; remove?: string }) => void` | —       | ✕        | Callback to register this element's id for `aria-describedby`                                                    |
+| `role`                | `AriaRole`                                             | —       | ✕        | ARIA role (e.g. `alert` for dynamic validation)                                                                  |
+| `validationStateIcon` | [Validation dictionary][dictionary-validation]         | —       | ✕        | When set, shows validation icon and applies state styling (e.g. `danger`)                                        |
+| `validationText`      | `ReactNode` \| `ReactNode[]`                           | —       | ✕        | Validation message or messages to display                                                                        |
 
 On top of the API options, the component accepts [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]
 and [escape hatches][readme-escape-hatches].
-
-## Modes
-
-- **inline**: Used by Checkbox, Radio, and Toggle (non-item).
 
 [aria-alert-role]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
 [dictionary-validation]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/DICTIONARIES.md#validation

--- a/packages/web-react/src/components/ValidationText/ValidationText.tsx
+++ b/packages/web-react/src/components/ValidationText/ValidationText.tsx
@@ -20,7 +20,6 @@ const ValidationText = <E extends ElementType = 'div'>(props: SpiritValidationTe
   const contextProps = useContextProps<Partial<FormFieldContextValue>>();
   const propsWithDefaults = {
     ...defaultProps,
-    formFieldMode: contextProps.formFieldMode,
     isDisabled: contextProps.isDisabled,
     ...props,
   };
@@ -31,7 +30,6 @@ const ValidationText = <E extends ElementType = 'div'>(props: SpiritValidationTe
     registerAria,
     role,
     validationText,
-    formFieldMode,
     isDisabled,
     ...restProps
   } = propsWithDefaults;
@@ -39,7 +37,6 @@ const ValidationText = <E extends ElementType = 'div'>(props: SpiritValidationTe
   const validationIconName = useValidationIcon({ validationStateIcon });
   const validationStateForStyles = validationStateIcon ?? contextProps.validationState;
   const { classProps } = useValidationTextStyleProps({
-    formFieldMode,
     validationStateIcon: validationStateForStyles,
     isDisabled,
   });

--- a/packages/web-react/src/components/ValidationText/__tests__/ValidationText.test.tsx
+++ b/packages/web-react/src/components/ValidationText/__tests__/ValidationText.test.tsx
@@ -9,7 +9,7 @@ import {
   validHtmlAttributesTest,
 } from '@local/tests';
 import { PropsProvider } from '../../../context';
-import { FormFieldModes, type SpiritValidationTextProps } from '../../../types';
+import { type SpiritValidationTextProps } from '../../../types';
 import { A11Y_ALERT_ROLE } from '../constants';
 import ValidationText from '../ValidationText';
 
@@ -30,6 +30,8 @@ describe('ValidationText', () => {
   formFieldContextPropsTest({
     renderComponent: (props) => <ValidationText {...props} validationText="validation text" />,
     text: 'validation text',
+    includeInlineMode: false,
+    includeItemMode: false,
     classNamePrefix: 'ValidationText',
   });
 
@@ -137,15 +139,6 @@ describe('ValidationText', () => {
     });
 
     expect(screen.getByText('validation text').tagName).toBe('DIV');
-  });
-
-  it('should render inline mode from direct prop', () => {
-    renderValidationText({
-      validationText: 'validation text',
-      formFieldMode: FormFieldModes.INLINE,
-    });
-
-    expect(screen.getByText('validation text')).toHaveClass('ValidationText--inline');
   });
 
   it('should render with html tags', () => {

--- a/packages/web-react/src/components/ValidationText/__tests__/useValidationTextStyleProps.test.ts
+++ b/packages/web-react/src/components/ValidationText/__tests__/useValidationTextStyleProps.test.ts
@@ -1,5 +1,4 @@
 import { renderHook } from '@testing-library/react';
-import { FormFieldModes } from '../../../types';
 import { useValidationTextStyleProps } from '../useValidationTextStyleProps';
 
 describe('useValidationTextStyleProps', () => {
@@ -32,15 +31,5 @@ describe('useValidationTextStyleProps', () => {
     const { result } = renderHook(() => useValidationTextStyleProps({ isDisabled: true }));
 
     expect(result.current.classProps).toContain('ValidationText--disabled');
-  });
-
-  it('should return inline class when formFieldMode is inline', () => {
-    const { result } = renderHook(() =>
-      useValidationTextStyleProps({
-        formFieldMode: FormFieldModes.INLINE,
-      }),
-    );
-
-    expect(result.current.classProps).toContain('ValidationText--inline');
   });
 });

--- a/packages/web-react/src/components/ValidationText/stories/ValidationText.stories.tsx
+++ b/packages/web-react/src/components/ValidationText/stories/ValidationText.stories.tsx
@@ -2,7 +2,6 @@ import { Markdown } from '@storybook/addon-docs/blocks';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 import { ValidationStates } from '../../../constants';
-import { FormFieldModes } from '../../../types';
 import ReadMe from '../README.md?raw';
 import { ValidationText } from '..';
 
@@ -20,10 +19,6 @@ const meta: Meta<typeof ValidationText> = {
       table: {
         defaultValue: { summary: 'div' },
       },
-    },
-    formFieldMode: {
-      control: 'select',
-      options: Object.values(FormFieldModes),
     },
     isDisabled: {
       control: 'boolean',

--- a/packages/web-react/src/components/ValidationText/useValidationTextStyleProps.ts
+++ b/packages/web-react/src/components/ValidationText/useValidationTextStyleProps.ts
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { useClassNamePrefix } from '../../hooks';
-import { type FormFieldContextValue, FormFieldModes, type ValidationState } from '../../types';
+import { type FormFieldContextValue, type ValidationState } from '../../types';
 
 export interface ValidationTextStyles {
   /** className for the root element */
@@ -12,21 +12,19 @@ export interface UseValidationTextStylePropsProps extends FormFieldContextValue 
 }
 
 export function useValidationTextStyleProps(props: UseValidationTextStylePropsProps): ValidationTextStyles {
-  const { formFieldMode, validationStateIcon, isDisabled } = props;
+  const { validationStateIcon, isDisabled } = props;
 
   const prefix = useClassNamePrefix('ValidationText');
   const dangerClass = `${prefix}--danger`;
   const warningClass = `${prefix}--warning`;
   const successClass = `${prefix}--success`;
   const disabledClass = `${prefix}--disabled`;
-  const inlineClass = `${prefix}--inline`;
 
   const classProps = classNames(prefix, {
     [dangerClass]: validationStateIcon === 'danger',
     [warningClass]: validationStateIcon === 'warning',
     [successClass]: validationStateIcon === 'success',
     [disabledClass]: isDisabled,
-    [inlineClass]: formFieldMode === FormFieldModes.INLINE,
   });
 
   return {

--- a/packages/web-react/src/types/shared/inputs.ts
+++ b/packages/web-react/src/types/shared/inputs.ts
@@ -49,6 +49,8 @@ export type FormFieldStyleProps = Pick<FormFieldContextValue, 'formFieldMode' | 
 export type LabelStyleProps = FormFieldStyleProps &
   Pick<FormFieldContextValue, 'isLabelHidden' | 'isRequired' | 'isItem'>;
 
+export type ValidationTextStyleProps = Pick<FormFieldContextValue, 'isDisabled'>;
+
 export interface Validation {
   /** Whether the input should display its "valid" or "invalid" visual styling. */
   validationState?: ValidationState;

--- a/packages/web-react/src/types/validationText.ts
+++ b/packages/web-react/src/types/validationText.ts
@@ -2,10 +2,10 @@ import { type ElementType } from 'react';
 import {
   type ChildrenProps,
   type FormFieldProps,
-  type FormFieldStyleProps,
   type StyleProps,
   type ValidationTextProp,
+  type ValidationTextStyleProps,
 } from './shared';
 
 export interface SpiritValidationTextProps<T extends ElementType = 'div'>
-  extends FormFieldProps<T>, ValidationTextProp, StyleProps, ChildrenProps, FormFieldStyleProps {}
+  extends FormFieldProps<T>, ValidationTextProp, StyleProps, ChildrenProps, ValidationTextStyleProps {}

--- a/packages/web-react/tests/providerTests/formFieldContextPropsTest.tsx
+++ b/packages/web-react/tests/providerTests/formFieldContextPropsTest.tsx
@@ -75,7 +75,6 @@ const DEFAULT_HELPER_INLINE_PROPS: TestProps = {};
 const DEFAULT_HELPER_ITEM_PROPS: TestProps = { isItem: true };
 const DEFAULT_HELPER_TEXT = 'Helper';
 
-const DEFAULT_VALIDATION_INLINE_PROPS: TestProps = { validationState: 'danger' };
 const DEFAULT_VALIDATION_DISABLED_PROPS: TestProps = { isDisabled: true, validationState: 'danger' };
 const DEFAULT_VALIDATION_STATE_CLASS = 'ValidationText--danger';
 const DEFAULT_VALIDATION_STATE_PROPS: TestProps = { validationState: 'danger' };
@@ -253,8 +252,6 @@ export const formFieldHelperTextContextPropsTest = ({
 export const formFieldValidationTextContextPropsTest = ({
   disabledProps = DEFAULT_VALIDATION_DISABLED_PROPS,
   includeDisabled = true,
-  includeInline = false,
-  inlineProps = DEFAULT_VALIDATION_INLINE_PROPS,
   labelText = DEFAULT_LABEL_TEXT,
   renderComponent,
   stateClass = DEFAULT_VALIDATION_STATE_CLASS,
@@ -262,17 +259,6 @@ export const formFieldValidationTextContextPropsTest = ({
   validationText = DEFAULT_VALIDATION_TEXT,
 }: FormFieldValidationTextContextPropsTestConfig) => {
   describe('validation text context propagation', () => {
-    if (includeInline) {
-      it('should apply inline class to nested ValidationText', () => {
-        expectClassForProps({
-          expectedClassName: 'ValidationText--inline',
-          props: { label: labelText, validationText, ...inlineProps },
-          renderComponent,
-          text: validationText,
-        });
-      });
-    }
-
     it('should apply validation state class to nested ValidationText', () => {
       expectClassForProps({
         expectedClassName: stateClass,

--- a/packages/web/src/scss/components/Checkbox/README.md
+++ b/packages/web/src/scss/components/Checkbox/README.md
@@ -40,9 +40,7 @@ See Validation state [dictionary][dictionary-validation].
   />
   <div class="Checkbox__text">
     <label class="Label Label--inline" for="checkbox-warning">Checkbox Label</label>
-    <div class="ValidationText ValidationText--warning ValidationText--inline" id="checkbox-warning-helper-text">
-      Warning validation text
-    </div>
+    <div class="ValidationText ValidationText--warning" id="checkbox-warning-helper-text">Warning validation text</div>
   </div>
 </div>
 
@@ -56,7 +54,7 @@ See Validation state [dictionary][dictionary-validation].
   />
   <div class="Checkbox__text">
     <label class="Label Label--inline" for="checkbox-danger">Checkbox Label</label>
-    <div class="ValidationText ValidationText--danger ValidationText--inline" id="checkbox-danger-helper-text">
+    <div class="ValidationText ValidationText--danger" id="checkbox-danger-helper-text">
       <ul>
         <li>First validation text</li>
         <li>Second validation text</li>
@@ -75,7 +73,7 @@ See Validation state [dictionary][dictionary-validation].
   />
   <div class="Checkbox__text">
     <label class="Label Label--inline" for="checkbox-warning">Checkbox Label</label>
-    <div class="ValidationText ValidationText--warning ValidationText--inline" id="checkbox-warning-helper-text">
+    <div class="ValidationText ValidationText--warning" id="checkbox-warning-helper-text">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
         <use href="/assets/icons/svg/sprite.svg#warning" />
       </svg>

--- a/packages/web/src/scss/components/Checkbox/index.html
+++ b/packages/web/src/scss/components/Checkbox/index.html
@@ -244,7 +244,7 @@
         />
         <div class="Checkbox__text">
           <label class="Label Label--inline" for="checkbox-warning">Checkbox Label</label>
-          <div class="ValidationText ValidationText--warning ValidationText--inline" id="checkbox-warning-validation-text">Warning validation text</div>
+          <div class="ValidationText ValidationText--warning" id="checkbox-warning-validation-text">Warning validation text</div>
         </div>
       </div>
 
@@ -258,7 +258,7 @@
         />
         <div class="Checkbox__text">
           <label for="checkbox-danger" class="Label Label--inline">Checkbox Label</label>
-          <div class="ValidationText ValidationText--danger ValidationText--inline" id="checkbox-danger-validation-text">
+          <div class="ValidationText ValidationText--danger" id="checkbox-danger-validation-text">
             <ul>
               <li>First validation text</li>
               <li>Second validation text</li>
@@ -279,7 +279,7 @@
         <div class="Checkbox__text">
           <label class="Label Label--inline" for="checkbox-warning-helper-text">Checkbox Label</label>
           <div class="HelperText HelperText--inline" id="checkbox-warning-helper-text-helper-text">Helper text</div>
-          <div class="ValidationText ValidationText--warning ValidationText--inline" id="checkbox-warning-helper-text-validation-text">Warning validation text</div>
+          <div class="ValidationText ValidationText--warning" id="checkbox-warning-helper-text-validation-text">Warning validation text</div>
         </div>
       </div>
 
@@ -309,7 +309,7 @@
         />
         <div class="Checkbox__text">
           <label class="Label Label--inline" for="checkbox-{{ state }}-validation-icon">Checkbox Label</label>
-          <div class="ValidationText ValidationText--{{ state }} ValidationText--inline" id="checkbox-{{ state }}-validation-icon-validation-text">
+          <div class="ValidationText ValidationText--{{ state }}" id="checkbox-{{ state }}-validation-icon-validation-text">
             <svg
               class="Icon"
               width="20"

--- a/packages/web/src/scss/components/Toggle/README.md
+++ b/packages/web/src/scss/components/Toggle/README.md
@@ -101,9 +101,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
 <div class="Toggle Toggle--inputPositionEnd Toggle--warning">
   <div class="Toggle__text">
     <label class="Label Label--inline" for="toggle-warning">Toggle Label</label>
-    <div class="ValidationText ValidationText--warning ValidationText--inline" id="toggle-warning-validation-text">
-      Validation text
-    </div>
+    <div class="ValidationText ValidationText--warning" id="toggle-warning-validation-text">Validation text</div>
   </div>
   <input
     type="checkbox"
@@ -118,7 +116,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
 <div class="Toggle Toggle--inputPositionEnd Toggle--danger">
   <div class="Toggle__text">
     <label for="toggle-danger" class="Label Label--inline">Toggle Label</label>
-    <ul class="ValidationText ValidationText--danger ValidationText--inline" id="toggle-danger-validation-text">
+    <ul class="ValidationText ValidationText--danger" id="toggle-danger-validation-text">
       <li>First validation text</li>
       <li>Second validation text</li>
     </ul>
@@ -135,7 +133,7 @@ a JS interaction class when controlled by JavaScript (`has-success`,
 <div class="Toggle Toggle--inputPositionEnd Toggle--warning">
   <div class="Toggle__text">
     <label class="Label Label--inline" for="toggle-warning">Toggle Label</label>
-    <div class="ValidationText ValidationText--warning ValidationText--inline" id="toggle-warning-validation-text">
+    <div class="ValidationText ValidationText--warning" id="toggle-warning-validation-text">
       <svg class="Icon" width="20" height="20" aria-hidden="true">
         <use href="/assets/icons/svg/sprite.svg#warning" />
       </svg>

--- a/packages/web/src/scss/components/Toggle/index.html
+++ b/packages/web/src/scss/components/Toggle/index.html
@@ -222,7 +222,7 @@
             id="toggle-warning-helper-text-helper-text-disabled"
           >Helper text</div>
           <div
-            class="ValidationText ValidationText--warning ValidationText--inline ValidationText--disabled"
+            class="ValidationText ValidationText--warning ValidationText--disabled"
             id="toggle-warning-helper-text-validation-text-disabled"
           >Validation text</div>
         </div>
@@ -361,7 +361,7 @@
             for="toggle-warning"
           >Toggle Label</label>
           <div
-            class="ValidationText ValidationText--warning ValidationText--inline"
+            class="ValidationText ValidationText--warning"
             id="toggle-warning-validation-text"
           >Validation text</div>
         </div>
@@ -382,7 +382,7 @@
             class="Label Label--inline"
           >Toggle Label</label>
           <div
-            class="ValidationText ValidationText--danger ValidationText--inline"
+            class="ValidationText ValidationText--danger"
             id="toggle-danger-validation-text"
           >
             <ul>
@@ -411,7 +411,7 @@
             id="toggle-warning-helper-text-helper-text"
           >Helper text</div>
           <div
-            class="ValidationText ValidationText--warning ValidationText--inline"
+            class="ValidationText ValidationText--warning"
             id="toggle-warning-helper-text-validation-text"
           >Validation text</div>
         </div>
@@ -445,7 +445,7 @@
             for="toggle-{{state}}-validation-icon"
           >Toggle Label</label>
           <div
-            class="ValidationText ValidationText--{{state}} ValidationText--inline"
+            class="ValidationText ValidationText--{{state}}"
             id="toggle-{{state}}-validation-textIcon"
           >
             <svg

--- a/packages/web/src/scss/components/ValidationText/README.md
+++ b/packages/web/src/scss/components/ValidationText/README.md
@@ -86,8 +86,8 @@ ValidationText works seamlessly with Spirit form components:
 
 **Inline Fields:**
 
-- [Checkbox][checkbox] — Single checkbox (use with `ValidationText--inline` modifier)
-- [Toggle][toggle] — Toggle switch (use with `ValidationText--inline` modifier)
+- [Checkbox][checkbox] — Single checkbox
+- [Toggle][toggle] — Toggle switch
 
 **Field Groups:**
 
@@ -107,15 +107,12 @@ ValidationText works seamlessly with Spirit form components:
 
 ### Inline Field (Checkbox and Toggle)
 
-Use the `ValidationText--inline` modifier class when ValidationText is inside an inline field (Checkbox and Toggle).
-It creates a stacking context so the validation text sits above the stretched label, keeping the text selectable and links clickable.
-
 ```html
 <div class="Checkbox Checkbox--inputPositionStart Checkbox--danger">
   <input type="checkbox" id="example" class="Checkbox__input" name="example" />
   <div class="Checkbox__text">
     <label class="Label Label--inline" for="example">Checkbox Label</label>
-    <div class="ValidationText ValidationText--danger ValidationText--inline">Danger validation text</div>
+    <div class="ValidationText ValidationText--danger">Danger validation text</div>
   </div>
 </div>
 ```

--- a/packages/web/src/scss/components/ValidationText/_ValidationText.scss
+++ b/packages/web/src/scss/components/ValidationText/_ValidationText.scss
@@ -1,5 +1,4 @@
-// 1. Make the text selectable and allow links to be clickable in the helper and validation texts.
-// 2. Automatically apply flex layout when an icon is directly present alongside content.
+// 1. Automatically apply flex layout when an icon is directly present alongside content.
 
 @use '../../tools/reset';
 @use '../../tools/typography';
@@ -32,12 +31,7 @@
     color: theme.$color-state-disabled;
 }
 
-.ValidationText--inline {
-    position: relative; // 1.
-    z-index: 1; // 1.
-}
-
-// 2.
+// 1.
 .ValidationText:has(> svg:first-child:not(:only-child)) {
     display: flex;
     column-gap: theme.$icon-gap;

--- a/packages/web/src/scss/components/ValidationText/index.html
+++ b/packages/web/src/scss/components/ValidationText/index.html
@@ -192,7 +192,7 @@
             class="Label Label--inline"
             for="validation-text-checkbox-danger"
           >Checkbox Label</label>
-          <div class="ValidationText ValidationText--danger ValidationText--inline">Danger validation text</div>
+          <div class="ValidationText ValidationText--danger">Danger validation text</div>
         </div>
       </div>
 
@@ -208,7 +208,7 @@
             class="Label Label--inline"
             for="validation-text-checkbox-warning"
           >Checkbox Label</label>
-          <div class="ValidationText ValidationText--warning ValidationText--inline">
+          <div class="ValidationText ValidationText--warning">
             <svg
               class="Icon"
               width="20"


### PR DESCRIPTION
## Description

Removes the `ValidationText--inline` modifier and related `formFieldMode` handling from `ValidationText` in both `web` and `web-react`. The inline stacking context was only needed while `Label` stretched over sibling text; with that layout fixed, Checkbox and Toggle validation text no longer needs a separate inline mode.

### Additional context

- Drops `formFieldMode` from `ValidationText` props, style hook, stories, and tests (context tests skip inline/item modes).
- Updates Checkbox, Toggle, and ValidationText demos, READMEs, and SCSS.
- Visual regression snapshots may need updating after CI runs.

### Issue reference

<!-- Add Jira link when available, e.g. https://jira.almacareer.tech/browse/DS-XXXX -->