### PR TITLE
feat(web-react): rename hasValidationStateIcon #DS-2490

### DIFF
--- a/packages/web-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/web-react/src/components/Checkbox/Checkbox.tsx
@@ -74,7 +74,7 @@ const _Checkbox = (props: SpiritCheckboxProps, ref: ForwardedRef<HTMLInputElemen
           {validationState && (
             <ValidationText
               id={`${id}-validation-text`}
-              {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
+              {...(hasValidationIcon && { validationStateIcon: validationState })}
               validationText={validationText}
               registerAria={register}
               role={validationTextRole}

--- a/packages/web-react/src/components/Checkbox/README.md
+++ b/packages/web-react/src/components/Checkbox/README.md
@@ -209,7 +209,7 @@ const CustomCheckbox = (props: SpiritCheckboxProps): JSX.Element => {
           {validationState && (
             <ValidationText
               id={`${id}-validation-text`}
-              {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
+              {...(hasValidationIcon && { validationStateIcon: validationState })}
               validationText={validationText}
               registerAria={register}
               role={validationTextRole}

--- a/packages/web-react/src/components/Checkbox/stories/Checkbox.stories.tsx
+++ b/packages/web-react/src/components/Checkbox/stories/Checkbox.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof Checkbox> = {
     docs: {
       page: () => <Markdown>{ReadMe}</Markdown>,
     },
-    controls: { exclude: ['hasValidationStateIcon'] },
+    controls: { exclude: ['validationStateIcon'] },
   },
   argTypes: {
     autoComplete: {

--- a/packages/web-react/src/components/FieldGroup/FieldGroup.tsx
+++ b/packages/web-react/src/components/FieldGroup/FieldGroup.tsx
@@ -65,7 +65,7 @@ const FieldGroup = (props: SpiritFieldGroupProps) => {
         {validationState && (
           <ValidationText
             id={`${id}-validation-text`}
-            {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
+            {...(hasValidationIcon && { validationStateIcon: validationState })}
             validationText={validationText}
             registerAria={register}
             role={validationTextRole}

--- a/packages/web-react/src/components/FieldGroup/stories/FieldGroup.stories.tsx
+++ b/packages/web-react/src/components/FieldGroup/stories/FieldGroup.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta<typeof FieldGroup> = {
     docs: {
       page: () => <Markdown>{ReadMe}</Markdown>,
     },
-    controls: { exclude: ['hasValidationStateIcon'] },
+    controls: { exclude: ['validationStateIcon'] },
   },
   argTypes: {
     children: {

--- a/packages/web-react/src/components/FileUploader/FileUploaderInput.tsx
+++ b/packages/web-react/src/components/FileUploader/FileUploaderInput.tsx
@@ -125,7 +125,7 @@ const FileUploaderInput = (props: SpiritFileUploaderInputProps) => {
           <ValidationText
             elementType="span"
             id={`${id}-validation-text`}
-            {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
+            {...(hasValidationIcon && { validationStateIcon: validationState })}
             validationText={validationText}
             registerAria={register}
             role={validationTextRole}

--- a/packages/web-react/src/components/FileUploader/stories/FileUploader.stories.tsx
+++ b/packages/web-react/src/components/FileUploader/stories/FileUploader.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof FileUploader> = {
     docs: {
       page: () => <Markdown>{ReadMe}</Markdown>,
     },
-    controls: { exclude: ['hasValidationStateIcon'] },
+    controls: { exclude: ['validationStateIcon'] },
   },
   argTypes: {
     children: {

--- a/packages/web-react/src/components/Select/README.md
+++ b/packages/web-react/src/components/Select/README.md
@@ -113,7 +113,7 @@ const CustomSelect = (props: SpiritSelectProps): JSX.Element => {
         {validationState && (
           <ValidationText
             id={`${id}-validation-text`}
-            {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
+            {...(hasValidationIcon && { validationStateIcon: validationState })}
             validationText={validationText}
             registerAria={register}
             role={validationTextRole}

--- a/packages/web-react/src/components/Select/Select.tsx
+++ b/packages/web-react/src/components/Select/Select.tsx
@@ -66,7 +66,7 @@ const _Select = (props: SpiritSelectProps, ref: ForwardedRef<HTMLSelectElement>)
         {validationState && (
           <ValidationText
             id={`${id}-validation-text`}
-            {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
+            {...(hasValidationIcon && { validationStateIcon: validationState })}
             validationText={validationText}
             registerAria={register}
             role={validationTextRole}

--- a/packages/web-react/src/components/Select/stories/Select.stories.tsx
+++ b/packages/web-react/src/components/Select/stories/Select.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof Select> = {
     docs: {
       page: () => <Markdown>{ReadMe}</Markdown>,
     },
-    controls: { exclude: ['hasValidationStateIcon'] },
+    controls: { exclude: ['validationStateIcon'] },
   },
   argTypes: {
     autoComplete: {

--- a/packages/web-react/src/components/Slider/Slider.tsx
+++ b/packages/web-react/src/components/Slider/Slider.tsx
@@ -83,7 +83,7 @@ const _Slider = (props: SpiritSliderProps, ref: ForwardedRef<HTMLInputElement>) 
         {validationState && (
           <ValidationText
             id={`${id}-validation-text`}
-            {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
+            {...(hasValidationIcon && { validationStateIcon: validationState })}
             registerAria={register}
             validationText={validationText}
             role={validationTextRole}

--- a/packages/web-react/src/components/Slider/stories/Slider.stories.tsx
+++ b/packages/web-react/src/components/Slider/stories/Slider.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof Slider> = {
     docs: {
       page: () => <Markdown>{ReadMe}</Markdown>,
     },
-    controls: { exclude: ['hasValidationStateIcon'] },
+    controls: { exclude: ['validationStateIcon'] },
     layout: 'centered',
   },
   argTypes: {

--- a/packages/web-react/src/components/TextArea/stories/TextArea.stories.tsx
+++ b/packages/web-react/src/components/TextArea/stories/TextArea.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof TextArea> = {
     docs: {
       page: () => <Markdown>{ReadMe}</Markdown>,
     },
-    controls: { exclude: ['hasValidationStateIcon'] },
+    controls: { exclude: ['validationStateIcon'] },
   },
   argTypes: {
     autoComplete: {

--- a/packages/web-react/src/components/TextField/stories/TextField.stories.tsx
+++ b/packages/web-react/src/components/TextField/stories/TextField.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof TextField> = {
     docs: {
       page: () => <Markdown>{ReadMe}</Markdown>,
     },
-    controls: { exclude: ['hasValidationStateIcon'] },
+    controls: { exclude: ['validationStateIcon'] },
   },
   argTypes: {
     autoComplete: {

--- a/packages/web-react/src/components/TextFieldBase/TextFieldBase.tsx
+++ b/packages/web-react/src/components/TextFieldBase/TextFieldBase.tsx
@@ -65,7 +65,7 @@ const _TextFieldBase = (props: SpiritTextFieldBaseProps, ref: ForwardedRef<HTMLI
   const validationTextElement = validationState ? (
     <ValidationText
       elementType="span"
-      {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
+      {...(hasValidationIcon && { validationStateIcon: validationState })}
       id={`${id}__validation-text`}
       validationText={validationText}
       registerAria={register}

--- a/packages/web-react/src/components/Toggle/Toggle.tsx
+++ b/packages/web-react/src/components/Toggle/Toggle.tsx
@@ -66,7 +66,7 @@ const _Toggle = (props: SpiritToggleProps, ref: ForwardedRef<HTMLInputElement>) 
           {validationState && (
             <ValidationText
               id={`${id}-validation-text`}
-              {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
+              {...(hasValidationIcon && { validationStateIcon: validationState })}
               validationText={validationText}
               registerAria={register}
               role={validationTextRole}

--- a/packages/web-react/src/components/Toggle/stories/Toggle.stories.tsx
+++ b/packages/web-react/src/components/Toggle/stories/Toggle.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof Toggle> = {
     docs: {
       page: () => <Markdown>{ReadMe}</Markdown>,
     },
-    controls: { exclude: ['hasValidationStateIcon'] },
+    controls: { exclude: ['validationStateIcon'] },
   },
   argTypes: {
     validationState: {

--- a/packages/web-react/src/components/UNSTABLE_File/UNSTABLE_File.tsx
+++ b/packages/web-react/src/components/UNSTABLE_File/UNSTABLE_File.tsx
@@ -100,7 +100,7 @@ const UNSTABLE_File = <E extends ElementType = 'li'>(props: SpiritUnstableFilePr
             <HelperText helperText={helperText} />
             {validationState && (
               <ValidationText
-                {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
+                {...(hasValidationIcon && { validationStateIcon: validationState })}
                 validationText={validationText}
                 role={validationTextRole}
               />

--- a/packages/web-react/src/components/UNSTABLE_File/stories/UNSTABLE_File.stories.tsx
+++ b/packages/web-react/src/components/UNSTABLE_File/stories/UNSTABLE_File.stories.tsx
@@ -33,7 +33,7 @@ const meta = {
       page: () => <Markdown>{ReadMe}</Markdown>,
     },
     controls: {
-      exclude: ['hasValidationStateIcon', 'previewSlot', 'onChange'],
+      exclude: ['validationStateIcon', 'previewSlot', 'onChange'],
     },
   },
   argTypes: {

--- a/packages/web-react/src/components/UNSTABLE_FileUpload/UNSTABLE_FileUpload.tsx
+++ b/packages/web-react/src/components/UNSTABLE_FileUpload/UNSTABLE_FileUpload.tsx
@@ -161,7 +161,7 @@ const UNSTABLE_FileUpload = (props: UnstableFileUploadProps) => {
               <ValidationText
                 elementType="span"
                 id={`${inputId}-validation-text`}
-                {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
+                {...(hasValidationIcon && { validationStateIcon: validationState })}
                 validationText={validationText}
                 registerAria={register}
                 role={validationTextRole}

--- a/packages/web-react/src/components/UNSTABLE_FileUpload/stories/UNSTABLE_FileUpload.stories.tsx
+++ b/packages/web-react/src/components/UNSTABLE_FileUpload/stories/UNSTABLE_FileUpload.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta<typeof UNSTABLE_FileUpload> = {
       page: () => <Markdown>{ReadMe}</Markdown>,
     },
     controls: {
-      exclude: ['hasValidationStateIcon', 'onFilesSelected', 'dropZoneRef', 'inputRef', 'children'],
+      exclude: ['validationStateIcon', 'onFilesSelected', 'dropZoneRef', 'inputRef', 'children'],
     },
   },
   argTypes: {

--- a/packages/web-react/src/components/UNSTABLE_Picker/UNSTABLE_Picker.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Picker/UNSTABLE_Picker.tsx
@@ -253,7 +253,7 @@ const _UNSTABLE_Picker = (props: SpiritUnstablePickerProps, ref: ForwardedRef<Sp
           {validationState && (
             <ValidationText
               id={`${pickerId}-validation-text`}
-              {...(hasValidationIcon && { hasValidationStateIcon: validationState })}
+              {...(hasValidationIcon && { validationStateIcon: validationState })}
               validationText={validationText}
               registerAria={register}
               role={validationTextRole}

--- a/packages/web-react/src/components/ValidationText/README.md
+++ b/packages/web-react/src/components/ValidationText/README.md
@@ -12,7 +12,7 @@ import { ValidationText } from '@alma-oss/spirit-web-react';
 <ValidationText validationText="Danger validation text" />
 ```
 
-When used inside form field components such as [Checkbox][readme-checkbox], [Radio][readme-radio], [TextField][readme-textfield], or [Toggle][readme-toggle], the parent provides context so the correct variant and disabled state are applied automatically. Validation state can also be taken from the parent context for styling, but the icon is rendered only when `hasValidationStateIcon` is set.
+When used inside form field components such as [Checkbox][readme-checkbox], [Radio][readme-radio], [TextField][readme-textfield], or [Toggle][readme-toggle], the parent provides context so the correct variant and disabled state are applied automatically. Validation state can also be taken from the parent context for styling, but the icon is rendered only when `validationStateIcon` is set. When composing fields manually, pass `validationStateIcon` from the field's `validationState` when `hasValidationIcon` is enabled — the same pattern built-in form fields use.
 
 ## With Explicit Props
 
@@ -21,11 +21,11 @@ You can override context by passing props directly:
 ```tsx
 <ValidationText
   id="my-validation-text"
-  validationText="Danger validation text"
   elementType="span"
-  hasValidationStateIcon="danger"
-  isDisabled={false}
   formFieldMode="inline"
+  isDisabled={false}
+  validationStateIcon="danger"
+  validationText="Danger validation text"
 />
 ```
 
@@ -35,16 +35,16 @@ When displaying validation text dynamically, set [`role="alert"`][aria-alert-rol
 
 ### API
 
-| Name                     | Type                                                   | Default | Required | Description                                                                                                                     |
-| ------------------------ | ------------------------------------------------------ | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `elementType`            | `ElementType`                                          | `div`   | ✕        | Element used as main wrapper. When `validationText` is an array, the component renders a `ul` inside the wrapper                |
-| `formFieldMode`          | `FormFieldMode`                                        | —       | ✕        | Explicit mode (`inline`, `item`); omit for the default layout used by box form field components, or take it from parent context |
-| `hasValidationStateIcon` | [Validation dictionary][dictionary-validation]         | —       | ✕        | When set, shows validation icon and applies state styling (e.g. `danger`)                                                       |
-| `id`                     | `string`                                               | —       | ✕        | Element id (e.g. for `aria-describedby`)                                                                                        |
-| `isDisabled`             | `bool`                                                 | `false` | ✕        | Disabled state; when omitted, taken from parent context                                                                         |
-| `registerAria`           | `(payload: { add?: string; remove?: string }) => void` | —       | ✕        | Callback to register this element's id for `aria-describedby`                                                                   |
-| `role`                   | `AriaRole`                                             | —       | ✕        | ARIA role (e.g. `alert` for dynamic validation)                                                                                 |
-| `validationText`         | `ReactNode` \| `ReactNode[]`                           | —       | ✕        | Validation message or messages to display                                                                                       |
+| Name                  | Type                                                   | Default | Required | Description                                                                                                                     |
+| --------------------- | ------------------------------------------------------ | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `elementType`         | `ElementType`                                          | `div`   | ✕        | Element used as main wrapper. When `validationText` is an array, the component renders a `ul` inside the wrapper                |
+| `formFieldMode`       | `FormFieldMode`                                        | —       | ✕        | Explicit mode (`inline`, `item`); omit for the default layout used by box form field components, or take it from parent context |
+| `id`                  | `string`                                               | —       | ✕        | Element id (e.g. for `aria-describedby`)                                                                                        |
+| `isDisabled`          | `bool`                                                 | `false` | ✕        | Disabled state; when omitted, taken from parent context                                                                         |
+| `registerAria`        | `(payload: { add?: string; remove?: string }) => void` | —       | ✕        | Callback to register this element's id for `aria-describedby`                                                                   |
+| `role`                | `AriaRole`                                             | —       | ✕        | ARIA role (e.g. `alert` for dynamic validation)                                                                                 |
+| `validationStateIcon` | [Validation dictionary][dictionary-validation]         | —       | ✕        | When set, shows validation icon and applies state styling (e.g. `danger`)                                                       |
+| `validationText`      | `ReactNode` \| `ReactNode[]`                           | —       | ✕        | Validation message or messages to display                                                                                       |
 
 On top of the API options, the component accepts [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]

--- a/packages/web-react/src/components/ValidationText/ValidationText.tsx
+++ b/packages/web-react/src/components/ValidationText/ValidationText.tsx
@@ -27,7 +27,7 @@ const ValidationText = <E extends ElementType = 'div'>(props: SpiritValidationTe
   const {
     elementType: Component = defaultProps.elementType as ElementType,
     id,
-    hasValidationStateIcon,
+    validationStateIcon,
     registerAria,
     role,
     validationText,
@@ -36,11 +36,11 @@ const ValidationText = <E extends ElementType = 'div'>(props: SpiritValidationTe
     ...restProps
   } = propsWithDefaults;
 
-  const validationIconName = useValidationIcon({ hasValidationStateIcon });
-  const validationStateForStyles = hasValidationStateIcon ?? contextProps.validationState;
+  const validationIconName = useValidationIcon({ validationStateIcon });
+  const validationStateForStyles = validationStateIcon ?? contextProps.validationState;
   const { classProps } = useValidationTextStyleProps({
     formFieldMode,
-    hasValidationStateIcon: validationStateForStyles,
+    validationStateIcon: validationStateForStyles,
     isDisabled,
   });
   const { styleProps, props: transferProps } = useStyleProps(restProps);
@@ -62,11 +62,11 @@ const ValidationText = <E extends ElementType = 'div'>(props: SpiritValidationTe
     return null;
   }
 
-  const nonArrayValidationText = hasValidationStateIcon ? <div>{validationText}</div> : validationText;
+  const nonArrayValidationText = validationStateIcon ? <div>{validationText}</div> : validationText;
 
   return (
     <Component {...transferProps} {...mergedStyleProps} id={id} role={role}>
-      {hasValidationStateIcon && <Icon name={validationIconName} boxSize={20} />}
+      {validationStateIcon && <Icon name={validationIconName} boxSize={20} />}
       {Array.isArray(validationText) ? (
         <ul>
           {validationText.map((item) => (

--- a/packages/web-react/src/components/ValidationText/__tests__/ValidationText.test.tsx
+++ b/packages/web-react/src/components/ValidationText/__tests__/ValidationText.test.tsx
@@ -63,10 +63,10 @@ describe('ValidationText', () => {
     expect(screen.getByText('validation text')).toHaveAttribute('role', A11Y_ALERT_ROLE);
   });
 
-  it('should render validation state icon and class when hasValidationStateIcon is set', () => {
+  it('should render validation state icon and class when validationStateIcon is set', () => {
     renderValidationText({
       validationText: 'validation text',
-      hasValidationStateIcon: 'danger',
+      validationStateIcon: 'danger',
     });
 
     const element = screen.getByText('validation text').parentElement as HTMLElement;
@@ -92,7 +92,7 @@ describe('ValidationText', () => {
   it('should use direct validation state icon over context validation state for styles', () => {
     render(
       <PropsProvider value={{ validationState: 'warning' }}>
-        <ValidationText validationText="validation text" hasValidationStateIcon="success" />
+        <ValidationText validationText="validation text" validationStateIcon="success" />
       </PropsProvider>,
     );
 

--- a/packages/web-react/src/components/ValidationText/__tests__/useValidationTextStyleProps.test.ts
+++ b/packages/web-react/src/components/ValidationText/__tests__/useValidationTextStyleProps.test.ts
@@ -9,21 +9,21 @@ describe('useValidationTextStyleProps', () => {
     expect(result.current.classProps).toContain('ValidationText');
   });
 
-  it('should return danger class when hasValidationStateIcon is danger', () => {
-    const { result } = renderHook(() => useValidationTextStyleProps({ hasValidationStateIcon: 'danger' }));
+  it('should return danger class when validationStateIcon is danger', () => {
+    const { result } = renderHook(() => useValidationTextStyleProps({ validationStateIcon: 'danger' }));
 
     expect(result.current.classProps).toContain('ValidationText');
     expect(result.current.classProps).toContain('ValidationText--danger');
   });
 
-  it('should return warning class when hasValidationStateIcon is warning', () => {
-    const { result } = renderHook(() => useValidationTextStyleProps({ hasValidationStateIcon: 'warning' }));
+  it('should return warning class when validationStateIcon is warning', () => {
+    const { result } = renderHook(() => useValidationTextStyleProps({ validationStateIcon: 'warning' }));
 
     expect(result.current.classProps).toContain('ValidationText--warning');
   });
 
-  it('should return success class when hasValidationStateIcon is success', () => {
-    const { result } = renderHook(() => useValidationTextStyleProps({ hasValidationStateIcon: 'success' }));
+  it('should return success class when validationStateIcon is success', () => {
+    const { result } = renderHook(() => useValidationTextStyleProps({ validationStateIcon: 'success' }));
 
     expect(result.current.classProps).toContain('ValidationText--success');
   });

--- a/packages/web-react/src/components/ValidationText/figma/ValidationText.figma.tsx
+++ b/packages/web-react/src/components/ValidationText/figma/ValidationText.figma.tsx
@@ -15,7 +15,7 @@ figma.connect(ValidationText, '<FIGMA_FILE_ID>?node-id=26437%3A2033', {
 figma.connect(ValidationText, '<FIGMA_FILE_ID>?node-id=26437%3A2033', {
   props: {
     ...commonProps,
-    hasValidationStateIcon: figma.enum('Type', {
+    validationStateIcon: figma.enum('Type', {
       Danger: 'danger',
       Warning: 'warning',
       Success: 'success',

--- a/packages/web-react/src/components/ValidationText/stories/ValidationText.stories.tsx
+++ b/packages/web-react/src/components/ValidationText/stories/ValidationText.stories.tsx
@@ -25,15 +25,15 @@ const meta: Meta<typeof ValidationText> = {
       control: 'select',
       options: Object.values(FormFieldModes),
     },
-    hasValidationStateIcon: {
-      control: 'select',
-      options: Object.values(ValidationStates),
-    },
     isDisabled: {
       control: 'boolean',
     },
     role: {
       control: 'text',
+    },
+    validationStateIcon: {
+      control: 'select',
+      options: Object.values(ValidationStates),
     },
     validationText: {
       control: 'text',
@@ -41,10 +41,10 @@ const meta: Meta<typeof ValidationText> = {
   },
   args: {
     elementType: 'div',
-    hasValidationStateIcon: 'danger',
     id: 'validation-text',
     isDisabled: false,
     role: 'alert',
+    validationStateIcon: 'danger',
     validationText: 'Danger validation text',
   },
 };

--- a/packages/web-react/src/components/ValidationText/useValidationIcon.ts
+++ b/packages/web-react/src/components/ValidationText/useValidationIcon.ts
@@ -1,10 +1,8 @@
 import { useIconName } from '../../hooks';
 import { type SpiritValidationTextProps } from '../../types';
 
-export function useValidationIcon({
-  hasValidationStateIcon,
-}: Pick<SpiritValidationTextProps, 'hasValidationStateIcon'>) {
-  const iconNameValue = useIconName(hasValidationStateIcon as string, {
+export function useValidationIcon({ validationStateIcon }: Pick<SpiritValidationTextProps, 'validationStateIcon'>) {
+  const iconNameValue = useIconName(validationStateIcon, {
     success: 'success',
     warning: 'warning',
     danger: 'danger',

--- a/packages/web-react/src/components/ValidationText/useValidationTextStyleProps.ts
+++ b/packages/web-react/src/components/ValidationText/useValidationTextStyleProps.ts
@@ -8,11 +8,11 @@ export interface ValidationTextStyles {
 }
 
 export interface UseValidationTextStylePropsProps extends FormFieldContextValue {
-  hasValidationStateIcon?: ValidationState;
+  validationStateIcon?: ValidationState;
 }
 
 export function useValidationTextStyleProps(props: UseValidationTextStylePropsProps): ValidationTextStyles {
-  const { formFieldMode, hasValidationStateIcon, isDisabled } = props;
+  const { formFieldMode, validationStateIcon, isDisabled } = props;
 
   const prefix = useClassNamePrefix('ValidationText');
   const dangerClass = `${prefix}--danger`;
@@ -22,9 +22,9 @@ export function useValidationTextStyleProps(props: UseValidationTextStylePropsPr
   const inlineClass = `${prefix}--inline`;
 
   const classProps = classNames(prefix, {
-    [dangerClass]: hasValidationStateIcon === 'danger',
-    [warningClass]: hasValidationStateIcon === 'warning',
-    [successClass]: hasValidationStateIcon === 'success',
+    [dangerClass]: validationStateIcon === 'danger',
+    [warningClass]: validationStateIcon === 'warning',
+    [successClass]: validationStateIcon === 'success',
     [disabledClass]: isDisabled,
     [inlineClass]: formFieldMode === FormFieldModes.INLINE,
   });

--- a/packages/web-react/src/types/shared/inputs.ts
+++ b/packages/web-react/src/types/shared/inputs.ts
@@ -91,8 +91,8 @@ export interface ValidationTextProp {
   role?: AriaRole;
   /** The validation text to display. */
   validationText?: ValidationTextType;
-  /** Whether the validation state icon should be displayed, and specify which type. */
-  hasValidationStateIcon?: ValidationState;
+  /** Validation state that controls icon display and styling (e.g. `danger`, `warning`, `success`). */
+  validationStateIcon?: ValidationState;
 }
 
 export interface RequiredProps {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

The prop accepts a ValidationState value (danger, warning, success), not a boolean.
Rename clarifies its purpose across ValidationText and form field consumers.

### Additional context

We don't need codemods, because in v4 this was an internal implementation, and this prop didn't exist.

### Issue reference

https://jira.almacareer.tech/browse/DS-2490

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
