### PR TITLE
feat(codemods): add `--import-sources` for wrapper package matching

### DIFF
--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -29,6 +29,7 @@ Other optional arguments include:
 
 - `-v`/`--version` - Displays current version
 - `-h`/`--help` - Displays this message
+- `-s`/`--import-sources` - Additional import sources to match (comma-separated). By default, codemods match `@alma-oss/spirit-web-react`. Use this flag for wrapper re-export packages.
 - `-e`/`--extensions` - Extensions of the transformed files, default: `ts,tsx,js,jsx`
 - `--parser` - Parser to use (babel, ts, tsx, flow), default: `tsx`
 - `--ignore` - Ignore files or directories, default: `**/node_modules/**`
@@ -37,6 +38,12 @@ For example, this could be the command you will run:
 
 ```shell
 npx @alma-oss/spirit-codemods -p ./src -t v2/web-react/fileuploader-prop-names -e js,jsx --parser babel
+```
+
+When your app imports Spirit components through a wrapper package, pass `-s` with the wrapper import source:
+
+```shell
+npx @alma-oss/spirit-codemods -p ./src -s @almacareer/cyborg-design-system -t v5/web-react/checkbox-margin-y
 ```
 
 ## Available Scripts

--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -40,10 +40,16 @@ For example, this could be the command you will run:
 npx @alma-oss/spirit-codemods -p ./src -t v2/web-react/fileuploader-prop-names -e js,jsx --parser babel
 ```
 
-When your app imports Spirit components through a wrapper package, pass `-s` with the wrapper import source:
+When your app imports Spirit components through a wrapper package, pass `-s` with the wrapper import source. Quote the value in zsh/bash so `@` is not mishandled:
 
 ```shell
-npx @alma-oss/spirit-codemods -p ./src -s @almacareer/cyborg-design-system -t v5/web-react/checkbox-margin-y
+npx @alma-oss/spirit-codemods -p ./src -s "@org/design-system" -t v5/web-react/flex-direction-values
+```
+
+Equivalent forms:
+
+```shell
+npx @alma-oss/spirit-codemods -p ./src --import-sources=@org/design-system -t v5/web-react/flex-direction-values
 ```
 
 ## Available Scripts

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -67,6 +67,7 @@
     "eslint": "catalog:lint",
     "eslint-config-spirit": "workspace:^",
     "jest": "catalog:test",
+    "npm-run-all2": "catalog:script",
     "shx": "catalog:script",
     "tsup": "catalog:build",
     "typescript": "catalog:types"

--- a/packages/codemods/scripts/copyTransforms.js
+++ b/packages/codemods/scripts/copyTransforms.js
@@ -1,42 +1,38 @@
 import fs from 'fs';
 import path from 'path';
 
-const sourcePath = './src/transforms';
-const destinationPath = './dist/transforms';
 const excludedDirectories = ['__tests__', '__testfixtures__'];
 
+const copyTasks = [
+  { source: './src/transforms', destination: './dist/transforms' },
+  { source: './src/helpers', destination: './dist/helpers' },
+];
+
 function copyFolderRecursive(src, dest) {
-  // Check if the source path exists
   if (!fs.existsSync(src)) {
     throw new Error(`Source path doesn't exist: ${src}`);
   }
 
-  // Create destination folder if it doesn't exist
   if (!fs.existsSync(dest)) {
-    fs.mkdirSync(dest);
+    fs.mkdirSync(dest, { recursive: true });
   }
 
-  // Get all files and subdirectories in the source path
   const items = fs.readdirSync(src);
 
-  // Copy each item to the destination path
   items.forEach((item) => {
     const srcPath = path.join(src, item);
     const destPath = path.join(dest, item);
 
-    // Check if the item is a directory
     if (fs.statSync(srcPath).isDirectory()) {
-      // Check if the directory is not in the excluded list
       if (!excludedDirectories.includes(item)) {
-        // Recursively copy the directory
         copyFolderRecursive(srcPath, destPath);
       }
     } else {
-      // Copy the file
       fs.copyFileSync(srcPath, destPath);
     }
   });
 }
 
-// Call the function to start the copy process
-copyFolderRecursive(sourcePath, destinationPath);
+copyTasks.forEach(({ source, destination }) => {
+  copyFolderRecursive(source, destination);
+});

