### PR TITLE
refactor(web,web-react): unify toggle html order with checkbox #DS-2322

### DIFF
--- a/docs/migrations/web/migration-v5.md
+++ b/docs/migrations/web/migration-v5.md
@@ -15,6 +15,7 @@ Introducing version 5 of the _spirit-web_ package.
   - [Tag: Appearance Feature Flag Removed](#tag-appearance-feature-flag-removed)
   - [Header: `UNSTABLE_Header` Stabilized, Previous `Header` CSS Removed](#header-unstable_header-stabilized-previous-header-css-removed)
   - [ControlButton: Expanded Size Scale Feature Flag Removed](#controlbutton-expanded-size-scale-feature-flag-removed)
+  - [Toggle: Input Before Label in HTML](#toggle-input-before-label-in-html)
 
 ## Component Changes
 
@@ -239,6 +240,41 @@ active stripe in the `box` variant) was removed.
 - For second-level items, use structural nesting and keep slot icons on parent category actions only.
 - If you relied on the vertical selected-state indicator, note that it has been removed; selection is now
 communicated through the action's background and color only.
+</details>
+
+### Toggle: Input Before Label in HTML
+
+Toggle markup now places the `<input class="Toggle__input">` element **before** the
+`<div class="Toggle__text">` block, matching Checkbox and Radio. Visual layout and
+`inputPosition` modifier classes are unchanged.
+
+#### Migration Guide
+
+<details>
+  <summary>🔧 Manual Migration Steps</summary>
+
+Swap the order of the input and text wrapper in your Toggle HTML.
+
+```html
+<!-- Before -->
+<div class="Toggle Toggle--inputPositionEnd">
+  <div class="Toggle__text">
+    <label class="Label Label--inline" for="toggle">Toggle Label</label>
+  </div>
+  <input type="checkbox" id="toggle" class="Toggle__input" name="toggle" />
+</div>
+
+<!-- After -->
+<div class="Toggle Toggle--inputPositionEnd">
+  <input type="checkbox" id="toggle" class="Toggle__input" name="toggle" />
+  <div class="Toggle__text">
+    <label class="Label Label--inline" for="toggle">Toggle Label</label>
+  </div>
+</div>
+```
+
+If you provided any custom CSS depending on the order of Toggle children, you will need to update it.
+
 </details>
 
 ---

--- a/packages/web-react/src/components/Toggle/Toggle.tsx
+++ b/packages/web-react/src/components/Toggle/Toggle.tsx
@@ -55,6 +55,19 @@ const _Toggle = (props: SpiritToggleProps, ref: ForwardedRef<HTMLInputElement>) 
       }}
     >
       <div style={styleProps.style} className={classNames(classProps.root, styleProps.className)}>
+        <input
+          {...otherProps}
+          {...ariaDescribedByProp}
+          {...ariaDetailsProp}
+          type="checkbox"
+          id={id}
+          className={classProps.input}
+          disabled={isDisabled}
+          checked={checked}
+          required={isRequired}
+          onChange={handleOnChange}
+          ref={ref}
+        />
         <div className={classProps.text}>
           <Label htmlFor={id}>{label}</Label>
           {details && (
@@ -73,19 +86,6 @@ const _Toggle = (props: SpiritToggleProps, ref: ForwardedRef<HTMLInputElement>) 
             />
           )}
         </div>
-        <input
-          {...otherProps}
-          {...ariaDescribedByProp}
-          {...ariaDetailsProp}
-          type="checkbox"
-          id={id}
-          className={classProps.input}
-          disabled={isDisabled}
-          checked={checked}
-          required={isRequired}
-          onChange={handleOnChange}
-          ref={ref}
-        />
       </div>
     </PropsProvider>
   );

--- a/packages/web-react/src/components/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/web-react/src/components/Toggle/__tests__/Toggle.test.tsx
@@ -57,6 +57,12 @@ describe('Toggle', () => {
     expect(label).toContainHTML('label');
   });
 
