### PR TITLE
fix(storybook): show all stories in dev sidebar

### DIFF
--- a/apps/storybook/main.ts
+++ b/apps/storybook/main.ts
@@ -15,7 +15,7 @@ const config: StorybookConfig = {
   tags: {
     figma: {
       excludeFromSidebar: isProd,
-      defaultFilterSelection: isProd ? 'exclude' : 'include',
+      ...(isProd && { defaultFilterSelection: 'exclude' as const }),
     },
   },
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Storybook dev sidebar showed only figma-tagged stories after the production figma filter was introduced. `defaultFilterSelection: 'include'` on dev activates the sidebar tag filter and limits the tree to figma stories only, instead of showing everything.

The fix removes the dev default filter selection and keeps figma exclusion only for production builds via `excludeFromSidebar` and `defaultFilterSelection: 'exclude'`.

### Additional context

If the sidebar still looks filtered after pulling this branch, reset the tag filter in Storybook or clear localStorage — the old filter state can persist in the browser.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->