### PR TITLE
refactor(web,web-react)!: drop has prefix from Stack modifiers #DS-1916

### DIFF
--- a/apps/demo/partials/header.hbs
+++ b/apps/demo/partials/header.hbs
@@ -82,7 +82,7 @@
       </button>
       <!-- DrawerCloseButton: end -->
 
-      <div class="Stack Stack--hasSpacing my-900" style="--stack-spacing: var(--spirit-space-1200)">
+      <div class="Stack Stack--spacing my-900" style="--stack-spacing: var(--spirit-space-1200)">
         <!-- Drawer Main Navigation: start -->
         <nav class="Navigation Navigation--vertical" aria-label="Main Navigation">
           <ul>

--- a/docs/migrations/web/migration-v5.md
+++ b/docs/migrations/web/migration-v5.md
@@ -9,6 +9,7 @@ Introducing version 5 of the _spirit-web_ package.
 - [Component Changes](#component-changes)
   - [Button: `Button--block` Modifier Removed](#button-button--block-modifier-removed)
   - [Flex: Direction Modifier Classes Changed](#flex-direction-modifier-classes-changed)
+  - [Stack: Modifier Classes Without `has` Prefix](#stack-modifier-classes-without-has-prefix)
   - [Tag: Appearance Feature Flag Removed](#tag-appearance-feature-flag-removed)
 
 ## Component Changes
@@ -76,6 +77,33 @@ Manually replace the modifier classes in your project.
 - `Flex--column` → `Flex--vertical`
 - `Flex--{breakpoint}--row` → `Flex--{breakpoint}--horizontal`
 - `Flex--{breakpoint}--column` → `Flex--{breakpoint}--vertical`
+
+### Stack: Modifier Classes Without `has` Prefix
+
+Stack CSS modifier classes no longer use the `has` verb prefix, consistent with other Spirit modifiers.
+
+#### Migration Guide
+
+Manually replace the modifier classes in your project.
+
+- `Stack--hasSpacing` → `Stack--spacing`
+- `Stack--hasIntermediateDividers` → `Stack--intermediateDividers`
+- `Stack--hasStartDivider` → `Stack--startDivider`
+- `Stack--hasEndDivider` → `Stack--endDivider`
+
+```html
+<!-- Before -->
+<ul class="Stack Stack--hasSpacing Stack--hasIntermediateDividers Stack--hasStartDivider Stack--hasEndDivider">
+  <li class="StackItem">Item 1</li>
+  <li class="StackItem">Item 2</li>
+</ul>
+
+<!-- After -->
+<ul class="Stack Stack--spacing Stack--intermediateDividers Stack--startDivider Stack--endDivider">
+  <li class="StackItem">Item 1</li>
+  <li class="StackItem">Item 2</li>
+</ul>
+```
 
 ### Tag: Appearance Feature Flag Removed
 

--- a/packages/web-react/src/components/Stack/__tests__/Stack.test.tsx
+++ b/packages/web-react/src/components/Stack/__tests__/Stack.test.tsx
@@ -49,7 +49,7 @@ describe('Stack', () => {
   it('should render with spacing', () => {
     render(<Stack data-testid="stack" hasSpacing />);
 
-    expect(screen.getByTestId('stack')).toHaveClass('Stack--hasSpacing');
+    expect(screen.getByTestId('stack')).toHaveClass('Stack--spacing');
   });
 
   it('should render with custom spacing', () => {
@@ -57,7 +57,7 @@ describe('Stack', () => {
 
     const element = screen.getByTestId('stack');
 
-    expect(element).toHaveClass('Stack--hasSpacing');
+    expect(element).toHaveClass('Stack--spacing');
     expect(element).toHaveStyle({ '--stack-spacing': 'var(--spirit-space-1000)' });
   });
 
@@ -68,7 +68,7 @@ describe('Stack', () => {
 
     const element = screen.getByTestId('stack');
 
-    expect(element).toHaveClass('Stack--hasSpacing');
+    expect(element).toHaveClass('Stack--spacing');
     expect(element).toHaveStyle({ '--stack-spacing': 'var(--spirit-space-100)' });
     expect(element).toHaveStyle({ '--stack-spacing-tablet': 'var(--spirit-space-1000)' });
     expect(element).toHaveStyle({ '--stack-spacing-desktop': 'var(--spirit-space-1200)' });
@@ -79,7 +79,7 @@ describe('Stack', () => {
 
     const element = screen.getByTestId('stack');
 
-    expect(element).toHaveClass('Stack--hasSpacing');
+    expect(element).toHaveClass('Stack--spacing');
     expect(element).toHaveStyle({ '--stack-spacing-tablet': 'var(--spirit-space-1000)' });
     expect(element).not.toHaveStyle({ '--stack-spacing': 'var(--spirit-space-100)' });
     expect(element).not.toHaveStyle({ '--stack-spacing-desktop': 'var(--spirit-space-1200)' });

--- a/packages/web-react/src/components/Stack/__tests__/useStackStyleProps.test.ts
+++ b/packages/web-react/src/components/Stack/__tests__/useStackStyleProps.test.ts
@@ -6,15 +6,9 @@ describe('useStackStyleProps', () => {
   it.each([
     // hasEndDivider, hasIntermediateDividers, hasSpacing, hasStartDivider, expectedClasses
     [false, false, false, false, 'Stack'],
-    [false, true, true, false, 'Stack Stack--hasIntermediateDividers Stack--hasSpacing'],
-    [false, false, true, false, 'Stack Stack--hasSpacing'],
-    [
-      true,
-      true,
-      true,
-      true,
-      'Stack Stack--hasEndDivider Stack--hasIntermediateDividers Stack--hasSpacing Stack--hasStartDivider',
-    ],
+    [false, true, true, false, 'Stack Stack--intermediateDividers Stack--spacing'],
+    [false, false, true, false, 'Stack Stack--spacing'],
+    [true, true, true, true, 'Stack Stack--endDivider Stack--intermediateDividers Stack--spacing Stack--startDivider'],
   ])(
     'should return classes',
     (hasEndDivider, hasIntermediateDividers, hasSpacing, hasStartDivider, expectedClasses) => {

--- a/packages/web-react/src/components/Stack/useStackStyleProps.ts
+++ b/packages/web-react/src/components/Stack/useStackStyleProps.ts
@@ -6,10 +6,10 @@ export function useStackStyleProps(props: StackStyleProps) {
   const { hasEndDivider, hasIntermediateDividers, hasSpacing, hasStartDivider, spacing, ...restProps } = props;
 
   const stackClass = useClassNamePrefix('Stack');
-  const stackBottomDividerClass = `${stackClass}--hasEndDivider`;
-  const stackMiddleDividersClass = `${stackClass}--hasIntermediateDividers`;
-  const stackSpacingClass = `${stackClass}--hasSpacing`;
-  const stackTopDividerClass = `${stackClass}--hasStartDivider`;
+  const stackBottomDividerClass = `${stackClass}--endDivider`;
+  const stackMiddleDividersClass = `${stackClass}--intermediateDividers`;
+  const stackSpacingClass = `${stackClass}--spacing`;
+  const stackTopDividerClass = `${stackClass}--startDivider`;
   const itemProps = `${stackClass}Item`;
   const stackStyle = useSpacingStyle(spacing, 'stack');
 

--- a/packages/web/src/scss/components/Card/index.html
+++ b/packages/web/src/scss/components/Card/index.html
@@ -2108,7 +2108,7 @@
             </div>
           </div>
           <div class="CardBody">
-            <div class="Stack Stack--hasSpacing" style="--stack-spacing: var(--spirit-space-400)">
+            <div class="Stack Stack--spacing" style="--stack-spacing: var(--spirit-space-400)">
               <!-- User content, no component classes -->
               <div class="CardEyebrow">Eyebrow</div>
               <h4 class="CardTitle CardTitle--heading">

--- a/packages/web/src/scss/components/Drawer/index.html
+++ b/packages/web/src/scss/components/Drawer/index.html
@@ -95,7 +95,7 @@
           </div>
         </fieldset>
         <fieldset class="border-0">
-          <div class="Stack Stack--hasSpacing">
+          <div class="Stack Stack--spacing">
             <div class="Checkbox">
               <input
                 name="is-closable-on-backdrop-click"

--- a/packages/web/src/scss/components/EmptyState/README.md
+++ b/packages/web/src/scss/components/EmptyState/README.md
@@ -14,7 +14,7 @@ EmptyState component is a composition of the following components:
 The `EmptyState` component is a main container responsible for positioning the [EmptyStateSection](#unstable-emptystatesection) components or content.
 
 ```html
-<div class="Stack Stack--hasSpacing EmptyState" style="--stack-spacing: var(--spirit-space-700);">
+<div class="Stack Stack--spacing EmptyState" style="--stack-spacing: var(--spirit-space-700);">
   <!-- EmptyStateSection components or content go here -->
 </div>
 ```
@@ -36,9 +36,9 @@ This component is based on the [Stack][stack] component and accepts all its vari
 ### Full Example
 
 ```html
-<div class="Stack Stack--hasSpacing EmptyState" style="--stack-spacing: var(--spirit-space-700);">
+<div class="Stack Stack--spacing EmptyState" style="--stack-spacing: var(--spirit-space-700);">
   <div class="Stack EmptyState__section">Placeholder</div>
-  <div class="Stack Stack--hasSpacing EmptyState__section" style="--stack-spacing: var(--spirit-space-500);">
+  <div class="Stack Stack--spacing EmptyState__section" style="--stack-spacing: var(--spirit-space-500);">
     <h2 class="typography-heading-xsmall-bold">Headline</h2>
     <p color="secondary" class="typography-body-medium-text-regular">Description</p>
   </div>

--- a/packages/web/src/scss/components/EmptyState/preview.html
+++ b/packages/web/src/scss/components/EmptyState/preview.html
@@ -6,7 +6,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <div class="Stack Stack--hasSpacing EmptyState" style="--stack-spacing: var(--spirit-space-900);">
+      <div class="Stack Stack--spacing EmptyState" style="--stack-spacing: var(--spirit-space-900);">
         <div class="Stack EmptyState__section">
           <div class="docs-Placeholder" style="max-width: 400px">
             <svg
@@ -36,7 +36,7 @@
               <p class="typography-body-small-regular text-secondary">Replace me with your own component</p></div>
           </div>
         </div>
-        <div class="Stack Stack--hasSpacing EmptyState__section"
+        <div class="Stack Stack--spacing EmptyState__section"
           style="--stack-spacing: var(--spirit-space-600);">
           <h2 class="typography-heading-xsmall-bold">Headline</h2>
           <p class="typography-body-medium-regular">

--- a/packages/web/src/scss/components/Footer/README.md
+++ b/packages/web/src/scss/components/Footer/README.md
@@ -46,7 +46,7 @@ the `<h3>` element matches the value of the `aria-labelledby` attribute of the `
 ```html
 <nav aria-labelledby="footer-navigation-section">
   <h3 class="typography-heading-xsmall-semibold mb-700" id="footer-navigation-section">Section headline</h3>
-  <ul class="Stack Stack--hasSpacing" style="--stack-spacing: var(--spirit-space-600)">
+  <ul class="Stack Stack--spacing" style="--stack-spacing: var(--spirit-space-600)">
     <li>
       <a href="https://www.example.com">Link</a>
     </li>
@@ -183,7 +183,7 @@ Responsive values can be defined using the `tablet` and `desktop` infixes.
       <!-- Repeat the `<nav>` block as many times as needed. -->
       <nav aria-labelledby="footer-navigation-section">
         <h3 class="typography-heading-xsmall-semibold mb-700" id="footer-navigation-section">Section headline</h3>
-        <ul class="Stack Stack--hasSpacing" style="--stack-spacing: var(--spirit-space-600)">
+        <ul class="Stack Stack--spacing" style="--stack-spacing: var(--spirit-space-600)">
           <li>
             <a href="https://www.example.com">Link</a>
           </li>

--- a/packages/web/src/scss/components/Footer/index.html
+++ b/packages/web/src/scss/components/Footer/index.html
@@ -47,7 +47,7 @@
               Section headline
             </h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600)"
             >
               <li>
@@ -71,7 +71,7 @@
               Section headline
             </h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600)"
             >
               <li>
@@ -98,7 +98,7 @@
               Section headline
             </h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600)"
             >
               <li>
@@ -131,7 +131,7 @@
               Section headline
             </h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600)"
             >
               <li>
@@ -155,7 +155,7 @@
               Section headline
             </h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600)"
             >
               <li>
@@ -179,7 +179,7 @@
               Section headline
             </h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600)"
             >
               <li>
@@ -402,7 +402,7 @@
               </a>
             </h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600)"
             >
               <li>
@@ -428,7 +428,7 @@
               </a>
             </h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600)"
             >
               <li>
@@ -457,7 +457,7 @@
               </a>
             </h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600)"
             >
               <li>
@@ -496,7 +496,7 @@
                 </a>
               </h3>
               <ul
-                class="Stack Stack--hasSpacing"
+                class="Stack Stack--spacing"
                 style="--stack-spacing: var(--spirit-space-600)"
               >
                 <li>
@@ -520,7 +520,7 @@
                 </a>
               </h3>
               <ul
-                class="Stack Stack--hasSpacing"
+                class="Stack Stack--spacing"
                 style="--stack-spacing: var(--spirit-space-600)"
               >
                 <li>
@@ -544,7 +544,7 @@
               </a>
             </h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600)"
             >
               <li>
@@ -570,7 +570,7 @@
               </a>
             </h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600)"
             >
               <li>
@@ -830,7 +830,7 @@
               class="typography-heading-xsmall-semibold mb-700"
             >Section headline</h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600);"
             >
               <li>
@@ -859,7 +859,7 @@
               class="typography-heading-xsmall-semibold mb-700"
             >Section headline</h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600);"
             >
               <li>
@@ -897,7 +897,7 @@
               Section headline
             </h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600);"
             >
               <li><a
@@ -934,7 +934,7 @@
               Section headline
             </h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600);"
             >
               <li><a
@@ -959,7 +959,7 @@
               Section headline
             </h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600);"
             >
               <li><a
@@ -984,7 +984,7 @@
               Section headline
             </h3>
             <ul
-              class="Stack Stack--hasSpacing"
+              class="Stack Stack--spacing"
               style="--stack-spacing: var(--spirit-space-600);"
             >
               <li><a

--- a/packages/web/src/scss/components/Matrix/README.md
+++ b/packages/web/src/scss/components/Matrix/README.md
@@ -36,17 +36,17 @@ Matrix to align multiple [Stack][stack] layouts:
 
 ```html
 <div class="Matrix">
-  <div class="Stack Stack--hasSpacing">
+  <div class="Stack Stack--spacing">
     <div>Stack 1</div>
     <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>
     <div>Lorem ipsum</div>
   </div>
-  <div class="Stack Stack--hasSpacing">
+  <div class="Stack Stack--spacing">
     <div>Stack 2</div>
     <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
     <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>
   </div>
-  <div class="Stack Stack--hasSpacing">
+  <div class="Stack Stack--spacing">
     <div>Stack 3</div>
     <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>
     <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>

--- a/packages/web/src/scss/components/Matrix/preview.html
+++ b/packages/web/src/scss/components/Matrix/preview.html
@@ -36,19 +36,19 @@
 
             <div class="Matrix">
 
-              <div class="Stack Stack--hasSpacing">
+              <div class="Stack Stack--spacing">
                 <div class="docs-Box docs-Box--multiline">Stack 1</div>
                 <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>
                 <div class="docs-Box docs-Box--multiline">Lorem ipsum</div>
               </div>
 
-              <div class="Stack Stack--hasSpacing">
+              <div class="Stack Stack--spacing">
                 <div class="docs-Box docs-Box--multiline">Stack 2</div>
                 <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
                 <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>
               </div>
 
-              <div class="Stack Stack--hasSpacing">
+              <div class="Stack Stack--spacing">
                 <div class="docs-Box docs-Box--multiline">Stack 3</div>
                 <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>
                 <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>
@@ -92,25 +92,25 @@
               "
             >
 
-              <div class="Stack Stack--hasSpacing">
+              <div class="Stack Stack--spacing">
                 <div class="docs-Box docs-Box--multiline">Stack 1</div>
                 <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>
                 <div class="docs-Box docs-Box--multiline">Lorem ipsum</div>
               </div>
 
-              <div class="Stack Stack--hasSpacing">
+              <div class="Stack Stack--spacing">
                 <div class="docs-Box docs-Box--multiline">Stack 2</div>
                 <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
                 <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>
               </div>
 
-              <div class="Stack Stack--hasSpacing">
+              <div class="Stack Stack--spacing">
                 <div class="docs-Box docs-Box--multiline">Stack 3</div>
                 <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>
                 <div class="docs-Box docs-Box--multiline">Lorem ipsum</div>
               </div>
 
-              <div class="Stack Stack--hasSpacing">
+              <div class="Stack Stack--spacing">
                 <div class="docs-Box docs-Box--multiline">Stack 4</div>
                 <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
                 <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>
@@ -149,25 +149,25 @@
         "
       >
 
-        <div class="Stack Stack--hasSpacing">
+        <div class="Stack Stack--spacing">
           <div class="docs-Box docs-Box--multiline">Stack 1</div>
           <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>
           <div class="docs-Box docs-Box--multiline">Lorem ipsum</div>
         </div>
 
-        <div class="Stack Stack--hasSpacing">
+        <div class="Stack Stack--spacing">
           <div class="docs-Box docs-Box--multiline">Stack 2</div>
           <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
           <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>
         </div>
 
-        <div class="Stack Stack--hasSpacing">
+        <div class="Stack Stack--spacing">
           <div class="docs-Box docs-Box--multiline">Stack 3</div>
           <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>
           <div class="docs-Box docs-Box--multiline">Lorem ipsum</div>
         </div>
 
-        <div class="Stack Stack--hasSpacing">
+        <div class="Stack Stack--spacing">
           <div class="docs-Box docs-Box--multiline">Stack 4</div>
           <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
           <div class="docs-Box docs-Box--multiline">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris.</div>

--- a/packages/web/src/scss/components/Modal/index.html
+++ b/packages/web/src/scss/components/Modal/index.html
@@ -222,7 +222,7 @@
             </form>
             <!-- Footer alignment demo: end -->
             <!-- Modal features demo: start -->
-            <form class="Stack Stack--hasSpacing">
+            <form class="Stack Stack--spacing">
               <div class="Checkbox">
                 <input
                   type="checkbox"
@@ -1032,7 +1032,7 @@
             </script>
             <form>
               <fieldset
-                class="Stack Stack--hasSpacing mb-800"
+                class="Stack Stack--spacing mb-800"
                 style="border: 0;"
               >
                 <legend hidden>Mobile</legend>
@@ -1116,7 +1116,7 @@
                 </div>
               </fieldset>
               <fieldset
-                class="Stack Stack--hasSpacing d-none d-tablet-grid mb-tablet-800"
+                class="Stack Stack--spacing d-none d-tablet-grid mb-tablet-800"
                 style="border: 0;"
               >
                 <legend hidden>Tablet</legend>
@@ -1202,7 +1202,7 @@
                 </div>
               </fieldset>
               <fieldset
-                class="Stack Stack--hasSpacing d-none d-desktop-grid"
+                class="Stack Stack--spacing d-none d-desktop-grid"
                 style="border: 0;"
               >
                 <legend hidden>Desktop</legend>

--- a/packages/web/src/scss/components/Stack/README.md
+++ b/packages/web/src/scss/components/Stack/README.md
@@ -9,7 +9,7 @@ Stack is a component that allows you to compose elements vertically.
 Usage with form fields:
 
 ```html
-<div class="Stack Stack--hasSpacing">
+<div class="Stack Stack--spacing">
   <div>
     <label for="textfield-stack-1" class="Label Label--required">Label</label>
     <div class="InputContainer InputContainer--medium">
@@ -43,22 +43,22 @@ Usage with a list:
 
 ## Variants
 
-⚠ `Stack--hasSpacing` with dividers uses the CSS `padding` property to be able to create dividers using the `border` property.
+⚠ `Stack--spacing` with dividers uses the CSS `padding` property to be able to create dividers using the `border` property.
 It is recommended to wrap the direct descendants of the `Stack` component to the proper HTML element.
 Otherwise, the applied spacing via vertical padding could break the visual view of the children's items.
 
-`Stack--hasSpacing` without dividers uses the CSS `gap` property.
+`Stack--spacing` without dividers uses the CSS `gap` property.
 
 ### Spacing Between Items
 
-👉 The vertical spacing between items is applied via `Stack--hasSpacing`. The size corresponds with the value of the design token `$space-600`.
+👉 The vertical spacing between items is applied via `Stack--spacing`. The size corresponds with the value of the design token `$space-600`.
 In case you need another spacing, please use utility classes or add custom-defined styles to the direct descendants.
 Keep in mind, that spacing is applied by the `gap` property or by `padding` property in case of dividers.
 
 Usage with spacing:
 
 ```html
-<ul class="Stack Stack--hasSpacing">
+<ul class="Stack Stack--spacing">
   <li>
     <div>Block 1</div>
   </li>
@@ -78,7 +78,7 @@ Usage with spacing:
 Usage with middle dividers:
 
 ```html
-<ul class="Stack Stack--hasIntermediateDividers">
+<ul class="Stack Stack--intermediateDividers">
   <li class="StackItem">
     <div>Block 1</div>
   </li>
@@ -94,7 +94,7 @@ Usage with middle dividers:
 Usage with inner and outer dividers:
 
 ```html
-<ul class="Stack Stack--hasIntermediateDividers Stack--hasStartDivider Stack--hasEndDivider">
+<ul class="Stack Stack--intermediateDividers Stack--startDivider Stack--endDivider">
   <li class="StackItem">
     <div>Block 1</div>
   </li>
@@ -112,7 +112,7 @@ Usage with inner and outer dividers:
 Usage with combination of spacing and dividers:
 
 ```html
-<ul class="Stack Stack--hasSpacing Stack--hasIntermediateDividers Stack--hasStartDivider Stack--hasEndDivider">
+<ul class="Stack Stack--spacing Stack--intermediateDividers Stack--startDivider Stack--endDivider">
   <li class="StackItem">
     <div>Block 1</div>
   </li>
@@ -127,12 +127,12 @@ Usage with combination of spacing and dividers:
 
 ## Custom Spacing
 
-Use CSS custom properties to define custom spacing between items in `Stack--hasSpacing`. Set the `--stack-spacing`
+Use CSS custom properties to define custom spacing between items in `Stack--spacing`. Set the `--stack-spacing`
 property to one of spacing token values defined on the `:root` element, e.g. `--stack-spacing: var(--spirit-space-800)`.
 This will set the spacing to `var(--spirit-space-800)` for all breakpoints.
 
 ```html
-<ul class="Stack Stack--hasSpacing" style="--stack-spacing: var(--spirit-space-1200)">
+<ul class="Stack Stack--spacing" style="--stack-spacing: var(--spirit-space-1200)">
   <li>
     <div>Block 1</div>
   </li>
@@ -158,7 +158,7 @@ breakpoint the default spacing will be used.
 Custom spacing from tablet up:
 
 ```html
-<ul class="Stack Stack--hasSpacing" style="--stack-spacing-tablet: var(--spirit-space-1200)">
+<ul class="Stack Stack--spacing" style="--stack-spacing-tablet: var(--spirit-space-1200)">
   <li>
     <div>Block 1</div>
   </li>
@@ -175,7 +175,7 @@ Custom spacing for each breakpoint:
 
 ```html
 <ul
-  class="Stack Stack--hasSpacing"
+  class="Stack Stack--spacing"
   style="--stack-spacing: var(--spirit-space-800); --stack-spacing-tablet: var(--spirit-space-1000); --stack-spacing-desktop: var(--spirit-space-1200)"
 >
   <li>
@@ -194,7 +194,7 @@ Custom spacing works with dividers too.
 
 ```html
 <ul
-  class="Stack Stack--hasSpacing Stack--hasIntermediateDividers Stack--hasStartDivider Stack--hasEndDivider"
+  class="Stack Stack--spacing Stack--intermediateDividers Stack--startDivider Stack--endDivider"
   style="--stack-spacing: var(--spirit-space-800)"
 >
   <li class="StackItem">

--- a/packages/web/src/scss/components/Stack/_Stack.scss
+++ b/packages/web/src/scss/components/Stack/_Stack.scss
@@ -8,7 +8,7 @@
     display: grid;
 }
 
-.Stack--hasSpacing {
+.Stack--spacing {
     @include responsive-properties.create-cascade(
         $property: 'gap',
         $input-custom-property-base-name: 'stack-spacing',
@@ -17,9 +17,9 @@
     );
 }
 
-.Stack--hasSpacing.Stack--hasStartDivider,
-.Stack--hasSpacing.Stack--hasEndDivider,
-.Stack--hasSpacing.Stack--hasIntermediateDividers {
+.Stack--spacing.Stack--startDivider,
+.Stack--spacing.Stack--endDivider,
+.Stack--spacing.Stack--intermediateDividers {
     gap: 0;
 }
 
@@ -30,48 +30,48 @@
     margin-block: 0;
 }
 
-.Stack--hasIntermediateDividers > *:not(.StackItem) {
+.Stack--intermediateDividers > *:not(.StackItem) {
     border-block-start: theme.$border;
 }
 
-.Stack--hasSpacing.Stack--hasStartDivider > *:not(.StackItem),
-.Stack--hasSpacing.Stack--hasEndDivider > *:not(.StackItem) {
+.Stack--spacing.Stack--startDivider > *:not(.StackItem),
+.Stack--spacing.Stack--endDivider > *:not(.StackItem) {
     padding-block: calc(var(--stack-spacing-internal) / 2);
 }
 
-.Stack--hasSpacing.Stack--hasIntermediateDividers > *:not(.StackItem) {
+.Stack--spacing.Stack--intermediateDividers > *:not(.StackItem) {
     padding-block: var(--stack-spacing-internal);
 }
 // stylelint-enable
 
-.Stack--hasSpacing.Stack--hasStartDivider > :not(.StackItem):first-child,
-.Stack--hasSpacing.Stack--hasEndDivider > :not(.StackItem):first-child,
-.Stack--hasSpacing.Stack--hasIntermediateDividers > :not(.StackItem):first-child {
+.Stack--spacing.Stack--startDivider > :not(.StackItem):first-child,
+.Stack--spacing.Stack--endDivider > :not(.StackItem):first-child,
+.Stack--spacing.Stack--intermediateDividers > :not(.StackItem):first-child {
     padding-block-start: 0;
 }
 
-.Stack--hasSpacing.Stack--hasStartDivider > :not(.StackItem):last-child,
-.Stack--hasSpacing.Stack--hasEndDivider > :not(.StackItem):last-child,
-.Stack--hasSpacing.Stack--hasIntermediateDividers > :not(.StackItem):last-child {
+.Stack--spacing.Stack--startDivider > :not(.StackItem):last-child,
+.Stack--spacing.Stack--endDivider > :not(.StackItem):last-child,
+.Stack--spacing.Stack--intermediateDividers > :not(.StackItem):last-child {
     padding-block-end: 0;
 }
 
-.Stack--hasIntermediateDividers > :not(.StackItem):first-child {
+.Stack--intermediateDividers > :not(.StackItem):first-child {
     border-block-start: none;
 }
 
-.Stack--hasStartDivider > :not(.StackItem):first-child {
+.Stack--startDivider > :not(.StackItem):first-child {
     border-block-start: theme.$border;
 }
 
-.Stack--hasEndDivider > :not(.StackItem):last-child {
+.Stack--endDivider > :not(.StackItem):last-child {
     border-block-end: theme.$border;
 }
 
-.Stack--hasSpacing.Stack--hasStartDivider > :not(.StackItem):first-child {
+.Stack--spacing.Stack--startDivider > :not(.StackItem):first-child {
     padding-block-start: var(--stack-spacing-internal);
 }
 
-.Stack--hasSpacing.Stack--hasEndDivider > :not(.StackItem):last-child {
+.Stack--spacing.Stack--endDivider > :not(.StackItem):last-child {
     padding-block-end: var(--stack-spacing-internal);
 }

--- a/packages/web/src/scss/components/Stack/_StackItem.scss
+++ b/packages/web/src/scss/components/Stack/_StackItem.scss
@@ -4,49 +4,49 @@
     margin-block: 0;
 }
 
-.Stack--hasIntermediateDividers > .StackItem {
+.Stack--intermediateDividers > .StackItem {
     border-block-start: theme.$border;
 }
 
-.Stack--hasIntermediateDividers > .StackItem:first-child {
+.Stack--intermediateDividers > .StackItem:first-child {
     border-block-start: none;
 }
 
-.Stack--hasStartDivider > .StackItem:first-child {
+.Stack--startDivider > .StackItem:first-child {
     border-block-start: theme.$border;
 }
 
-.Stack--hasEndDivider > .StackItem:last-child {
+.Stack--endDivider > .StackItem:last-child {
     border-block-end: theme.$border;
 }
 
 // stylelint-disable selector-max-class -- We must add correct paddings to StackItems to place dividers correctly.
-.Stack--hasSpacing.Stack--hasStartDivider > .StackItem,
-.Stack--hasSpacing.Stack--hasEndDivider > .StackItem {
+.Stack--spacing.Stack--startDivider > .StackItem,
+.Stack--spacing.Stack--endDivider > .StackItem {
     padding-block: calc(var(--stack-spacing-internal) / 2);
 }
 
-.Stack--hasSpacing.Stack--hasIntermediateDividers > .StackItem {
+.Stack--spacing.Stack--intermediateDividers > .StackItem {
     padding-block: var(--stack-spacing-internal);
 }
 
-.Stack--hasSpacing.Stack--hasStartDivider > .StackItem:first-child,
-.Stack--hasSpacing.Stack--hasEndDivider > .StackItem:first-child,
-.Stack--hasSpacing.Stack--hasIntermediateDividers > .StackItem:first-child {
+.Stack--spacing.Stack--startDivider > .StackItem:first-child,
+.Stack--spacing.Stack--endDivider > .StackItem:first-child,
+.Stack--spacing.Stack--intermediateDividers > .StackItem:first-child {
     padding-block-start: 0;
 }
 
-.Stack--hasSpacing.Stack--hasStartDivider > .StackItem:last-child,
-.Stack--hasSpacing.Stack--hasEndDivider > .StackItem:last-child,
-.Stack--hasSpacing.Stack--hasIntermediateDividers > .StackItem:last-child {
+.Stack--spacing.Stack--startDivider > .StackItem:last-child,
+.Stack--spacing.Stack--endDivider > .StackItem:last-child,
+.Stack--spacing.Stack--intermediateDividers > .StackItem:last-child {
     padding-block-end: 0;
 }
 
-.Stack--hasSpacing.Stack--hasStartDivider > .StackItem:first-child {
+.Stack--spacing.Stack--startDivider > .StackItem:first-child {
     padding-block-start: var(--stack-spacing-internal);
 }
 
-.Stack--hasSpacing.Stack--hasEndDivider > .StackItem:last-child {
+.Stack--spacing.Stack--endDivider > .StackItem:last-child {
     padding-block-end: var(--stack-spacing-internal);
 }
 // stylelint-enable

--- a/packages/web/src/scss/components/Stack/index.html
+++ b/packages/web/src/scss/components/Stack/index.html
@@ -10,7 +10,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <div class="Stack Stack--hasSpacing">
+      <div class="Stack Stack--spacing">
         <div>
           <label
             for="textfield-stack-1"
@@ -77,7 +77,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <ul class="Stack Stack--hasSpacing">
+      <ul class="Stack Stack--spacing">
         {{#each @root.blocks as |block|}}
         <li>
           <div class="docs-Box">
@@ -101,7 +101,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <ul class="Stack Stack--hasIntermediateDividers Stack--hasSpacing">
+      <ul class="Stack Stack--intermediateDividers Stack--spacing">
         {{#each @root.blocks as |block|}}
         <li class="StackItem">
           <div class="docs-Box">
@@ -125,7 +125,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <ul class="Stack Stack--hasIntermediateDividers Stack--hasEndDivider Stack--hasStartDivider Stack--hasSpacing">
+      <ul class="Stack Stack--intermediateDividers Stack--endDivider Stack--startDivider Stack--spacing">
         {{#each @root.blocks as |block|}}
         <li class="StackItem">
           <div class="docs-Box">
@@ -149,7 +149,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <ul class="Stack Stack--hasIntermediateDividers">
+      <ul class="Stack Stack--intermediateDividers">
         {{#each @root.blocks as |block|}}
         <li class="StackItem">
           <div class="docs-Box">
@@ -174,7 +174,7 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <ul
-        class="Stack Stack--hasSpacing"
+        class="Stack Stack--spacing"
         style="--stack-spacing: var(--spirit-space-1200)"
       >
         {{#each @root.blocks as |block|}}
@@ -201,7 +201,7 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <ul
-        class="Stack Stack--hasSpacing"
+        class="Stack Stack--spacing"
         style="--stack-spacing-tablet: var(--spirit-space-1200)"
       >
         {{#each @root.blocks as |block|}}
@@ -228,7 +228,7 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <ul
-        class="Stack Stack--hasSpacing"
+        class="Stack Stack--spacing"
         style="--stack-spacing: var(--spirit-space-100);--stack-spacing-tablet: var(--spirit-space-1000);--stack-spacing-desktop: var(--spirit-space-1200)"
       >
         {{#each @root.blocks as |block|}}
@@ -255,7 +255,7 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <ul
-        class="Stack Stack--hasSpacing Stack--hasStartDivider Stack--hasEndDivider Stack--hasIntermediateDividers"
+        class="Stack Stack--spacing Stack--startDivider Stack--endDivider Stack--intermediateDividers"
         style="--stack-spacing: var(--spirit-space-800)"
       >
         {{#each @root.blocks as |block|}}

--- a/packages/web/src/scss/components/Toast/index.html
+++ b/packages/web/src/scss/components/Toast/index.html
@@ -264,7 +264,7 @@
       <form>
         <fieldset style="border: 0;">
           <legend class="mb-500">New Toast:</legend>
-          <div class="Stack Stack--hasSpacing">
+          <div class="Stack Stack--spacing">
             <div>
               <label
                 for="toast-color"

--- a/packages/web/src/scss/components/UNSTABLE_FileUpload/README.md
+++ b/packages/web/src/scss/components/UNSTABLE_FileUpload/README.md
@@ -177,7 +177,7 @@ Use [UNSTABLE_File][readme-file] to display a list of uploaded files.
 Place the file list after the `UNSTABLE_FileUpload` wrapper.
 
 👉 To provide information about file list to AT, wrap the file list in a container (`ul`) with an appropriate `aria-label` (e.g. `aria-label="Uploaded files"`).
-If you need a vertical spacing, you can use `Stack` with `Stack--hasSpacing` on the file list container.
+If you need a vertical spacing, you can use `Stack` with `Stack--spacing` on the file list container.
 
 ```html
 <div class="UNSTABLE_FileUpload mb-800">
@@ -188,7 +188,7 @@ If you need a vertical spacing, you can use `Stack` with `Stack--hasSpacing` on 
 </div>
 
 <!-- File list using UNSTABLE_File -->
-<ul class="Stack Stack--hasSpacing" aria-label="Uploaded files">
+<ul class="Stack Stack--spacing" aria-label="Uploaded files">
   <li class="UNSTABLE_File">
     <div class="UNSTABLE_File__preview">
       <svg class="Icon" width="20" height="20" aria-hidden="true">

--- a/packages/web/src/scss/components/UNSTABLE_FileUpload/index.html
+++ b/packages/web/src/scss/components/UNSTABLE_FileUpload/index.html
@@ -487,7 +487,7 @@
         </div>
       </div>
 
-      <ul class="Stack Stack--hasSpacing" aria-label="Uploaded files">
+      <ul class="Stack Stack--spacing" aria-label="Uploaded files">
         <li class="UNSTABLE_File">
           <div class="UNSTABLE_File__preview">
             <svg

--- a/packages/web/src/scss/components/UNSTABLE_Header/index.html
+++ b/packages/web/src/scss/components/UNSTABLE_Header/index.html
@@ -241,7 +241,7 @@
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
-          <div class="Stack Stack--hasSpacing Stack--hasIntermediateDividers my-900" style="--stack-spacing: var(--spirit-space-900)">
+          <div class="Stack Stack--spacing Stack--intermediateDividers my-900" style="--stack-spacing: var(--spirit-space-900)">
 
             <nav class="Navigation Navigation--vertical" aria-label="Profile">
               <ul>
@@ -435,7 +435,7 @@
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
-          <div class="Stack Stack--hasSpacing Stack--hasIntermediateDividers my-900" style="--stack-spacing: var(--spirit-space-900)">
+          <div class="Stack Stack--spacing Stack--intermediateDividers my-900" style="--stack-spacing: var(--spirit-space-900)">
 
             <nav class="Navigation Navigation--vertical" aria-label="Profile">
               <ul>
@@ -728,7 +728,7 @@
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
-          <div class="Stack Stack--hasSpacing Stack--hasIntermediateDividers my-900" style="--stack-spacing: var(--spirit-space-900)">
+          <div class="Stack Stack--spacing Stack--intermediateDividers my-900" style="--stack-spacing: var(--spirit-space-900)">
 
             <nav class="Navigation Navigation--vertical" aria-label="Profile">
               <ul>

--- a/packages/web/src/scss/helpers/dynamic-color/index.html
+++ b/packages/web/src/scss/helpers/dynamic-color/index.html
@@ -48,21 +48,21 @@
             </button>
             <form
               id="dynamic-color-playground-form"
-              class="Stack Stack--hasSpacing p-800"
+              class="Stack Stack--spacing p-800"
               style="--stack-spacing: var(--spirit-space-900);"
               autocomplete="off"
               aria-labelledby="dynamic-color-playground-heading"
             >
               <h3 id="dynamic-color-playground-heading">Coefficient controls</h3>
               <div
-                class="Stack Stack--hasSpacing Stack--hasIntermediateDividers"
+                class="Stack Stack--spacing Stack--intermediateDividers"
                 style="--stack-spacing: var(--spirit-space-900);"
               >
                 <div class="StackItem">
-                  <fieldset class="Stack Stack--hasSpacing border-0 p-0">
+                  <fieldset class="Stack Stack--spacing border-0 p-0">
                     <legend class="typography-body-medium-semibold mb-900">Background state: hover</legend>
                     <div
-                      class="Stack Stack--hasSpacing"
+                      class="Stack Stack--spacing"
                       style="--stack-spacing: var(--spirit-space-800);"
                     >
                       <div>
@@ -207,10 +207,10 @@
                   </fieldset>
                 </div>
                 <div class="StackItem">
-                  <fieldset class="Stack Stack--hasSpacing border-0 p-0">
+                  <fieldset class="Stack Stack--spacing border-0 p-0">
                     <legend class="typography-body-medium-semibold mb-900">Background state: active</legend>
                     <div
-                      class="Stack Stack--hasSpacing"
+                      class="Stack Stack--spacing"
                       style="--stack-spacing: var(--spirit-space-800);"
                     >
                       <div>
@@ -353,10 +353,10 @@
                   </fieldset>
                 </div>
                 <div class="StackItem">
-                  <fieldset class="Stack Stack--hasSpacing border-0 p-0">
+                  <fieldset class="Stack Stack--spacing border-0 p-0">
                     <legend class="typography-body-medium-semibold mb-900">Background: selected</legend>
                     <div
-                      class="Stack Stack--hasSpacing"
+                      class="Stack Stack--spacing"
                       style="--stack-spacing: var(--spirit-space-800);"
                     >
                       <div>
@@ -499,10 +499,10 @@
                   </fieldset>
                 </div>
                 <div class="StackItem">
-                  <fieldset class="Stack Stack--hasSpacing border-0 p-0">
+                  <fieldset class="Stack Stack--spacing border-0 p-0">
                     <legend class="typography-body-medium-semibold mb-900">Border</legend>
                     <div
-                      class="Stack Stack--hasSpacing"
+                      class="Stack Stack--spacing"
                       style="--stack-spacing: var(--spirit-space-800);"
                     >
                       <div>
@@ -645,10 +645,10 @@
                   </fieldset>
                 </div>
                 <div class="StackItem">
-                  <fieldset class="Stack Stack--hasSpacing border-0 p-0">
+                  <fieldset class="Stack Stack--spacing border-0 p-0">
                     <legend class="typography-body-medium-semibold mb-900">Common Formula (advanced)</legend>
                     <div
-                      class="Stack Stack--hasSpacing"
+                      class="Stack Stack--spacing"
                       style="--stack-spacing: var(--spirit-space-800);"
                     >
                       <div>
@@ -862,7 +862,7 @@
                 </div>
               </div>
               <div
-                class="Stack Stack--vertical Stack--hasSpacing Stack--alignmentXStretch Stack--alignmentYStretch"
+                class="Stack Stack--vertical Stack--spacing Stack--alignmentXStretch Stack--alignmentYStretch"
                 role="group"
                 aria-label="Playground actions"
               >


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

- Rename Stack CSS modifier classes to remove the `has` verb prefix, aligning with Spirit modifier conventions (same approach as Flex direction classes in v5).
- Update `useStackStyleProps`, SCSS, demos, READMEs, and unit tests to use the new class names.
- Add Stack modifier migration steps to [web v5 migration guide](docs/migrations/web/migration-v5.md).

**Class renames:**
- `Stack--hasSpacing` → `Stack--spacing`
- `Stack--hasIntermediateDividers` → `Stack--intermediateDividers`
- `Stack--hasStartDivider` → `Stack--startDivider`
- `Stack--hasEndDivider` → `Stack--endDivider`

React props (`hasSpacing`, `hasIntermediateDividers`, etc.) are unchanged — only CSS class names are affected.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

https://jira.almacareer.tech/browse/DS-1916

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