+  it('should have text classname', () => {
+    render(<Toggle id="test-toggle" label="Toggle Label" />);
+
+    expect(screen.getByRole('checkbox').nextElementSibling).toHaveClass('Toggle__text');
+  });
+
   it('should have input classname', () => {
     render(<Toggle id="test-toggle" label="Toggle Label" />);
 
@@ -134,10 +140,11 @@ describe('Toggle', () => {
       />,
     );
 
-    const element = screen.getByRole('checkbox').previousElementSibling?.firstChild as HTMLElement;
+    const textWrapper = screen.getByRole('checkbox').nextElementSibling as HTMLElement;
+    const label = textWrapper.querySelector('label') as HTMLElement;
 
-    expect(element).toHaveTextContent('Toggle Label');
-    expect(element.innerHTML).toBe('Toggle <b>Label</b>');
+    expect(label).toHaveTextContent('Toggle Label');
+    expect(label.innerHTML).toBe('Toggle <b>Label</b>');
   });
 
   it('should render validation icon when hasValidationIcon is set', () => {

--- a/packages/web/src/scss/components/Checkbox/_Checkbox.scss
+++ b/packages/web/src/scss/components/Checkbox/_Checkbox.scss
@@ -84,11 +84,4 @@ $_field-name: 'Checkbox';
     background-color: form-fields-settings.$input-background-color;
 }
 
-@include form-fields-tools.input-position(
-    $component-class: $_field-name,
-    $positions: (
-        'start': row,
-        'end': row-reverse,
-    ),
-    $default-position: 'start'
-);
+@include form-fields-tools.input-position($component-class: $_field-name, $default-position: 'start');

--- a/packages/web/src/scss/components/InputDetails/README.md
+++ b/packages/web/src/scss/components/InputDetails/README.md
@@ -31,8 +31,9 @@ It can be used internally in the form components.
 
 ```html
 <div class="Toggle Toggle--inputPositionEnd">
+  <input type="checkbox" id="consent" class="Toggle__input" name="consent" required aria-details="consent-details" />
   <div class="Toggle__text">
-    <label class="Toggle__label Toggle__label--required" for="consent">I agree to the terms and conditions</label>
+    <label class="Label Label--inline Label--required" for="consent">I agree to the terms and conditions</label>
     <div id="consent-details" class="InputDetails">
       <button
         type="button"
@@ -44,7 +45,6 @@ It can be used internally in the form components.
       </button>
     </div>
   </div>
-  <input type="checkbox" id="consent" class="Toggle__input" name="consent" required aria-details="consent-details" />
 </div>
 <!-- Modal definitions -->
 ```
@@ -84,13 +84,6 @@ To render the `InputDetails` component in a disabled state, add the `InputDetail
 
 ```html
 <div class="Toggle Toggle--inputPositionEnd Toggle--disabled">
-  <div class="Toggle__text">
-    <label class="Toggle__label Toggle__label--required" for="consent">I agree to the terms and conditions</label>
-    <div id="consent-details" class="InputDetails InputDetails--disabled">
-      <button type="button" class="link-underlined link-inherit" disabled>See full terms and conditions</button>
-      <button type="button" class="link-underlined link-inherit" disabled>See privacy policy</button>
-    </div>
-  </div>
   <input
     type="checkbox"
     id="consent"
@@ -100,6 +93,13 @@ To render the `InputDetails` component in a disabled state, add the `InputDetail
     required
     aria-details="consent-details"
   />
+  <div class="Toggle__text">
+    <label class="Label Label--inline Label--required" for="consent">I agree to the terms and conditions</label>
+    <div id="consent-details" class="InputDetails InputDetails--disabled">
+      <button type="button" class="link-underlined link-inherit" disabled>See full terms and conditions</button>
+      <button type="button" class="link-underlined link-inherit" disabled>See privacy policy</button>
+    </div>
+  </div>
 </div>
 ```
 

--- a/packages/web/src/scss/components/InputDetails/index.html
+++ b/packages/web/src/scss/components/InputDetails/index.html
@@ -93,6 +93,15 @@
     <div class="docs-Stack docs-Stack--start">
 
       <div class="Toggle Toggle--inputPositionEnd Toggle--danger">
+        <input
+          type="checkbox"
+          id="input-details-toggle"
+          class="Toggle__input"
+          name="consent"
+          required
+          aria-details="input-details-toggle-details"
+          aria-describedby="consent-full-example-helper-text consent-full-example-validation-text"
+        />
         <div class="Toggle__text">
           <label class="Label Label--inline Label--required" for="input-details-toggle">I agree to the terms and conditions</label>
           <div id="input-details-toggle-details" class="InputDetails">
@@ -124,15 +133,6 @@
             You must agree to continue
           </div>
         </div>
-        <input
-          type="checkbox"
-          id="input-details-toggle"
-          class="Toggle__input"
-          name="consent"
-          required
-          aria-details="input-details-toggle-details"
-          aria-describedby="consent-full-example-helper-text consent-full-example-validation-text"
-        />
       </div>
 
     </div>
@@ -150,6 +150,16 @@
     <div class="docs-Stack docs-Stack--start">
 
       <div class="Toggle Toggle--inputPositionEnd Toggle--disabled Toggle--danger">
+        <input
+          type="checkbox"
+          id="input-details-toggle-disabled"
+          class="Toggle__input"
+          name="consent-disabled"
+          required
+          disabled
+          aria-details="input-details-toggle-disabled-details"
+          aria-describedby="input-details-toggle-disabled-helper-text input-details-toggle-disabled-validation-text"
+        />
         <div class="Toggle__text">
           <label class="Label Label--inline Label--required Label--disabled" for="input-details-toggle-disabled">I agree to the terms and conditions</label>
           <div id="input-details-toggle-disabled-details" class="InputDetails InputDetails--disabled">
@@ -183,16 +193,6 @@
             You must agree to continue
           </div>
         </div>
-        <input
-          type="checkbox"
-          id="input-details-toggle-disabled"
-          class="Toggle__input"
-          name="consent-disabled"
-          required
-          disabled
-          aria-details="input-details-toggle-disabled-details"
-          aria-describedby="input-details-toggle-disabled-helper-text input-details-toggle-disabled-validation-text"
-        />
       </div>
 
     </div>

--- a/packages/web/src/scss/components/Radio/_Radio.scss
+++ b/packages/web/src/scss/components/Radio/_Radio.scss
@@ -83,11 +83,4 @@ $_field-name: 'Radio';
     background-color: form-fields-settings.$input-background-color;
 }
 
-@include form-fields-tools.input-position(
-    $component-class: $_field-name,
-    $positions: (
-        'start': row,
-        'end': row-reverse,
-    ),
-    $default-position: 'start'
-);
+@include form-fields-tools.input-position($component-class: $_field-name, $default-position: 'start');

--- a/packages/web/src/scss/components/Toggle/README.md
+++ b/packages/web/src/scss/components/Toggle/README.md
@@ -9,10 +9,10 @@ the native input element and styles it to look like a toggle switch.
 
 ```html
 <div class="Toggle Toggle--inputPositionEnd">
+  <input type="checkbox" id="toggle-default" class="Toggle__input" name="default" />
   <div class="Toggle__text">
     <label class="Label Label--inline" for="toggle-default">Toggle Label</label>
-  </span>
-  <input type="checkbox" id="toggle-default" class="Toggle__input" name="default" />
+  </div>
 </div>
 ```
 
@@ -23,10 +23,10 @@ modifier class to the input. This will add a visual indicators to the toggle swi
 
 ```html
 <div class="Toggle Toggle--inputPositionEnd">
+  <input type="checkbox" id="toggle-indicators" class="Toggle__input Toggle__input--indicators" name="default" />
   <div class="Toggle__text">
     <label class="Label Label--inline" for="toggle-indicators">Toggle Label</label>
   </div>
-  <input type="checkbox" id="toggle-indicators" class="Toggle__input Toggle__input--indicators" name="default" />
 </div>
 ```
 
@@ -37,10 +37,10 @@ Add the `required` attribute to the input to mark it as required and add the
 
 ```html
 <div class="Toggle Toggle--inputPositionEnd">
+  <input type="checkbox" id="toggle-required" class="Toggle__input" name="required" required />
   <div class="Toggle__text">
     <label class="Label Label--inline Label--required" for="toggle-required">Toggle Label</label>
   </div>
-  <input type="checkbox" id="toggle-required" class="Toggle__input" name="required" required />
 </div>
 ```
 
@@ -48,10 +48,10 @@ Add the `required` attribute to the input to mark it as required and add the
 
 ```html
 <div class="Toggle Toggle--inputPositionEnd">
+  <input type="checkbox" id="toggle-hidden-label" class="Toggle__input" name="hidden-label" />
   <div class="Toggle__text">
     <label class="Label Label--inline accessibility-hidden" for="toggle-hidden-label">Toggle Label</label>
   </div>
-  <input type="checkbox" id="toggle-hidden-label" class="Toggle__input" name="hidden-label" />
 </div>
 ```
 
@@ -66,10 +66,6 @@ To add helper text, use the [HelperText][readme-helper-text] component:
 
 ```html
 <div class="Toggle Toggle--inputPositionEnd">
-  <div class="Toggle__text">
-    <label class="Label Label--inline" for="toggle-helper-text">Toggle Label</label>
-    <div class="HelperText" id="toggle-helper-text-helper-text">Helper text</div>
-  </div>
   <input
     type="checkbox"
     id="toggle-helper-text"
@@ -77,6 +73,10 @@ To add helper text, use the [HelperText][readme-helper-text] component:
     name="helper-text"
     aria-describedby="toggle-helper-text-helper-text"
   />
+  <div class="Toggle__text">
+    <label class="Label Label--inline" for="toggle-helper-text">Toggle Label</label>
+    <div class="HelperText" id="toggle-helper-text-helper-text">Helper text</div>
+  </div>
 </div>
 ```
 
@@ -92,17 +92,13 @@ a JS interaction class when controlled by JavaScript (`has-success`,
 
 ```html
 <div class="Toggle Toggle--inputPositionEnd Toggle--success">
+  <input type="checkbox" id="toggle-success" class="Toggle__input" name="default" />
   <div class="Toggle__text">
     <label class="Label Label--inline" for="toggle-success">Toggle Label</label>
   </div>
-  <input type="checkbox" id="toggle-success" class="Toggle__input" name="default" />
 </div>
 
 <div class="Toggle Toggle--inputPositionEnd Toggle--warning">
-  <div class="Toggle__text">
-    <label class="Label Label--inline" for="toggle-warning">Toggle Label</label>
-    <div class="ValidationText ValidationText--warning" id="toggle-warning-validation-text">Validation text</div>
-  </div>
   <input
     type="checkbox"
     id="toggle-warning"
@@ -111,16 +107,13 @@ a JS interaction class when controlled by JavaScript (`has-success`,
     aria-describedby="toggle-warning-validation-text"
     checked
   />
+  <div class="Toggle__text">
+    <label class="Label Label--inline" for="toggle-warning">Toggle Label</label>
+    <div class="ValidationText ValidationText--warning" id="toggle-warning-validation-text">Validation text</div>
+  </div>
 </div>
 
 <div class="Toggle Toggle--inputPositionEnd Toggle--danger">
-  <div class="Toggle__text">
-    <label for="toggle-danger" class="Label Label--inline">Toggle Label</label>
-    <ul class="ValidationText ValidationText--danger" id="toggle-danger-validation-text">
-      <li>First validation text</li>
-      <li>Second validation text</li>
-    </ul>
-  </div>
   <input
     type="checkbox"
     id="toggle-danger"
@@ -128,9 +121,24 @@ a JS interaction class when controlled by JavaScript (`has-success`,
     name="default"
     aria-describedby="toggle-danger-validation-text"
   />
+  <div class="Toggle__text">
+    <label for="toggle-danger" class="Label Label--inline">Toggle Label</label>
+    <ul class="ValidationText ValidationText--danger" id="toggle-danger-validation-text">
+      <li>First validation text</li>
+      <li>Second validation text</li>
+    </ul>
+  </div>
 </div>
 
 <div class="Toggle Toggle--inputPositionEnd Toggle--warning">
+  <input
+    type="checkbox"
+    id="toggle-warning"
+    class="Toggle__input"
+    name="default"
+    aria-describedby="toggle-warning-validation-text"
+    checked
+  />
   <div class="Toggle__text">
     <label class="Label Label--inline" for="toggle-warning">Toggle Label</label>
     <div class="ValidationText ValidationText--warning" id="toggle-warning-validation-text">
@@ -140,14 +148,6 @@ a JS interaction class when controlled by JavaScript (`has-success`,
       <span>Validation text with icon</span>
     </div>
   </div>
-  <input
-    type="checkbox"
-    id="toggle-warning"
-    class="Toggle__input"
-    name="default"
-    aria-describedby="toggle-warning-validation-text"
-    checked
-  />
 </div>
 ```
 
@@ -164,6 +164,13 @@ components mix CSS with JS by design and handle prefixes their own way.**
 
 ```html
 <div class="Toggle Toggle--inputPositionEnd has-success">
+  <input
+    type="checkbox"
+    id="toggle-success"
+    class="Toggle__input"
+    name="default"
+    aria-describedby="toggle-success-validation-text"
+  />
   <div class="Toggle__text">
     <label class="Label Label--inline" for="toggle-success">Toggle Label</label>
     <div
@@ -174,13 +181,6 @@ components mix CSS with JS by design and handle prefixes their own way.**
       Validation text
     </div>
   </div>
-  <input
-    type="checkbox"
-    id="toggle-success"
-    class="Toggle__input"
-    name="default"
-    aria-describedby="toggle-success-validation-text"
-  />
 </div>
 ```
 
@@ -208,6 +208,14 @@ class to render supplementary content (such as modal triggers) below the label.
 
 ```html
 <div class="Toggle Toggle--inputPositionEnd">
+  <input
+    type="checkbox"
+    id="toggle-consent-emphasized"
+    class="Toggle__input"
+    name="consent"
+    required
+    aria-details="toggle-consent-emphasized-details"
+  />
   <div class="Toggle__text">
     <label class="Label Label--inline Label--required" for="toggle-consent-emphasized">
       <span class="typography-body-medium-semibold">I agree to the terms and conditions</span>
@@ -223,14 +231,6 @@ class to render supplementary content (such as modal triggers) below the label.
       </button>
     </div>
   </div>
-  <input
-    type="checkbox"
-    id="toggle-consent-emphasized"
-    class="Toggle__input"
-    name="consent"
-    required
-    aria-details="toggle-consent-emphasized-details"
-  />
 </div>
 <!-- Modal definitions -->
 ```
@@ -239,6 +239,15 @@ class to render supplementary content (such as modal triggers) below the label.
 
 ```html
 <div class="Toggle Toggle--inputPositionEnd Toggle--danger">
+  <input
+    type="checkbox"
+    id="toggle-consent-full"
+    class="Toggle__input"
+    name="consent"
+    required
+    aria-describedby="toggle-consent-full-helper-text toggle-consent-full-validation-text"
+    aria-details="toggle-consent-full-details"
+  />
   <div class="Toggle__text">
     <label class="Label Label--inline Label--required" for="toggle-consent-full">
       I agree to the terms and privacy policy
@@ -268,15 +277,6 @@ class to render supplementary content (such as modal triggers) below the label.
       You must agree to continue
     </div>
   </div>
-  <input
-    type="checkbox"
-    id="toggle-consent-full"
-    class="Toggle__input"
-    name="consent"
-    required
-    aria-describedby="toggle-consent-full-helper-text toggle-consent-full-validation-text"
-    aria-details="toggle-consent-full-details"
-  />
 </div>
 <!-- Modal definitions -->
 ```
@@ -297,10 +297,10 @@ JS interaction class when controlled by JavaScript:
 
 ```html
 <div class="Toggle Toggle--inputPositionEnd Toggle--disabled">
+  <input type="checkbox" id="toggle-disabled" class="Toggle__input" name="default" disabled />
   <div class="Toggle__text">
     <label class="Label Label--inline Label--disabled" for="toggle-disabled">Toggle Label</label>
   </div>
-  <input type="checkbox" id="toggle-disabled" class="Toggle__input" name="default" disabled />
 </div>
 ```
 
@@ -312,10 +312,10 @@ The input position can be set to `end` (default) or `start`.
 
 ```html
 <div class="Toggle Toggle--inputPositionStart">
+  <input type="checkbox" id="toggle-position-start" class="Toggle__input" name="position" />
   <div class="Toggle__text">
     <label class="Label Label--inline" for="toggle-position-start">Toggle Label</label>
   </div>
-  <input type="checkbox" id="toggle-position-start" class="Toggle__input" name="position" />
 </div>
 ```
 
@@ -325,10 +325,10 @@ Use responsive breakpoint modifiers to change input position at different screen
 
 ```html
 <div class="Toggle Toggle--tablet--inputPositionStart">
+  <input type="checkbox" id="toggle-position-responsive" class="Toggle__input" name="position" />
   <div class="Toggle__text">
     <label class="Label Label--inline" for="toggle-position-responsive">Toggle Label</label>
   </div>
-  <input type="checkbox" id="toggle-position-responsive" class="Toggle__input" name="position" />
 </div>
 ```
 

--- a/packages/web/src/scss/components/Toggle/_Toggle.scss
+++ b/packages/web/src/scss/components/Toggle/_Toggle.scss
@@ -154,11 +154,4 @@ $_field-name: 'Toggle';
     }
 }
 
