### PR TITLE
feat(web)!: align `Breadcrumbs` and `Navigation` with new design #DS-2554

### DIFF
--- a/packages/web-react/src/components/Header/demo/HeaderWithNavigation/ProfileNavigation.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithNavigation/ProfileNavigation.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Icon } from '../../../Icon';
 import { Navigation, NavigationAvatar, NavigationItem } from '../../../Navigation';
-import { Text } from '../../../Text';
 
 interface ProfileNavigationProps {
   isSquare?: boolean;
@@ -11,9 +10,7 @@ const ProfileNavigation = ({ isSquare = false }: ProfileNavigationProps) => (
   <Navigation aria-label="Profile" direction="vertical">
     <NavigationItem alignmentY="left">
       <NavigationAvatar avatarContent={<Icon name="profile" />} aria-label="Profile of Jiří Bárta" isSquare={isSquare}>
-        <Text elementType="span" size="small" emphasis="semibold">
-          My Account
-        </Text>
+        My Account
       </NavigationAvatar>
     </NavigationItem>
   </Navigation>

--- a/packages/web-react/src/components/Header/demo/HeaderWithNavigation/SecondaryHorizontalNavigation.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithNavigation/SecondaryHorizontalNavigation.tsx
@@ -4,7 +4,6 @@ import { Button } from '../../../Button';
 import { ButtonLink } from '../../../ButtonLink';
 import { Icon } from '../../../Icon';
 import { Navigation, NavigationAvatar, NavigationItem } from '../../../Navigation';
-import { Text } from '../../../Text';
 import { VisuallyHidden } from '../../../VisuallyHidden';
 
 interface SecondaryHorizontalNavigationProps {
@@ -25,9 +24,7 @@ const SecondaryHorizontalNavigation: FunctionComponent<SecondaryHorizontalNaviga
     </NavigationItem>
     <NavigationItem alignmentY="center" hideOn={['mobile', 'tablet']}>
       <NavigationAvatar avatarContent={<Icon name="profile" />} aria-label="Profile of Jiří Bárta">
-        <Text elementType="span" size="small" emphasis="semibold">
-          My Account
-        </Text>
+        My Account
       </NavigationAvatar>
     </NavigationItem>
     <NavigationItem hideOn={['mobile', 'tablet']}>

--- a/packages/web-react/src/components/Header/demo/HeaderWithNavigation/SecondaryHorizontalNavigationDropdown.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithNavigation/SecondaryHorizontalNavigationDropdown.tsx
@@ -3,7 +3,6 @@ import { type PolymorphicRef, type SpiritNavigationAvatarProps } from '../../../
 import { Dropdown, DropdownPopover, DropdownTrigger } from '../../../Dropdown';
 import { Icon } from '../../../Icon';
 import { NavigationAvatar } from '../../../Navigation';
-import { Text } from '../../../Text';
 import { DropdownPopoverContent } from '../HeaderWithNavigationAndNestedItems/MainHorizontalNavigationDropdown';
 
 const _NavigationAvatarAsDropdownTrigger = (
@@ -41,10 +40,8 @@ const SecondaryHorizontalNavigationDropdown = ({
         aria-label="Profile of Jiří Bárta"
         isSquare={isSquare}
       >
-        <Text elementType="span" size="small" emphasis="semibold">
-          My Account
-        </Text>
-        <Icon name={`chevron-${isAvatarDropdownOpen ? 'up' : 'down'}`} boxSize={20} />
+        My Account
+        <Icon name={`chevron-${isAvatarDropdownOpen ? 'up' : 'down'}`} />
       </DropdownTrigger>
       <DropdownPopover>
         <DropdownPopoverContent />

--- a/packages/web-react/src/components/Header/demo/HeaderWithNavigationAndNestedItems/MainHorizontalNavigationDropdown.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithNavigationAndNestedItems/MainHorizontalNavigationDropdown.tsx
@@ -49,7 +49,7 @@ const MainHorizontalNavigationDropdown = () => {
     >
       <DropdownTrigger elementType={NavigationActionAsDropdownTrigger}>
         Menu
-        <Icon name={`chevron-${isNavigationActionDropdownOpen ? 'up' : 'down'}`} boxSize={20} />
+        <Icon name={`chevron-${isNavigationActionDropdownOpen ? 'up' : 'down'}`} />
       </DropdownTrigger>
       <DropdownPopover>
         <DropdownPopoverContent />

--- a/packages/web-react/src/components/Header/figma/Header.figma.tsx
+++ b/packages/web-react/src/components/Header/figma/Header.figma.tsx
@@ -9,7 +9,6 @@ import { Icon } from '../../Icon';
 import { Navigation, NavigationAction, NavigationAvatar, NavigationItem } from '../../Navigation';
 import { ProductLogo } from '../../ProductLogo';
 import { Stack, StackItem } from '../../Stack';
-import { Text } from '../../Text';
 import Header from '../Header';
 import HeaderLogo from '../HeaderLogo';
 
@@ -46,9 +45,7 @@ const HeaderWithNavigationLoggedIn = ({ itemVariant }: { itemVariant: Navigation
             <Navigation marginLeft="auto" aria-label="Secondary Navigation">
               <NavigationItem alignmentY="center" hideOn={['mobile', 'tablet']}>
                 <NavigationAvatar avatarContent={<Icon name="profile" />} aria-label="Profile of Jiří Bárta">
-                  <Text elementType="span" size="small" emphasis="semibold">
-                    My Account
-                  </Text>
+                  My Account
                 </NavigationAvatar>
               </NavigationItem>
               <NavigationItem hideOn="desktop">
@@ -76,9 +73,7 @@ const HeaderWithNavigationLoggedIn = ({ itemVariant }: { itemVariant: Navigation
               <Navigation aria-label="Profile" direction="vertical">
                 <NavigationItem alignmentY="left">
                   <NavigationAvatar avatarContent={<Icon name="profile" />} aria-label="Profile of Jiří Bárta" isSquare>
-                    <Text elementType="span" size="small" emphasis="semibold">
-                      My Account
-                    </Text>
+                    My Account
                   </NavigationAvatar>
                 </NavigationItem>
               </Navigation>

--- a/packages/web-react/src/components/Navigation/README.md
+++ b/packages/web-react/src/components/Navigation/README.md
@@ -163,9 +163,7 @@ The `NavigationAvatar` is a component that is styled to be used as a navigation 
 
 ```tsx
 <NavigationAvatar avatarContent={<Icon name="profile" />} aria-label="Profile of Jiří Bárta">
-  <Text elementType="span" size="small" emphasis="semibold">
-    My Account
-  </Text>
+  <span className="typography-action-small">My Account</span>
 </NavigationAvatar>
 ```
 
@@ -173,9 +171,7 @@ If you want the avatar to be square, don't forget to add the `isSquare` prop to 
 
 ```tsx
 <NavigationAvatar avatarContent={<Icon name="profile" />} isSquare aria-label="Profile of Jiří Bárta">
-  <Text elementType="span" size="small" emphasis="semibold">
-    My Account
-  </Text>
+  <span className="typography-action-small">My Account</span>
 </NavigationAvatar>
 ```
 
@@ -189,9 +185,7 @@ Available sizes: `xsmall`, `small`, `medium`, `large`, `xlarge`.
 
 ```tsx
 <NavigationAvatar avatarContent={<Icon name="profile" />} avatarSize="xsmall" aria-label="Profile of Jiří Bárta">
-  <Text elementType="span" size="small" emphasis="semibold">
-    My Account
-  </Text>
+  <span className="typography-action-small">My Account</span>
 </NavigationAvatar>
 ```
 
@@ -203,9 +197,7 @@ You can also use responsive sizes with a responsive object, e.g. `avatarSize={{ 
   avatarSize={{ mobile: 'small', tablet: 'medium', desktop: 'large' }}
   aria-label="Profile of Jiří Bárta"
 >
-  <Text elementType="span" size="small" emphasis="semibold">
-    My Account
-  </Text>
+  <span className="typography-action-small">My Account</span>
 </NavigationAvatar>
 ```
 

--- a/packages/web-react/src/components/Navigation/demo/NavigationAvatarWithDropdown.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationAvatarWithDropdown.tsx
@@ -34,7 +34,7 @@ const NavigationAvatarWithDropdown = () => {
             aria-label={AVATAR_ARIA_LABEL}
           >
             {AVATAR_TEXT}
-            <Icon name={`chevron-${isDropdownOpen ? 'up' : 'down'}`} boxSize={20} />
+            <Icon name={`chevron-${isDropdownOpen ? 'up' : 'down'}`} />
           </DropdownTrigger>
           <DropdownPopover>{DROPDOWN_ITEMS}</DropdownPopover>
         </Dropdown>
@@ -54,7 +54,7 @@ const NavigationAvatarWithDropdown = () => {
             aria-label={AVATAR_ARIA_LABEL}
           >
             {AVATAR_TEXT}
-            <Icon name={`chevron-${isSquareDropdownOpen ? 'up' : 'down'}`} boxSize={20} />
+            <Icon name={`chevron-${isSquareDropdownOpen ? 'up' : 'down'}`} />
           </DropdownTrigger>
           <DropdownPopover>{DROPDOWN_ITEMS}</DropdownPopover>
         </Dropdown>

--- a/packages/web-react/src/components/Navigation/demo/NavigationHorizontalWithDropdown.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationHorizontalWithDropdown.tsx
@@ -37,7 +37,7 @@ const NavigationHorizontalWithDropdown = () => {
         >
           <DropdownTrigger elementType={NavigationActionAsDropdownTrigger}>
             Dropdown
-            <Icon name={`chevron-${isNavigationActionDropdownOpen ? 'up' : 'down'}`} boxSize={20} />
+            <Icon name={`chevron-${isNavigationActionDropdownOpen ? 'up' : 'down'}`} />
           </DropdownTrigger>
           <DropdownPopover>
             <Item elementType="a" href="#">

--- a/packages/web-react/src/components/Navigation/demo/navigationAvatarDemoHelpers.tsx
+++ b/packages/web-react/src/components/Navigation/demo/navigationAvatarDemoHelpers.tsx
@@ -3,17 +3,12 @@ import { type PolymorphicRef, type SpiritNavigationAvatarProps } from '../../../
 import { Icon } from '../../Icon';
 import { Item } from '../../Item';
 import { Label } from '../../Label';
-import { Text } from '../../Text';
 import NavigationAvatar from '../NavigationAvatar';
 
 // Shared constants
 export const AVATAR_CONTENT = <Icon name="profile" />;
 export const AVATAR_ARIA_LABEL = 'Profile of Jiří Bárta';
-export const AVATAR_TEXT = (
-  <Text elementType="span" size="small" emphasis="semibold">
-    My Account
-  </Text>
-);
+export const AVATAR_TEXT = 'My Account';
 
 // Shared dropdown items
 export const DROPDOWN_ITEMS = (

--- a/packages/web/src/scss/components/Breadcrumbs/README.md
+++ b/packages/web/src/scss/components/Breadcrumbs/README.md
@@ -9,25 +9,25 @@ Shows where the user is within the app hierarchy.
   <ol>
     <li class="d-none d-tablet-flex">
       <a href="#rootUrl" class="link-primary link-underlined">Root</a>
-      <svg class="Icon" width="24" height="24">
+      <svg class="Icon" width="24" height="24" aria-hidden="true">
         <use href="/icons/svg/sprite.svg#chevron-right" />
       </svg>
     </li>
     <li class="d-none d-tablet-flex">
       <a href="#categoryUrl" class="link-primary link-underlined">Category</a>
-      <svg class="Icon" width="24" height="24">
+      <svg class="Icon" width="24" height="24" aria-hidden="true">
         <use href="/icons/svg/sprite.svg#chevron-right" />
       </svg>
     </li>
     <li class="d-tablet-none">
-      <svg class="Icon" width="24" height="24">
+      <svg class="Icon" width="24" height="24" aria-hidden="true">
         <use href="/icons/svg/sprite.svg#chevron-left" />
       </svg>
       <a href="#subcategoryUrl" class="link-primary link-underlined">Back</a>
     </li>
     <li class="d-none d-tablet-flex">
       <a href="#subcategoryUrl" class="link-primary link-underlined">Subcategory</a>
-      <svg class="Icon" width="24" height="24">
+      <svg class="Icon" width="24" height="24" aria-hidden="true">
         <use href="/icons/svg/sprite.svg#chevron-right" />
       </svg>
     </li>
@@ -50,7 +50,7 @@ For comprehensive guidance on handling text truncation, translations, and multip
   <a href="#currentUrl" aria-current="page" class="link-secondary text-truncate" style="max-width: 100px;">
     This is a very long title of the current page
   </a>
-  <svg class="Icon" width="24" height="24">
+  <svg class="Icon" width="24" height="24" aria-hidden="true">
     <use href="/icons/svg/sprite.svg#chevron-right" />
   </svg>
 </li>

--- a/packages/web/src/scss/components/Breadcrumbs/_Breadcrumbs.scss
+++ b/packages/web/src/scss/components/Breadcrumbs/_Breadcrumbs.scss
@@ -1,10 +1,13 @@
 @use 'sass:map';
-@use 'theme';
+@use '@tokens' as tokens;
 @use '../../tools/breakpoint';
 @use '../../tools/svg';
 @use '../../tools/typography';
+@use 'theme';
 
 .Breadcrumbs {
+    --#{tokens.$css-variable-prefix}icon-composition-size: #{theme.$icon-size};
+
     @include typography.generate(theme.$typography);
 
     width: 100%;

--- a/packages/web/src/scss/components/Breadcrumbs/_theme.scss
+++ b/packages/web/src/scss/components/Breadcrumbs/_theme.scss
@@ -1,4 +1,5 @@
 @use '@tokens' as tokens;
+@use '../../tools/units';
 
 $breakpoints: tokens.$breakpoints;
 
@@ -7,3 +8,5 @@ $color: tokens.$text-secondary;
 
 $gap-mobile-up: tokens.$space-300;
 $gap-tablet-up: tokens.$space-500;
+
+$icon-size: units.px-to-rem(20px);

--- a/packages/web/src/scss/components/Breadcrumbs/preview.html
+++ b/packages/web/src/scss/components/Breadcrumbs/preview.html
@@ -9,25 +9,45 @@
       <ol>
         <li class="d-none d-tablet-flex">
           <a href="#rootUrl" class="link-primary link-underlined">Root</a>
-          <svg width="24" height="24">
+          <svg
+            class="Icon"
+            width="24"
+            height="24"
+            aria-hidden="true"
+          >
             <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         <li class="d-none d-tablet-flex">
           <a href="#categoryUrl" class="link-primary link-underlined">Category</a>
-          <svg width="24" height="24">
+          <svg
+            class="Icon"
+            width="24"
+            height="24"
+            aria-hidden="true"
+          >
             <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         <li class="d-tablet-none">
-          <svg width="24" height="24">
+          <svg
+            class="Icon"
+            width="24"
+            height="24"
+            aria-hidden="true"
+          >
             <use href="/assets/icons/svg/sprite.svg#chevron-left" />
           </svg>
           <a href="#subcategoryUrl" class="link-primary link-underlined">Back</a>
         </li>
         <li class="d-none d-tablet-flex">
           <a href="#subcategoryUrl" class="link-primary link-underlined">Subcategory</a>
-          <svg width="24" height="24">
+          <svg
+            class="Icon"
+            width="24"
+            height="24"
+            aria-hidden="true"
+          >
             <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
@@ -59,25 +79,45 @@
       <ol>
         <li class="d-none d-tablet-flex">
           <a href="#rootUrl" class="link-primary link-underlined">Root</a>
-          <svg width="24" height="24">
+          <svg
+            class="Icon"
+            width="24"
+            height="24"
+            aria-hidden="true"
+          >
             <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         <li class="d-none d-tablet-flex">
           <a href="#categoryUrl" class="link-primary link-underlined">Category</a>
-          <svg width="24" height="24">
+          <svg
+            class="Icon"
+            width="24"
+            height="24"
+            aria-hidden="true"
+          >
             <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         <li class="d-tablet-none">
-          <svg width="24" height="24">
+          <svg
+            class="Icon"
+            width="24"
+            height="24"
+            aria-hidden="true"
+          >
             <use href="/assets/icons/svg/sprite.svg#chevron-left" />
           </svg>
           <a href="#subcategoryUrl" class="link-primary link-underlined">Back</a>
         </li>
         <li class="d-none d-tablet-flex">
           <a href="#subcategoryUrl" class="link-primary link-underlined">Subcategory</a>
-          <svg width="24" height="24">
+          <svg
+            class="Icon"
+            width="24"
+            height="24"
+            aria-hidden="true"
+          >
             <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
@@ -105,25 +145,45 @@
       <ol>
         <li class="d-none d-tablet-flex">
           <a href="#rootUrl" class="link-primary link-underlined">Root</a>
-          <svg width="24" height="24">
+          <svg
+            class="Icon"
+            width="24"
+            height="24"
+            aria-hidden="true"
+          >
             <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         <li class="d-none d-tablet-flex">
           <a href="#categoryUrl" class="link-primary link-underlined">Category</a>
-          <svg width="24" height="24">
+          <svg
+            class="Icon"
+            width="24"
+            height="24"
+            aria-hidden="true"
+          >
             <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>
         <li class="d-tablet-none">
-          <svg width="24" height="24">
+          <svg
+            class="Icon"
+            width="24"
+            height="24"
+            aria-hidden="true"
+          >
             <use href="/assets/icons/svg/sprite.svg#chevron-left" />
           </svg>
           <a href="#subcategoryUrl" class="link-primary link-underlined">Back</a>
         </li>
         <li class="d-none d-tablet-flex">
           <a href="#subcategoryUrl" class="link-primary link-underlined">Subcategory</a>
-          <svg width="24" height="24">
+          <svg
+            class="Icon"
+            width="24"
+            height="24"
+            aria-hidden="true"
+          >
             <use href="/assets/icons/svg/sprite.svg#chevron-right" />
           </svg>
         </li>

--- a/packages/web/src/scss/components/Header/preview.html
+++ b/packages/web/src/scss/components/Header/preview.html
@@ -177,7 +177,7 @@
                       <use href="/assets/icons/svg/sprite.svg#profile" />
                     </svg>
                   </span>
-                  <span class="typography-body-small-semibold">My Account</span>
+                  My Account
                 </a>
               </li>
               <li class="NavigationItem NavigationItem--alignmentYCenter d-only-mobile-none d-only-tablet-none">
@@ -257,7 +257,7 @@
                           <use href="/assets/icons/svg/sprite.svg#profile" />
                         </svg>
                       </span>
-                      <span class="typography-body-small-semibold">My Account</span>
+                      My Account
                     </a>
                   </li>
                 </ul>
@@ -378,7 +378,7 @@
                       <use href="/assets/icons/svg/sprite.svg#profile" />
                     </svg>
                   </span>
-                  <span class="typography-body-small-semibold">My Account</span>
+                  My Account
                 </a>
               </li>
               <li class="NavigationItem NavigationItem--alignmentYCenter d-only-mobile-none d-only-tablet-none">
@@ -459,7 +459,7 @@
                           <use href="/assets/icons/svg/sprite.svg#profile" />
                         </svg>
                       </span>
-                      <span class="typography-body-small-semibold">My Account</span>
+                      My Account
                     </a>
                   </li>
                 </ul>
@@ -647,7 +647,7 @@
                         <use href="/assets/icons/svg/sprite.svg#profile" />
                       </svg>
                     </span>
-                    <span class="typography-body-small-semibold">My Account</span>
+                    My Account
                     <svg
                       width="20"
                       height="20"
@@ -774,7 +774,7 @@
                           <use href="/assets/icons/svg/sprite.svg#profile" />
                         </svg>
                       </span>
-                      <span class="typography-body-small-semibold">My Account</span>
+                      My Account
                     </a>
                   </li>
                 </ul>

--- a/packages/web/src/scss/components/Navigation/README.md
+++ b/packages/web/src/scss/components/Navigation/README.md
@@ -151,7 +151,7 @@ The `NavigationAvatar` is a component that is styled to be used as a navigation 
       <use href="/assets/icons/svg/sprite.svg#profile" />
     </svg>
   </span>
-  <span class="typography-body-small-semibold">My Account</span>
+  <span class="typography-action-small">My Account</span>
 </a>
 ```
 
@@ -164,7 +164,7 @@ If you want the avatar to be square, don't forget to add the `NavigationAvatar--
       <use href="/assets/icons/svg/sprite.svg#profile" />
     </svg>
   </span>
-  <span class="typography-body-small-semibold">My Account</span>
+  <span class="typography-action-small">My Account</span>
 </a>
 ```
 
@@ -183,7 +183,7 @@ Available sizes: `xsmall`, `small`, `medium`, `large`, `xlarge`.
       <use href="/assets/icons/svg/sprite.svg#profile" />
     </svg>
   </span>
-  <span class="typography-body-small-semibold">My Account</span>
+  <span class="typography-action-small">My Account</span>
 </a>
 ```
 
@@ -196,7 +196,7 @@ You can also use responsive sizes with breakpoint-specific classes, e.g. `Avatar
       <use href="/assets/icons/svg/sprite.svg#profile" />
     </svg>
   </span>
-  <span class="typography-body-small-semibold">My Account</span>
+  <span class="typography-action-small">My Account</span>
 </a>
 ```
 
@@ -225,7 +225,7 @@ With NavigationAction and NavigationAvatar components:
             <use href="/assets/icons/svg/sprite.svg#profile" />
           </svg>
         </span>
-        <span class="typography-body-small-semibold">My Account</span>
+        <span class="typography-action-small">My Account</span>
       </a>
     </li>
   </ul>
@@ -250,7 +250,7 @@ With Buttons and NavigationAvatar:
             <use href="/assets/icons/svg/sprite.svg#profile" />
           </svg>
         </span>
-        <span class="typography-body-small-semibold">My Account</span>
+        <span class="typography-action-small">My Account</span>
       </a>
     </li>
   </ul>

--- a/packages/web/src/scss/components/Navigation/_NavigationAction.scss
+++ b/packages/web/src/scss/components/Navigation/_NavigationAction.scss
@@ -1,8 +1,7 @@
-// 1. We want specific typography for nested items in the Navigation component.
-// 2. We want the selected and open states to override the hover and active states.
-// 3. Nested sub-item slots are hidden via structural nesting.
-// 4. Keep open parent gray when a selected sub-item is present.
-// 5. Label may be wrapped in a span; use display: contents so flex gap still applies between label text, slots, and icons.
+// 1. We want the selected and open states to override the hover and active states.
+// 2. Nested sub-item slots are hidden via structural nesting.
+// 3. Keep open parent gray when a selected sub-item is present.
+// 4. Label may be wrapped in a span; use display: contents so flex gap still applies between label text, slots, and icons.
 
 @use '@tokens' as tokens;
 @use '../../tools/dictionaries';
@@ -15,8 +14,6 @@
 }
 
 .NavigationAction {
-    --#{tokens.$css-variable-prefix}icon-composition-size: #{theme.$action-slot-icon-size};
-
     position: relative;
     display: flex;
     gap: theme.$action-gap;
@@ -48,7 +45,7 @@
     background-color: theme.$action-stripe-background-color-state-default;
 }
 
-// 5.
+// 4.
 .NavigationAction > span:not(.NavigationAction__slot) {
     display: contents;
 }
@@ -58,7 +55,7 @@
     align-items: center;
 }
 
-// stylelint-disable-next-line selector-max-compound-selectors -- 3.
+// stylelint-disable-next-line selector-max-compound-selectors -- 2.
 .Navigation--vertical > ul ul .NavigationAction__slot {
     display: none;
 }
@@ -68,6 +65,8 @@
 }
 
 .Navigation--horizontal {
+    --#{tokens.$css-variable-prefix}icon-composition-size: #{theme.$horizontal-action-slot-icon-size};
+
     @include dictionaries.generate-variants(
         $class-name: 'NavigationAction',
         $dictionary-values: theme.$action-shape-variant-dictionary,
@@ -76,19 +75,13 @@
 }
 
 .Navigation--vertical {
+    --#{tokens.$css-variable-prefix}icon-composition-size: #{theme.$vertical-action-slot-icon-size};
+
     @include dictionaries.generate-variants(
         $class-name: 'NavigationAction',
         $dictionary-values: theme.$action-shape-variant-dictionary,
         $config: theme.$vertical-action-shape-variant-config
     );
-}
-
-// stylelint-disable-next-line selector-max-compound-selectors, selector-max-specificity -- 1.
-.Navigation--vertical
-    > ul
-    ul
-    .NavigationAction:not(:is(.NavigationAction--selected, .NavigationAction[aria-expanded='true'])) {
-    @include typography.generate(theme.$vertical-action-typography-nested);
 }
 
 .NavigationAction--selected {
@@ -103,7 +96,7 @@
     background-color: theme.$action-background-color-state-open;
 }
 
-// stylelint-disable-next-line selector-max-specificity, selector-max-class -- 4.
+// stylelint-disable-next-line selector-max-specificity, selector-max-class -- 3.
 .Navigation--vertical .NavigationItem:has(> .NavigationAction--selected) > .NavigationAction[aria-expanded='true'] {
     color: theme.$action-color-state-default;
     background-color: theme.$action-background-color-state-open;
@@ -146,7 +139,7 @@
     background-color: theme.$horizontal-action-stripe-background-color-state-active;
 }
 
-// stylelint-disable selector-max-specificity, selector-max-class -- 2.
+// stylelint-disable selector-max-specificity, selector-max-class -- 1.
 .Navigation--horizontal .NavigationAction--box.NavigationAction--selected {
     @media (hover: hover) {
         &:hover::after {

--- a/packages/web/src/scss/components/Navigation/_NavigationAvatar.scss
+++ b/packages/web/src/scss/components/Navigation/_NavigationAvatar.scss
@@ -12,6 +12,8 @@
 }
 
 .NavigationAvatar {
+    @include typography.generate(theme.$avatar-typography);
+
     display: flex;
     gap: theme.$avatar-gap;
     align-items: center;

--- a/packages/web/src/scss/components/Navigation/_theme.scss
+++ b/packages/web/src/scss/components/Navigation/_theme.scss
@@ -26,11 +26,9 @@ $action-color-state-disabled: tokens.$disabled-content;
 $action-color-state-hover: tokens.$component-navigation-item-state-hover;
 $action-color-state-selected: tokens.$component-navigation-item-state-selected;
 
-$action-gap: tokens.$space-700;
+$action-gap: tokens.$space-500;
 
 $action-shape-variant-dictionary: dictionaries.$shape-variants;
-
-$action-slot-icon-size: units.px-to-rem(20px);
 
 $action-stripe-background-color-selected-state-active: tokens.$component-navigation-item-stripe-state-selected;
 $action-stripe-background-color-selected-state-default: tokens.$component-navigation-item-stripe-state-selected;
@@ -40,7 +38,7 @@ $action-stripe-background-color-state-default: transparent;
 $horizontal-action-stripe-background-color-state-active: tokens.$component-navigation-item-stripe-state-unselected;
 $horizontal-action-stripe-background-color-state-hover: tokens.$component-navigation-item-stripe-state-unselected;
 $horizontal-action-stripe-size: units.px-to-rem(2px);
-$horizontal-action-typography: tokens.$body-small-semibold;
+$horizontal-action-typography: tokens.$action-small;
 $horizontal-action-shape-variant-config: (
     box: (
         padding-x: tokens.$space-700,
@@ -53,9 +51,9 @@ $horizontal-action-shape-variant-config: (
         border-radius: tokens.$radius-full,
     ),
 );
+$horizontal-action-slot-icon-size: units.px-to-rem(16px);
 
-$vertical-action-typography-nested: tokens.$body-medium-regular;
-$vertical-action-typography: tokens.$body-medium-semibold;
+$vertical-action-typography: tokens.$action-medium;
 $vertical-action-shape-variant-config: (
     box: (
         padding-x: tokens.$space-700,
@@ -68,11 +66,12 @@ $vertical-action-shape-variant-config: (
         border-radius: tokens.$radius-full,
     ),
 );
+$vertical-action-slot-icon-size: units.px-to-rem(20px);
 
 $avatar-gap: tokens.$space-500;
-$avatar-padding-y: tokens.$space-400;
-$avatar-padding-end: tokens.$space-600;
-$avatar-padding-start: tokens.$space-500;
+$avatar-padding-y: tokens.$space-300;
+$avatar-padding-end: tokens.$space-700;
+$avatar-padding-start: tokens.$space-300;
 
 $avatar-color-state-default: tokens.$component-navigation-item-state-default;
 $avatar-color-state-hover: tokens.$component-navigation-item-state-hover;
@@ -86,3 +85,4 @@ $avatar-background-color-state-default: tokens.$component-navigation-item-backgr
 $avatar-background-color-state-hover: tokens.$component-navigation-item-background-state-hover;
 $avatar-background-color-state-active: tokens.$component-navigation-item-background-state-active;
 $avatar-background-color-state-selected: tokens.$component-navigation-item-background-state-selected;
+$avatar-typography: tokens.$action-small;

--- a/packages/web/src/scss/components/Navigation/index.html
+++ b/packages/web/src/scss/components/Navigation/index.html
@@ -583,7 +583,7 @@
                   <use href="/assets/icons/svg/sprite.svg#profile" />
                 </svg>
               </span>
-              <span class="typography-body-small-semibold">My Account</span>
+              My Account
             </div>
           </li>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
@@ -598,7 +598,7 @@
                   <use href="/assets/icons/svg/sprite.svg#profile" />
                 </svg>
               </span>
-              <span class="typography-body-small-semibold">My Account</span>
+              My Account
             </div>
           </li>
         </ul>
@@ -632,7 +632,7 @@
                   <use href="/assets/icons/svg/sprite.svg#profile" />
                 </svg>
               </span>
-              <span class="typography-body-small-semibold">My Account</span>
+              My Account
             </a>
           </li>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
@@ -647,7 +647,7 @@
                   <use href="/assets/icons/svg/sprite.svg#profile" />
                 </svg>
               </span>
-              <span class="typography-body-small-semibold">My Account</span>
+              My Account
             </a>
           </li>
         </ul>
@@ -690,7 +690,7 @@
                     <use href="/assets/icons/svg/sprite.svg#profile" />
                   </svg>
                 </span>
-                <span class="typography-body-small-semibold">My Account</span>
+                My Account
                 <svg
                   width="20"
                   height="20"
@@ -760,7 +760,7 @@
                     <use href="/assets/icons/svg/sprite.svg#profile" />
                   </svg>
                 </span>
-                <span class="typography-body-small-semibold">My Account</span>
+                My Account
                 <svg
                   width="20"
                   height="20"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

- [x] ~replace `<span className="typography-action-small" />` with `<ActionText />` in the React once the component is created #2770~ → Not needed. We can apply `typography-action-small` style in the `.NavigationAvatar` 🎉  

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

https://jira.almacareer.tech/browse/DS-2554

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
