### PR TITLE
refactor(web,web-react)!: safely remove deprecations in SCSS 

### DIFF
--- a/packages/web/src/scss/components/Button/_theme.scss
+++ b/packages/web/src/scss/components/Button/_theme.scss
@@ -54,9 +54,7 @@ $loading-color-dictionary-overrides: (
     ),
 );
 
-// @deprecated We are deprecating `buttons` token check.
-// In the next major version, we can be sure the required token will be present so no check will be needed.
-$size-dictionary: tokens-tools.get-variable-keys-if-exists('buttons', dictionaries.$size);
+$size-dictionary: map.keys(tokens.$buttons);
 
 $size-config: map.deep-merge(
     form-fields-settings.$box-field-size-config,

--- a/packages/web/src/scss/components/Container/_theme.scss
+++ b/packages/web/src/scss/components/Container/_theme.scss
@@ -1,12 +1,8 @@
 @use 'sass:map';
 @use '@tokens' as tokens;
-@use '../../settings/dictionaries';
-@use '../../tools/tokens' as tokens-tools;
 @use 'tools';
 
-// @deprecated We are deprecating the default max width, it will be removed with next major version.
-// Apart from that, we are also deprecating the 'get-size' function and the usage of the 'get-variable-if-exists' function. In the next major version, we can be sure the required tokens will be present so no check will be needed.
-$container-max-width: tokens-tools.get-variable-if-exists('container-xlarge-max-width', tokens.$container-max-width);
+$container-max-width: tokens.$container-xlarge-max-width;
 $container-paddings: map.get(tokens.$containers, padding);
 $container-breakpoints: tokens.$breakpoints;
 
@@ -21,7 +17,7 @@ $size-config: ();
     $size-config: map.merge(
         $size-config,
         (
-            $size: tools.get-size($size, $container-max-width),
+            $size: map.get($container-size-tokens, $size),
         )
     );
 }

--- a/packages/web/src/scss/components/Container/_tools.scss
+++ b/packages/web/src/scss/components/Container/_tools.scss
@@ -1,6 +1,5 @@
 @use 'sass:map';
 @use '../../tools/breakpoint';
-@use '../../tools/tokens' as tokens-tools;
 
 @mixin paddings($paddings, $breakpoints) {
     @each $name, $breakpoint in $breakpoints {
@@ -8,10 +7,4 @@
             --container-padding-inline: #{map.get($paddings, $name)};
         }
     }
-}
-
-// @deprecated We are deprecating the default max width, it will be removed with next major version.
-// Apart from that, we are also deprecating the 'get-size' function and the usage of the 'get-variable-if-exists' function. In the next major version, we can be sure the required tokens will be present so no check will be needed.
-@function get-size($size, $default-size) {
-    @return ('max-width': tokens-tools.get-variable-if-exists('container-#{$size}-max-width', $default-size));
 }

--- a/packages/web/src/scss/components/PricingPlan/_theme.scss
+++ b/packages/web/src/scss/components/PricingPlan/_theme.scss
@@ -1,5 +1,4 @@
 @use '@tokens' as tokens;
-@use '../../tools/tokens' as tokens-tools;
 @use '../../tools/units';
 
 $min-width: units.px-to-rem(288px);
@@ -40,17 +39,6 @@ $footer-rows: 1;
 $footer-padding-top: tokens.$space-700;
 $footer-padding-bottom: tokens.$space-900;
 
-// @deprecated We are deprecating the usage of the 'get-variable-if-exists' function.
-// In the next major version, we can be sure the required token will be present so no check will be needed.
-$highlighted-border-color: tokens-tools.get-variable-if-exists(
-    'component-pricing-plan-highlighted-border',
-    tokens.$emotion-informative-border-basic
-);
-$highlighted-background-color: tokens-tools.get-variable-if-exists(
-    'component-pricing-plan-highlighted-background',
-    tokens.$emotion-informative-background-subtle
-);
-$highlighted-body-feature-icon-color: tokens-tools.get-variable-if-exists(
-    'component-pricing-plan-highlighted-content',
-    tokens.$emotion-informative-content-basic
-);
+$highlighted-border-color: tokens.$component-pricing-plan-highlighted-border;
+$highlighted-background-color: tokens.$component-pricing-plan-highlighted-background;
+$highlighted-body-feature-icon-color: tokens.$component-pricing-plan-highlighted-content;

--- a/packages/web/src/scss/components/Skeleton/_Skeleton.scss
+++ b/packages/web/src/scss/components/Skeleton/_Skeleton.scss
@@ -1,84 +1,78 @@
-@use 'sass:map';
-@use 'sass:meta';
 @use '@tokens' as tokens;
 @use '../../tools/breakpoint';
 @use '../../tools/responsive-properties';
 @use 'theme';
 @use 'tools';
 