-@include form-fields-tools.input-position(
-    $component-class: $_field-name,
-    $positions: (
-        'start': row-reverse,
-        'end': row,
-    ),
-    $default-position: 'end'
-);
+@include form-fields-tools.input-position($component-class: $_field-name, $default-position: 'end');

--- a/packages/web/src/scss/components/Toggle/index.html
+++ b/packages/web/src/scss/components/Toggle/index.html
@@ -9,27 +9,21 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <div class="Toggle Toggle--inputPositionEnd">
-        <div class="Toggle__text">
-          <label
-            class="Label Label--inline"
-            for="toggle-default"
-          >Toggle Label</label>
-        </div>
         <input
           type="checkbox"
           id="toggle-default"
           class="Toggle__input"
           name="default"
         />
-      </div>
-
-      <div class="Toggle Toggle--inputPositionEnd">
         <div class="Toggle__text">
           <label
             class="Label Label--inline"
-            for="toggle-default-checked"
+            for="toggle-default"
           >Toggle Label</label>
         </div>
+      </div>
+
+      <div class="Toggle Toggle--inputPositionEnd">
         <input
           type="checkbox"
           id="toggle-default-checked"
@@ -37,6 +31,12 @@
           name="default"
           checked
         />
+        <div class="Toggle__text">
+          <label
+            class="Label Label--inline"
+            for="toggle-default-checked"
+          >Toggle Label</label>
+        </div>
       </div>
 
     </div>
