### PR TITLE
chore(repo): add `make bootstrap` target for install, build, and start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,11 @@ start:
 	@$(PKG_MANAGER) run start --scope @alma-oss/spirit-$(pkg)
 endif
 
+bootstrap: ## Start from scratch
+	make install
+	make build
+	make start
+
 ## —— Testing 🚦 ——————————————————————————————————————————————————————————————
 
 format: ## Checks code formatting of all packages


### PR DESCRIPTION
## Description

Adds a `make bootstrap` Makefile target that runs `install`, `build`, and `start` in sequence — a one-command way to set up and launch the development environment from scratch.

### Additional context

Renamed from the originally proposed `restart` per review feedback (`bootstrap` better describes a full fresh setup).

### Issue reference

N/A