### PR TITLE
fix(demo): sync theme switcher select state without DOMContentLoaded

### DIFF
--- a/apps/demo/partials/layout/base.hbs
+++ b/apps/demo/partials/layout/base.hbs
@@ -95,15 +95,8 @@
       const storedTheme = readStoredTheme();
       if (storedTheme) {
         applyTheme(storedTheme, themes);
+        document.addEventListener('readystatechange', () => syncSelects(storedTheme));
       }
-
-      document.addEventListener('DOMContentLoaded', () => {
-        const currentTheme = readStoredTheme();
-        if (!currentTheme || !isThemeAvailable(currentTheme, themes)) {
-          return;
-        }
-        syncSelects(currentTheme);
-      });
 
       const allowedOriginPattern = /^https:\/\/([a-zA-Z0-9-]+\.)*supernova-docs\.io$/;
 

--- a/apps/demo/partials/themeSwitcher.hbs
+++ b/apps/demo/partials/themeSwitcher.hbs
@@ -1,7 +1,7 @@
 <div class="Stack Stack--spacing" style="--stack-spacing: var(--spirit-space-400)">
   <label for="{{id}}" class="Label {{#if isLabelHidden }}accessibility-hidden{{/if}}">Theme</label>
   <div class="InputContainer InputContainer--fill InputContainer--medium">
-    <select id="{{id}}" name="theme" onchange="switchTheme(event)" autocomplete="off">
+    <select id="{{id}}" name="theme" onchange="switchTheme(event)" autocomplete="off" data-theme-switcher>
       {{#each @themes as |theme|}}
         <option value="{{theme.id}}">{{theme.name}}</option>
       {{/each}}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

The theme switcher selects briefly showed the wrong value on load because `syncSelects`
was deferred to `DOMContentLoaded`, by which time the browser had already painted
the default option. Separately, `syncSelects` had no reliable way to find the select
elements without depending on name-attribute selectors.

Replaced the `DOMContentLoaded` listener with a `readystatechange` listener so syncing
happens as soon as the document becomes interactive, and added a `data-theme-switcher`
attribute to each `<select>` in `themeSwitcher.hbs` so `syncSelects` can target them
explicitly. The extra availability check in the old handler was redundant because
`applyTheme` already guards against unavailable themes.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->