@@ -54,27 +54,21 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <div class="Toggle Toggle--inputPositionEnd">
-        <div class="Toggle__text">
-          <label
-            class="Label Label--inline"
-            for="toggle-indicators"
-          >Toggle Label</label>
-        </div>
         <input
           type="checkbox"
           id="toggle-indicators"
           class="Toggle__input Toggle__input--indicators"
           name="default"
         />
-      </div>
-
-      <div class="Toggle Toggle--inputPositionEnd">
         <div class="Toggle__text">
           <label
             class="Label Label--inline"
-            for="toggle-indicators-checked"
+            for="toggle-indicators"
           >Toggle Label</label>
         </div>
+      </div>
+
+      <div class="Toggle Toggle--inputPositionEnd">
         <input
           type="checkbox"
           id="toggle-indicators-checked"
@@ -82,6 +76,12 @@
           name="default"
           checked
         />
+        <div class="Toggle__text">
+          <label
+            class="Label Label--inline"
+            for="toggle-indicators-checked"
+          >Toggle Label</label>
+        </div>
       </div>
 
     </div>
@@ -99,12 +99,6 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <div class="Toggle Toggle--inputPositionEnd">
-        <div class="Toggle__text">
-          <label
-            class="Label Label--inline Label--required"
-            for="toggle-required"
-          >Toggle Label</label>
-        </div>
         <input
           type="checkbox"
           id="toggle-required"