--- a/packages/codemods/src/cli.ts
+++ b/packages/codemods/src/cli.ts
@@ -13,13 +13,18 @@ export default async function cli(args: string[]) {
     .example('-p ./')
     .option('-t, --transformation', 'Codemod transformation name to run')
     .example('-t v2/web-react/codemodName')
+    .option(
+      '-s, --import-sources',
+      'Additional import sources to match (comma-separated). Defaults to @alma-oss/spirit-web-react',
+    )
+    .example('-s @almacareer/cyborg-design-system')
     .option('-e, --extensions', 'Extensions to look for when transforming files, default: ts,tsx,js,jsx')
     .example('-e ts, tsx, js, jsx')
     .option('-i, --ignore', 'Ignore files or directories, default: **/node_modules/**')
     .example('-i **/node_modules/**')
     .option('-r, --parser', 'Parser to use (babel, ts, tsx, flow), default: tsx')
     .example('--parser babel')
-    .action(async ({ path: codePath, transformation, extensions, ignore, parser }) => {
+    .action(async ({ path: codePath, transformation, importSources, extensions, ignore, parser }) => {
       const defaultExtensions = 'ts,tsx,js,jsx';
       const defaultIgnore = '**/node_modules/**';
       const defaultParser = 'tsx';
@@ -42,9 +47,24 @@ export default async function cli(args: string[]) {
         process.exit(1);
       }
 
-      const { stdout } = await $`jscodeshift --transform ${codemodPath} --extensions ${
-        extensions || defaultExtensions
-      } --ignore-pattern=${ignore || defaultIgnore} --parser=${parser || defaultParser} ${codePath}`;
+      const jscodeshiftArgs = [
+        '--transform',
+        codemodPath,
+        '--extensions',
+        extensions || defaultExtensions,
+        '--ignore-pattern',
+        ignore || defaultIgnore,
+        '--parser',
+        parser || defaultParser,
+      ];
+
+      if (importSources) {
+        jscodeshiftArgs.push('--importSources', importSources);
+      }
+
+      jscodeshiftArgs.push(codePath);
+
+      const { stdout } = await $({ stdio: 'pipe' })`jscodeshift ${jscodeshiftArgs}`;
 
       // stdout object from jscodeshift
       logMessage(stdout);

--- a/packages/codemods/src/cli.ts
+++ b/packages/codemods/src/cli.ts
@@ -2,8 +2,11 @@ import { $ } from 'execa';
 import sade from 'sade';
 import { fs, path } from 'zx';
 import { _dirname, errorMessage, logMessage } from './helpers';
+import { resolveImportSources } from './helpers/resolveImportSources';
 
 const packageJson = fs.readJsonSync(path.resolve(_dirname, './package.json'));
+
+export { resolveImportSources } from './helpers/resolveImportSources';
 
 export default async function cli(args: string[]) {
   sade('spirit-codemods', true)
@@ -17,7 +20,7 @@ export default async function cli(args: string[]) {
       '-s, --import-sources',
       'Additional import sources to match (comma-separated). Defaults to @alma-oss/spirit-web-react',
     )
-    .example('-s @almacareer/cyborg-design-system')
+    .example('-s @org/design-system')
     .option('-e, --extensions', 'Extensions to look for when transforming files, default: ts,tsx,js,jsx')
     .example('-e ts, tsx, js, jsx')
     .option('-i, --ignore', 'Ignore files or directories, default: **/node_modules/**')
@@ -28,6 +31,7 @@ export default async function cli(args: string[]) {
       const defaultExtensions = 'ts,tsx,js,jsx';
       const defaultIgnore = '**/node_modules/**';
       const defaultParser = 'tsx';
+      const resolvedImportSources = resolveImportSources(args, importSources);
 
       if (!codePath || !fs.existsSync(codePath)) {
         errorMessage(codePath);
@@ -58,15 +62,14 @@ export default async function cli(args: string[]) {
         parser || defaultParser,
       ];
 
-      if (importSources) {
-        jscodeshiftArgs.push('--importSources', importSources);
+      if (resolvedImportSources) {
+        jscodeshiftArgs.push('--importSources', resolvedImportSources);
       }
 
       jscodeshiftArgs.push(codePath);
 
-      const { stdout } = await $({ stdio: 'pipe' })`jscodeshift ${jscodeshiftArgs}`;
+      const { stdout } = await $({ stdio: 'pipe' })('jscodeshift', jscodeshiftArgs);
 
-      // stdout object from jscodeshift
       logMessage(stdout);
 
       process.exit(0);

--- a/packages/codemods/src/helpers/__tests__/resolveImportSources.test.ts
+++ b/packages/codemods/src/helpers/__tests__/resolveImportSources.test.ts
@@ -1,0 +1,29 @@
+import { resolveImportSources } from '../resolveImportSources';
+
+describe('resolveImportSources', () => {
+  it('should return parsed value from sade when present', () => {
+    expect(resolveImportSources(['-p', './src', '-s', '@org/design-system'], '@org/design-system')).toBe(
+      '@org/design-system',
+    );
+  });
+
+  it('should read --import-sources= form from argv', () => {
+    expect(resolveImportSources(['-p', './src', '--import-sources=@org/design-system'])).toBe('@org/design-system');
+  });
+
+  it('should read -s value from next argv token', () => {
+    expect(resolveImportSources(['-p', './src', '-s', '@org/design-system', '-t', 'v5/web-react/item-props'])).toBe(
+      '@org/design-system',
+    );
+  });
+
+  it('should find loose scoped package after -s when zsh drops the bound value', () => {
+    expect(
+      resolveImportSources(['-p', './src', '-s', '-t', 'v5/web-react/flex-direction-values', '@org/design-system']),
+    ).toBe('@org/design-system');
+  });
+
+  it('should return undefined when no import sources are provided', () => {
+    expect(resolveImportSources(['-p', './src', '-t', 'v5/web-react/item-props'])).toBeUndefined();
+  });
+});

--- a/packages/codemods/src/helpers/__tests__/spiritWebReactImport.test.ts
+++ b/packages/codemods/src/helpers/__tests__/spiritWebReactImport.test.ts
@@ -1,0 +1,60 @@
+import {
+  createImportSourceMatcher,
+  DEFAULT_SPIRIT_WEB_REACT_IMPORT_SOURCES,
+  getImportSources,
+  isSpiritWebReactImport,
+} from '../spiritWebReactImport';
+
+describe('spiritWebReactImport', () => {
+  describe('getImportSources', () => {
+    it('should return default sources when no options are provided', () => {
+      expect(getImportSources()).toEqual([...DEFAULT_SPIRIT_WEB_REACT_IMPORT_SOURCES]);
+    });
+
+    it('should merge additional sources from options', () => {
+      expect(getImportSources({ importSources: '@almacareer/cyborg-design-system' })).toEqual([
+        ...DEFAULT_SPIRIT_WEB_REACT_IMPORT_SOURCES,
+        '@almacareer/cyborg-design-system',
+      ]);
+    });
+
+    it('should deduplicate and trim comma-separated sources', () => {
+      expect(
+        getImportSources({
+          importSources: ' @almacareer/cyborg-design-system , @alma-oss/spirit-web-react , @custom/wrapper ',
+        }),
+      ).toEqual([...DEFAULT_SPIRIT_WEB_REACT_IMPORT_SOURCES, '@almacareer/cyborg-design-system', '@custom/wrapper']);
+    });
+  });
+
+  describe('isSpiritWebReactImport', () => {
+    const sources = getImportSources({ importSources: '@almacareer/cyborg-design-system' });
+
+    it('should match exact default import sources', () => {
+      expect(isSpiritWebReactImport('@alma-oss/spirit-web-react', sources)).toBe(true);
+    });
+
+    it('should not match legacy lmc-eu imports by default', () => {
+      expect(isSpiritWebReactImport('@lmc-eu/spirit-web-react', getImportSources())).toBe(false);
+    });
+
+    it('should match subpath imports', () => {
+      expect(isSpiritWebReactImport('@alma-oss/spirit-web-react/components/Button', sources)).toBe(true);
+      expect(isSpiritWebReactImport('@almacareer/cyborg-design-system/Item', sources)).toBe(true);
+    });
+
+    it('should not match unrelated packages', () => {
+      expect(isSpiritWebReactImport('@other/package', sources)).toBe(false);
+      expect(isSpiritWebReactImport('@almacareer/cyborg-design-system-extra', sources)).toBe(false);
+    });
+  });
+
+  describe('createImportSourceMatcher', () => {
+    it('should return a predicate compatible with jscodeshift filters', () => {
+      const isSpiritImport = createImportSourceMatcher(['@almacareer/cyborg-design-system']);
+
+      expect(isSpiritImport('@almacareer/cyborg-design-system')).toBe(true);
+      expect(isSpiritImport('@alma-oss/spirit-web-react')).toBe(false);
+    });
+  });
+});

--- a/packages/codemods/src/helpers/finishTransform.ts
+++ b/packages/codemods/src/helpers/finishTransform.ts
@@ -1,0 +1,19 @@
+import { Collection, FileInfo } from 'jscodeshift';
+import { removeParentheses } from './removeParentheses';
+
+type FinishTransformOptions = {
+  quote?: 'single' | 'double';
+};
+
+export const finishTransform = (
+  fileInfo: FileInfo,
+  root: Collection,
+  hasChanges: boolean,
+  options?: FinishTransformOptions,
+): string => {
+  if (!hasChanges) {
+    return fileInfo.source;
+  }
+
+  return removeParentheses(root.toSource(options?.quote ? { quote: options.quote } : undefined));
+};

--- a/packages/codemods/src/helpers/index.ts
+++ b/packages/codemods/src/helpers/index.ts
@@ -8,4 +8,6 @@ export {
   getImportSources,
   isSpiritWebReactImport,
 } from './spiritWebReactImport';
+export { finishTransform } from './finishTransform';
+export { getOwnRecordValue, hasOwnRecordKey } from './recordUtils';
 export { _dirname, errorMessage, infoMessage, logMessage, removeParentheses };

--- a/packages/codemods/src/helpers/index.ts
+++ b/packages/codemods/src/helpers/index.ts
@@ -2,4 +2,10 @@ import { errorMessage, infoMessage, logMessage } from './message';
 import { _dirname } from './path';
 import { removeParentheses } from './removeParentheses';
 
+export {
+  createImportSourceMatcher,
+  DEFAULT_SPIRIT_WEB_REACT_IMPORT_SOURCES,
+  getImportSources,
+  isSpiritWebReactImport,
+} from './spiritWebReactImport';
 export { _dirname, errorMessage, infoMessage, logMessage, removeParentheses };

--- a/packages/codemods/src/helpers/recordUtils.ts
+++ b/packages/codemods/src/helpers/recordUtils.ts
@@ -1,0 +1,5 @@
+export const getOwnRecordValue = <T>(record: Record<string, T>, key: string): T | undefined =>
+  Object.prototype.hasOwnProperty.call(record, key) ? record[key] : undefined;
+
+export const hasOwnRecordKey = (record: Record<string, unknown>, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(record, key);

--- a/packages/codemods/src/helpers/renameComponent.ts
+++ b/packages/codemods/src/helpers/renameComponent.ts
@@ -22,8 +22,9 @@ export const renameComponent = (
   componentName: string,
   newComponentName: string,
   importSources: string[] = getImportSources(),
-) => {
+): boolean => {
   const isSpiritImport = createImportSourceMatcher(importSources);
+  let hasChanges = false;
 
   const importStatements = root.find(j.ImportDeclaration, {
     source: {
@@ -42,6 +43,8 @@ export const renameComponent = (
 
     // Check if 'componentName' specifier is present
     if (componentSpecifier.length > 0) {
+      hasChanges = true;
+
       // Find opening tags for 'componentName' components
       root
         .find<JSXOpeningElement>(j.JSXOpeningElement, {
@@ -86,4 +89,6 @@ export const renameComponent = (
       });
     }
   }
+
+  return hasChanges;
 };

--- a/packages/codemods/src/helpers/renameComponent.ts
+++ b/packages/codemods/src/helpers/renameComponent.ts
@@ -1,4 +1,5 @@
 import core, { Collection, JSXClosingElement, JSXIdentifier, JSXOpeningElement } from 'jscodeshift';
+import { createImportSourceMatcher, getImportSources } from './spiritWebReactImport';
 
 /**
  * Renames a component - updating import statements and JSX tags.
@@ -11,6 +12,7 @@ import core, { Collection, JSXClosingElement, JSXIdentifier, JSXOpeningElement }
  * @param {Collection} root - The root collection of the jscodeshift AST to search and modify.
  * @param {string} componentName - The name of the component to rename.
  * @param {string} newComponentName - The new name to replace the old component name with.
+ * @param {string[]} importSources - Import sources to match.
  *
  * @returns {void} - This function modifies the AST in place and does not return a value.
  */
@@ -19,10 +21,13 @@ export const renameComponent = (
   root: Collection,
   componentName: string,
   newComponentName: string,
+  importSources: string[] = getImportSources(),
 ) => {
+  const isSpiritImport = createImportSourceMatcher(importSources);
+
   const importStatements = root.find(j.ImportDeclaration, {
     source: {
-      value: (value: string) => /^@alma-oss\/spirit-web-react(\/.*)?$/.test(value),
+      value: (value: string) => isSpiritImport(value),
     },
   });
 

--- a/packages/codemods/src/helpers/resolveImportSources.ts
+++ b/packages/codemods/src/helpers/resolveImportSources.ts
@@ -1,0 +1,30 @@
+export const resolveImportSources = (argv: string[], parsed?: string): string | undefined => {
+  if (parsed) {
+    return parsed;
+  }
+
+  const equalForm = argv.find((arg) => arg.startsWith('--import-sources='));
+
+  if (equalForm) {
+    return equalForm.slice('--import-sources='.length);
+  }
+
+  const flagIndex = argv.findIndex((arg) => arg === '-s' || arg === '--import-sources');
+
+  if (flagIndex !== -1) {
+    const next = argv[flagIndex + 1];
+
+    if (next && !next.startsWith('-')) {
+      return next;
+    }
+
+    // zsh may leave a scoped package as a loose token when `-s @org/pkg` is not quoted
+    const scopedPackage = argv.slice(flagIndex + 1).find((arg) => /^@[^/]+\/.+/.test(arg));
+
+    if (scopedPackage) {
+      return scopedPackage;
+    }
+  }
+
+  return undefined;
+};

--- a/packages/codemods/src/helpers/spiritWebReactImport.ts
+++ b/packages/codemods/src/helpers/spiritWebReactImport.ts
@@ -1,0 +1,31 @@
+export const DEFAULT_SPIRIT_WEB_REACT_IMPORT_SOURCES = ['@alma-oss/spirit-web-react'] as const;
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const getImportSources = (options?: Record<string, unknown>): string[] => {
+  const sources = new Set<string>(DEFAULT_SPIRIT_WEB_REACT_IMPORT_SOURCES);
+
+  if (typeof options?.importSources === 'string' && options.importSources.length > 0) {
+    options.importSources.split(',').forEach((source) => {
+      const trimmed = source.trim();
+
+      if (trimmed.length > 0) {
+        sources.add(trimmed);
+      }
+    });
+  }
+
+  return [...sources];
+};
+
+export const isSpiritWebReactImport = (value: string, sources: string[]): boolean =>
+  sources.some((source) => {
+    const escapedSource = escapeRegExp(source);
+
+    return new RegExp(`^${escapedSource}(\\/.*)?$`).test(value);
+  });
+
+export const createImportSourceMatcher =
+  (sources: string[]): ((value: string) => boolean) =>
+  (value: string) =>
+    isSpiritWebReactImport(value, sources);

--- a/packages/codemods/src/transforms/v5/web-react/README.md
+++ b/packages/codemods/src/transforms/v5/web-react/README.md
@@ -19,6 +19,7 @@ Links that already have any `color` prop are left untouched.
 
 ```sh
 npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/alert-link-color-inherit
+npx @alma-oss/spirit-codemods -p <path> -s "@org/design-system" -t v5/web-react/alert-link-color-inherit
 ```
 
 #### Example
@@ -56,6 +57,7 @@ It does not change `hasValidationIcon` on form field components such as `TextFie
 
 ```sh
 npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/validation-state-icon-prop
+npx @alma-oss/spirit-codemods -p <path> -s "@org/design-system" -t v5/web-react/validation-state-icon-prop
 ```
 
 #### Example
@@ -68,11 +70,13 @@ npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/validation-state-icon-pr
 ### `v5/web-react/flex-direction-values` - Replace Flex Direction Prop Values `row` with `horizontal` and `column` with `vertical`
 
 This codemod updates `direction` values of `Flex` component by replacing `row` to `horizontal` and `column` to `vertical`.
+Only updates `Flex` imported from `@alma-oss/spirit-web-react` or additional `-s` import sources. Files with no matching import or no `direction` changes are left unchanged — including plain `.ts` files without JSX.
 
 #### Usage
 
 ```sh
 npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/flex-direction-values
+npx @alma-oss/spirit-codemods -p <path> -s "@org/design-system" -t v5/web-react/flex-direction-values
 ```
 
 #### Example
@@ -388,6 +392,7 @@ The component-specific `DrawerCloseButton`, `ModalCloseButton`, and `TooltipClos
 
 ```sh
 npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/close-buttons-to-close-button
+npx @alma-oss/spirit-codemods -p <path> -s "@org/design-system" -t v5/web-react/close-buttons-to-close-button
 ```
 
 #### Example

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/alert-link-color-inherit.import-sources.input.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/alert-link-color-inherit.import-sources.input.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import { Alert as SpiritAlert, Link as SpiritLink } from '@org/design-system';
+import { Alert, Link } from '@other/design-system';
+
+export const MyComponent = () => (
+  <>
+    <SpiritAlert color="success">
+      See <SpiritLink href="/faq">FAQ</SpiritLink> for more info.
+    </SpiritAlert>
+
+    <Alert color="success">
+      See <Link href="/faq">FAQ</Link> for more info.
+    </Alert>
+  </>
+);

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/alert-link-color-inherit.import-sources.output.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/alert-link-color-inherit.import-sources.output.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import { Alert as SpiritAlert, Link as SpiritLink } from '@org/design-system';
+import { Alert, Link } from '@other/design-system';
+
+export const MyComponent = () => (
+  <>
+    <SpiritAlert color="success">
+      See <SpiritLink href="/faq" color="inherit">FAQ</SpiritLink> for more info.
+    </SpiritAlert>
+
+    <Alert color="success">
+      See <Link href="/faq">FAQ</Link> for more info.
+    </Alert>
+  </>
+);

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/close-buttons-to-close-button.import-sources.input.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/close-buttons-to-close-button.import-sources.input.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import {
+  Modal,
+  ModalCloseButton as ModalDismissButton,
+  Tooltip,
+  TooltipCloseButton as TooltipDismissButton,
+} from '@org/design-system';
+import { CloseButton as OtherCloseButton } from '@other/design-system';
+
+export const MyModal = ({ id, isOpen, onClose }) => (
+  <Modal id={id} isOpen={isOpen} onClose={onClose}>
+    <ModalDismissButton id={id} isOpen={isOpen} onClose={onClose} label="Close">
+      Close
+    </ModalDismissButton>
+  </Modal>
+);
+
+export const MyTooltip = ({ onClose }) => (
+  <Tooltip>
+    <TooltipDismissButton onClick={onClose} label="Close" />
+    <OtherCloseButton label="Other" />
+  </Tooltip>
+);

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/close-buttons-to-close-button.import-sources.output.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/close-buttons-to-close-button.import-sources.output.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import { Modal, Tooltip, CloseButton } from '@org/design-system';
+import { CloseButton as OtherCloseButton } from '@other/design-system';
+
+export const MyModal = ({ id, isOpen, onClose }) => (
+  <Modal id={id} isOpen={isOpen} onClose={onClose}>
+    <CloseButton
+      size="xlarge"
+      aria-controls={id}
+      aria-expanded={isOpen}
+      onClick={onClose}
+      label="Close">
+      Close
+    </CloseButton>
+  </Modal>
+);
+
+export const MyTooltip = ({ onClose }) => (
+  <Tooltip>
+    <CloseButton aria-expanded="true" onClick={onClose} label="Close" />
+    <OtherCloseButton label="Other" />
+  </Tooltip>
+);

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/collapse-isDisposable-prop.input.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/collapse-isDisposable-prop.input.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 // @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
-import { UncontrolledCollapse } from '@lmc-eu/spirit-web-react';
+import { UncontrolledCollapse } from '@alma-oss/spirit-web-react';
 
 export const MyComponent = () => (
   <>

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/collapse-isDisposable-prop.output.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/collapse-isDisposable-prop.output.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 // @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
-import { UncontrolledCollapse } from '@lmc-eu/spirit-web-react';
+import { UncontrolledCollapse } from '@alma-oss/spirit-web-react';
 
 export const MyComponent = () => (
   <>

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/drawer-panel-close-button-composition.import-sources.input.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/drawer-panel-close-button-composition.import-sources.input.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import {
+  Drawer,
+  DrawerCloseButton as DrawerDismissButton,
+  DrawerPanel as SpiritDrawerPanel,
+} from '@org/design-system';
+
+export const WithCloseButton = ({ isOpen, onClose }) => (
+  <Drawer id="my-drawer" isOpen={isOpen} onClose={onClose} aria-label="Navigation">
+    <SpiritDrawerPanel closeButton={<DrawerDismissButton size="medium" />}>
+      <p>Drawer content</p>
+    </SpiritDrawerPanel>
+  </Drawer>
+);

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/drawer-panel-close-button-composition.import-sources.output.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/drawer-panel-close-button-composition.import-sources.output.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import {
+  Drawer,
+  DrawerPanel as SpiritDrawerPanel,
+  CloseButton,
+  DrawerPanelHeader,
+  DrawerPanelBody,
+} from '@org/design-system';
+
+export const WithCloseButton = ({ isOpen, onClose }) => (
+  <Drawer id="my-drawer" isOpen={isOpen} onClose={onClose} aria-label="Navigation">
+    <SpiritDrawerPanel><DrawerPanelHeader><CloseButton
+          size="medium"
+          aria-expanded={TODO_drawerIsOpen}
+          aria-controls={TODO_drawerId}
+          onClick={TODO_drawerOnClose} /></DrawerPanelHeader><DrawerPanelBody>
+        <p>Drawer content</p>
+      </DrawerPanelBody></SpiritDrawerPanel>
+  </Drawer>
+);

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/flex-direction-values.input.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/flex-direction-values.input.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 // @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
-import { Flex } from '@lmc-eu/spirit-web-react';
+import { Flex } from '@alma-oss/spirit-web-react';
 
 export const MyComponent = () => (
   <>

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/flex-direction-values.output.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/flex-direction-values.output.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 // @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
-import { Flex } from '@lmc-eu/spirit-web-react';
+import { Flex } from '@alma-oss/spirit-web-react';
 
 export const MyComponent = () => (
   <>

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/validation-state-icon-prop.import-sources.input.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/validation-state-icon-prop.import-sources.input.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import { ValidationText as SpiritValidationText } from '@org/design-system';
+import { ValidationText } from '@other/design-system';
+
+export const MyComponent = () => (
+  <>
+    <SpiritValidationText validationText="Saved successfully." hasValidationStateIcon="success" />
+    <ValidationText validationText="Other message." hasValidationStateIcon="warning" />
+  </>
+);

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/validation-state-icon-prop.import-sources.output.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/validation-state-icon-prop.import-sources.output.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import { ValidationText as SpiritValidationText } from '@org/design-system';
+import { ValidationText } from '@other/design-system';
+
+export const MyComponent = () => (
+  <>
+    <SpiritValidationText validationText="Saved successfully." validationStateIcon="success" />
+    <ValidationText validationText="Other message." hasValidationStateIcon="warning" />
+  </>
+);

--- a/packages/codemods/src/transforms/v5/web-react/__tests__/alert-link-color-inherit.test.ts
+++ b/packages/codemods/src/transforms/v5/web-react/__tests__/alert-link-color-inherit.test.ts
@@ -1,3 +1,9 @@
 import { testTransform } from '../../../../../tests/testUtils';
 
 testTransform(__dirname, 'alert-link-color-inherit');
+testTransform(
+  __dirname,
+  'alert-link-color-inherit',
+  { importSources: '@org/design-system' },
+  'alert-link-color-inherit.import-sources',
+);

--- a/packages/codemods/src/transforms/v5/web-react/__tests__/close-buttons-to-close-button.test.ts
+++ b/packages/codemods/src/transforms/v5/web-react/__tests__/close-buttons-to-close-button.test.ts
@@ -1,3 +1,9 @@
 import { testTransform } from '../../../../../tests/testUtils';
 
 testTransform(__dirname, 'close-buttons-to-close-button');
+testTransform(
+  __dirname,
+  'close-buttons-to-close-button',
+  { importSources: '@org/design-system' },
+  'close-buttons-to-close-button.import-sources',
+);

--- a/packages/codemods/src/transforms/v5/web-react/__tests__/drawer-panel-close-button-composition.test.ts
+++ b/packages/codemods/src/transforms/v5/web-react/__tests__/drawer-panel-close-button-composition.test.ts
@@ -1,3 +1,9 @@
 import { testTransform } from '../../../../../tests/testUtils';
 
 testTransform(__dirname, 'drawer-panel-close-button-composition');
+testTransform(
+  __dirname,
+  'drawer-panel-close-button-composition',
+  { importSources: '@org/design-system' },
+  'drawer-panel-close-button-composition.import-sources',
+);

--- a/packages/codemods/src/transforms/v5/web-react/__tests__/validation-state-icon-prop.test.ts
+++ b/packages/codemods/src/transforms/v5/web-react/__tests__/validation-state-icon-prop.test.ts
@@ -1,3 +1,9 @@
 import { testTransform } from '../../../../../tests/testUtils';
 
 testTransform(__dirname, 'validation-state-icon-prop');
+testTransform(
+  __dirname,
+  'validation-state-icon-prop',
+  { importSources: '@org/design-system' },
+  'validation-state-icon-prop.import-sources',
+);

--- a/packages/codemods/src/transforms/v5/web-react/alert-link-color-inherit.ts
+++ b/packages/codemods/src/transforms/v5/web-react/alert-link-color-inherit.ts
@@ -1,16 +1,15 @@
 import { API, FileInfo, JSXOpeningElement } from 'jscodeshift';
-import { removeParentheses } from '../../../helpers';
-
-const SPIRIT_WEB_REACT_MODULE = /^@alma-oss\/spirit-web-react(\/.*)?$/;
+import { createImportSourceMatcher, getImportSources, removeParentheses } from '../../../helpers';
 
 const hasColorAttribute = (openingElement: JSXOpeningElement): boolean =>
   (openingElement.attributes ?? []).some(
     (attr) => attr.type === 'JSXAttribute' && attr.name.type === 'JSXIdentifier' && attr.name.name === 'color',
   );
 
-const transform = (fileInfo: FileInfo, api: API) => {
+const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
+  const isSpiritImport = createImportSourceMatcher(getImportSources(options));
   let hasChanges = false;
 
   const alertLocalNames = new Set<string>();
@@ -19,7 +18,7 @@ const transform = (fileInfo: FileInfo, api: API) => {
   root
     .find(j.ImportDeclaration, {
       source: {
-        value: (value: string) => SPIRIT_WEB_REACT_MODULE.test(value),
+        value: (value: string) => isSpiritImport(value),
       },
     })
     .forEach((path) => {

--- a/packages/codemods/src/transforms/v5/web-react/button-icon-margin-removal.ts
+++ b/packages/codemods/src/transforms/v5/web-react/button-icon-margin-removal.ts
@@ -1,16 +1,17 @@
 import { API, FileInfo, JSXExpressionContainer } from 'jscodeshift';
-import { removeParentheses } from '../../../helpers';
+import { createImportSourceMatcher, getImportSources, removeParentheses } from '../../../helpers';
 
 const DEFAULT_SPACING = 'space-400';
 
-const transform = (fileInfo: FileInfo, api: API) => {
+const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
+  const isSpiritImport = createImportSourceMatcher(getImportSources(options));
 
   // Find import statements for the specific module
   const importStatements = root.find(j.ImportDeclaration, {
     source: {
-      value: (value: string) => /^@(alma-oss)\/spirit-web-react(\/.*)?$/.test(value),
+      value: (value: string) => isSpiritImport(value),
     },
   });
 

--- a/packages/codemods/src/transforms/v5/web-react/button-icon-margin-removal.ts
+++ b/packages/codemods/src/transforms/v5/web-react/button-icon-margin-removal.ts
@@ -1,5 +1,5 @@
 import { API, FileInfo, JSXExpressionContainer } from 'jscodeshift';
-import { createImportSourceMatcher, getImportSources, removeParentheses } from '../../../helpers';
+import { createImportSourceMatcher, finishTransform, getImportSources } from '../../../helpers';
 
 const DEFAULT_SPACING = 'space-400';
 
@@ -8,138 +8,136 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
   const root = j(fileInfo.source);
   const isSpiritImport = createImportSourceMatcher(getImportSources(options));
 
-  // Find import statements for the specific module
   const importStatements = root.find(j.ImportDeclaration, {
     source: {
       value: (value: string) => isSpiritImport(value),
     },
   });
 
-  // Check if the module is imported
-  if (importStatements.length > 0) {
-    // Find all Button, ButtonLink, and ControlButton JSX elements
-    root
-      .find(j.JSXElement, {
-        openingElement: {
-          name: {
-            type: 'JSXIdentifier',
-            name: (name: string) => name === 'Button' || name === 'ButtonLink' || name === 'ControlButton',
-          },
-        },
-      })
-      .forEach((buttonElementPath) => {
-        const buttonOpeningElement = buttonElementPath.node.openingElement;
-        let spacingValue: string | JSXExpressionContainer | null = null;
-        let hasNonDefaultSpacing = false;
-
-        // Find all Icon elements within this Button/ButtonLink/ControlButton
-        j(buttonElementPath)
-          .find(j.JSXOpeningElement, {
-            name: {
-              type: 'JSXIdentifier',
-              name: 'Icon',
-            },
-          })
-          .forEach((iconPath) => {
-            // Remove marginRight, marginLeft, and marginX attributes from Icon
-            // and collect their values to set spacing prop if needed
-            if (iconPath.node.attributes) {
-              iconPath.node.attributes = iconPath.node.attributes.filter((attr) => {
-                if (
-                  attr.type === 'JSXAttribute' &&
-                  attr.name.type === 'JSXIdentifier' &&
-                  (attr.name.name === 'marginRight' || attr.name.name === 'marginLeft' || attr.name.name === 'marginX')
-                ) {
-                  // Extract the value
-                  if (attr.value) {
-                    if (attr.value.type === 'StringLiteral') {
-                      const { value } = attr.value;
-                      if (value !== DEFAULT_SPACING) {
-                        spacingValue = value;
-                        hasNonDefaultSpacing = true;
-                      }
-                    } else if (attr.value.type === 'JSXExpressionContainer') {
-                      const expr = attr.value.expression;
-                      if (expr.type === 'ObjectExpression') {
-                        // Handle responsive object: { mobile: 'space-400', tablet: 'space-600' }
-                        const obj: Record<string, string> = {};
-                        let hasNonDefault = false;
-
-                        expr.properties.forEach((prop) => {
-                          if (
-                            prop.type === 'ObjectProperty' &&
-                            prop.key.type === 'Identifier' &&
-                            prop.value.type === 'StringLiteral'
-                          ) {
-                            const key = prop.key.name;
-                            const { value } = prop.value;
-                            obj[key] = value;
-                            if (value !== DEFAULT_SPACING) {
-                              hasNonDefault = true;
-                            }
-                          }
-                        });
-
-                        // If any value is non-default, set the spacing prop with the entire object
-                        if (hasNonDefault) {
-                          spacingValue = j.jsxExpressionContainer(
-                            j.objectExpression(
-                              Object.entries(obj).map(([key, val]) =>
-                                j.objectProperty(j.identifier(key), j.literal(val)),
-                              ),
-                            ),
-                          );
-                          hasNonDefaultSpacing = true;
-                        }
-                      } else if (expr.type === 'StringLiteral') {
-                        const { value } = expr;
-                        if (value !== DEFAULT_SPACING) {
-                          spacingValue = value;
-                          hasNonDefaultSpacing = true;
-                        }
-                      }
-                    }
-                  }
-
-                  return false; // Remove this attribute
-                }
-
-                return true; // Keep other attributes
-              });
-            }
-          });
-
-        // If we found a non-default spacing value, set the spacing prop on the button
-        if (hasNonDefaultSpacing && spacingValue !== null && buttonOpeningElement.attributes) {
-          // Check if spacing prop already exists
-          const existingSpacingIndex = buttonOpeningElement.attributes.findIndex(
-            (attr) =>
-              attr.type === 'JSXAttribute' && attr.name.type === 'JSXIdentifier' && attr.name.name === 'spacing',
-          );
-
-          if (existingSpacingIndex >= 0) {
-            // Update existing spacing prop
-            const existingAttr = buttonOpeningElement.attributes[existingSpacingIndex];
-            if (existingAttr.type === 'JSXAttribute') {
-              if (typeof spacingValue === 'string') {
-                existingAttr.value = j.literal(spacingValue);
-              } else {
-                existingAttr.value = spacingValue;
-              }
-            }
-          } else {
-            // Add new spacing prop
-            const spacingAttr = j.jsxAttribute(
-              j.jsxIdentifier('spacing'),
-              typeof spacingValue === 'string' ? j.literal(spacingValue) : spacingValue,
-            );
-            buttonOpeningElement.attributes.push(spacingAttr);
-          }
-        }
-      });
+  if (importStatements.length === 0) {
+    return fileInfo.source;
   }
 
-  return removeParentheses(root.toSource());
+  let hasChanges = false;
+
+  root
+    .find(j.JSXElement, {
+      openingElement: {
+        name: {
+          type: 'JSXIdentifier',
+          name: (name: string) => name === 'Button' || name === 'ButtonLink' || name === 'ControlButton',
+        },
+      },
+    })
+    .forEach((buttonElementPath) => {
+      const buttonOpeningElement = buttonElementPath.node.openingElement;
+      let spacingValue: string | JSXExpressionContainer | null = null;
+      let hasNonDefaultSpacing = false;
+
+      j(buttonElementPath)
+        .find(j.JSXOpeningElement, {
+          name: {
+            type: 'JSXIdentifier',
+            name: 'Icon',
+          },
+        })
+        .forEach((iconPath) => {
+          if (!iconPath.node.attributes) {
+            return;
+          }
+
+          const originalLength = iconPath.node.attributes.length;
+
+          iconPath.node.attributes = iconPath.node.attributes.filter((attr) => {
+            if (
+              attr.type === 'JSXAttribute' &&
+              attr.name.type === 'JSXIdentifier' &&
+              (attr.name.name === 'marginRight' || attr.name.name === 'marginLeft' || attr.name.name === 'marginX')
+            ) {
+              if (attr.value) {
+                if (attr.value.type === 'StringLiteral') {
+                  const { value } = attr.value;
+                  if (value !== DEFAULT_SPACING) {
+                    spacingValue = value;
+                    hasNonDefaultSpacing = true;
+                  }
+                } else if (attr.value.type === 'JSXExpressionContainer') {
+                  const expr = attr.value.expression;
+                  if (expr.type === 'ObjectExpression') {
+                    const obj: Record<string, string> = {};
+                    let hasNonDefault = false;
+
+                    expr.properties.forEach((prop) => {
+                      if (
+                        prop.type === 'ObjectProperty' &&
+                        prop.key.type === 'Identifier' &&
+                        prop.value.type === 'StringLiteral'
+                      ) {
+                        const key = prop.key.name;
+                        const { value } = prop.value;
+                        obj[key] = value;
+                        if (value !== DEFAULT_SPACING) {
+                          hasNonDefault = true;
+                        }
+                      }
+                    });
+
+                    if (hasNonDefault) {
+                      spacingValue = j.jsxExpressionContainer(
+                        j.objectExpression(
+                          Object.entries(obj).map(([key, val]) => j.objectProperty(j.identifier(key), j.literal(val))),
+                        ),
+                      );
+                      hasNonDefaultSpacing = true;
+                    }
+                  } else if (expr.type === 'StringLiteral') {
+                    const { value } = expr;
+                    if (value !== DEFAULT_SPACING) {
+                      spacingValue = value;
+                      hasNonDefaultSpacing = true;
+                    }
+                  }
+                }
+              }
+
+              return false;
+            }
+
+            return true;
+          });
+
+          if (iconPath.node.attributes.length !== originalLength) {
+            hasChanges = true;
+          }
+        });
+
+      if (hasNonDefaultSpacing && spacingValue !== null && buttonOpeningElement.attributes) {
+        const existingSpacingIndex = buttonOpeningElement.attributes.findIndex(
+          (attr) => attr.type === 'JSXAttribute' && attr.name.type === 'JSXIdentifier' && attr.name.name === 'spacing',
+        );
+
+        if (existingSpacingIndex >= 0) {
+          const existingAttr = buttonOpeningElement.attributes[existingSpacingIndex];
+          if (existingAttr.type === 'JSXAttribute') {
+            if (typeof spacingValue === 'string') {
+              existingAttr.value = j.literal(spacingValue);
+            } else {
+              existingAttr.value = spacingValue;
+            }
+          }
+        } else {
+          const spacingAttr = j.jsxAttribute(
+            j.jsxIdentifier('spacing'),
+            typeof spacingValue === 'string' ? j.literal(spacingValue) : spacingValue,
+          );
+          buttonOpeningElement.attributes.push(spacingAttr);
+        }
+
+        hasChanges = true;
+      }
+    });
+
+  return finishTransform(fileInfo, root, hasChanges);
 };
 
 export default transform;

--- a/packages/codemods/src/transforms/v5/web-react/close-buttons-to-close-button.ts
+++ b/packages/codemods/src/transforms/v5/web-react/close-buttons-to-close-button.ts
@@ -1,7 +1,5 @@
 import { API, FileInfo, JSXAttribute, JSXIdentifier, JSXSpreadAttribute } from 'jscodeshift';
-import { removeParentheses } from '../../../helpers';
-
-const SPIRIT_WEB_REACT_MODULE = /^@alma-oss\/spirit-web-react(\/.*)?$/;
+import { createImportSourceMatcher, getImportSources, removeParentheses } from '../../../helpers';
 
 // ModalCloseButton received the close handling through dedicated props; CloseButton uses the
 // underlying ControlButton/ARIA contract instead.
@@ -19,13 +17,14 @@ const hasAttribute = (attributes: (JSXAttribute | JSXSpreadAttribute)[], name: s
       attribute.type === 'JSXAttribute' && attribute.name.type === 'JSXIdentifier' && attribute.name.name === name,
   );
 
-const transform = (fileInfo: FileInfo, api: API) => {
+const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
+  const isSpiritImport = createImportSourceMatcher(getImportSources(options));
 
   const spiritImports = root.find(j.ImportDeclaration, {
     source: {
-      value: (value: string) => SPIRIT_WEB_REACT_MODULE.test(value),
+      value: (value: string) => isSpiritImport(value),
     },
   });
 
@@ -58,6 +57,7 @@ const transform = (fileInfo: FileInfo, api: API) => {
     return fileInfo.source;
   }
 
+  const removedLocalNames = new Set([...modalLocalNames, ...tooltipLocalNames]);
   let usesCloseButton = false;
 
   root.find(j.JSXOpeningElement).forEach((path) => {
@@ -102,7 +102,7 @@ const transform = (fileInfo: FileInfo, api: API) => {
   });
 
   root.find(j.JSXClosingElement).forEach((path) => {
-    if (path.node.name.type === 'JSXIdentifier' && REMOVED_COMPONENTS.has(path.node.name.name)) {
+    if (path.node.name.type === 'JSXIdentifier' && removedLocalNames.has(path.node.name.name)) {
       (path.node.name as JSXIdentifier).name = 'CloseButton';
     }
   });
@@ -111,7 +111,10 @@ const transform = (fileInfo: FileInfo, api: API) => {
     return fileInfo.source;
   }
 
-  const isCloseButtonAlreadyImported = root.find(j.ImportSpecifier, { imported: { name: 'CloseButton' } }).length > 0;
+  const isCloseButtonAlreadyImported =
+    spiritImports.find(j.ImportSpecifier, {
+      imported: { name: 'CloseButton' },
+    }).length > 0;
 
   // Drop the removed close-button specifiers from the Spirit imports.
   spiritImports.forEach((path) => {

--- a/packages/codemods/src/transforms/v5/web-react/collapse-isDisposable-prop.ts
+++ b/packages/codemods/src/transforms/v5/web-react/collapse-isDisposable-prop.ts
@@ -1,14 +1,15 @@
 import { API, FileInfo } from 'jscodeshift';
-import { removeParentheses } from '../../../helpers';
+import { createImportSourceMatcher, getImportSources, removeParentheses } from '../../../helpers';
 
-const transform = (fileInfo: FileInfo, api: API) => {
+const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
+  const isSpiritImport = createImportSourceMatcher(getImportSources(options));
 
   // Find import statements for the specific module and Button specifier
   const importStatements = root.find(j.ImportDeclaration, {
     source: {
-      value: (value: string) => /^@lmc-eu\/spirit-web-react(\/.*)?$/.test(value),
+      value: (value: string) => isSpiritImport(value),
     },
   });
 

--- a/packages/codemods/src/transforms/v5/web-react/collapse-isDisposable-prop.ts
+++ b/packages/codemods/src/transforms/v5/web-react/collapse-isDisposable-prop.ts
@@ -6,44 +6,49 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
   const root = j(fileInfo.source);
   const isSpiritImport = createImportSourceMatcher(getImportSources(options));
 
-  // Find import statements for the specific module and Button specifier
   const importStatements = root.find(j.ImportDeclaration, {
     source: {
       value: (value: string) => isSpiritImport(value),
     },
   });
 
-  // Check if the module is imported
-  if (importStatements.length > 0) {
-    const componentSpecifier = importStatements.find(j.ImportSpecifier, {
-      imported: {
-        type: 'Identifier',
+  if (importStatements.length === 0) {
+    return fileInfo.source;
+  }
+
+  const componentSpecifier = importStatements.find(j.ImportSpecifier, {
+    imported: {
+      type: 'Identifier',
+      name: 'UncontrolledCollapse',
+    },
+  });
+
+  if (componentSpecifier.length === 0) {
+    return fileInfo.source;
+  }
+
+  let hasChanges = false;
+
+  root
+    .find(j.JSXOpeningElement, {
+      name: {
+        type: 'JSXIdentifier',
         name: 'UncontrolledCollapse',
       },
+    })
+    .find(j.JSXAttribute, {
+      name: {
+        type: 'JSXIdentifier',
+        name: 'hideOnCollapse',
+      },
+    })
+    .forEach((attributePath) => {
+      attributePath.node.name.name = 'isDisposable';
+      hasChanges = true;
     });
 
-    // Check if UncontrolledCollapse specifier is present
-    if (componentSpecifier.length > 0) {
-      // Find UncontrolledCollapse components in the module
-      const components = root.find(j.JSXOpeningElement, {
-        name: {
-          type: 'JSXIdentifier',
-          name: 'UncontrolledCollapse',
-        },
-      });
-
-      // Rename 'hideOnCollapse' attribute to 'isDisposable' in UncontrolledCollapse components
-      components
-        .find(j.JSXAttribute, {
-          name: {
-            type: 'JSXIdentifier',
-            name: 'hideOnCollapse',
-          },
-        })
-        .forEach((attributePath) => {
-          attributePath.node.name.name = 'isDisposable';
-        });
-    }
+  if (!hasChanges) {
+    return fileInfo.source;
   }
 
   return removeParentheses(root.toSource());

--- a/packages/codemods/src/transforms/v5/web-react/control-button-size-scale.ts
+++ b/packages/codemods/src/transforms/v5/web-react/control-button-size-scale.ts
@@ -5,17 +5,16 @@ const transform = (fileInfo: FileInfo, api: API) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
 
-  // The previous default size was `medium`, so an omitted `size` has to be remapped too
   const PREVIOUS_DEFAULT_SIZE = 'medium';
 
-  // Define the mapping from old size values to the remapped (one step larger) ones
   const sizeMap: { [key: string]: string } = {
     small: 'medium',
     medium: 'large',
     large: 'xlarge',
   };
 
-  // Find all ControlButton components
+  let hasChanges = false;
+
   root.find(j.JSXOpeningElement, { name: { type: 'JSXIdentifier', name: 'ControlButton' } }).forEach((elementPath) => {
     const { attributes } = elementPath.node;
 
@@ -27,13 +26,12 @@ const transform = (fileInfo: FileInfo, api: API) => {
       (attribute) => attribute.type === 'JSXAttribute' && attribute.name.name === 'size',
     );
 
-    // Without an explicit `size`, the previous default (`medium`) was applied. Add the remapped value
-    // unless a spread attribute might already provide `size`.
     if (!sizeAttribute) {
       const hasSpreadAttribute = attributes.some((attribute) => attribute.type === 'JSXSpreadAttribute');
 
       if (!hasSpreadAttribute) {
         attributes.push(j.jsxAttribute(j.jsxIdentifier('size'), j.stringLiteral(sizeMap[PREVIOUS_DEFAULT_SIZE])));
+        hasChanges = true;
       }
 
       return;
@@ -43,16 +41,13 @@ const transform = (fileInfo: FileInfo, api: API) => {
       return;
     }
 
-    // Handle string literal values
     if (sizeAttribute.value.type === 'StringLiteral') {
       const newValue = sizeMap[sizeAttribute.value.value];
       if (newValue) {
         sizeAttribute.value = j.stringLiteral(newValue);
+        hasChanges = true;
       }
-    }
-
-    // Handle responsive object values
-    else if (
+    } else if (
       sizeAttribute.value.type === 'JSXExpressionContainer' &&
       sizeAttribute.value.expression.type === 'ObjectExpression'
     ) {
@@ -66,23 +61,24 @@ const transform = (fileInfo: FileInfo, api: API) => {
         ) {
           const oldValue = property.value.value;
 
-          // Update the value if it matches a key in sizeMap
           if (oldValue in sizeMap) {
-            // Manually create a single-quoted Literal
             property.value = j.literal(sizeMap[oldValue]);
-            // We need single quotes in object values
             // @ts-expect-error extra is not defined on Literal
             property.value.extra = {
               raw: `'${sizeMap[oldValue]}'`,
               rawValue: sizeMap[oldValue],
             };
+            hasChanges = true;
           }
         }
       });
     }
   });
 
-  // Convert the transformed code to source with double quotes for strings
+  if (!hasChanges) {
+    return fileInfo.source;
+  }
+
   return removeParentheses(root.toSource({ quote: 'double' }));
 };
 

--- a/packages/codemods/src/transforms/v5/web-react/drawer-panel-close-button-composition.ts
+++ b/packages/codemods/src/transforms/v5/web-react/drawer-panel-close-button-composition.ts
@@ -1,7 +1,5 @@
 import { API, FileInfo, Identifier, JSXAttribute, JSXElement, JSXIdentifier, JSXSpreadAttribute } from 'jscodeshift';
-import { removeParentheses } from '../../../helpers';
-
-const SPIRIT_WEB_REACT_MODULE = /^@alma-oss\/spirit-web-react(\/.*)?$/;
+import { createImportSourceMatcher, getImportSources, removeParentheses } from '../../../helpers';
 
 // DrawerCloseButton took its wiring from the drawer context, which is unavailable at the call site.
 // The codemod scaffolds the props with `TODO_`-prefixed placeholder identifiers so the build fails
@@ -23,99 +21,115 @@ const hasAttr = (attributes: (JSXAttribute | JSXSpreadAttribute)[], name: string
     (attr) => attr.type === 'JSXAttribute' && attr.name.type === 'JSXIdentifier' && attr.name.name === name,
   );
 
-const transform = (fileInfo: FileInfo, api: API) => {
+const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
+  const isSpiritImport = createImportSourceMatcher(getImportSources(options));
 
   const spiritImports = root.find(j.ImportDeclaration, {
-    source: { value: (value: string) => SPIRIT_WEB_REACT_MODULE.test(value) },
+    source: { value: (value: string) => isSpiritImport(value) },
   });
 
   if (spiritImports.length === 0) {
     return fileInfo.source;
   }
 
-  const drawerPanelImport = spiritImports.find(j.ImportSpecifier, {
-    imported: { type: 'Identifier', name: 'DrawerPanel' },
+  const drawerPanelLocalNames = new Set<string>();
+  const drawerCloseButtonLocalNames = new Set<string>();
+
+  spiritImports.forEach((importPath) => {
+    importPath.node.specifiers?.forEach((specifier) => {
+      if (specifier.type === 'ImportSpecifier' && specifier.imported.type === 'Identifier') {
+        const importedName = specifier.imported.name;
+        const localName = specifier.local?.name ?? importedName;
+
+        if (importedName === 'DrawerPanel') {
+          drawerPanelLocalNames.add(localName);
+        }
+
+        if (importedName === 'DrawerCloseButton') {
+          drawerCloseButtonLocalNames.add(localName);
+        }
+      }
+    });
   });
 
-  if (drawerPanelImport.length === 0) {
+  if (drawerPanelLocalNames.size === 0) {
     return fileInfo.source;
   }
 
   let modified = false;
   let hadDrawerCloseButton = false;
 
-  root
-    .find(j.JSXElement, {
-      openingElement: { name: { type: 'JSXIdentifier', name: 'DrawerPanel' } },
-    })
-    .forEach((path) => {
-      const { openingElement } = path.node;
-      const attrs = (openingElement.attributes ?? []) as (JSXAttribute | JSXSpreadAttribute)[];
+  root.find(j.JSXElement).forEach((path) => {
+    const { openingElement } = path.node;
 
-      const closeButtonAttr = findAttr(attrs, 'closeButton');
-      if (!closeButtonAttr) return;
+    if (openingElement.name.type !== 'JSXIdentifier' || !drawerPanelLocalNames.has(openingElement.name.name)) {
+      return;
+    }
 
-      openingElement.attributes = attrs.filter(
-        (attr) =>
-          !(attr.type === 'JSXAttribute' && attr.name.type === 'JSXIdentifier' && attr.name.name === 'closeButton'),
-      );
+    const attrs = (openingElement.attributes ?? []) as (JSXAttribute | JSXSpreadAttribute)[];
 
-      const closeButtonValue =
-        closeButtonAttr.value?.type === 'JSXExpressionContainer' &&
-        closeButtonAttr.value.expression.type !== 'JSXEmptyExpression'
-          ? closeButtonAttr.value.expression
-          : null;
+    const closeButtonAttr = findAttr(attrs, 'closeButton');
+    if (!closeButtonAttr) return;
 
-      // If the closeButton value is a DrawerCloseButton, replace it with a scaffolded CloseButton.
-      if (
-        closeButtonValue?.type === 'JSXElement' &&
-        closeButtonValue.openingElement.name.type === 'JSXIdentifier' &&
-        closeButtonValue.openingElement.name.name === 'DrawerCloseButton'
-      ) {
-        const cbAttrs = (closeButtonValue.openingElement.attributes ?? []) as (JSXAttribute | JSXSpreadAttribute)[];
+    openingElement.attributes = attrs.filter(
+      (attr) =>
+        !(attr.type === 'JSXAttribute' && attr.name.type === 'JSXIdentifier' && attr.name.name === 'closeButton'),
+    );
 
-        if (!hasAttr(cbAttrs, 'size')) {
-          cbAttrs.unshift(j.jsxAttribute(j.jsxIdentifier('size'), j.stringLiteral('large')));
-        }
+    const closeButtonValue =
+      closeButtonAttr.value?.type === 'JSXExpressionContainer' &&
+      closeButtonAttr.value.expression.type !== 'JSXEmptyExpression'
+        ? closeButtonAttr.value.expression
+        : null;
 
-        DRAWER_TODO_ATTRIBUTES.forEach(([attrName, placeholder]) => {
-          if (!hasAttr(cbAttrs, attrName)) {
-            cbAttrs.push(
-              j.jsxAttribute(j.jsxIdentifier(attrName), j.jsxExpressionContainer(j.identifier(placeholder))),
-            );
-          }
-        });
+    // If the closeButton value is a DrawerCloseButton, replace it with a scaffolded CloseButton.
+    if (
+      closeButtonValue?.type === 'JSXElement' &&
+      closeButtonValue.openingElement.name.type === 'JSXIdentifier' &&
+      drawerCloseButtonLocalNames.has(closeButtonValue.openingElement.name.name)
+    ) {
+      const cbAttrs = (closeButtonValue.openingElement.attributes ?? []) as (JSXAttribute | JSXSpreadAttribute)[];
 
-        closeButtonValue.openingElement.attributes = cbAttrs;
-        (closeButtonValue.openingElement.name as JSXIdentifier).name = 'CloseButton';
-        if (closeButtonValue.closingElement) {
-          (closeButtonValue.closingElement.name as JSXIdentifier).name = 'CloseButton';
-        }
-
-        hadDrawerCloseButton = true;
+      if (!hasAttr(cbAttrs, 'size')) {
+        cbAttrs.unshift(j.jsxAttribute(j.jsxIdentifier('size'), j.stringLiteral('large')));
       }
 
-      const headerChildren: NonNullable<JSXElement['children']> = closeButtonValue
-        ? [closeButtonValue as NonNullable<JSXElement['children']>[number]]
-        : [];
+      DRAWER_TODO_ATTRIBUTES.forEach(([attrName, placeholder]) => {
+        if (!hasAttr(cbAttrs, attrName)) {
+          cbAttrs.push(j.jsxAttribute(j.jsxIdentifier(attrName), j.jsxExpressionContainer(j.identifier(placeholder))));
+        }
+      });
 
-      const headerElement = j.jsxElement(
-        j.jsxOpeningElement(j.jsxIdentifier('DrawerPanelHeader'), []),
-        j.jsxClosingElement(j.jsxIdentifier('DrawerPanelHeader')),
-        headerChildren,
-      );
+      closeButtonValue.openingElement.attributes = cbAttrs;
+      (closeButtonValue.openingElement.name as JSXIdentifier).name = 'CloseButton';
+      if (closeButtonValue.closingElement) {
+        (closeButtonValue.closingElement.name as JSXIdentifier).name = 'CloseButton';
+      }
 
-      const bodyElement = j.jsxElement(
-        j.jsxOpeningElement(j.jsxIdentifier('DrawerPanelBody'), []),
-        j.jsxClosingElement(j.jsxIdentifier('DrawerPanelBody')),
-        path.node.children ?? [],
-      );
+      hadDrawerCloseButton = true;
+    }
 
-      path.node.children = [headerElement, bodyElement];
-      modified = true;
-    });
+    const headerChildren: NonNullable<JSXElement['children']> = closeButtonValue
+      ? [closeButtonValue as NonNullable<JSXElement['children']>[number]]
+      : [];
+
+    const headerElement = j.jsxElement(
+      j.jsxOpeningElement(j.jsxIdentifier('DrawerPanelHeader'), []),
+      j.jsxClosingElement(j.jsxIdentifier('DrawerPanelHeader')),
+      headerChildren,
+    );
+
+    const bodyElement = j.jsxElement(
+      j.jsxOpeningElement(j.jsxIdentifier('DrawerPanelBody'), []),
+      j.jsxClosingElement(j.jsxIdentifier('DrawerPanelBody')),
+      path.node.children ?? [],
+    );
+
+    path.node.children = [headerElement, bodyElement];
+    modified = true;
+  });
 
   if (!modified) {
     return fileInfo.source;

--- a/packages/codemods/src/transforms/v5/web-react/flex-direction-values.ts
+++ b/packages/codemods/src/transforms/v5/web-react/flex-direction-values.ts
@@ -1,65 +1,130 @@
-import { API, FileInfo } from 'jscodeshift';
-import { removeParentheses } from '../../../helpers';
+import { API, ASTPath, FileInfo, JSXAttribute, JSXMemberExpression, JSXOpeningElement } from 'jscodeshift';
+import { createImportSourceMatcher, getImportSources, removeParentheses } from '../../../helpers';
 
-const transform = (fileInfo: FileInfo, api: API) => {
-  const j = api.jscodeshift;
-  const root = j(fileInfo.source);
+const DIRECTION_MAP: Record<string, string> = {
+  row: 'horizontal',
+  column: 'vertical',
+};
 
-  // Define the mapping from old direction values to new ones
-  const directionMap: { [key: string]: string } = {
-    row: 'horizontal',
-    column: 'vertical',
-  };
+const isImportedFlexElement = (
+  element: JSXOpeningElement,
+  flexNamedImports: Set<string>,
+  namespaceImports: Set<string>,
+): boolean => {
+  if (element.name.type === 'JSXIdentifier') {
+    return flexNamedImports.has(element.name.name);
+  }
 
-  // Find all Flex components
-  root
-    .find(j.JSXOpeningElement, { name: { type: 'JSXIdentifier', name: 'Flex' } })
-    .find(j.JSXAttribute, { name: { type: 'JSXIdentifier', name: 'direction' } })
-    .forEach((attributePath) => {
-      const attribute = attributePath.node;
+  if (element.name.type !== 'JSXMemberExpression') {
+    return false;
+  }
 
-      if (attribute.value) {
-        // Handle string literal values
-        if (attribute.value.type === 'StringLiteral') {
-          const newValue = directionMap[attribute.value.value];
-          if (newValue) {
-            attribute.value = j.stringLiteral(newValue);
-          }
-        }
+  const memberExpression = element.name as JSXMemberExpression;
+  const objectName = memberExpression.object.type === 'JSXIdentifier' ? memberExpression.object.name : undefined;
+  const propertyName = memberExpression.property.type === 'JSXIdentifier' ? memberExpression.property.name : undefined;
 
-        // Handle object values
-        else if (
-          attribute.value.type === 'JSXExpressionContainer' &&
-          attribute.value.expression.type === 'ObjectExpression'
-        ) {
-          const objectExpression = attribute.value.expression;
+  return Boolean(objectName && propertyName === 'Flex' && namespaceImports.has(objectName));
+};
 
-          objectExpression.properties.forEach((property) => {
-            if (
-              property.type === 'ObjectProperty' &&
-              (property.key.type === 'Identifier' || property.key.type === 'Literal') &&
-              property.value.type === 'StringLiteral'
-            ) {
-              const oldValue = property.value.value;
+const updateDirectionAttribute = (j: API['jscodeshift'], attribute: JSXAttribute): boolean => {
+  if (!attribute.value) {
+    return false;
+  }
 
-              // Update the value if it matches a key in directionMap
-              if (oldValue in directionMap) {
-                // Manually create a single-quoted Literal
-                property.value = j.literal(directionMap[oldValue]);
-                // We need single quotes in object values
-                // @ts-expect-error extra is not defined on Literal
-                property.value.extra = {
-                  raw: `'${directionMap[oldValue]}'`,
-                  rawValue: directionMap[oldValue],
-                };
-              }
-            }
-          });
+  let hasChanges = false;
+
+  if (attribute.value.type === 'StringLiteral') {
+    const newValue = DIRECTION_MAP[attribute.value.value];
+
+    if (newValue) {
+      attribute.value = j.stringLiteral(newValue);
+      hasChanges = true;
+    }
+
+    return hasChanges;
+  }
+
+  if (attribute.value.type === 'JSXExpressionContainer' && attribute.value.expression.type === 'ObjectExpression') {
+    attribute.value.expression.properties.forEach((property) => {
+      if (
+        property.type === 'ObjectProperty' &&
+        (property.key.type === 'Identifier' || property.key.type === 'Literal') &&
+        property.value.type === 'StringLiteral'
+      ) {
+        const oldValue = property.value.value;
+
+        if (oldValue in DIRECTION_MAP) {
+          property.value = j.literal(DIRECTION_MAP[oldValue]);
+          // @ts-expect-error extra is not defined on Literal
+          property.value.extra = {
+            raw: `'${DIRECTION_MAP[oldValue]}'`,
+            rawValue: DIRECTION_MAP[oldValue],
+          };
+          hasChanges = true;
         }
       }
     });
+  }
 
-  // Convert the transformed code to source with double quotes for strings
+  return hasChanges;
+};
+
+const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+  const isSpiritImport = createImportSourceMatcher(getImportSources(options));
+  const flexNamedImports = new Set<string>();
+  const namespaceImports = new Set<string>();
+
+  root
+    .find(j.ImportDeclaration, {
+      source: {
+        value: (value: string) => isSpiritImport(value),
+      },
+    })
+    .forEach((importPath) => {
+      importPath.node.specifiers?.forEach((specifier) => {
+        if (
+          specifier.type === 'ImportSpecifier' &&
+          specifier.imported.type === 'Identifier' &&
+          specifier.imported.name === 'Flex'
+        ) {
+          flexNamedImports.add(specifier.local?.name ?? specifier.imported.name);
+        }
+
+        if (specifier.type === 'ImportNamespaceSpecifier' && specifier.local?.name) {
+          namespaceImports.add(specifier.local.name);
+        }
+      });
+    });
+
+  if (flexNamedImports.size === 0 && namespaceImports.size === 0) {
+    return fileInfo.source;
+  }
+
+  let hasChanges = false;
+
+  root.find(j.JSXOpeningElement).forEach((elementPath: ASTPath<JSXOpeningElement>) => {
+    if (!isImportedFlexElement(elementPath.node, flexNamedImports, namespaceImports)) {
+      return;
+    }
+
+    elementPath.node.attributes?.forEach((attribute) => {
+      if (
+        attribute.type === 'JSXAttribute' &&
+        attribute.name.type === 'JSXIdentifier' &&
+        attribute.name.name === 'direction' &&
+        updateDirectionAttribute(j, attribute)
+      ) {
+        hasChanges = true;
+      }
+    });
+  });
+
+  if (!hasChanges) {
+    return fileInfo.source;
+  }
+
   return removeParentheses(root.toSource({ quote: 'double' }));
 };
 

--- a/packages/codemods/src/transforms/v5/web-react/forms-isFluid-prop-removal.ts
+++ b/packages/codemods/src/transforms/v5/web-react/forms-isFluid-prop-removal.ts
@@ -1,7 +1,5 @@
 import { API, FileInfo, JSXAttribute, JSXMemberExpression, JSXOpeningElement, JSXSpreadAttribute } from 'jscodeshift';
-import { removeParentheses } from '../../../helpers';
-
-const SPIRIT_WEB_REACT_MODULE = /^@(alma-oss|lmc-eu)\/spirit-web-react(\/.*)?$/;
+import { createImportSourceMatcher, getImportSources, removeParentheses } from '../../../helpers';
 
 const TARGET_COMPONENTS = new Set([
   'TextField',
@@ -48,16 +46,17 @@ const removeIsFluidAttribute = (attributes: (JSXAttribute | JSXSpreadAttribute)[
   });
 };
 
-const transform = (fileInfo: FileInfo, api: API) => {
+const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
+  const isSpiritImport = createImportSourceMatcher(getImportSources(options));
   const namedImports = new Set<string>();
   const namespaceImports = new Set<string>();
 
   root
     .find(j.ImportDeclaration, {
       source: {
-        value: (value: string) => SPIRIT_WEB_REACT_MODULE.test(value),
+        value: (value: string) => isSpiritImport(value),
       },
     })
     .forEach((path) => {

--- a/packages/codemods/src/transforms/v5/web-react/header-unstable-to-stable.ts
+++ b/packages/codemods/src/transforms/v5/web-react/header-unstable-to-stable.ts
@@ -1,8 +1,6 @@
 import { API, FileInfo, Identifier } from 'jscodeshift';
-import { removeParentheses } from '../../../helpers';
+import { createImportSourceMatcher, getImportSources, removeParentheses } from '../../../helpers';
 import { renameComponent } from '../../../helpers/renameComponent';
-
-const SPIRIT_WEB_REACT_MODULE = /^@alma-oss\/spirit-web-react(\/.*)?$/;
 
 const IDENTIFIER_RENAMES: Record<string, string> = {
   UNSTABLE_Header: 'Header',
@@ -11,18 +9,20 @@ const IDENTIFIER_RENAMES: Record<string, string> = {
   useUnstableHeaderStyleProps: 'useHeaderStyleProps',
 };
 
-const transform = (fileInfo: FileInfo, api: API) => {
+const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
+  const importSources = getImportSources(options);
+  const isSpiritImport = createImportSourceMatcher(importSources);
 
   // Rename JSX component tags and their import specifiers
-  renameComponent(j, root, 'UNSTABLE_Header', 'Header');
-  renameComponent(j, root, 'UNSTABLE_HeaderLogo', 'HeaderLogo');
+  renameComponent(j, root, 'UNSTABLE_Header', 'Header', importSources);
+  renameComponent(j, root, 'UNSTABLE_HeaderLogo', 'HeaderLogo', importSources);
 
   // Rename TypeScript type identifiers and hook imports
   const importStatements = root.find(j.ImportDeclaration, {
     source: {
-      value: (value: string) => SPIRIT_WEB_REACT_MODULE.test(value),
+      value: (value: string) => isSpiritImport(value),
     },
   });
 

--- a/packages/codemods/src/transforms/v5/web-react/header-unstable-to-stable.ts
+++ b/packages/codemods/src/transforms/v5/web-react/header-unstable-to-stable.ts
@@ -1,5 +1,5 @@
 import { API, FileInfo, Identifier } from 'jscodeshift';
-import { createImportSourceMatcher, getImportSources, removeParentheses } from '../../../helpers';
+import { createImportSourceMatcher, finishTransform, getImportSources, getOwnRecordValue } from '../../../helpers';
 import { renameComponent } from '../../../helpers/renameComponent';
 
 const IDENTIFIER_RENAMES: Record<string, string> = {
@@ -14,31 +14,45 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
   const root = j(fileInfo.source);
   const importSources = getImportSources(options);
   const isSpiritImport = createImportSourceMatcher(importSources);
+  let hasChanges = false;
 
-  // Rename JSX component tags and their import specifiers
-  renameComponent(j, root, 'UNSTABLE_Header', 'Header', importSources);
-  renameComponent(j, root, 'UNSTABLE_HeaderLogo', 'HeaderLogo', importSources);
+  if (renameComponent(j, root, 'UNSTABLE_Header', 'Header', importSources)) {
+    hasChanges = true;
+  }
 
-  // Rename TypeScript type identifiers and hook imports
+  if (renameComponent(j, root, 'UNSTABLE_HeaderLogo', 'HeaderLogo', importSources)) {
+    hasChanges = true;
+  }
+
   const importStatements = root.find(j.ImportDeclaration, {
     source: {
       value: (value: string) => isSpiritImport(value),
     },
   });
 
+  if (importStatements.length === 0) {
+    return fileInfo.source;
+  }
+
   importStatements.forEach((importPath) => {
     importPath.node.specifiers?.forEach((specifier) => {
       if (
         specifier.type === 'ImportSpecifier' &&
         specifier.imported.type === 'Identifier' &&
-        IDENTIFIER_RENAMES[specifier.imported.name]
+        getOwnRecordValue(IDENTIFIER_RENAMES, specifier.imported.name)
       ) {
         const oldName = specifier.imported.name;
-        const newName = IDENTIFIER_RENAMES[oldName];
-        (specifier.imported as Identifier).name = newName;
-        // If the local alias matches the old name, update it too
-        if (specifier.local?.type === 'Identifier' && specifier.local.name === oldName) {
-          (specifier.local as Identifier).name = newName;
+        const newName = getOwnRecordValue(IDENTIFIER_RENAMES, oldName);
+
+        if (newName) {
+          (specifier.imported as Identifier).name = newName;
+
+          // If the local alias matches the old name, update it too
+          if (specifier.local?.type === 'Identifier' && specifier.local.name === oldName) {
+            (specifier.local as Identifier).name = newName;
+          }
+
+          hasChanges = true;
         }
       }
     });
@@ -48,13 +62,14 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
   root
     .find(j.Identifier, (node: Identifier) => Object.keys(IDENTIFIER_RENAMES).includes(node.name))
     .forEach((path) => {
-      const newName = IDENTIFIER_RENAMES[path.node.name];
+      const newName = getOwnRecordValue(IDENTIFIER_RENAMES, path.node.name);
       if (newName) {
         path.node.name = newName;
+        hasChanges = true;
       }
     });
 
-  return removeParentheses(root.toSource({ quote: 'single' }));
+  return finishTransform(fileInfo, root, hasChanges, { quote: 'single' });
 };
 
 export default transform;

--- a/packages/codemods/src/transforms/v5/web-react/item-props.ts
+++ b/packages/codemods/src/transforms/v5/web-react/item-props.ts
@@ -10,9 +10,8 @@ import {
   JSXOpeningElement,
   JSXSpreadAttribute,
 } from 'jscodeshift';
-import { removeParentheses } from '../../../helpers';
+import { removeParentheses, createImportSourceMatcher, getImportSources } from '../../../helpers';
 
-const SPIRIT_WEB_REACT_MODULE = /^@alma-oss\/spirit-web-react(\/.*)?$/;
 const ITEM_COMPONENT = 'Item';
 const CHECK_ICON_NAME = 'check-plain';
 
@@ -65,14 +64,18 @@ const isTargetElement = (element: JSXOpeningElement, { namedImports, namespaceIm
   return Boolean(objectName && propertyName === ITEM_COMPONENT && namespaceImports.has(objectName));
 };
 
-const getItemImports = (j: API['jscodeshift'], root: Collection): SpiritImports => {
+const getItemImports = (
+  j: API['jscodeshift'],
+  root: Collection,
+  isSpiritImport: (value: string) => boolean,
+): SpiritImports => {
   const namedImports = new Set<string>();
   const namespaceImports = new Set<string>();
 
   root
     .find(j.ImportDeclaration, {
       source: {
-        value: (value: string) => SPIRIT_WEB_REACT_MODULE.test(value),
+        value: (value: string) => isSpiritImport(value),
       },
     })
     .forEach((path) => {
@@ -101,9 +104,14 @@ const getItemImports = (j: API['jscodeshift'], root: Collection): SpiritImports 
   return { namedImports, namespaceImports };
 };
 
-const addNamedImport = (j: API['jscodeshift'], root: Collection, importedName: string): string => {
+const addNamedImport = (
+  j: API['jscodeshift'],
+  root: Collection,
+  importedName: string,
+  isSpiritImport: (value: string) => boolean,
+): string => {
   const importDeclarations = root.find(j.ImportDeclaration, {
-    source: { value: (value: string) => SPIRIT_WEB_REACT_MODULE.test(value) },
+    source: { value: (value: string) => isSpiritImport(value) },
   });
   let localName = importedName;
   let sourceValue = '@alma-oss/spirit-web-react';
@@ -389,10 +397,11 @@ const shouldAddEndSlot = (selectionDecoratorAttribute: JSXAttribute | undefined,
   return false;
 };
 
-const transform = (fileInfo: FileInfo, api: API) => {
+const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
-  const itemImports = getItemImports(j, root);
+  const isSpiritImport = createImportSourceMatcher(getImportSources(options));
+  const itemImports = getItemImports(j, root, isSpiritImport);
 
   if (itemImports.namedImports.size === 0 && itemImports.namespaceImports.size === 0) {
     return fileInfo.source;
@@ -425,9 +434,11 @@ const transform = (fileInfo: FileInfo, api: API) => {
     shouldImportHelperText ||= Boolean(helperTextAttribute);
   });
 
-  const iconLocalName = shouldImportIcon ? addNamedImport(j, root, 'Icon') : 'Icon';
-  const labelLocalName = shouldImportLabel ? addNamedImport(j, root, 'Label') : 'Label';
-  const helperTextLocalName = shouldImportHelperText ? addNamedImport(j, root, 'HelperText') : 'HelperText';
+  const iconLocalName = shouldImportIcon ? addNamedImport(j, root, 'Icon', isSpiritImport) : 'Icon';
+  const labelLocalName = shouldImportLabel ? addNamedImport(j, root, 'Label', isSpiritImport) : 'Label';
+  const helperTextLocalName = shouldImportHelperText
+    ? addNamedImport(j, root, 'HelperText', isSpiritImport)
+    : 'HelperText';
 
   root.find(j.JSXElement).forEach((path) => {
     const { openingElement } = path.node;

--- a/packages/codemods/src/transforms/v5/web-react/item-props.ts
+++ b/packages/codemods/src/transforms/v5/web-react/item-props.ts
@@ -10,7 +10,7 @@ import {
   JSXOpeningElement,
   JSXSpreadAttribute,
 } from 'jscodeshift';
-import { removeParentheses, createImportSourceMatcher, getImportSources } from '../../../helpers';
+import { createImportSourceMatcher, finishTransform, getImportSources } from '../../../helpers';
 
 const ITEM_COMPONENT = 'Item';
 const CHECK_ICON_NAME = 'check-plain';
@@ -109,7 +109,7 @@ const addNamedImport = (
   root: Collection,
   importedName: string,
   isSpiritImport: (value: string) => boolean,
-): string => {
+): { localName: string; added: boolean } => {
   const importDeclarations = root.find(j.ImportDeclaration, {
     source: { value: (value: string) => isSpiritImport(value) },
   });
@@ -142,14 +142,14 @@ const addNamedImport = (
   });
 
   if (localName !== importedName) {
-    return localName;
+    return { localName, added: false };
   }
 
   const hasImport =
     importDeclarations.find(j.ImportSpecifier, { imported: { type: 'Identifier', name: importedName } }).length > 0;
 
   if (hasImport) {
-    return localName;
+    return { localName, added: false };
   }
 
   if (importDeclarationForSpecifier) {
@@ -157,14 +157,14 @@ const addNamedImport = (
       path.node.specifiers = [...(path.node.specifiers ?? []), j.importSpecifier(j.identifier(importedName))];
     });
 
-    return localName;
+    return { localName, added: true };
   }
 
   importDeclarations
     .at(0)
     .insertAfter(j.importDeclaration([j.importSpecifier(j.identifier(importedName))], j.stringLiteral(sourceValue)));
 
-  return localName;
+  return { localName, added: true };
 };
 
 const resolveBooleanAttributeState = (attribute: JSXAttribute | undefined): BooleanAttributeState => {
@@ -434,11 +434,23 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
     shouldImportHelperText ||= Boolean(helperTextAttribute);
   });
 
-  const iconLocalName = shouldImportIcon ? addNamedImport(j, root, 'Icon', isSpiritImport) : 'Icon';
-  const labelLocalName = shouldImportLabel ? addNamedImport(j, root, 'Label', isSpiritImport) : 'Label';
-  const helperTextLocalName = shouldImportHelperText
+  let hasChanges = false;
+
+  const iconImport = shouldImportIcon
+    ? addNamedImport(j, root, 'Icon', isSpiritImport)
+    : { localName: 'Icon', added: false };
+  const labelImport = shouldImportLabel
+    ? addNamedImport(j, root, 'Label', isSpiritImport)
+    : { localName: 'Label', added: false };
+  const helperTextImport = shouldImportHelperText
     ? addNamedImport(j, root, 'HelperText', isSpiritImport)
-    : 'HelperText';
+    : { localName: 'HelperText', added: false };
+
+  hasChanges ||= iconImport.added || labelImport.added || helperTextImport.added;
+
+  const iconLocalName = iconImport.localName;
+  const labelLocalName = labelImport.localName;
+  const helperTextLocalName = helperTextImport.localName;
 
   root.find(j.JSXElement).forEach((path) => {
     const { openingElement } = path.node;
@@ -454,12 +466,14 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
     const isSelectedAttribute = getAttribute(openingElement, 'isSelected');
     const isDisabledAttribute = getAttribute(openingElement, 'isDisabled');
     const children: JSXElement[] = [];
+    let elementChanged = false;
 
     if (!hasAttribute(openingElement, 'elementType')) {
       openingElement.attributes = [
         j.jsxAttribute(j.jsxIdentifier('elementType'), j.stringLiteral('button')),
         ...(openingElement.attributes ?? []),
       ];
+      elementChanged = true;
     }
 
     if (
@@ -478,32 +492,45 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
           ),
         ),
       );
+      elementChanged = true;
     }
 
     if (iconNameAttribute && !hasAttribute(openingElement, 'startSlot')) {
       openingElement.attributes?.unshift(
         j.jsxAttribute(j.jsxIdentifier('startSlot'), createIconElement(j, iconNameAttribute.value, iconLocalName)),
       );
+      elementChanged = true;
     }
 
     if (labelAttribute) {
       children.push(createLabelElement(j, labelAttribute.value, labelLocalName));
+      elementChanged = true;
     }
 
     if (helperTextAttribute) {
       children.push(createHelperTextElement(j, helperTextAttribute.value, helperTextLocalName));
+      elementChanged = true;
     }
 
+    const attributesBeforeRemoval = openingElement.attributes?.length ?? 0;
     removeAttributes(openingElement, ['iconName', 'label', 'helperText', 'selectionDecorator']);
+    if ((openingElement.attributes?.length ?? 0) !== attributesBeforeRemoval) {
+      elementChanged = true;
+    }
 
     if (children.length > 0) {
       openingElement.selfClosing = false;
       path.node.closingElement = j.jsxClosingElement(openingElement.name);
       path.node.children = [...children, ...(path.node.children ?? [])];
+      elementChanged = true;
+    }
+
+    if (elementChanged) {
+      hasChanges = true;
     }
   });
 
-  return removeParentheses(root.toSource());
+  return finishTransform(fileInfo, root, hasChanges);
 };
 
 export default transform;

--- a/packages/codemods/src/transforms/v5/web-react/scrollview-arrows-to-controls.ts
+++ b/packages/codemods/src/transforms/v5/web-react/scrollview-arrows-to-controls.ts
@@ -7,10 +7,8 @@ import {
   JSXOpeningElement,
   JSXSpreadAttribute,
 } from 'jscodeshift';
-import { removeParentheses } from '../../../helpers';
+import { removeParentheses, createImportSourceMatcher, getImportSources } from '../../../helpers';
 import { renameComponent } from '../../../helpers/renameComponent';
-
-const SPIRIT_WEB_REACT_MODULE = /^@alma-oss\/spirit-web-react(\/.*)?$/;
 
 const IDENTIFIER_RENAMES: Record<string, string> = {
   useScrollViewArrows: 'useScrollViewControls',
@@ -68,15 +66,17 @@ const renameJsxAttributes = (attributes: (JSXAttribute | JSXSpreadAttribute)[] |
   });
 };
 
-const transform = (fileInfo: FileInfo, api: API) => {
+const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
+  const importSources = getImportSources(options);
+  const isSpiritImport = createImportSourceMatcher(importSources);
   const namedImports = new Set<string>();
   const namespaceImports = new Set<string>();
 
   const hasSpiritWebReactImport = root.find(j.ImportDeclaration, {
     source: {
-      value: (value: string) => SPIRIT_WEB_REACT_MODULE.test(value),
+      value: (value: string) => isSpiritImport(value),
     },
   });
 
@@ -172,7 +172,7 @@ const transform = (fileInfo: FileInfo, api: API) => {
     });
   }
 
-  renameComponent(j, root, 'ScrollViewArrows', 'ScrollViewControls');
+  renameComponent(j, root, 'ScrollViewArrows', 'ScrollViewControls', importSources);
 
   if (namedImports.has('ScrollViewArrows')) {
     namedImports.delete('ScrollViewArrows');

--- a/packages/codemods/src/transforms/v5/web-react/scrollview-arrows-to-controls.ts
+++ b/packages/codemods/src/transforms/v5/web-react/scrollview-arrows-to-controls.ts
@@ -7,7 +7,7 @@ import {
   JSXOpeningElement,
   JSXSpreadAttribute,
 } from 'jscodeshift';
-import { removeParentheses, createImportSourceMatcher, getImportSources } from '../../../helpers';
+import { finishTransform, createImportSourceMatcher, getImportSources, getOwnRecordValue } from '../../../helpers';
 import { renameComponent } from '../../../helpers/renameComponent';
 
 const IDENTIFIER_RENAMES: Record<string, string> = {
@@ -52,18 +52,23 @@ const isScrollViewElement = (
   );
 };
 
-const renameJsxAttributes = (attributes: (JSXAttribute | JSXSpreadAttribute)[] | undefined) => {
+const renameJsxAttributes = (attributes: (JSXAttribute | JSXSpreadAttribute)[] | undefined): boolean => {
+  let changed = false;
+
   attributes?.forEach((attribute) => {
     if (attribute.type !== 'JSXAttribute' || attribute.name.type !== 'JSXIdentifier') {
       return;
     }
 
-    const newName = SCROLL_VIEW_PROP_RENAMES[attribute.name.name];
+    const newName = getOwnRecordValue(SCROLL_VIEW_PROP_RENAMES, attribute.name.name);
 
     if (newName) {
       attribute.name.name = newName;
+      changed = true;
     }
   });
+
+  return changed;
 };
 
 const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
@@ -84,12 +89,14 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
     return fileInfo.source;
   }
 
+  let hasChanges = false;
+
   hasSpiritWebReactImport.forEach((path) => {
     path.node.specifiers?.forEach((specifier) => {
       if (specifier.type === 'ImportSpecifier' && specifier.imported.type === 'Identifier') {
         const importedName = specifier.imported.name;
         const localName = specifier.local?.name ?? importedName;
-        const renamedImportedName = IDENTIFIER_RENAMES[importedName];
+        const renamedImportedName = getOwnRecordValue(IDENTIFIER_RENAMES, importedName);
 
         if (renamedImportedName) {
           specifier.imported.name = renamedImportedName;
@@ -99,6 +106,8 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
           } else if (specifier.local.name === importedName) {
             specifier.local.name = renamedImportedName;
           }
+
+          hasChanges = true;
         }
 
         if (SCROLL_VIEW_COMPONENTS.has(importedName) || SCROLL_VIEW_COMPONENTS.has(renamedImportedName ?? '')) {
@@ -113,10 +122,11 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
   });
 
   root.find(j.Identifier).forEach((path) => {
-    const newName = IDENTIFIER_RENAMES[path.node.name];
+    const newName = getOwnRecordValue(IDENTIFIER_RENAMES, path.node.name);
 
     if (newName) {
       (path.node as Identifier).name = newName;
+      hasChanges = true;
     }
   });
 
@@ -125,7 +135,9 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
       return;
     }
 
-    renameJsxAttributes(path.node.attributes);
+    if (renameJsxAttributes(path.node.attributes)) {
+      hasChanges = true;
+    }
   });
 
   root
@@ -140,6 +152,7 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
 
       if (object.type === 'Identifier' && object.name === 'classProps') {
         (path.node.property as Identifier).name = 'controls';
+        hasChanges = true;
       }
     });
 
@@ -161,6 +174,8 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
           if (property.value.type === 'Identifier' && property.value.name === 'arrows') {
             property.value.name = 'controls';
           }
+
+          hasChanges = true;
         }
       });
     }
@@ -169,17 +184,20 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
   if (root.find(j.Identifier, { name: 'useScrollViewControls' }).length > 0) {
     root.find(j.Identifier, { name: 'arrows' }).forEach((path) => {
       (path.node as Identifier).name = 'controls';
+      hasChanges = true;
     });
   }
 
-  renameComponent(j, root, 'ScrollViewArrows', 'ScrollViewControls', importSources);
+  if (renameComponent(j, root, 'ScrollViewArrows', 'ScrollViewControls', importSources)) {
+    hasChanges = true;
+  }
 
   if (namedImports.has('ScrollViewArrows')) {
     namedImports.delete('ScrollViewArrows');
     namedImports.add('ScrollViewControls');
   }
 
-  return removeParentheses(root.toSource({ quote: 'double' }));
+  return finishTransform(fileInfo, root, hasChanges, { quote: 'double' });
 };
 
 export default transform;

--- a/packages/codemods/src/transforms/v5/web-react/stack-wrap-children-in-stack-item.ts
+++ b/packages/codemods/src/transforms/v5/web-react/stack-wrap-children-in-stack-item.ts
@@ -1,5 +1,5 @@
 import { API, FileInfo, Identifier } from 'jscodeshift';
-import { createImportSourceMatcher, getImportSources, removeParentheses } from '../../../helpers';
+import { createImportSourceMatcher, finishTransform, getImportSources } from '../../../helpers';
 
 const DIVIDER_PROPS = new Set(['hasIntermediateDividers', 'hasStartDivider', 'hasEndDivider']);
 
@@ -26,7 +26,7 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
     return fileInfo.source;
   }
 
-  let needsStackItemImport = false;
+  let hasChanges = false;
 
   root
     .find(j.JSXElement, {
@@ -53,7 +53,7 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
           return child;
         }
 
-        needsStackItemImport = true;
+        hasChanges = true;
 
         const innerChildren = child.type === 'JSXFragment' ? child.children : [child];
 
@@ -65,7 +65,7 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
       });
     });
 
-  if (needsStackItemImport) {
+  if (hasChanges) {
     const stackItemAlreadyImported =
       importStatements.find(j.ImportSpecifier, {
         imported: { type: 'Identifier', name: 'StackItem' },
@@ -83,7 +83,7 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
     }
   }
 
-  return removeParentheses(root.toSource({ quote: 'single' }));
+  return finishTransform(fileInfo, root, hasChanges, { quote: 'single' });
 };
 
 export default transform;

--- a/packages/codemods/src/transforms/v5/web-react/stack-wrap-children-in-stack-item.ts
+++ b/packages/codemods/src/transforms/v5/web-react/stack-wrap-children-in-stack-item.ts
@@ -1,16 +1,16 @@
 import { API, FileInfo, Identifier } from 'jscodeshift';
-import { removeParentheses } from '../../../helpers';
+import { createImportSourceMatcher, getImportSources, removeParentheses } from '../../../helpers';
 
-const SPIRIT_WEB_REACT_MODULE = /^@alma-oss\/spirit-web-react(\/.*)?$/;
 const DIVIDER_PROPS = new Set(['hasIntermediateDividers', 'hasStartDivider', 'hasEndDivider']);
 
-const transform = (fileInfo: FileInfo, api: API) => {
+const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
+  const isSpiritImport = createImportSourceMatcher(getImportSources(options));
 
   const importStatements = root.find(j.ImportDeclaration, {
     source: {
-      value: (value: string) => SPIRIT_WEB_REACT_MODULE.test(value),
+      value: (value: string) => isSpiritImport(value),
     },
   });
 

--- a/packages/codemods/src/transforms/v5/web-react/unstable-file-component-name.ts
+++ b/packages/codemods/src/transforms/v5/web-react/unstable-file-component-name.ts
@@ -1,5 +1,5 @@
 import { API, FileInfo, Identifier } from 'jscodeshift';
-import { removeParentheses } from '../../../helpers';
+import { removeParentheses, getImportSources } from '../../../helpers';
 import { renameComponent } from '../../../helpers/renameComponent';
 
 const IDENTIFIER_RENAMES: Record<string, string> = {
@@ -17,12 +17,13 @@ const IDENTIFIER_RENAMES: Record<string, string> = {
   UnstableFileProps: 'FileProps',
 };
 
-const transform = (fileInfo: FileInfo, api: API) => {
+const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
+  const importSources = getImportSources(options);
 
-  renameComponent(j, root, 'UNSTABLE_FileImagePreview', 'FileImagePreview');
-  renameComponent(j, root, 'UNSTABLE_File', 'File');
+  renameComponent(j, root, 'UNSTABLE_FileImagePreview', 'FileImagePreview', importSources);
+  renameComponent(j, root, 'UNSTABLE_File', 'File', importSources);
 
   root.find(j.Identifier).forEach((path) => {
     const newName = IDENTIFIER_RENAMES[path.node.name];

--- a/packages/codemods/src/transforms/v5/web-react/unstable-file-component-name.ts
+++ b/packages/codemods/src/transforms/v5/web-react/unstable-file-component-name.ts
@@ -1,5 +1,5 @@
 import { API, FileInfo, Identifier } from 'jscodeshift';
-import { removeParentheses, getImportSources } from '../../../helpers';
+import { finishTransform, getImportSources, getOwnRecordValue } from '../../../helpers';
 import { renameComponent } from '../../../helpers/renameComponent';
 
 const IDENTIFIER_RENAMES: Record<string, string> = {
@@ -21,25 +21,37 @@ const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
   const importSources = getImportSources(options);
+  let hasChanges = false;
 
-  renameComponent(j, root, 'UNSTABLE_FileImagePreview', 'FileImagePreview', importSources);
-  renameComponent(j, root, 'UNSTABLE_File', 'File', importSources);
+  if (renameComponent(j, root, 'UNSTABLE_FileImagePreview', 'FileImagePreview', importSources)) {
+    hasChanges = true;
+  }
+
+  if (renameComponent(j, root, 'UNSTABLE_File', 'File', importSources)) {
+    hasChanges = true;
+  }
 
   root.find(j.Identifier).forEach((path) => {
-    const newName = IDENTIFIER_RENAMES[path.node.name];
+    const newName = getOwnRecordValue(IDENTIFIER_RENAMES, path.node.name);
 
     if (newName) {
       (path.node as Identifier).name = newName;
+      hasChanges = true;
     }
   });
 
   root.find(j.ImportDeclaration).forEach((path) => {
     if (typeof path.node.source.value === 'string') {
-      path.node.source.value = path.node.source.value.replace('UNSTABLE_File', 'File');
+      const updated = path.node.source.value.replace('UNSTABLE_File', 'File');
+
+      if (updated !== path.node.source.value) {
+        path.node.source.value = updated;
+        hasChanges = true;
+      }
     }
   });
 
-  return removeParentheses(root.toSource({ quote: 'single' }));
+  return finishTransform(fileInfo, root, hasChanges, { quote: 'single' });
 };
 
 export default transform;

--- a/packages/codemods/src/transforms/v5/web-react/unstable-fileupload-component-name.ts
+++ b/packages/codemods/src/transforms/v5/web-react/unstable-fileupload-component-name.ts
@@ -1,5 +1,5 @@
 import { API, FileInfo, Identifier, JSXAttribute, JSXOpeningElement, JSXSpreadAttribute } from 'jscodeshift';
-import { removeParentheses } from '../../../helpers';
+import { getImportSources, removeParentheses } from '../../../helpers';
 import { renameComponent } from '../../../helpers/renameComponent';
 
 const FILE_UPLOAD_COMPONENTS = new Set(['UNSTABLE_FileUpload', 'FileUpload']);
@@ -30,9 +30,10 @@ const renameFileUploadJsxAttributes = (attributes: (JSXAttribute | JSXSpreadAttr
   });
 };
 
-const transform = (fileInfo: FileInfo, api: API) => {
+const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
+  const importSources = getImportSources(options);
 
   root.find(j.JSXOpeningElement).forEach((path) => {
     const element = path.node as JSXOpeningElement;
@@ -42,7 +43,7 @@ const transform = (fileInfo: FileInfo, api: API) => {
     }
   });
 
-  renameComponent(j, root, 'UNSTABLE_FileUpload', 'FileUpload');
+  renameComponent(j, root, 'UNSTABLE_FileUpload', 'FileUpload', importSources);
 
   root.find(j.Identifier).forEach((path) => {
     const newName = IDENTIFIER_RENAMES[path.node.name];

--- a/packages/codemods/src/transforms/v5/web-react/unstable-fileupload-component-name.ts
+++ b/packages/codemods/src/transforms/v5/web-react/unstable-fileupload-component-name.ts
@@ -1,5 +1,5 @@
 import { API, FileInfo, Identifier, JSXAttribute, JSXOpeningElement, JSXSpreadAttribute } from 'jscodeshift';
-import { getImportSources, removeParentheses } from '../../../helpers';
+import { finishTransform, getImportSources, getOwnRecordValue } from '../../../helpers';
 import { renameComponent } from '../../../helpers/renameComponent';
 
 const FILE_UPLOAD_COMPONENTS = new Set(['UNSTABLE_FileUpload', 'FileUpload']);
@@ -16,50 +16,64 @@ const IDENTIFIER_RENAMES: Record<string, string> = {
   UnstableFileUploadProps: 'FileUploadProps',
 };
 
-const renameFileUploadJsxAttributes = (attributes: (JSXAttribute | JSXSpreadAttribute)[] | undefined) => {
+const renameFileUploadJsxAttributes = (attributes: (JSXAttribute | JSXSpreadAttribute)[] | undefined): boolean => {
+  let hasChanges = false;
+
   attributes?.forEach((attribute) => {
     if (attribute.type !== 'JSXAttribute' || attribute.name.type !== 'JSXIdentifier') {
       return;
     }
 
-    const newName = FILE_UPLOAD_PROP_RENAMES[attribute.name.name];
+    const newName = getOwnRecordValue(FILE_UPLOAD_PROP_RENAMES, attribute.name.name);
 
     if (newName) {
       attribute.name.name = newName;
+      hasChanges = true;
     }
   });
+
+  return hasChanges;
 };
 
 const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
   const importSources = getImportSources(options);
+  let hasChanges = false;
 
   root.find(j.JSXOpeningElement).forEach((path) => {
     const element = path.node as JSXOpeningElement;
 
     if (element.name.type === 'JSXIdentifier' && FILE_UPLOAD_COMPONENTS.has(element.name.name)) {
-      renameFileUploadJsxAttributes(element.attributes);
+      hasChanges ||= renameFileUploadJsxAttributes(element.attributes);
     }
   });
 
-  renameComponent(j, root, 'UNSTABLE_FileUpload', 'FileUpload', importSources);
+  if (renameComponent(j, root, 'UNSTABLE_FileUpload', 'FileUpload', importSources)) {
+    hasChanges = true;
+  }
 
   root.find(j.Identifier).forEach((path) => {
-    const newName = IDENTIFIER_RENAMES[path.node.name];
+    const newName = getOwnRecordValue(IDENTIFIER_RENAMES, path.node.name);
 
     if (newName) {
       (path.node as Identifier).name = newName;
+      hasChanges = true;
     }
   });
 
   root.find(j.ImportDeclaration).forEach((path) => {
     if (typeof path.node.source.value === 'string') {
-      path.node.source.value = path.node.source.value.replace('UNSTABLE_FileUpload', 'FileUpload');
+      const updated = path.node.source.value.replace('UNSTABLE_FileUpload', 'FileUpload');
+
+      if (updated !== path.node.source.value) {
+        path.node.source.value = updated;
+        hasChanges = true;
+      }
     }
   });
 
-  return removeParentheses(root.toSource({ quote: 'single' }));
+  return finishTransform(fileInfo, root, hasChanges, { quote: 'single' });
 };
 
 export default transform;

--- a/packages/codemods/src/transforms/v5/web-react/validation-state-icon-prop.ts
+++ b/packages/codemods/src/transforms/v5/web-react/validation-state-icon-prop.ts
@@ -1,48 +1,54 @@
 import { API, FileInfo } from 'jscodeshift';
-import { removeParentheses } from '../../../helpers';
+import { createImportSourceMatcher, finishTransform, getImportSources } from '../../../helpers';
 
-const SPIRIT_WEB_REACT_MODULE = /^@alma-oss\/spirit-web-react(\/.*)?$/;
-
-const transform = (fileInfo: FileInfo, api: API) => {
+const transform = (fileInfo: FileInfo, api: API, options: Record<string, unknown> = {}) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
+  const isSpiritImport = createImportSourceMatcher(getImportSources(options));
+  const validationTextLocalNames = new Set<string>();
+  let hasChanges = false;
 
   const importStatements = root.find(j.ImportDeclaration, {
     source: {
-      value: (value: string) => SPIRIT_WEB_REACT_MODULE.test(value),
+      value: (value: string) => isSpiritImport(value),
     },
   });
 
-  if (importStatements.length > 0) {
-    const componentSpecifier = importStatements.find(j.ImportSpecifier, {
-      imported: {
-        type: 'Identifier',
-        name: 'ValidationText',
-      },
+  importStatements.forEach((path) => {
+    path.node.specifiers?.forEach((specifier) => {
+      if (
+        specifier.type === 'ImportSpecifier' &&
+        specifier.imported.type === 'Identifier' &&
+        specifier.imported.name === 'ValidationText'
+      ) {
+        validationTextLocalNames.add(specifier.local?.name ?? specifier.imported.name);
+      }
     });
+  });
 
-    if (componentSpecifier.length > 0) {
-      const components = root.find(j.JSXOpeningElement, {
-        name: {
-          type: 'JSXIdentifier',
-          name: 'ValidationText',
-        },
-      });
-
-      components
-        .find(j.JSXAttribute, {
-          name: {
-            type: 'JSXIdentifier',
-            name: 'hasValidationStateIcon',
-          },
-        })
-        .forEach((attributePath) => {
-          attributePath.node.name.name = 'validationStateIcon';
-        });
-    }
+  if (validationTextLocalNames.size === 0) {
+    return fileInfo.source;
   }
 
-  return removeParentheses(root.toSource());
+  root
+    .find(j.JSXOpeningElement, {
+      name: {
+        type: 'JSXIdentifier',
+        name: (name: string) => validationTextLocalNames.has(name),
+      },
+    })
+    .find(j.JSXAttribute, {
+      name: {
+        type: 'JSXIdentifier',
+        name: 'hasValidationStateIcon',
+      },
+    })
+    .forEach((attributePath) => {
+      attributePath.node.name.name = 'validationStateIcon';
+      hasChanges = true;
+    });
+
+  return finishTransform(fileInfo, root, hasChanges);
 };
 
 export default transform;

--- a/packages/codemods/tests/testUtils.ts
+++ b/packages/codemods/tests/testUtils.ts
@@ -1,8 +1,13 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { defineTest } = require('jscodeshift/dist/testUtils');
 
-export const testTransform = (directory: string, name: string) => {
-  defineTest(directory, name, null, name, {
+export const testTransform = (
+  directory: string,
+  name: string,
+  options: Record<string, unknown> | null = null,
+  fixtureName = name,
+) => {
+  defineTest(directory, name, options, fixtureName, {
     parser: 'tsx',
     fixture: 'input',
     snapshot: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,6 +69,7 @@ __metadata:
     filedirname: "catalog:script"
     jest: "catalog:test"
     jscodeshift: "catalog:script"
+    npm-run-all2: "catalog:script"
     sade: "catalog:script"
     shx: "catalog:script"
     tsup: "catalog:build"


### PR DESCRIPTION
## Description

v5 codemods only matched imports from `@alma-oss/spirit-web-react`, so consumer apps that re-export Spirit through a wrapper package (e.g. `@almacareer/cyborg-design-system`) were skipped entirely. This adds a shared import-source helper, wires it through all v5 import-gated transforms, and exposes it via a new `-s` / `--import-sources` CLI flag.

### Additional context

- Default matching is `@alma-oss/spirit-web-react` only (since v4, `@lmc-eu` is out of scope; use the v4 `package-scope-change` codemod or pass `-s` explicitly if needed).
- Wrapper usage example: `npx @alma-oss/spirit-codemods -p ./src -s @almacareer/cyborg-design-system -t v5/web-react/checkbox-margin-y`
- Includes a Cyborg-style fixture test for `checkbox-margin-y`.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->