-// @deprecated We are deprecating `gradient-skeleton` token check.
-// In the next major version, we can be sure the required token will be present so no check will be needed.
-@if map.has-key(meta.module-variables(tokens), 'gradient-skeleton') {
-    .Skeleton {
-        width: 100%;
-    }
+.Skeleton {
+    width: 100%;
+}
 
-    .Skeleton--text {
-        @include tools.generate-item-sizes(
-            $class-name: 'Skeleton',
-            $sizes: tools.generate-text-sizes(theme.$sizes-body, 'mobile')
-        );
-    }
+.Skeleton--text {
+    @include tools.generate-item-sizes(
+        $class-name: 'Skeleton',
+        $sizes: tools.generate-text-sizes(theme.$sizes-body, 'mobile')
+    );
+}
 
-    .Skeleton--heading {
-        @each $breakpoint-name, $breakpoint-value in theme.$breakpoints {
-            @include breakpoint.up($breakpoint-value) {
-                @include tools.generate-item-sizes(
-                    $class-name: 'Skeleton',
-                    $sizes: tools.generate-text-sizes(theme.$sizes-heading, $breakpoint-name)
-                );
-            }
+.Skeleton--heading {
+    @each $breakpoint-name, $breakpoint-value in theme.$breakpoints {
+        @include breakpoint.up($breakpoint-value) {
+            @include tools.generate-item-sizes(
+                $class-name: 'Skeleton',
+                $sizes: tools.generate-text-sizes(theme.$sizes-heading, $breakpoint-name)
+            );
         }
     }
+}
 
-    .Skeleton--shape {
-        @include responsive-properties.create-cascade(
-            $property: 'border-radius',
-            $input-custom-property-base-name: '#{tokens.$css-variable-prefix}skeleton-shape-radius',
-            $breakpoints: theme.$breakpoints,
-            $fallback-value: theme.$shape-default-border-radius
-        );
+.Skeleton--shape {
+    @include responsive-properties.create-cascade(
+        $property: 'border-radius',
+        $input-custom-property-base-name: '#{tokens.$css-variable-prefix}skeleton-shape-radius',
+        $breakpoints: theme.$breakpoints,
+        $fallback-value: theme.$shape-default-border-radius
+    );
 
-        display: inline-flex;
-        flex-shrink: 0;
-        width: var(--#{tokens.$css-variable-prefix}skeleton-shape-width);
-        height: var(--#{tokens.$css-variable-prefix}skeleton-shape-height);
-        border: theme.$shape-border-width solid theme.$shape-border-color;
+    display: inline-flex;
+    flex-shrink: 0;
+    width: var(--#{tokens.$css-variable-prefix}skeleton-shape-width);
+    height: var(--#{tokens.$css-variable-prefix}skeleton-shape-height);
+    border: theme.$shape-border-width solid theme.$shape-border-color;
+}
+
+.Skeleton__item,
+.Skeleton--shape {
+    background: theme.$item-gradient;
+    background-size: 600% 600%;
+
+    @media (prefers-reduced-motion: no-preference) {
+        animation: skeleton-loading 2.5s infinite;
+    }
+}
+
+.Skeleton--text > .Skeleton__item,
+.Skeleton--heading > .Skeleton__item {
+    display: block;
+    width: 100%;
+    height: var(--#{tokens.$css-variable-prefix}skeleton-height, #{theme.$typography-default-height});
+    border-radius: theme.$typography-border-radius;
+
+    &:not(:last-child) {
+        margin-bottom: theme.$margin-bottom;
     }
 
-    .Skeleton__item,
-    .Skeleton--shape {
-        background: theme.$item-gradient;
-        background-size: 600% 600%;
+    &:last-child:not(:only-child) {
+        width: 80%;
+    }
+}
 
-        @media (prefers-reduced-motion: no-preference) {
-            animation: skeleton-loading 2.5s infinite;
-        }
+@keyframes skeleton-loading {
+    0% {
+        background-position: 100% 50%;
     }
 
-    .Skeleton--text > .Skeleton__item,
-    .Skeleton--heading > .Skeleton__item {
-        display: block;
-        width: 100%;
-        height: var(--#{tokens.$css-variable-prefix}skeleton-height, #{theme.$typography-default-height});
-        border-radius: theme.$typography-border-radius;
-
-        &:not(:last-child) {
-            margin-bottom: theme.$margin-bottom;
-        }
-
-        &:last-child:not(:only-child) {
-            width: 80%;
-        }
-    }
-
-    @keyframes skeleton-loading {
-        0% {
-            background-position: 100% 50%;
-        }
-
-        100% {
-            background-position: 0 50%;
-        }
+    100% {
+        background-position: 0 50%;
     }
 }

--- a/packages/web/src/scss/components/Skeleton/_theme.scss
+++ b/packages/web/src/scss/components/Skeleton/_theme.scss
@@ -1,12 +1,9 @@
 @use '@tokens' as tokens;
-@use '../../tools/tokens' as tokens-tools;
 @use 'tools';
 
 $margin-bottom: tokens.$space-400;
 
-// @deprecated We are deprecating the usage of the 'get-variable-if-exists' function.
-// In the next major version, we can be sure the required token will be present so no check will be needed.
-$item-gradient: tokens-tools.get-variable-if-exists('gradient-skeleton');
+$item-gradient: tokens.$gradient-skeleton;
 $breakpoints: tokens.$breakpoints;
 
 $typography-border-radius: tokens.$radius-300;

--- a/packages/web/src/scss/components/Timeline/_TimelineMarker.scss
+++ b/packages/web/src/scss/components/Timeline/_TimelineMarker.scss
@@ -1,33 +1,17 @@
-// 1. Add fallbacks in case the timeline size is not defined in HTML (i.e. keep previous behavior).
-
-@use 'sass:map';
 @use '@tokens' as tokens;
 @use '../../tools/typography';
 @use 'theme';
 
-// @deprecated We are deprecating the default timeline size in favor of the size CSS modifier class.
-// Migration: remove the default timeline size from this file. The CSS modifier class is already used in the HTML.
-$_default-timeline-size: small; // 1.
-
 .TimelineMarker {
-    @include typography.from-css-variables(
-        $infix: 'timeline',
-        $fallback-config: map.get(theme.$size-config, $_default-timeline-size, typography, mobile)
-    );
+    @include typography.from-css-variables($infix: 'timeline');
 
     display: flex;
     grid-area: marker;
     align-self: center;
     align-items: center;
     justify-content: center;
-    width: var(
-        --#{tokens.$css-variable-prefix}timeline-marker-size,
-        #{map.get(theme.$size-config, $_default-timeline-size, marker-size)}
-    );
-    height: var(
-        --#{tokens.$css-variable-prefix}timeline-marker-size,
-        #{map.get(theme.$size-config, $_default-timeline-size, marker-size)}
-    );
+    width: var(--#{tokens.$css-variable-prefix}timeline-marker-size);
+    height: var(--#{tokens.$css-variable-prefix}timeline-marker-size);
     margin-block: theme.$timeline-marker-margin;
 }
 
@@ -45,27 +29,14 @@ $_default-timeline-size: small; // 1.
         content: '';
         position: absolute;
         inset: 0;
-        width: var(
-            --#{tokens.$css-variable-prefix}timeline-dot-size,
-            #{map.get(theme.$size-config, $_default-timeline-size, dot-size)}
-        );
-        height: var(
-            --#{tokens.$css-variable-prefix}timeline-dot-size,
-            #{map.get(theme.$size-config, $_default-timeline-size, dot-size)}
-        );
+        width: var(--#{tokens.$css-variable-prefix}timeline-dot-size);
+        height: var(--#{tokens.$css-variable-prefix}timeline-dot-size);
         margin: auto;
         border-radius: theme.$timeline-marker-dot-radius;
         background-color: currentcolor;
     }
 }
 
-// @deprecated The `.TimelineMarker` class in this selector is deprecated.
-// In the next major version, we can be sure the required `.TimelineMarker--icon` class will be present so no backward compatibility will be needed.
-// Migration: delete the `.TimelineMarker` class from this selector.
-.TimelineMarker,
 .TimelineMarker--icon {
-    --#{tokens.$css-variable-prefix}icon-composition-size: var(
-        --#{tokens.$css-variable-prefix}timeline-icon-size,
-        #{map.get(theme.$size-config, $_default-timeline-size, icon-size)}
-    );
+    --#{tokens.$css-variable-prefix}icon-composition-size: var(--#{tokens.$css-variable-prefix}timeline-icon-size);
 }

--- a/packages/web/src/scss/components/UNSTABLE_Header/_theme.scss
+++ b/packages/web/src/scss/components/UNSTABLE_Header/_theme.scss
@@ -1,12 +1,9 @@
 @use '@tokens' as tokens;
-@use '../../tools/tokens' as tokens-tools;
 @use '../../tools/units';
 
 $height: units.px-to-rem(72px);
 $border-width: tokens.$border-width-100;
 $border-style: solid;
 
-// @deprecated We are deprecating the usage of the 'get-variable-if-exists' function.
-// In the next major version, we can be sure the required token will be present so no check will be needed.
-$border-color: tokens-tools.get-variable-if-exists('component-header-border', tokens.$border-basic);
+$border-color: tokens.$component-header-border;
 $background-color: tokens.$component-header-background;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Several SCSS backward-compatibility guards were marked `@deprecated` because they were added when certain tokens or HTML patterns could not be guaranteed — now that those guarantees exist, the guards are dead code. This PR removes the four guards with no remaining blockers: the `buttons` token existence check in `Button`, the `gradient-skeleton` token guard wrapping the entire `Skeleton` component and the default-size fallback variable in `Timeline`.

Deprecations that remain (`DS-1884`, `DS-2322`, v5 feature flags, and `Header`) are excluded because they are blocked on other tickets or dedicated PRs.

### Additional context

The following deprecations are intentionally **not** removed in this PR:
- **DS-1884** — form field typography fallback (blocked on making form field sizes mandatory)
- **DS-2322** — `input-position()` `$positions` parameter (blocked on Toggle HTML order unification)
- **`$enable-v5-*` feature flags** and **`Header` SCSS** — part of another PRs (#2731, …)
- **DS-2639** – deprecation related to the Stack + StackItem (#2736)

### Issue reference

https://jira.almacareer.tech/browse/DS-2633