@@ -112,6 +106,12 @@
           name="default"
           required
         />
+        <div class="Toggle__text">
+          <label
+            class="Label Label--inline Label--required"
+            for="toggle-required"
+          >Toggle Label</label>
+        </div>
       </div>
 
     </div>
@@ -129,18 +129,18 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <div class="Toggle Toggle--inputPositionEnd">
-        <div class="Toggle__text">
-          <label
-            class="Label Label--inline accessibility-hidden"
-            for="toggle-hidden-label"
-          >Toggle Label</label>
-        </div>
         <input
           type="checkbox"
           id="toggle-hidden-label"
           class="Toggle__input"
           name="default"
         />
+        <div class="Toggle__text">
+          <label
+            class="Label Label--inline accessibility-hidden"
+            for="toggle-hidden-label"
+          >Toggle Label</label>
+        </div>
       </div>
 
     </div>
@@ -158,12 +158,6 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <div class="Toggle Toggle--inputPositionEnd Toggle--disabled">
-        <div class="Toggle__text">
-          <label
-            class="Label Label--inline Label--disabled"
-            for="toggle-default-disabled"
-          >Toggle Label</label>
-        </div>
         <input
           type="checkbox"
           id="toggle-default-disabled"
@@ -171,15 +165,15 @@
           name="default"
           disabled
         />
-      </div>
-
-      <div class="Toggle Toggle--inputPositionEnd Toggle--disabled">
         <div class="Toggle__text">
           <label
             class="Label Label--inline Label--disabled"
-            for="toggle-default-checked-disabled"
+            for="toggle-default-disabled"
           >Toggle Label</label>
         </div>
+      </div>
+
+      <div class="Toggle Toggle--inputPositionEnd Toggle--disabled">
         <input
           type="checkbox"
           id="toggle-default-checked-disabled"
@@ -188,9 +182,23 @@
           checked
           disabled
         />
+        <div class="Toggle__text">
+          <label
+            class="Label Label--inline Label--disabled"
+            for="toggle-default-checked-disabled"
+          >Toggle Label</label>
+        </div>
       </div>
 
       <div class="Toggle Toggle--inputPositionEnd Toggle--disabled">
+        <input
+          type="checkbox"
+          id="toggle-helper-text-disabled"
+          class="Toggle__input"
+          name="default"
+          aria-describedby="toggle-helper-text-disabled-helper-text"
+          disabled
+        />
         <div class="Toggle__text">
           <label
             class="Label Label--inline Label--disabled"
@@ -201,17 +209,18 @@
             id="toggle-helper-text-disabled-helper-text"
           >Helper text</div>
         </div>
-        <input
-          type="checkbox"
-          id="toggle-helper-text-disabled"
-          class="Toggle__input"
-          name="default"
-          aria-describedby="toggle-helper-text-disabled-helper-text"
-          disabled
-        />
       </div>
 
       <div class="Toggle Toggle--warning Toggle--disabled">
+        <input
+          type="checkbox"
+          id="toggle-warning-helper-text-disabled"
+          class="Toggle__input"
+          name="default"
+          aria-describedby="toggle-warning-helper-text-helper-text-disabled toggle-warning-helper-text-validation-text-disabled"
+          checked
+          disabled
+        />
         <div class="Toggle__text">
           <label
             class="Label Label--inline Label--disabled"
@@ -226,24 +235,9 @@
             id="toggle-warning-helper-text-validation-text-disabled"
           >Validation text</div>
         </div>
-        <input
-          type="checkbox"
-          id="toggle-warning-helper-text-disabled"
-          class="Toggle__input"
-          name="default"
-          aria-describedby="toggle-warning-helper-text-helper-text toggle-warning-helper-text-validation-text"
-          checked
-          disabled
-        />
       </div>
 
       <div class="Toggle Toggle--inputPositionEnd Toggle--disabled">
-        <div class="Toggle__text">
-          <label
-            class="Label Label--inline Label--disabled"
-            for="toggle-indicators-disabled"
-          >Toggle Label</label>
-        </div>
         <input
           type="checkbox"
           id="toggle-indicators-disabled"
@@ -251,15 +245,15 @@
           name="default"
           disabled
         />
-      </div>
-
-      <div class="Toggle Toggle--inputPositionEnd Toggle--disabled">
         <div class="Toggle__text">
           <label
             class="Label Label--inline Label--disabled"
-            for="toggle-indicators-disabled-checked"
+            for="toggle-indicators-disabled"
           >Toggle Label</label>
         </div>
+      </div>
+
+      <div class="Toggle Toggle--inputPositionEnd Toggle--disabled">
         <input
           type="checkbox"
           id="toggle-indicators-disabled-checked"
@@ -268,6 +262,12 @@
           disabled
           checked
         />
+        <div class="Toggle__text">
+          <label
+            class="Label Label--inline Label--disabled"
+            for="toggle-indicators-disabled-checked"
+          >Toggle Label</label>
+        </div>
       </div>
 
     </div>
@@ -285,6 +285,13 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <div class="Toggle Toggle--inputPositionEnd">
+        <input
+          type="checkbox"
+          id="toggle-helper-text"
+          class="Toggle__input"
+          name="default"
+          aria-describedby="toggle-helper-text-helper-text"
+        />
         <div class="Toggle__text">
           <label
             class="Label Label--inline"
@@ -295,16 +302,17 @@
             id="toggle-helper-text-helper-text"
           >Helper text</div>
         </div>
-        <input
-          type="checkbox"
-          id="toggle-helper-text"
-          class="Toggle__input"
-          name="default"
-          aria-describedby="toggle-helper-text-helper-text"
-        />
       </div>
 
       <div class="Toggle Toggle--inputPositionEnd">
+        <input
+          type="checkbox"
+          id="toggle-helper-text-checked"
+          class="Toggle__input"
+          name="default"
+          aria-describedby="toggle-helper-text-checked-helper-text"
+          checked
+        />
         <div class="Toggle__text">
           <label
             class="Label Label--inline"
@@ -315,14 +323,6 @@
             id="toggle-helper-text-checked-helper-text"
           >Helper text</div>
         </div>
-        <input
-          type="checkbox"
-          id="toggle-helper-text-checked"
-          class="Toggle__input"
-          name="default"
-          aria-describedby="toggle-helper-text-checked-helper-text"
-          checked
-        />
       </div>
 
     </div>
@@ -340,21 +340,29 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <div class="Toggle Toggle--inputPositionEnd Toggle--success">
-        <div class="Toggle__text">
-          <label
-            class="Label Label--inline"
-            for="toggle-success"
-          >Toggle Label</label>
-        </div>
         <input
           type="checkbox"
           id="toggle-success"
           class="Toggle__input"
           name="default"
         />
+        <div class="Toggle__text">
+          <label
+            class="Label Label--inline"
+            for="toggle-success"
+          >Toggle Label</label>
+        </div>
       </div>
 
       <div class="Toggle Toggle--inputPositionEnd Toggle--warning">
+        <input
+          type="checkbox"
+          id="toggle-warning"
+          class="Toggle__input"
+          name="default"
+          aria-describedby="toggle-warning-validation-text"
+          checked
+        />
         <div class="Toggle__text">
           <label
             class="Label Label--inline"
@@ -365,17 +373,16 @@
             id="toggle-warning-validation-text"
           >Validation text</div>
         </div>
-        <input
-          type="checkbox"
-          id="toggle-warning"
-          class="Toggle__input"
-          name="default"
-          aria-describedby="toggle-warning-validation-text"
-          checked
-        />
       </div>
 
       <div class="Toggle Toggle--inputPositionEnd Toggle--danger">
+        <input
+          type="checkbox"
+          id="toggle-danger"
+          class="Toggle__input"
+          name="default"
+          aria-describedby="toggle-danger-validation-text"
+        />
         <div class="Toggle__text">
           <label
             for="toggle-danger"
@@ -391,16 +398,17 @@
             </ul>
           </div>
         </div>
-        <input
-          type="checkbox"
-          id="toggle-danger"
-          class="Toggle__input"
-          name="default"
-          aria-describedby="toggle-danger-validation-text"
-        />
       </div>
 
       <div class="Toggle Toggle--inputPositionEnd Toggle--warning">
+        <input
+          type="checkbox"
+          id="toggle-warning-helper-text"
+          class="Toggle__input"
+          name="default"
+          aria-describedby="toggle-warning-helper-text-helper-text toggle-warning-helper-text-validation-text"
+          checked
+        />
         <div class="Toggle__text">
           <label
             class="Label Label--inline"
@@ -415,14 +423,6 @@
             id="toggle-warning-helper-text-validation-text"
           >Validation text</div>
         </div>
-        <input
-          type="checkbox"
-          id="toggle-warning-helper-text"
-          class="Toggle__input"
-          name="default"
-          aria-describedby="toggle-warning-helper-text-helper-text toggle-warning-helper-text-validation-text"
-          checked
-        />
       </div>
 
     </div>
@@ -438,7 +438,15 @@
       {{setVar "states" "success" "warning" "danger" }}
       {{#each @root.states as |state|}}
 
-      <div class="Toggle Toggle--{{state}}">
+      <div class="Toggle Toggle--{{state}} Toggle--inputPositionEnd">
+        <input
+          type="checkbox"
+          id="toggle-{{state}}-validation-icon"
+          class="Toggle__input"
+          name="default"
+          aria-describedby="toggle-{{state}}-validation-text-icon"
+          checked
+        />
         <div class="Toggle__text">
           <label
             class="Label Label--inline"
@@ -446,7 +454,7 @@
           >Toggle Label</label>
           <div
             class="ValidationText ValidationText--{{state}}"
-            id="toggle-{{state}}-validation-textIcon"
+            id="toggle-{{state}}-validation-text-icon"
           >
             <svg
               class="Icon"
@@ -459,14 +467,6 @@
             <span>This is {{state}} validation text. Long validation text to show how it wraps.</span>
           </div>
         </div>
-        <input
-          type="checkbox"
-          id="toggle-{{state}}-validation-icon"
-          class="Toggle__input"
-          name="default"
-          aria-describedby="toggle-{{state}}-validation-text-icon"
-          checked
-        />
       </div>
 
       {{/each}}
@@ -484,48 +484,48 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <div class="Toggle Toggle--inputPositionStart">
-        <div class="Toggle__text">
-          <label
-            class="Label Label--inline"
-            for="toggle-position-start"
-          >Input on Start</label>
-        </div>
         <input
           type="checkbox"
           id="toggle-position-start"
           class="Toggle__input"
           name="positionStart"
         />
-      </div>
-
-      <div class="Toggle Toggle--inputPositionEnd">
         <div class="Toggle__text">
           <label
             class="Label Label--inline"
-            for="toggle-position-end"
-          >Input on End (Default)</label>
+            for="toggle-position-start"
+          >Input on Start</label>
         </div>
+      </div>
+
+      <div class="Toggle Toggle--inputPositionEnd">
         <input
           type="checkbox"
           id="toggle-position-end"
           class="Toggle__input"
           name="positionEnd"
         />
-      </div>
-
-      <div class="Toggle Toggle--inputPositionEnd Toggle--tablet--inputPositionStart Toggle--desktop--inputPositionEnd">
         <div class="Toggle__text">
           <label
             class="Label Label--inline"
-            for="toggle-position-responsive"
-          >Responsive Position</label>
+            for="toggle-position-end"
+          >Input on End (Default)</label>
         </div>
+      </div>
+
+      <div class="Toggle Toggle--inputPositionEnd Toggle--tablet--inputPositionStart Toggle--desktop--inputPositionEnd">
         <input
           type="checkbox"
           id="toggle-position-responsive"
           class="Toggle__input"
           name="positionResponsive"
         />
+        <div class="Toggle__text">
+          <label
+            class="Label Label--inline"
+            for="toggle-position-responsive"
+          >Responsive Position</label>
+        </div>
       </div>
 
     </div>
@@ -543,6 +543,14 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <div class="Toggle Toggle--inputPositionEnd">
+        <input
+          type="checkbox"
+          id="toggle-consent-emphasized-label"
+          class="Toggle__input"
+          name="consent"
+          required
+          aria-details="toggle-consent-emphasized-label-details"
+        />
         <div class="Toggle__text">
           <label class="Label Label--inline Label--required" for="toggle-consent-emphasized-label"><span class="typography-body-medium-semibold">I agree to the terms and conditions</span></label>
           <div id="toggle-consent-emphasized-label-details" class="InputDetails">
@@ -558,14 +566,6 @@
             </button>
           </div>
         </div>
-        <input
-          type="checkbox"
-          id="toggle-consent-emphasized-label"
-          class="Toggle__input"
-          name="consent"
-          required
-          aria-details="toggle-consent-emphasized-label-details"
-        />
       </div>
 
     </div>
@@ -583,6 +583,15 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <div class="Toggle Toggle--inputPositionEnd Toggle--danger">
+        <input
+          type="checkbox"
+          id="toggle-consent-full-example"
+          class="Toggle__input"
+          name="consent"
+          required
+          aria-describedby="toggle-consent-full-example-helper-text toggle-consent-full-example-validation-text"
+          aria-details="toggle-consent-full-example-details"
+        />
         <div class="Toggle__text">
           <label class="Label Label--inline Label--required" for="toggle-consent-full-example">I agree to the terms and privacy policy</label>
           <div id="toggle-consent-full-example-details" class="InputDetails">
@@ -610,15 +619,6 @@
           <div class="HelperText" id="toggle-consent-full-example-helper-text">Please read the documents carefully before agreeing</div>
           <div class="ValidationText ValidationText--danger" id="toggle-consent-full-example-validation-text">You must agree to continue</div>
         </div>
-        <input
-          type="checkbox"
-          id="toggle-consent-full-example"
-          class="Toggle__input"
-          name="consent"
-          required
-          aria-describedby="toggle-consent-full-example-helper-text toggle-consent-full-example-validation-text"
-          aria-details="toggle-consent-full-example-details"
-        />
       </div>
 
     </div>

--- a/packages/web/src/scss/tools/__tests__/_form-fields.test.scss
+++ b/packages/web/src/scss/tools/__tests__/_form-fields.test.scss
@@ -45,14 +45,7 @@
 
         @include test.assert() {
             @include test.output() {
-                @include form-fields.input-position(
-                    $component-class: 'TestComponent',
-                    $positions: (
-                        'start': row,
-                        'end': row-reverse,
-                    ),
-                    $default-position: 'start'
-                );
+                @include form-fields.input-position($component-class: 'TestComponent', $default-position: 'start');
             }
 
             @include test.expect() {

--- a/packages/web/src/scss/tools/_form-fields.scss
+++ b/packages/web/src/scss/tools/_form-fields.scss
@@ -246,13 +246,14 @@
 // Creates modifier classes (e.g., `.Component--inputPositionStart`, `.Component--tablet--inputPositionEnd`)
 // that control flex-direction to position the input element relative to its label.
 //
-// @deprecated The $positions parameter will be removed when the order of input and label in Toggle HTML are unified.
-// Also, we will make the position modifier classes mandatory in the next version, so the `$default-selector` logic can
-// be deleted.
-// Migration: Remove the $positions parameter here and from the mixin calls. The default
-// ('start': row, 'end': row-reverse) will become the only option. Delete the `$default-selector` logic.
-// https://jira.almacareer.tech/browse/DS-2322
-@mixin input-position($component-class, $positions: ('start': row, 'end': row-reverse), $default-position: 'start') {
+// @deprecated We will make the position modifier classes mandatory in the next version, so the `$default-selector`
+// logic can be deleted.
+@mixin input-position($component-class, $default-position: 'start') {
+    $positions: (
+        'start': row,
+        'end': row-reverse,
+    );
+
     @each $breakpoint-name, $breakpoint-value in tokens.$breakpoints {
         $infix: breakpoint.get-modifier('infix', $breakpoint-name, $breakpoint-value);
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Toggle was the only inline form field with inverted DOM order (`__text` before `input`), which forced a separate `input-position` mapping in SCSS. This PR aligns Toggle with Checkbox and Radio by placing the input first, then removes the redundant `$positions` mixin argument now that all components share one flex-direction mapping.

Vanilla HTML markup must swap element order (breaking change for `spirit-web`). The React `<Toggle>` API is unchanged; only internal DOM order is updated.

### Additional context

- E2E toggle snapshot should remain visually identical — update with `make test-e2e-update` only if CI fails.
- The `$default-selector` fallback in `input-position` is intentionally kept for a follow-up major cleanup.

### Issue reference

https://jira.almacareer.tech/browse/DS-2322

## Test plan

- [x] `yarn test:unit` in `packages/web` and `packages/web-react` (Toggle tests)
- [ ] Visual check: Toggle `inputPosition` start/end/responsive in docsite
- [ ] E2E visual regression for Toggle demo page