### PR TITLE
feat(web,web-react)!: expose `DrawerPanel` composition sub-components #DS-2656

### DIFF
--- a/apps/demo/partials/header.hbs
+++ b/apps/demo/partials/header.hbs
@@ -64,7 +64,7 @@
 <!-- Drawer: start -->
 <dialog id="off-canvas-navigation" class="Drawer Drawer--right" aria-label="Menu">
   <div class="DrawerPanel">
-    <div class="DrawerPanel__header">
+    <header class="DrawerPanelHeader">
       <button
         type="button"
         class="ControlButton ControlButton--large text-color-scheme dynamic-color-background-interactive accessibility-tap-target ControlButton--hasBackground dynamic-color-border ControlButton--symmetrical"
@@ -78,8 +78,8 @@
         </svg>
         <span class="accessibility-hidden">Close</span>
       </button>
-    </div>
-    <div class="DrawerPanel__content">
+    </header>
+    <div class="DrawerPanelBody">
 
       <div class="Stack Stack--spacing mb-900" style="--stack-spacing: var(--spirit-space-1200)">
         <!-- Drawer Main Navigation: start -->

--- a/docs/migrations/web-react/migration-v5.md
+++ b/docs/migrations/web-react/migration-v5.md
@@ -28,6 +28,7 @@ Introducing version 5 of the _spirit-web-react_ package.
   - [Stack: Wrap Direct Children in `StackItem` When Using Dividers](#stack-wrap-direct-children-in-stackitem-when-using-dividers)
   - [ControlButton: Expanded Size Scale Feature Flag Removed](#controlbutton-expanded-size-scale-feature-flag-removed)
   - [Close Buttons Unified Into `CloseButton`](#close-buttons-unified-into-closebutton)
+  - [DrawerPanel: Restructured with Sub-components](#drawerpanel-restructured-with-sub-components)
 
 ## General Changes
 
@@ -725,22 +726,23 @@ communicated through the action's background and color only.
 
 ### Close Buttons Unified Into `CloseButton`
 
-The component-specific close buttons — `DrawerCloseButton`, `ModalCloseButton`, and `TooltipCloseButton` — have
-been **removed** in favor of the single shared [`CloseButton`][readme-close-button] component. Their prop types
-(`DrawerCloseButtonProps`, `ModalCloseButtonProps`, `TooltipCloseButtonProps`) were removed as well.
+The component-specific close buttons — `ModalCloseButton` and `TooltipCloseButton` — have been **removed** in
+favor of the single shared [`CloseButton`][readme-close-button] component. Their prop types
+(`ModalCloseButtonProps`, `TooltipCloseButtonProps`) were removed as well.
 
 The Modal and Tooltip close buttons are rendered internally (through `ModalHeader`'s `hasCloseButton` and
-`TooltipPopover`'s `isDismissible`), so most projects only need to migrate direct usages and `DrawerCloseButton`.
+`TooltipPopover`'s `isDismissible`), so most projects only need to migrate direct usages.
 
-| Removed                    | Replacement                                                                                                                                 |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<ModalCloseButton … />`   | `<CloseButton size="xlarge" aria-controls={id} aria-expanded={isOpen} onClick={onClose} … />`                                               |
-| `<TooltipCloseButton … />` | `<CloseButton aria-expanded="true" onClick={onClose} … />`                                                                                  |
-| `<DrawerCloseButton />`    | `<CloseButton size="large" aria-controls={id} aria-expanded={isOpen} onClick={onClose} … />` (codemod scaffolds with `TODO_*` placeholders) |
+`DrawerCloseButton` was also removed — see [DrawerPanel: Restructured with Sub-components](#drawerpanel-restructured-with-sub-components) for the complete Drawer migration.
+
+| Removed                    | Replacement                                                                                   |
+| -------------------------- | --------------------------------------------------------------------------------------------- |
+| `<ModalCloseButton … />`   | `<CloseButton size="xlarge" aria-controls={id} aria-expanded={isOpen} onClick={onClose} … />` |
+| `<TooltipCloseButton … />` | `<CloseButton aria-expanded="true" onClick={onClose} … />`                                    |
 
 #### Migration Guide
 
-🪄 Use codemods to migrate all three close buttons:
+🪄 Use codemods to migrate:
 
 ```sh
 npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/close-buttons-to-close-button
@@ -748,31 +750,8 @@ npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/close-buttons-to-close-b
 
 👉 See [Codemods documentation][readme-codemods] for more details.
 
-ℹ️ `ModalCloseButton` and `TooltipCloseButton` are migrated fully. `DrawerCloseButton` took its `onClick`,
-`aria-controls`, and `aria-expanded` from the drawer context, which is unavailable at the call site, so the
-codemod **scaffolds** it: it emits a `CloseButton size="large"` with `TODO_drawerIsOpen`, `TODO_drawerId`, and
-`TODO_drawerOnClose` placeholder identifiers. They are intentionally undefined — your build fails until you
-replace them with the drawer's open state, `id`, and `onClose` handler (see below).
-
 <details>
   <summary>🔧 Manual Migration Steps</summary>
-
-**`DrawerCloseButton`** — the codemod replaces it with a scaffolded `CloseButton` carrying `TODO_*` placeholder
-identifiers. Finish the migration by replacing each placeholder with the drawer's real open state, `id`, and
-`onClose` handler:
-
-```diff
-  <Drawer id="my-drawer" isOpen={isOpen} onClose={handleClose}>
-    <DrawerPanel
-      closeButton={
--       <CloseButton size="large" aria-expanded={TODO_drawerIsOpen} aria-controls={TODO_drawerId} onClick={TODO_drawerOnClose} />
-+       <CloseButton size="large" aria-expanded={isOpen} aria-controls="my-drawer" onClick={handleClose} />
-      }
-    >
-      {/* … */}
-    </DrawerPanel>
-  </Drawer>
-```
 
 **`ModalCloseButton`** — only if you used it directly; `ModalHeader` still renders it for you via `hasCloseButton`:
 
@@ -793,11 +772,71 @@ identifiers. Finish the migration by replacing each placeholder with the drawer'
 
 ---
 
+### DrawerPanel: Restructured with Sub-components
+
+`DrawerCloseButton` has been removed. The panel's interior is now structured with two explicit sub-components:
+
+- **`DrawerPanelHeader`** — renders the top bar; place the close button (and any title) here.
+- **`DrawerPanelBody`** — renders the scrollable body; accepts `hasSpacing` for built-in padding.
+
+Additionally, `<Drawer>` now requires an `aria-label` so the underlying `<dialog>` element has an accessible name.
+
+| Removed                       | Replacement                                                   |
+| ----------------------------- | ------------------------------------------------------------- |
+| `<DrawerCloseButton />`       | `<CloseButton size="large" … />` inside `<DrawerPanelHeader>` |
+| `hasSpacing` on `DrawerPanel` | `hasSpacing` on `DrawerPanelBody`                             |
+
+#### Migration Guide
+
+🪄 Use the codemod to migrate automatically:
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/drawer-panel-close-button-composition
+```
+
+ℹ️ The codemod replaces `DrawerCloseButton` with a scaffolded `CloseButton size="large"` carrying
+`TODO_drawerIsOpen`, `TODO_drawerId`, and `TODO_drawerOnClose` placeholder identifiers. They are intentionally
+undefined — your build fails until you replace them with the drawer's open state, `id`, and `onClose` handler.
+
+👉 See [Codemods documentation][readme-codemods] for more details.
+
+<details>
+  <summary>🔧 Manual Migration Steps</summary>
+
+```diff
+- <Drawer id="my-drawer" isOpen={isOpen} onClose={handleClose}>
++ <Drawer id="my-drawer" isOpen={isOpen} onClose={handleClose} aria-label="Navigation">
+    <DrawerPanel
+-     closeButton={<DrawerCloseButton />}
+-     hasSpacing
+    >
++     <DrawerPanelHeader>
++       <CloseButton size="large" aria-expanded={isOpen} aria-controls="my-drawer" onClick={handleClose} />
++     </DrawerPanelHeader>
++     <DrawerPanelBody hasSpacing>
+        {/* drawer body */}
++     </DrawerPanelBody>
+    </DrawerPanel>
+  </Drawer>
+```
+
+Update your imports:
+
+```diff
+- import { Drawer, DrawerCloseButton, DrawerPanel } from '@alma-oss/spirit-web-react';
++ import { CloseButton, Drawer, DrawerPanel, DrawerPanelHeader, DrawerPanelBody } from '@alma-oss/spirit-web-react';
+```
+
+</details>
+
+---
+
 Please refer back to these instructions or reach out to our team if you encounter any issues during migration.
 
 [migration-guide-web]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/migrations/web/migration-v5.md
 [readme-close-button]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/CloseButton/README.md
 [readme-codemods]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/codemods/README.md
+[readme-drawer]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/Drawer/README.md
 [readme-file]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/File/README.md
 [readme-file-upload]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/FileUpload/README.md
 [readme-grid]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/Grid/README.md

--- a/docs/migrations/web/migration-v5.md
+++ b/docs/migrations/web/migration-v5.md
@@ -24,6 +24,7 @@ Introducing version 5 of the _spirit-web_ package.
   - [ControlButton: Expanded Size Scale Feature Flag Removed](#controlbutton-expanded-size-scale-feature-flag-removed)
   - [Disabled Utility for Color-Scheme Components](#disabled-utility-for-color-scheme-components)
   - [Toggle: Input Before Label in HTML](#toggle-input-before-label-in-html)
+  - [DrawerPanel: Restructured with Sub-components](#drawerpanel-restructured-with-sub-components)
 
 ## General Changes
 
@@ -632,8 +633,43 @@ If you provided any custom CSS depending on the order of Toggle children, you wi
 
 ---
 
+### DrawerPanel: Restructured with Sub-components
+
+The `DrawerPanel` interior has been restructured. The old `DrawerPanel__content` element — which previously
+wrapped both the close button and the drawer body — has been replaced by two explicit sub-components:
+`DrawerPanelHeader` for the close button and `DrawerPanelBody` for the scrollable body.
+
+| Old class              | New classes                             |
+| ---------------------- | --------------------------------------- |
+| `DrawerPanel__content` | `DrawerPanelHeader` + `DrawerPanelBody` |
+
+#### Migration Guide
+
+<details>
+  <summary>🔧 Manual Migration Steps</summary>
+
+```diff
+  <div class="DrawerPanel">
+-   <div class="DrawerPanel__content">
+-     <!-- close button -->
+-     <!-- drawer body -->
+-   </div>
++   <header class="DrawerPanelHeader">
++     <!-- close button -->
++   </header>
++   <div class="DrawerPanelBody">
++     <!-- drawer body -->
++   </div>
+  </div>
+```
+
+</details>
+
+---
+
 Please refer back to these instructions or reach out to our team if you encounter any issues during migration.
 
+[readme-drawer]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/Drawer/README.md
 [readme-grid]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/Grid/README.md
 [readme-header]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/Header/README.md
 [readme-item]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/Item/README.md

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/close-buttons-to-close-button.input.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/close-buttons-to-close-button.input.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 // @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
-import { Drawer, DrawerCloseButton, DrawerPanel, Modal, ModalCloseButton, Tooltip, TooltipCloseButton } from '@alma-oss/spirit-web-react';
-
-export const MyDrawer = ({ id, isOpen, onClose }) => (
-  <Drawer id={id} isOpen={isOpen} onClose={onClose}>
-    <DrawerPanel closeButton={<DrawerCloseButton />}>Drawer content</DrawerPanel>
-  </Drawer>
-);
+import { Modal, ModalCloseButton, Tooltip, TooltipCloseButton } from '@alma-oss/spirit-web-react';
 
 export const MyModal = ({ id, isOpen, onClose }) => (
   <Modal id={id} isOpen={isOpen} onClose={onClose}>

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/close-buttons-to-close-button.output.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/close-buttons-to-close-button.output.tsx
@@ -1,16 +1,6 @@
 import React from 'react';
 // @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
-import { Drawer, DrawerPanel, Modal, Tooltip, CloseButton } from '@alma-oss/spirit-web-react';
-
-export const MyDrawer = ({ id, isOpen, onClose }) => (
-  <Drawer id={id} isOpen={isOpen} onClose={onClose}>
-    <DrawerPanel closeButton={<CloseButton
-      size="large"
-      aria-expanded={TODO_drawerIsOpen}
-      aria-controls={TODO_drawerId}
-      onClick={TODO_drawerOnClose} />}>Drawer content</DrawerPanel>
-  </Drawer>
-);
+import { Modal, Tooltip, CloseButton } from '@alma-oss/spirit-web-react';
 
 export const MyModal = ({ id, isOpen, onClose }) => (
   <Modal id={id} isOpen={isOpen} onClose={onClose}>

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/drawer-panel-close-button-composition.input.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/drawer-panel-close-button-composition.input.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import { Drawer, DrawerCloseButton, DrawerPanel } from '@alma-oss/spirit-web-react';
+
+export const WithCloseButton = ({ isOpen, onClose }) => (
+  <Drawer id="my-drawer" isOpen={isOpen} onClose={onClose} aria-label="Navigation">
+    <DrawerPanel closeButton={<DrawerCloseButton />}>
+      <p>Drawer content</p>
+    </DrawerPanel>
+  </Drawer>
+);
+
+export const WithoutCloseButton = ({ isOpen, onClose }) => (
+  <Drawer id="my-drawer-no-btn" isOpen={isOpen} onClose={onClose} aria-label="Navigation">
+    <DrawerPanel>
+      <p>Unaffected drawer</p>
+    </DrawerPanel>
+  </Drawer>
+);

--- a/packages/codemods/src/transforms/v5/web-react/__testfixtures__/drawer-panel-close-button-composition.output.tsx
+++ b/packages/codemods/src/transforms/v5/web-react/__testfixtures__/drawer-panel-close-button-composition.output.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+// @ts-ignore: No declaration -- The library is not installed; we don't need to install it for fixtures.
+import { Drawer, DrawerPanel, CloseButton, DrawerPanelHeader, DrawerPanelBody } from '@alma-oss/spirit-web-react';
+
+export const WithCloseButton = ({ isOpen, onClose }) => (
+  <Drawer id="my-drawer" isOpen={isOpen} onClose={onClose} aria-label="Navigation">
+    <DrawerPanel><DrawerPanelHeader><CloseButton
+          size='large'
+          aria-expanded={TODO_drawerIsOpen}
+          aria-controls={TODO_drawerId}
+          onClick={TODO_drawerOnClose} /></DrawerPanelHeader><DrawerPanelBody>
+        <p>Drawer content</p>
+      </DrawerPanelBody></DrawerPanel>
+  </Drawer>
+);
+
+export const WithoutCloseButton = ({ isOpen, onClose }) => (
+  <Drawer id="my-drawer-no-btn" isOpen={isOpen} onClose={onClose} aria-label="Navigation">
+    <DrawerPanel>
+      <p>Unaffected drawer</p>
+    </DrawerPanel>
+  </Drawer>
+);

--- a/packages/codemods/src/transforms/v5/web-react/__tests__/drawer-panel-close-button-composition.test.ts
+++ b/packages/codemods/src/transforms/v5/web-react/__tests__/drawer-panel-close-button-composition.test.ts
@@ -1,0 +1,3 @@
+import { testTransform } from '../../../../../tests/testUtils';
+
+testTransform(__dirname, 'drawer-panel-close-button-composition');

--- a/packages/codemods/src/transforms/v5/web-react/close-buttons-to-close-button.ts
+++ b/packages/codemods/src/transforms/v5/web-react/close-buttons-to-close-button.ts
@@ -11,16 +11,7 @@ const MODAL_ATTRIBUTE_RENAMES: Record<string, string> = {
   onClose: 'onClick',
 };
 
-// DrawerCloseButton took its wiring from the drawer context, which is unavailable at the call site.
-// The codemod scaffolds the props with `TODO_`-prefixed placeholder identifiers so the build fails
-// until the user finishes the wiring (replacing them with the drawer's open state, id, and handler).
-const DRAWER_TODO_ATTRIBUTES: Array<[name: string, placeholder: string]> = [
-  ['aria-expanded', 'TODO_drawerIsOpen'],
-  ['aria-controls', 'TODO_drawerId'],
-  ['onClick', 'TODO_drawerOnClose'],
-];
-
-const REMOVED_COMPONENTS = new Set(['DrawerCloseButton', 'ModalCloseButton', 'TooltipCloseButton']);
+const REMOVED_COMPONENTS = new Set(['ModalCloseButton', 'TooltipCloseButton']);
 
 const hasAttribute = (attributes: (JSXAttribute | JSXSpreadAttribute)[], name: string): boolean =>
   attributes.some(
@@ -43,7 +34,6 @@ const transform = (fileInfo: FileInfo, api: API) => {
   }
 
   // Resolve the local names the removed components are imported under (handles aliasing).
-  const drawerLocalNames = new Set<string>();
   const modalLocalNames = new Set<string>();
   const tooltipLocalNames = new Set<string>();
 
@@ -52,10 +42,6 @@ const transform = (fileInfo: FileInfo, api: API) => {
       if (specifier.type === 'ImportSpecifier' && specifier.imported.type === 'Identifier') {
         const importedName = specifier.imported.name;
         const localName = specifier.local?.name ?? importedName;
-
-        if (importedName === 'DrawerCloseButton') {
-          drawerLocalNames.add(localName);
-        }
 
         if (importedName === 'ModalCloseButton') {
           modalLocalNames.add(localName);
@@ -68,7 +54,7 @@ const transform = (fileInfo: FileInfo, api: API) => {
     });
   });
 
-  if (drawerLocalNames.size === 0 && modalLocalNames.size === 0 && tooltipLocalNames.size === 0) {
+  if (modalLocalNames.size === 0 && tooltipLocalNames.size === 0) {
     return fileInfo.source;
   }
 
@@ -81,29 +67,14 @@ const transform = (fileInfo: FileInfo, api: API) => {
       return;
     }
 
-    const isDrawer = drawerLocalNames.has(name.name);
     const isModal = modalLocalNames.has(name.name);
     const isTooltip = tooltipLocalNames.has(name.name);
 
-    if (!isDrawer && !isModal && !isTooltip) {
+    if (!isModal && !isTooltip) {
       return;
     }
 
     const attributes = path.node.attributes ?? [];
-
-    if (isDrawer) {
-      if (!hasAttribute(attributes, 'size')) {
-        attributes.unshift(j.jsxAttribute(j.jsxIdentifier('size'), j.stringLiteral('large')));
-      }
-
-      DRAWER_TODO_ATTRIBUTES.forEach(([attributeName, placeholder]) => {
-        if (!hasAttribute(attributes, attributeName)) {
-          attributes.push(
-            j.jsxAttribute(j.jsxIdentifier(attributeName), j.jsxExpressionContainer(j.identifier(placeholder))),
-          );
-        }
-      });
-    }
 
     if (isModal) {
       attributes.forEach((attribute) => {

--- a/packages/codemods/src/transforms/v5/web-react/drawer-panel-close-button-composition.ts
+++ b/packages/codemods/src/transforms/v5/web-react/drawer-panel-close-button-composition.ts
@@ -1,0 +1,165 @@
+import { API, FileInfo, Identifier, JSXAttribute, JSXElement, JSXIdentifier, JSXSpreadAttribute } from 'jscodeshift';
+import { removeParentheses } from '../../../helpers';
+
+const SPIRIT_WEB_REACT_MODULE = /^@alma-oss\/spirit-web-react(\/.*)?$/;
+
+// DrawerCloseButton took its wiring from the drawer context, which is unavailable at the call site.
+// The codemod scaffolds the props with `TODO_`-prefixed placeholder identifiers so the build fails
+// until the user finishes the wiring (replacing them with the drawer's open state, id, and handler).
+const DRAWER_TODO_ATTRIBUTES: Array<[name: string, placeholder: string]> = [
+  ['aria-expanded', 'TODO_drawerIsOpen'],
+  ['aria-controls', 'TODO_drawerId'],
+  ['onClick', 'TODO_drawerOnClose'],
+];
+
+const findAttr = (attributes: (JSXAttribute | JSXSpreadAttribute)[], name: string): JSXAttribute | undefined =>
+  attributes.find(
+    (attr): attr is JSXAttribute =>
+      attr.type === 'JSXAttribute' && attr.name.type === 'JSXIdentifier' && attr.name.name === name,
+  );
+
+const hasAttr = (attributes: (JSXAttribute | JSXSpreadAttribute)[], name: string): boolean =>
+  attributes.some(
+    (attr) => attr.type === 'JSXAttribute' && attr.name.type === 'JSXIdentifier' && attr.name.name === name,
+  );
+
+const transform = (fileInfo: FileInfo, api: API) => {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+
+  const spiritImports = root.find(j.ImportDeclaration, {
+    source: { value: (value: string) => SPIRIT_WEB_REACT_MODULE.test(value) },
+  });
+
+  if (spiritImports.length === 0) {
+    return fileInfo.source;
+  }
+
+  const drawerPanelImport = spiritImports.find(j.ImportSpecifier, {
+    imported: { type: 'Identifier', name: 'DrawerPanel' },
+  });
+
+  if (drawerPanelImport.length === 0) {
+    return fileInfo.source;
+  }
+
+  let modified = false;
+  let hadDrawerCloseButton = false;
+
+  root
+    .find(j.JSXElement, {
+      openingElement: { name: { type: 'JSXIdentifier', name: 'DrawerPanel' } },
+    })
+    .forEach((path) => {
+      const { openingElement } = path.node;
+      const attrs = (openingElement.attributes ?? []) as (JSXAttribute | JSXSpreadAttribute)[];
+
+      const closeButtonAttr = findAttr(attrs, 'closeButton');
+      if (!closeButtonAttr) return;
+
+      openingElement.attributes = attrs.filter(
+        (attr) =>
+          !(attr.type === 'JSXAttribute' && attr.name.type === 'JSXIdentifier' && attr.name.name === 'closeButton'),
+      );
+
+      const closeButtonValue =
+        closeButtonAttr.value?.type === 'JSXExpressionContainer' &&
+        closeButtonAttr.value.expression.type !== 'JSXEmptyExpression'
+          ? closeButtonAttr.value.expression
+          : null;
+
+      // If the closeButton value is a DrawerCloseButton, replace it with a scaffolded CloseButton.
+      if (
+        closeButtonValue?.type === 'JSXElement' &&
+        closeButtonValue.openingElement.name.type === 'JSXIdentifier' &&
+        closeButtonValue.openingElement.name.name === 'DrawerCloseButton'
+      ) {
+        const cbAttrs = (closeButtonValue.openingElement.attributes ?? []) as (JSXAttribute | JSXSpreadAttribute)[];
+
+        if (!hasAttr(cbAttrs, 'size')) {
+          cbAttrs.unshift(j.jsxAttribute(j.jsxIdentifier('size'), j.stringLiteral('large')));
+        }
+
+        DRAWER_TODO_ATTRIBUTES.forEach(([attrName, placeholder]) => {
+          if (!hasAttr(cbAttrs, attrName)) {
+            cbAttrs.push(
+              j.jsxAttribute(j.jsxIdentifier(attrName), j.jsxExpressionContainer(j.identifier(placeholder))),
+            );
+          }
+        });
+
+        closeButtonValue.openingElement.attributes = cbAttrs;
+        (closeButtonValue.openingElement.name as JSXIdentifier).name = 'CloseButton';
+        if (closeButtonValue.closingElement) {
+          (closeButtonValue.closingElement.name as JSXIdentifier).name = 'CloseButton';
+        }
+
+        hadDrawerCloseButton = true;
+      }
+
+      const headerChildren: NonNullable<JSXElement['children']> = closeButtonValue
+        ? [closeButtonValue as NonNullable<JSXElement['children']>[number]]
+        : [];
+
+      const headerElement = j.jsxElement(
+        j.jsxOpeningElement(j.jsxIdentifier('DrawerPanelHeader'), []),
+        j.jsxClosingElement(j.jsxIdentifier('DrawerPanelHeader')),
+        headerChildren,
+      );
+
+      const bodyElement = j.jsxElement(
+        j.jsxOpeningElement(j.jsxIdentifier('DrawerPanelBody'), []),
+        j.jsxClosingElement(j.jsxIdentifier('DrawerPanelBody')),
+        path.node.children ?? [],
+      );
+
+      path.node.children = [headerElement, bodyElement];
+      modified = true;
+    });
+
+  if (!modified) {
+    return fileInfo.source;
+  }
+
+  spiritImports.forEach((importPath) => {
+    const specifiers = importPath.node.specifiers ?? [];
+
+    const hasDrawerPanel = specifiers.some(
+      (spec) => spec.type === 'ImportSpecifier' && (spec.imported as Identifier).name === 'DrawerPanel',
+    );
+
+    if (!hasDrawerPanel) return;
+
+    if (hadDrawerCloseButton) {
+      importPath.node.specifiers = specifiers.filter(
+        (spec) => !(spec.type === 'ImportSpecifier' && (spec.imported as Identifier).name === 'DrawerCloseButton'),
+      );
+    }
+
+    const updatedSpecifiers = importPath.node.specifiers ?? [];
+
+    const alreadyHasCloseButton = updatedSpecifiers.some(
+      (spec) => spec.type === 'ImportSpecifier' && (spec.imported as Identifier).name === 'CloseButton',
+    );
+    const alreadyHasHeader = updatedSpecifiers.some(
+      (spec) => spec.type === 'ImportSpecifier' && (spec.imported as Identifier).name === 'DrawerPanelHeader',
+    );
+    const alreadyHasBody = updatedSpecifiers.some(
+      (spec) => spec.type === 'ImportSpecifier' && (spec.imported as Identifier).name === 'DrawerPanelBody',
+    );
+
+    if (hadDrawerCloseButton && !alreadyHasCloseButton) {
+      updatedSpecifiers.push(j.importSpecifier(j.identifier('CloseButton')));
+    }
+    if (!alreadyHasHeader) {
+      updatedSpecifiers.push(j.importSpecifier(j.identifier('DrawerPanelHeader')));
+    }
+    if (!alreadyHasBody) {
+      updatedSpecifiers.push(j.importSpecifier(j.identifier('DrawerPanelBody')));
+    }
+  });
+
+  return removeParentheses(root.toSource({ quote: 'single' }));
+};
+
+export default transform;

--- a/packages/web-react/src/components/Drawer/DrawerPanel.tsx
+++ b/packages/web-react/src/components/Drawer/DrawerPanel.tsx
@@ -15,7 +15,7 @@ const _DrawerPanel = <E extends ElementType = DrawerPanelElementType>(
   props: DrawerPanelProps<E>,
   ref: PolymorphicRef<E>,
 ) => {
-  const { elementType = 'div', children, closeButton, ...restProps } = props;
+  const { elementType = 'div', children, ...restProps } = props;
 
   const Component = elementType as ElementType;
 
@@ -25,8 +25,7 @@ const _DrawerPanel = <E extends ElementType = DrawerPanelElementType>(
 
   return (
     <Component {...(otherProps as HTMLAttributes<HTMLElement>)} {...mergedStyleProps} ref={ref}>
-      {closeButton && <div className={classProps.header}>{closeButton}</div>}
-      <div className={classProps.content}>{children}</div>
+      {children}
     </Component>
   );
 };

--- a/packages/web-react/src/components/Drawer/DrawerPanelBody.tsx
+++ b/packages/web-react/src/components/Drawer/DrawerPanelBody.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import classNames from 'classnames';
+import React from 'react';
+import { useStyleProps } from '../../hooks';
+import { type DrawerPanelBodyProps } from '../../types';
+import { useDrawerStyleProps } from './useDrawerStyleProps';
+
+const DrawerPanelBody = ({ children, hasSpacing = false, ...restProps }: DrawerPanelBodyProps) => {
+  const { classProps } = useDrawerStyleProps({ hasSpacing });
+  const { styleProps, props: otherProps } = useStyleProps(restProps);
+
+  return (
+    <div {...otherProps} {...styleProps} className={classNames(classProps.content, styleProps.className)}>
+      {children}
+    </div>
+  );
+};
+
+DrawerPanelBody.spiritComponent = 'DrawerPanelBody';
+
+export default DrawerPanelBody;

--- a/packages/web-react/src/components/Drawer/DrawerPanelHeader.tsx
+++ b/packages/web-react/src/components/Drawer/DrawerPanelHeader.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import classNames from 'classnames';
+import React from 'react';
+import { useStyleProps } from '../../hooks';
+import { type DrawerPanelHeaderProps } from '../../types';
+import { useDrawerStyleProps } from './useDrawerStyleProps';
+
+const DrawerPanelHeader = ({ children, ...restProps }: DrawerPanelHeaderProps) => {
+  const { classProps } = useDrawerStyleProps();
+  const { styleProps, props: otherProps } = useStyleProps(restProps);
+
+  return (
+    <header {...otherProps} {...styleProps} className={classNames(classProps.header, styleProps.className)}>
+      {children}
+    </header>
+  );
+};
+
+DrawerPanelHeader.spiritComponent = 'DrawerPanelHeader';
+
+export default DrawerPanelHeader;

--- a/packages/web-react/src/components/Drawer/README.md
+++ b/packages/web-react/src/components/Drawer/README.md
@@ -6,19 +6,15 @@ The Drawer is a composition of several subcomponents:
 
 - [Drawer](#drawer)
   - [DrawerPanel](#drawerpanel)
-    - [CloseButton](#closebutton)
-
-## Accessibility Guidelines
-
-👉 The animation effect of this component is dependent on the
-`prefers-reduced-motion` media query.
+    - [DrawerPanelHeader](#drawerpanelheader)
+    - [DrawerPanelBody](#drawerpanelcontent)
 
 ## Drawer
 
 ```tsx
 const [isOpen, setOpen] = useState(false);
 
-<Drawer id="drawer-dialog-example" isOpen={isOpen} onClose={() => setOpen(false)}>
+<Drawer id="drawer-dialog-example" isOpen={isOpen} onClose={() => setOpen(false)} aria-label="Drawer">
   {/* Drawer Panel goes here */}
 </Drawer>;
 ```
@@ -28,7 +24,7 @@ const [isOpen, setOpen] = useState(false);
 The `Drawer` component allows aligning the content panel horizontally to the left or right side of the screen using `alignmentX` prop. By default, the drawer content panel is aligned to the right.
 
 ```tsx
-<Drawer id="drawer-dialog-example" isOpen={isOpen} onClose={() => setOpen(false)} alignmentX="left">
+<Drawer id="drawer-dialog-example" isOpen={isOpen} onClose={() => setOpen(false)} alignmentX="left" aria-label="Drawer">
   {/* Drawer Panel goes here */}
 </Drawer>
 ```
@@ -38,7 +34,13 @@ The `Drawer` component allows aligning the content panel horizontally to the lef
 By default, the drawer will close when the backdrop is clicked. You can disable this behavior by setting the `closeOnBackdropClick` prop to `false`.
 
 ```tsx
-<Drawer id="drawer-dialog-example" isOpen={isOpen} onClose={() => setOpen(false)} closeOnBackdropClick={false}>
+<Drawer
+  id="drawer-dialog-example"
+  isOpen={isOpen}
+  onClose={() => setOpen(false)}
+  closeOnBackdropClick={false}
+  aria-label="Drawer"
+>
   {/* Drawer content goes here */}
 </Drawer>
 ```
@@ -48,7 +50,13 @@ By default, the drawer will close when the backdrop is clicked. You can disable 
 By default, the drawer will close when the escape key is pressed. You can disable this behavior by setting the `closeOnEscapeKeyDown` prop to `false`.
 
 ```tsx
-<Drawer id="drawer-dialog-example" isOpen={isOpen} onClose={() => setOpen(false)} closeOnEscapeKeyDown={false}>
+<Drawer
+  id="drawer-dialog-example"
+  isOpen={isOpen}
+  onClose={() => setOpen(false)}
+  closeOnEscapeKeyDown={false}
+  aria-label="Drawer"
+>
   {/* Drawer content goes here */}
 </Drawer>
 ```
@@ -74,13 +82,58 @@ and [escape hatches][readme-escape-hatches].
 ## DrawerPanel
 
 The `DrawerPanel` component is a container for the content that will be displayed in the drawer.
-Should there be any spacing around the content of `DrawerPanel`, you need to provide it yourself.
-The `children` are rendered in the panel content area, and the `closeButton` is rendered automatically
-inside the panel header.
+It is composed from the `DrawerPanelHeader` and `DrawerPanelBody` sub-components.
+
+```tsx
+<DrawerPanel>
+  <DrawerPanelHeader>
+    <CloseButton
+      size="large"
+      aria-expanded={isOpen}
+      aria-controls="drawer-dialog-example"
+      onClick={() => setOpen(false)}
+    />
+  </DrawerPanelHeader>
+  <DrawerPanelBody hasSpacing>{/* Drawer content goes here */}</DrawerPanelBody>
+</DrawerPanel>
+```
+
+### API
+
+| Name          | Type          | Default | Required | Description                          |
+| ------------- | ------------- | ------- | -------- | ------------------------------------ |
+| `children`    | `ReactNode`   | —       | ✕        | Children node                        |
+| `elementType` | `ElementType` | `div`   | ✕        | Type of element used as drawer panel |
+
+## DrawerPanelHeader
+
+The `DrawerPanelHeader` component is a container rendered at the top of the `DrawerPanel`.
+It is typically used to hold the `CloseButton`.
+
+```tsx
+<DrawerPanelHeader>
+  <CloseButton
+    size="large"
+    aria-expanded={isOpen}
+    aria-controls="drawer-dialog-example"
+    onClick={() => setOpen(false)}
+  />
+</DrawerPanelHeader>
+```
+
+### API
+
+| Name       | Type        | Default | Required | Description   |
+| ---------- | ----------- | ------- | -------- | ------------- |
+| `children` | `ReactNode` | —       | ✕        | Children node |
+
+On top of the API options, the components accept [additional attributes][readme-additional-attributes].
+If you need more control over the styling of a component, you can use [style props][readme-style-props]
+and [escape hatches][readme-escape-hatches].
 
 ### CloseButton
 
-Pass the shared [`CloseButton`][close-button] through the `closeButton` prop. It is **not** wired up
+Pass the shared [`CloseButton`][close-button] inside `DrawerPanelHeader`. It is **not** wired up
 automatically, so provide:
 
 - `onClick` — your drawer's `onClose` handler
@@ -88,36 +141,60 @@ automatically, so provide:
 - `aria-expanded` — the drawer's open state
 - `size="large"` — to match the drawer close-button size
 
+See the [`CloseButton`][close-button] documentation for its full API.
+
+## DrawerPanelBody
+
+The `DrawerPanelBody` component is a container for the main content of the `DrawerPanel`.
+
+By default it has no inner spacing. Set the `hasSpacing` prop to apply inner spacing consistent with
+`DrawerPanelHeader`, so you don't have to add it yourself.
+
 ```tsx
-<DrawerPanel
-  closeButton={
-    <CloseButton
-      size="large"
-      aria-expanded={isOpen}
-      aria-controls="drawer-dialog-example"
-      onClick={() => setOpen(false)}
-    />
-  }
->
-  {/* Drawer content goes here */}
-</DrawerPanel>
+<DrawerPanelBody hasSpacing>{/* Drawer content goes here */}</DrawerPanelBody>
 ```
 
-See the [`CloseButton`][close-button] documentation for its full API.
+👉 For examples with `Navigation` content inside `DrawerPanelBody`, see the [Header][header-readme] component.
 
 ### API
 
-| Name          | Type          | Default | Required | Description                                      |
-| ------------- | ------------- | ------- | -------- | ------------------------------------------------ |
-| `children`    | `ReactNode`   | —       | ✕        | Children node rendered in the panel content area |
-| `closeButton` | `ReactNode`   | —       | ✕        | Close button rendered inside the panel header    |
-| `elementType` | `ElementType` | `div`   | ✕        | Type of element used as drawer panel             |
+| Name         | Type        | Default | Required | Description                                               |
+| ------------ | ----------- | ------- | -------- | --------------------------------------------------------- |
+| `children`   | `ReactNode` | —       | ✕        | Children node                                             |
+| `hasSpacing` | `bool`      | `false` | ✕        | Whether the content has inner spacing matching the header |
+
+On top of the API options, the components accept [additional attributes][readme-additional-attributes].
+If you need more control over the styling of a component, you can use [style props][readme-style-props]
+and [escape hatches][readme-escape-hatches].
+
+## Accessibility
+
+Always provide an accessible name for the `Drawer` using `aria-label` so screen readers can announce what the dialog contains:
+
+```tsx
+<Drawer id="drawer-example" isOpen={isOpen} onClose={handleClose} aria-label="Navigation">
+  {/* … */}
+</Drawer>
+```
+
+ℹ️ `DrawerPanelHeader` renders as a `<header>` element. When nested inside a `<dialog>`, `<header>` does not
+carry the `banner` landmark role (per HTML-AAM), so there is no landmark pollution.
+
+ℹ️ The animation effect of this component is dependent on the
+`prefers-reduced-motion` media query.
 
 ## Full Example
 
 ```tsx
 import React, { useState } from 'react';
-import { Button, CloseButton, Drawer, DrawerPanel } from '@alma-oss/spirit-web-react';
+import {
+  Button,
+  CloseButton,
+  Drawer,
+  DrawerPanel,
+  DrawerPanelHeader,
+  DrawerPanelBody,
+} from '@alma-oss/spirit-web-react';
 
 export const Example = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -130,13 +207,12 @@ export const Example = () => {
         Open Drawer
       </Button>
 
-      <Drawer id="drawer-example" isOpen={isOpen} onClose={handleClose}>
-        <DrawerPanel
-          closeButton={
+      <Drawer id="drawer-example" isOpen={isOpen} onClose={handleClose} aria-label="Drawer">
+        <DrawerPanel>
+          <DrawerPanelHeader>
             <CloseButton size="large" aria-expanded={isOpen} aria-controls="drawer-example" onClick={handleClose} />
-          }
-        >
-          <div>Drawer content</div>
+          </DrawerPanelHeader>
+          <DrawerPanelBody hasSpacing>Drawer content</DrawerPanelBody>
         </DrawerPanel>
       </Drawer>
     </>
@@ -145,6 +221,7 @@ export const Example = () => {
 ```
 
 [close-button]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/CloseButton/README.md
+[header-readme]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/Header/README.md
 [mdn-dialog-element]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
 [readme-additional-attributes]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/README.md#additional-attributes
 [readme-escape-hatches]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/README.md#escape-hatches

--- a/packages/web-react/src/components/Drawer/__tests__/Drawer.accessibility.test.tsx
+++ b/packages/web-react/src/components/Drawer/__tests__/Drawer.accessibility.test.tsx
@@ -1,8 +1,11 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { runAxe } from '@local/tests/testUtils/runAxe';
+import { CloseButton } from '../../CloseButton';
 import Drawer from '../Drawer';
 import DrawerPanel from '../DrawerPanel';
+import DrawerPanelBody from '../DrawerPanelBody';
+import DrawerPanelHeader from '../DrawerPanelHeader';
 import '@local/tests/mocks/dialog';
 
 describe('Drawer accessibility', () => {
@@ -10,7 +13,12 @@ describe('Drawer accessibility', () => {
     await act(async () => {
       render(
         <Drawer id="drawer-example" isOpen onClose={() => {}}>
-          <DrawerPanel>Drawer content</DrawerPanel>
+          <DrawerPanel>
+            <DrawerPanelHeader>
+              <CloseButton size="large" aria-expanded aria-controls="drawer-example" onClick={() => {}} />
+            </DrawerPanelHeader>
+            <DrawerPanelBody hasSpacing>Drawer content</DrawerPanelBody>
+          </DrawerPanel>
         </Drawer>,
       );
     });

--- a/packages/web-react/src/components/Drawer/__tests__/DrawerPanel.test.tsx
+++ b/packages/web-react/src/components/Drawer/__tests__/DrawerPanel.test.tsx
@@ -36,29 +36,13 @@ describe('DrawerPanel', () => {
     expect(screen.getByTestId('test')).toHaveClass('DrawerPanel');
   });
 
-  it('should render with correct class for content', () => {
-    render(<DrawerPanel data-testid="test">Test content</DrawerPanel>);
-
-    expect(screen.getByText('Test content')).toHaveClass('DrawerPanel__content');
-    expect(screen.getByText('Test content')).toContainHTML('div');
-  });
-
-  it('should render the close button inside the panel header', () => {
+  it('should render children directly without wrapper', () => {
     render(
-      <DrawerPanel data-testid="test" closeButton={<button type="button">Close</button>}>
-        Test content
+      <DrawerPanel data-testid="test">
+        <span>Test content</span>
       </DrawerPanel>,
     );
 
-    const closeButton = screen.getByRole('button', { name: 'Close' });
-
-    expect(closeButton).toBeInTheDocument();
-    expect(closeButton.parentElement).toHaveClass('DrawerPanel__header');
-  });
-
-  it('should not render the panel header when no close button is provided', () => {
-    const { container } = render(<DrawerPanel data-testid="test">Test content</DrawerPanel>);
-
-    expect(container.querySelector('.DrawerPanel__header')).not.toBeInTheDocument();
+    expect(screen.getByText('Test content').parentElement).toHaveClass('DrawerPanel');
   });
 });

--- a/packages/web-react/src/components/Drawer/__tests__/DrawerPanelBody.test.tsx
+++ b/packages/web-react/src/components/Drawer/__tests__/DrawerPanelBody.test.tsx
@@ -1,0 +1,51 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
+import DrawerPanelBody from '../DrawerPanelBody';
+
+describe('DrawerPanelBody', () => {
+  classNamePrefixProviderTest(DrawerPanelBody, 'DrawerPanelBody');
+
+  stylePropsTest(DrawerPanelBody);
+
+  restPropsTest(DrawerPanelBody, 'div');
+
+  validHtmlAttributesTest(DrawerPanelBody);
+
+  ariaAttributesTest(DrawerPanelBody);
+
+  it('should render with correct class', () => {
+    render(<DrawerPanelBody data-testid="test" />);
+
+    expect(screen.getByTestId('test')).toHaveClass('DrawerPanelBody');
+  });
+
+  it('should render children', () => {
+    render(<DrawerPanelBody data-testid="test">Test content</DrawerPanelBody>);
+
+    expect(screen.getByTestId('test')).toHaveTextContent('Test content');
+  });
+
+  it('should not render the spacing modifier by default', () => {
+    render(<DrawerPanelBody data-testid="test">Test content</DrawerPanelBody>);
+
+    expect(screen.getByTestId('test')).not.toHaveClass('DrawerPanelBody--spacing');
+  });
+
+  it('should render the spacing modifier when hasSpacing is set', () => {
+    render(
+      <DrawerPanelBody data-testid="test" hasSpacing>
+        Test content
+      </DrawerPanelBody>,
+    );
+
+    expect(screen.getByTestId('test')).toHaveClass('DrawerPanelBody--spacing');
+  });
+});

--- a/packages/web-react/src/components/Drawer/__tests__/DrawerPanelHeader.test.tsx
+++ b/packages/web-react/src/components/Drawer/__tests__/DrawerPanelHeader.test.tsx
@@ -1,0 +1,41 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import {
+  ariaAttributesTest,
+  classNamePrefixProviderTest,
+  restPropsTest,
+  stylePropsTest,
+  validHtmlAttributesTest,
+} from '@local/tests';
+import DrawerPanelHeader from '../DrawerPanelHeader';
+
+describe('DrawerPanelHeader', () => {
+  classNamePrefixProviderTest(DrawerPanelHeader, 'DrawerPanelHeader');
+
+  stylePropsTest(DrawerPanelHeader);
+
+  restPropsTest(DrawerPanelHeader, 'header');
+
+  validHtmlAttributesTest(DrawerPanelHeader);
+
+  ariaAttributesTest(DrawerPanelHeader);
+
+  it('should render with correct class', () => {
+    render(<DrawerPanelHeader />);
+
+    expect(screen.getByRole('banner')).toHaveClass('DrawerPanelHeader');
+  });
+
+  it('should render children', () => {
+    render(
+      <DrawerPanelHeader>
+        <button type="button">Close</button>
+      </DrawerPanelHeader>,
+    );
+
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+
+    expect(closeButton).toBeInTheDocument();
+  });
+});

--- a/packages/web-react/src/components/Drawer/__tests__/useDrawerStyleProps.test.ts
+++ b/packages/web-react/src/components/Drawer/__tests__/useDrawerStyleProps.test.ts
@@ -7,8 +7,8 @@ describe('useDrawerStyleProps', () => {
 
     expect(result.current.classProps.root).toBe('Drawer Drawer--right');
     expect(result.current.classProps.panel).toBe('DrawerPanel');
-    expect(result.current.classProps.header).toBe('DrawerPanel__header');
-    expect(result.current.classProps.content).toBe('DrawerPanel__content');
+    expect(result.current.classProps.header).toBe('DrawerPanelHeader');
+    expect(result.current.classProps.content).toBe('DrawerPanelBody');
   });
 
   it('should return custom alignment', () => {
@@ -16,5 +16,11 @@ describe('useDrawerStyleProps', () => {
 
     expect(result.current.classProps.root).toBe('Drawer Drawer--left');
     expect(result.current.classProps.panel).toBe('DrawerPanel');
+  });
+
+  it('should return the content spacing modifier when hasSpacing is set', () => {
+    const { result } = renderHook(() => useDrawerStyleProps({ hasSpacing: true }));
+
+    expect(result.current.classProps.content).toBe('DrawerPanelBody DrawerPanelBody--spacing');
   });
 });

--- a/packages/web-react/src/components/Drawer/demo/DrawerDefault.tsx
+++ b/packages/web-react/src/components/Drawer/demo/DrawerDefault.tsx
@@ -6,6 +6,8 @@ import { Box } from '../../Box';
 import { CloseButton } from '../../CloseButton';
 import Drawer from '../Drawer';
 import DrawerPanel from '../DrawerPanel';
+import DrawerPanelBody from '../DrawerPanelBody';
+import DrawerPanelHeader from '../DrawerPanelHeader';
 
 const DrawerDefault = () => {
   const [isDrawerOpen, setDrawerOpen] = useState(false);
@@ -83,21 +85,20 @@ const DrawerDefault = () => {
         id="example-basic"
         isOpen={isDrawerOpen}
         onClose={handleDrawerClose}
+        aria-label="Drawer"
         closeOnBackdropClick={isClosableOnBackdropClick}
         closeOnEscapeKeyDown={isClosableOnEscapeKey}
       >
-        <DrawerPanel
-          data-testid="drawer-panel"
-          closeButton={
+        <DrawerPanel data-testid="drawer-panel">
+          <DrawerPanelHeader>
             <CloseButton
               size="large"
               aria-expanded={isDrawerOpen}
               aria-controls="example-basic"
               onClick={handleDrawerClose}
             />
-          }
-        >
-          <div className="px-700 pb-900">{content}</div>
+          </DrawerPanelHeader>
+          <DrawerPanelBody hasSpacing>{content}</DrawerPanelBody>
         </DrawerPanel>
       </Drawer>
     </>

--- a/packages/web-react/src/components/Drawer/figma/Drawer.figma.tsx
+++ b/packages/web-react/src/components/Drawer/figma/Drawer.figma.tsx
@@ -3,15 +3,18 @@ import React from 'react';
 import { CloseButton } from '../../CloseButton';
 import Drawer from '../Drawer';
 import DrawerPanel from '../DrawerPanel';
+import DrawerPanelBody from '../DrawerPanelBody';
+import DrawerPanelHeader from '../DrawerPanelHeader';
 
 figma.connect(Drawer, '<FIGMA_FILE_ID>?node-id=27293%3A7890', {
   props: {},
   example: (props) => (
-    <Drawer id="drawer-example" isOpen onClose={() => {}} {...props}>
-      <DrawerPanel
-        closeButton={<CloseButton size="large" aria-expanded aria-controls="drawer-example" onClick={() => {}} />}
-      >
-        <div>Drawer content</div>
+    <Drawer id="drawer-example" isOpen onClose={() => {}} aria-label="Drawer" {...props}>
+      <DrawerPanel>
+        <DrawerPanelHeader>
+          <CloseButton size="large" aria-expanded aria-controls="drawer-example" onClick={() => {}} />
+        </DrawerPanelHeader>
+        <DrawerPanelBody hasSpacing>Drawer content</DrawerPanelBody>
       </DrawerPanel>
     </Drawer>
   ),

--- a/packages/web-react/src/components/Drawer/index.ts
+++ b/packages/web-react/src/components/Drawer/index.ts
@@ -1,4 +1,6 @@
 export { default as Drawer } from './Drawer';
 export { default as DrawerPanel } from './DrawerPanel';
+export { default as DrawerPanelBody } from './DrawerPanelBody';
+export { default as DrawerPanelHeader } from './DrawerPanelHeader';
 export * from './DrawerContext';
 export * from './useDrawerStyleProps';

--- a/packages/web-react/src/components/Drawer/stories/Drawer.stories.tsx
+++ b/packages/web-react/src/components/Drawer/stories/Drawer.stories.tsx
@@ -8,6 +8,8 @@ import { Button } from '../../Button';
 import { CloseButton } from '../../CloseButton';
 import Drawer from '../Drawer';
 import DrawerPanel from '../DrawerPanel';
+import DrawerPanelBody from '../DrawerPanelBody';
+import DrawerPanelHeader from '../DrawerPanelHeader';
 import ReadMe from '../README.md?raw';
 
 const meta: Meta<typeof Drawer> = {
@@ -82,20 +84,20 @@ const DrawerWithHooks = (args: SpiritDrawerProps) => {
         id="example-basic"
         isOpen={isDrawerOpen}
         onClose={handleDrawerClose}
+        aria-label="Drawer"
         closeOnBackdropClick={closeOnBackdropClick}
         closeOnEscapeKeyDown={closeOnEscapeKeyDown}
       >
-        <DrawerPanel
-          closeButton={
+        <DrawerPanel>
+          <DrawerPanelHeader>
             <CloseButton
               size="large"
               aria-expanded={isDrawerOpen}
               aria-controls="example-basic"
               onClick={handleDrawerClose}
             />
-          }
-        >
-          <div className="p-800">Drawer content</div>
+          </DrawerPanelHeader>
+          <DrawerPanelBody hasSpacing>Drawer content</DrawerPanelBody>
         </DrawerPanel>
       </Drawer>
     </>

--- a/packages/web-react/src/components/Drawer/stories/DrawerPanel.stories.tsx
+++ b/packages/web-react/src/components/Drawer/stories/DrawerPanel.stories.tsx
@@ -6,6 +6,8 @@ import { type DrawerPanelProps } from '../../../types';
 import { CloseButton } from '../../CloseButton';
 import Drawer from '../Drawer';
 import DrawerPanel from '../DrawerPanel';
+import DrawerPanelBody from '../DrawerPanelBody';
+import DrawerPanelHeader from '../DrawerPanelHeader';
 import ReadMe from '../README.md?raw';
 
 const meta: Meta<typeof DrawerPanel> = {
@@ -26,8 +28,6 @@ const meta: Meta<typeof DrawerPanel> = {
   },
   args: {
     elementType: 'div',
-    closeButton: <CloseButton size="large" aria-expanded aria-controls="drawer-panel-demo" onClick={() => {}} />,
-    children: <div className="p-800">Drawer content</div>,
   },
 };
 
@@ -37,7 +37,7 @@ type Story = StoryObj<typeof DrawerPanel>;
 export const DrawerPanelPlayground: Story = {
   name: 'DrawerPanel',
   render: (args) => {
-    const { elementType, children, closeButton } = args as Partial<DrawerPanelProps>;
+    const { elementType } = args as Partial<DrawerPanelProps>;
 
     return (
       <Drawer
@@ -45,11 +45,15 @@ export const DrawerPanelPlayground: Story = {
         id="drawer-panel-demo"
         isOpen
         onClose={() => {}}
+        aria-label="Drawer"
         closeOnBackdropClick={false}
         closeOnEscapeKeyDown={false}
       >
-        <DrawerPanel elementType={elementType} closeButton={closeButton}>
-          {children}
+        <DrawerPanel elementType={elementType}>
+          <DrawerPanelHeader>
+            <CloseButton size="large" aria-expanded aria-controls="drawer-panel-demo" onClick={() => {}} />
+          </DrawerPanelHeader>
+          <DrawerPanelBody hasSpacing>Drawer content</DrawerPanelBody>
         </DrawerPanel>
       </Drawer>
     );

--- a/packages/web-react/src/components/Drawer/useDrawerStyleProps.ts
+++ b/packages/web-react/src/components/Drawer/useDrawerStyleProps.ts
@@ -7,6 +7,7 @@ import { DRAWER_ALIGNMENT_DEFAULT } from './constants';
 export interface UseDrawerStylesProps extends DrawerPanelProps {
   drawerAlignmentX?: DrawerAlignmentXType;
   isOpen?: boolean;
+  hasSpacing?: boolean;
 }
 
 export interface UseDrawerStylesReturn {
@@ -20,7 +21,7 @@ export interface UseDrawerStylesReturn {
 }
 
 export const useDrawerStyleProps = (props: UseDrawerStylesProps = {}): UseDrawerStylesReturn => {
-  const { drawerAlignmentX = DRAWER_ALIGNMENT_DEFAULT, isOpen = false } = props;
+  const { drawerAlignmentX = DRAWER_ALIGNMENT_DEFAULT, isOpen = false, hasSpacing = false } = props;
 
   const drawerClass = useClassNamePrefix('Drawer');
   const drawerAlignXClasses: Record<DrawerAlignmentXType, string> = {
@@ -28,8 +29,8 @@ export const useDrawerStyleProps = (props: UseDrawerStylesProps = {}): UseDrawer
     right: `${drawerClass}--right`,
   };
   const drawerPanelClass = `${drawerClass}Panel`;
-  const drawerPanelHeaderClass = `${drawerPanelClass}__header`;
-  const drawerContentClass = `${drawerPanelClass}__content`;
+  const drawerPanelHeaderClass = `${drawerClass}PanelHeader`;
+  const drawerBodyClass = `${drawerClass}PanelBody`;
 
   const classProps = {
     root: classNames(drawerClass, drawerAlignXClasses[drawerAlignmentX], {
@@ -37,7 +38,9 @@ export const useDrawerStyleProps = (props: UseDrawerStylesProps = {}): UseDrawer
     }),
     panel: drawerPanelClass,
     header: drawerPanelHeaderClass,
-    content: drawerContentClass,
+    content: classNames(drawerBodyClass, {
+      [`${drawerBodyClass}--spacing`]: hasSpacing,
+    }),
   };
 
   return {

--- a/packages/web-react/src/components/Header/demo/HeaderWithNavigation.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithNavigation.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { CloseButton } from '../../CloseButton';
 import { Container } from '../../Container';
-import { Drawer, DrawerPanel } from '../../Drawer';
+import { Drawer, DrawerPanel, DrawerPanelBody, DrawerPanelHeader } from '../../Drawer';
 import { Flex } from '../../Flex';
 import { ProductLogo } from '../../ProductLogo';
 import { defaultSvgLogo } from '../../ProductLogo/demo/ProductLogoDefault';
@@ -32,28 +32,29 @@ const HeaderWithNavigation = () => {
         </Container>
       </Header>
 
-      <Drawer id="drawer-navigation" isOpen={isDrawerOpen} onClose={() => setDrawerOpen(false)}>
-        <DrawerPanel
-          closeButton={
+      <Drawer id="drawer-navigation" isOpen={isDrawerOpen} onClose={() => setDrawerOpen(false)} aria-label="Navigation">
+        <DrawerPanel>
+          <DrawerPanelHeader>
             <CloseButton
               size="large"
               aria-expanded={isDrawerOpen}
               aria-controls="drawer-navigation"
               onClick={() => setDrawerOpen(false)}
             />
-          }
-        >
-          <Stack hasIntermediateDividers hasSpacing marginBottom="space-900" spacing="space-900">
-            <StackItem>
-              <ProfileNavigation />
-            </StackItem>
-            <StackItem>
-              <MainNavigation direction="vertical" />
-            </StackItem>
-            <StackItem>
-              <SecondaryVerticalNavigation />
-            </StackItem>
-          </Stack>
+          </DrawerPanelHeader>
+          <DrawerPanelBody>
+            <Stack hasIntermediateDividers hasSpacing marginBottom="space-900" spacing="space-900">
+              <StackItem>
+                <ProfileNavigation />
+              </StackItem>
+              <StackItem>
+                <MainNavigation direction="vertical" />
+              </StackItem>
+              <StackItem>
+                <SecondaryVerticalNavigation />
+              </StackItem>
+            </Stack>
+          </DrawerPanelBody>
         </DrawerPanel>
       </Drawer>
     </>

--- a/packages/web-react/src/components/Header/demo/HeaderWithNavigationAndNestedItems.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithNavigationAndNestedItems.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { CloseButton } from '../../CloseButton';
 import { Container } from '../../Container';
-import { Drawer, DrawerPanel } from '../../Drawer';
+import { Drawer, DrawerPanel, DrawerPanelBody, DrawerPanelHeader } from '../../Drawer';
 import { Flex } from '../../Flex';
 import { ProductLogo } from '../../ProductLogo';
 import { defaultSvgLogo } from '../../ProductLogo/demo/ProductLogoDefault';
@@ -33,35 +33,41 @@ const HeaderWithNavigationAndNestedItems = () => {
         </Container>
       </Header>
 
-      <Drawer id="drawer-navigation-expanded" isOpen={isDrawerOpen} onClose={() => setDrawerOpen(false)}>
-        <DrawerPanel
-          closeButton={
+      <Drawer
+        id="drawer-navigation-expanded"
+        isOpen={isDrawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        aria-label="Navigation"
+      >
+        <DrawerPanel>
+          <DrawerPanelHeader>
             <CloseButton
               size="large"
               aria-expanded={isDrawerOpen}
               aria-controls="drawer-navigation-expanded"
               onClick={() => setDrawerOpen(false)}
             />
-          }
-        >
-          <Stack
-            hasStartDivider
-            hasIntermediateDividers
-            hasEndDivider
-            hasSpacing
-            marginBottom="space-900"
-            spacing="space-900"
-          >
-            <StackItem>
-              <ProfileNavigation isSquare />
-            </StackItem>
-            <StackItem>
-              <MainVerticalNavigation />
-            </StackItem>
-            <StackItem>
-              <SecondaryVerticalNavigation />
-            </StackItem>
-          </Stack>
+          </DrawerPanelHeader>
+          <DrawerPanelBody>
+            <Stack
+              hasStartDivider
+              hasIntermediateDividers
+              hasEndDivider
+              hasSpacing
+              marginBottom="space-900"
+              spacing="space-900"
+            >
+              <StackItem>
+                <ProfileNavigation isSquare />
+              </StackItem>
+              <StackItem>
+                <MainVerticalNavigation />
+              </StackItem>
+              <StackItem>
+                <SecondaryVerticalNavigation />
+              </StackItem>
+            </Stack>
+          </DrawerPanelBody>
         </DrawerPanel>
       </Drawer>
     </>

--- a/packages/web-react/src/components/Header/demo/HeaderWithPillNavigation.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithPillNavigation.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { CloseButton } from '../../CloseButton';
 import { Container } from '../../Container';
-import { Drawer, DrawerPanel } from '../../Drawer';
+import { Drawer, DrawerPanel, DrawerPanelBody, DrawerPanelHeader } from '../../Drawer';
 import { Flex } from '../../Flex';
 import { ProductLogo } from '../../ProductLogo';
 import { defaultSvgLogo } from '../../ProductLogo/demo/ProductLogoDefault';
@@ -32,28 +32,34 @@ const HeaderWithPillNavigation = () => {
         </Container>
       </Header>
 
-      <Drawer id="drawer-navigation-pill" isOpen={isDrawerOpen} onClose={() => setDrawerOpen(false)}>
-        <DrawerPanel
-          closeButton={
+      <Drawer
+        id="drawer-navigation-pill"
+        isOpen={isDrawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        aria-label="Navigation"
+      >
+        <DrawerPanel>
+          <DrawerPanelHeader>
             <CloseButton
               size="large"
               aria-expanded={isDrawerOpen}
               aria-controls="drawer-navigation-pill"
               onClick={() => setDrawerOpen(false)}
             />
-          }
-        >
-          <Stack hasIntermediateDividers hasSpacing marginBottom="space-900" spacing="space-900">
-            <StackItem>
-              <ProfileNavigation />
-            </StackItem>
-            <StackItem>
-              <MainNavigation direction="vertical" variant="pill" />
-            </StackItem>
-            <StackItem>
-              <SecondaryVerticalNavigation />
-            </StackItem>
-          </Stack>
+          </DrawerPanelHeader>
+          <DrawerPanelBody>
+            <Stack hasIntermediateDividers hasSpacing marginBottom="space-900" spacing="space-900">
+              <StackItem>
+                <ProfileNavigation />
+              </StackItem>
+              <StackItem>
+                <MainNavigation direction="vertical" variant="pill" />
+              </StackItem>
+              <StackItem>
+                <SecondaryVerticalNavigation />
+              </StackItem>
+            </Stack>
+          </DrawerPanelBody>
         </DrawerPanel>
       </Drawer>
     </>

--- a/packages/web-react/src/components/Header/figma/Header.figma.tsx
+++ b/packages/web-react/src/components/Header/figma/Header.figma.tsx
@@ -4,7 +4,7 @@ import { type NavigationActionVariantsType } from '../../../types';
 import { Button, ButtonLink } from '../../Button';
 import { CloseButton } from '../../CloseButton';
 import { Container } from '../../Container';
-import { Drawer, DrawerPanel } from '../../Drawer';
+import { Drawer, DrawerPanel, DrawerPanelBody, DrawerPanelHeader } from '../../Drawer';
 import { Flex } from '../../Flex';
 import { Icon } from '../../Icon';
 import { Navigation, NavigationAction, NavigationAvatar, NavigationItem } from '../../Navigation';
@@ -70,58 +70,68 @@ const HeaderWithNavigationLoggedIn = ({ itemVariant }: { itemVariant: Navigation
         </Container>
       </Header>
 
-      <Drawer id="drawer-navigation-expanded" isOpen={isDrawerOpen} onClose={() => setDrawerOpen(false)}>
-        <DrawerPanel
-          closeButton={
+      <Drawer
+        id="drawer-navigation-expanded"
+        isOpen={isDrawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        aria-label="Navigation"
+      >
+        <DrawerPanel>
+          <DrawerPanelHeader>
             <CloseButton
               size="large"
               aria-expanded={isDrawerOpen}
               aria-controls="drawer-navigation-expanded"
               onClick={() => setDrawerOpen(false)}
             />
-          }
-        >
-          <Stack hasIntermediateDividers hasSpacing marginBottom="space-900" spacing="space-900">
-            <StackItem>
-              <Navigation aria-label="Profile" direction="vertical">
-                <NavigationItem alignmentY="left">
-                  <NavigationAvatar avatarContent={<Icon name="profile" />} aria-label="Profile of Jiří Bárta" isSquare>
-                    <Text elementType="span" size="small" emphasis="semibold">
-                      My Account
-                    </Text>
-                  </NavigationAvatar>
-                </NavigationItem>
-              </Navigation>
-            </StackItem>
-            <StackItem>
-              <Navigation aria-label="Main Navigation" direction="vertical">
-                <NavigationItem>
-                  <NavigationAction href="#" isSelected variant={itemVariant}>
-                    Selected
-                  </NavigationAction>
-                </NavigationItem>
-                <NavigationItem>
-                  <NavigationAction href="#" variant={itemVariant}>
-                    Link
-                  </NavigationAction>
-                </NavigationItem>
-                <NavigationItem>
-                  <NavigationAction href="#" isDisabled variant={itemVariant}>
-                    Disabled
-                  </NavigationAction>
-                </NavigationItem>
-              </Navigation>
-            </StackItem>
-            <StackItem>
-              <Navigation aria-label="Secondary Navigation" direction="vertical">
-                <NavigationItem>
-                  <ButtonLink href="#" color="secondary">
-                    Log Out
-                  </ButtonLink>
-                </NavigationItem>
-              </Navigation>
-            </StackItem>
-          </Stack>
+          </DrawerPanelHeader>
+          <DrawerPanelBody>
+            <Stack hasIntermediateDividers hasSpacing marginBottom="space-900" spacing="space-900">
+              <StackItem>
+                <Navigation aria-label="Profile" direction="vertical">
+                  <NavigationItem alignmentY="left">
+                    <NavigationAvatar
+                      avatarContent={<Icon name="profile" />}
+                      aria-label="Profile of Jiří Bárta"
+                      isSquare
+                    >
+                      <Text elementType="span" size="small" emphasis="semibold">
+                        My Account
+                      </Text>
+                    </NavigationAvatar>
+                  </NavigationItem>
+                </Navigation>
+              </StackItem>
+              <StackItem>
+                <Navigation aria-label="Main Navigation" direction="vertical">
+                  <NavigationItem>
+                    <NavigationAction href="#" isSelected variant={itemVariant}>
+                      Selected
+                    </NavigationAction>
+                  </NavigationItem>
+                  <NavigationItem>
+                    <NavigationAction href="#" variant={itemVariant}>
+                      Link
+                    </NavigationAction>
+                  </NavigationItem>
+                  <NavigationItem>
+                    <NavigationAction href="#" isDisabled variant={itemVariant}>
+                      Disabled
+                    </NavigationAction>
+                  </NavigationItem>
+                </Navigation>
+              </StackItem>
+              <StackItem>
+                <Navigation aria-label="Secondary Navigation" direction="vertical">
+                  <NavigationItem>
+                    <ButtonLink href="#" color="secondary">
+                      Log Out
+                    </ButtonLink>
+                  </NavigationItem>
+                </Navigation>
+              </StackItem>
+            </Stack>
+          </DrawerPanelBody>
         </DrawerPanel>
       </Drawer>
     </>
@@ -183,50 +193,56 @@ const HeaderWithNavigationLoggedOut = ({ itemVariant }: { itemVariant: Navigatio
         </Container>
       </Header>
 
-      <Drawer id="drawer-navigation-expanded" isOpen={isDrawerOpen} onClose={() => setDrawerOpen(false)}>
-        <DrawerPanel
-          closeButton={
+      <Drawer
+        id="drawer-navigation-expanded"
+        isOpen={isDrawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        aria-label="Navigation"
+      >
+        <DrawerPanel>
+          <DrawerPanelHeader>
             <CloseButton
               size="large"
               aria-expanded={isDrawerOpen}
               aria-controls="drawer-navigation-expanded"
               onClick={() => setDrawerOpen(false)}
             />
-          }
-        >
-          <Stack hasIntermediateDividers hasSpacing marginBottom="space-900" spacing="space-900">
-            <StackItem>
-              <Navigation aria-label="Main Navigation" direction="vertical">
-                <NavigationItem>
-                  <NavigationAction href="#" isSelected variant={itemVariant}>
-                    Selected
-                  </NavigationAction>
-                </NavigationItem>
-                <NavigationItem>
-                  <NavigationAction href="#" variant={itemVariant}>
-                    Link
-                  </NavigationAction>
-                </NavigationItem>
-                <NavigationItem>
-                  <NavigationAction href="#" isDisabled variant={itemVariant}>
-                    Disabled
-                  </NavigationAction>
-                </NavigationItem>
-              </Navigation>
-            </StackItem>
-            <StackItem>
-              <Navigation aria-label="Secondary Navigation" direction="vertical">
-                <NavigationItem>
-                  <ButtonLink href="#" color="secondary">
-                    Register
-                  </ButtonLink>
-                </NavigationItem>
-                <NavigationItem>
-                  <ButtonLink href="#">Log In</ButtonLink>
-                </NavigationItem>
-              </Navigation>
-            </StackItem>
-          </Stack>
+          </DrawerPanelHeader>
+          <DrawerPanelBody>
+            <Stack hasIntermediateDividers hasSpacing marginBottom="space-900" spacing="space-900">
+              <StackItem>
+                <Navigation aria-label="Main Navigation" direction="vertical">
+                  <NavigationItem>
+                    <NavigationAction href="#" isSelected variant={itemVariant}>
+                      Selected
+                    </NavigationAction>
+                  </NavigationItem>
+                  <NavigationItem>
+                    <NavigationAction href="#" variant={itemVariant}>
+                      Link
+                    </NavigationAction>
+                  </NavigationItem>
+                  <NavigationItem>
+                    <NavigationAction href="#" isDisabled variant={itemVariant}>
+                      Disabled
+                    </NavigationAction>
+                  </NavigationItem>
+                </Navigation>
+              </StackItem>
+              <StackItem>
+                <Navigation aria-label="Secondary Navigation" direction="vertical">
+                  <NavigationItem>
+                    <ButtonLink href="#" color="secondary">
+                      Register
+                    </ButtonLink>
+                  </NavigationItem>
+                  <NavigationItem>
+                    <ButtonLink href="#">Log In</ButtonLink>
+                  </NavigationItem>
+                </Navigation>
+              </StackItem>
+            </Stack>
+          </DrawerPanelBody>
         </DrawerPanel>
       </Drawer>
     </>

--- a/packages/web-react/src/types/drawer.ts
+++ b/packages/web-react/src/types/drawer.ts
@@ -1,9 +1,10 @@
-import { type ComponentPropsWithRef, type ElementType, type ReactNode, type SyntheticEvent } from 'react';
+import { type ComponentPropsWithRef, type ElementType, type SyntheticEvent } from 'react';
 import { type AlignmentX } from '../constants';
 import {
   type ChildrenProps,
   type OmittedExtendedUnsafeStyleProps,
   type SpiritDialogElementProps,
+  type SpiritDivElementProps,
   type StyleProps,
 } from './shared';
 
@@ -20,13 +21,18 @@ export type DrawerPanelHandlingProps = {
 
 export type DrawerPanelBaseProps<E extends ElementType = DrawerPanelElementType> = {
   elementType?: E;
-  /** The close button rendered automatically inside the panel header. */
-  closeButton?: ReactNode;
 } & ChildrenProps &
   StyleProps;
 
 export type DrawerPanelProps<E extends ElementType = DrawerPanelElementType> = DrawerPanelBaseProps<E> &
   OmittedExtendedUnsafeStyleProps<ComponentPropsWithRef<E>, keyof DrawerPanelBaseProps<E>>;
+
+export interface DrawerPanelHeaderProps extends SpiritDivElementProps, ChildrenProps {}
+
+export interface DrawerPanelBodyProps extends SpiritDivElementProps, ChildrenProps {
+  /** Whether the content has inner spacing consistent with the panel header. */
+  hasSpacing?: boolean;
+}
 
 export interface DrawerBaseProps extends Omit<SpiritDialogElementProps, 'id'>, DrawerPanelHandlingProps, ChildrenProps {
   alignmentX?: DrawerAlignmentXType;

--- a/packages/web/src/scss/components/Drawer/README.md
+++ b/packages/web/src/scss/components/Drawer/README.md
@@ -6,15 +6,13 @@ The Drawer is a composition of several subcomponents:
 
 - [Drawer](#drawer)
   - [DrawerPanel](#drawerpanel)
-    - [ControlButton](#close-button)
-
-👉 The animation effect of this component is dependent on the
-`prefers-reduced-motion` media query.
+    - [DrawerPanelHeader](#drawerpanelheader)
+    - [DrawerPanelBody](#drawerpanelcontent)
 
 ## Drawer
 
 ```html
-<dialog id="my-drawer-dialog" class="Drawer Drawer--right">
+<dialog id="my-drawer-dialog" class="Drawer Drawer--right" aria-label="Drawer">
   <!-- Drawer panel goes here  -->
 </dialog>
 ```
@@ -24,7 +22,7 @@ The Drawer is a composition of several subcomponents:
 The `Drawer` component allows aligning the content panel horizontally to the left or right side of the screen using `--left` or `--right` modifier. The default alignment of the drawer content panel is to the right.
 
 ```html
-<dialog id="my-drawer-dialog" class="Drawer Drawer--left">
+<dialog id="my-drawer-dialog" class="Drawer Drawer--left" aria-label="Drawer">
   <!-- Drawer panel goes here  -->
 </dialog>
 ```
@@ -32,22 +30,33 @@ The `Drawer` component allows aligning the content panel horizontally to the lef
 ## DrawerPanel
 
 The `DrawerPanel` component is a container for the content that will be displayed in the drawer.
-Should there be any spacing around the content of `DrawerPanel`, you need to provide it yourself.
+It is composed from the `DrawerPanelHeader` and `DrawerPanelBody` sub-components.
 
 ```html
 <div class="DrawerPanel">
-  <div class="DrawerPanel__header">
+  <header class="DrawerPanelHeader">
     <!-- Close button goes here -->
-  </div>
-  <div class="DrawerPanel__content">
+  </header>
+  <div class="DrawerPanelBody DrawerPanelBody--spacing">
     <!-- Drawer content goes here -->
   </div>
 </div>
 ```
 
-## Close Button
+## DrawerPanelHeader
 
-Close button is a [ControlButton][control-button] that closes the drawer when clicked.
+The `DrawerPanelHeader` component is a container rendered at the top of the `DrawerPanel`.
+It is typically used to hold the close button.
+
+```html
+<header class="DrawerPanelHeader">
+  <!-- Close button goes here -->
+</header>
+```
+
+### Close Button
+
+Close button is a [ControlButton][readme-control-button] that closes the drawer when clicked.
 
 ```html
 <button
@@ -65,12 +74,40 @@ Close button is a [ControlButton][control-button] that closes the drawer when cl
 </button>
 ```
 
+## DrawerPanelBody
+
+The `DrawerPanelBody` component is a container for the main content of the `DrawerPanel`.
+
+By default it has no inner spacing. Add the `DrawerPanelBody--spacing` modifier
+to apply inner spacing consistent with `DrawerPanelHeader`, so you don't have to add it yourself.
+
+```html
+<div class="DrawerPanelBody DrawerPanelBody--spacing">
+  <!-- Drawer content goes here -->
+</div>
+```
+
+👉 For examples with `Navigation` content inside `DrawerPanelBody`, see the [Header][readme-header] component.
+
+## Accessibility
+
+Always provide an accessible name for the `Drawer` using the `aria-label` attribute so screen readers can announce what the dialog contains:
+
+```html
+<dialog id="drawer-example" class="Drawer Drawer--right" aria-label="Navigation">
+  <!-- … -->
+</dialog>
+```
+
+ℹ️ The animation effect of this component is dependent on the
+`prefers-reduced-motion` media query.
+
 ## Full Example
 
 ```html
-<dialog id="drawer-example" class="Drawer Drawer--right">
+<dialog id="drawer-example" class="Drawer Drawer--right" aria-label="Drawer">
   <div class="DrawerPanel">
-    <div class="DrawerPanel__header">
+    <header class="DrawerPanelHeader">
       <button
         type="button"
         class="ControlButton ControlButton--large text-color-scheme dynamic-color-background-interactive accessibility-tap-target ControlButton--hasBackground dynamic-color-border ControlButton--symmetrical"
@@ -84,8 +121,8 @@ Close button is a [ControlButton][control-button] that closes the drawer when cl
         </svg>
         <span class="accessibility-hidden">Close</span>
       </button>
-    </div>
-    <div class="DrawerPanel__content">
+    </header>
+    <div class="DrawerPanelBody DrawerPanelBody--spacing">
       <!-- Drawer content goes here  -->
     </div>
   </div>
@@ -102,4 +139,5 @@ const offcanvas = new Offcanvas(drawerElement, { modal: false });
 
 The drawer panel will slide in as usual, but the rest of the page stays clickable and scrollable.
 
-[control-button]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/ControlButton/README.md
+[readme-control-button]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/ControlButton/README.md
+[readme-header]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/Header/README.md

--- a/packages/web/src/scss/components/Drawer/_Drawer.scss
+++ b/packages/web/src/scss/components/Drawer/_Drawer.scss
@@ -9,7 +9,7 @@
 .Drawer {
     --#{tokens.$css-variable-prefix}drawer-translate-x: 0%;
 
-    @include typography.generate(theme.$drawer-typography);
+    @include typography.generate(theme.$typography);
 
     all: unset;
     position: fixed;
@@ -21,7 +21,7 @@
     height: 100%;
     max-height: none;
     border: none;
-    background-color: theme.$drawer-backdrop-background-color;
+    background-color: theme.$backdrop-background-color;
     visibility: hidden;
 
     &::backdrop {
@@ -31,10 +31,10 @@
     @media (prefers-reduced-motion: no-preference) {
         /* stylelint-disable declaration-property-value-disallowed-list -- 1. */
         transition:
-            display theme.$drawer-transition-duration allow-discrete,
-            overlay theme.$drawer-transition-duration allow-discrete,
-            visibility theme.$drawer-transition-duration,
-            opacity theme.$drawer-transition-duration;
+            display theme.$transition-duration allow-discrete,
+            overlay theme.$transition-duration allow-discrete,
+            visibility theme.$transition-duration,
+            opacity theme.$transition-duration;
         /* stylelint-enable declaration-property-value-disallowed-list */
     }
 }

--- a/packages/web/src/scss/components/Drawer/_DrawerPanel.scss
+++ b/packages/web/src/scss/components/Drawer/_DrawerPanel.scss
@@ -5,34 +5,18 @@
     display: flex;
     flex-direction: column;
     box-sizing: border-box;
-    width: var(--#{tokens.$css-variable-prefix}drawer-panel-width, #{theme.$drawer-panel-width});
-    height: theme.$drawer-panel-height;
-    max-height: theme.$drawer-panel-max-height;
-    color: theme.$drawer-panel-text-color;
-    background-color: theme.$drawer-panel-background-color;
-    box-shadow: theme.$drawer-panel-shadow;
+    width: var(--#{tokens.$css-variable-prefix}drawer-panel-width, #{theme.$panel-width});
+    height: theme.$panel-height;
+    max-height: theme.$panel-max-height;
+    color: theme.$panel-text-color;
+    background-color: theme.$panel-background-color;
+    box-shadow: theme.$panel-shadow;
     transform: translateX(var(--#{tokens.$css-variable-prefix}drawer-translate-x));
     pointer-events: auto;
 
     @media (prefers-reduced-motion: no-preference) {
         transition-property: transform;
-        transition-duration: theme.$drawer-transition-duration;
-        transition-timing-function: theme.$drawer-transition-timing;
+        transition-duration: theme.$transition-duration;
+        transition-timing-function: theme.$transition-timing;
     }
-}
-
-.DrawerPanel__header {
-    display: flex;
-    column-gap: theme.$drawer-panel-header-gap;
-    justify-content: flex-end;
-    padding-inline: theme.$drawer-panel-header-padding-x;
-    padding-block: theme.$drawer-panel-header-padding-y;
-}
-
-.DrawerPanel__content {
-    display: flex;
-    flex-grow: 1;
-    flex-direction: column;
-    overflow-y: auto;
-    overscroll-behavior: contain;
 }

--- a/packages/web/src/scss/components/Drawer/_DrawerPanelBody.scss
+++ b/packages/web/src/scss/components/Drawer/_DrawerPanelBody.scss
@@ -1,0 +1,14 @@
+@use 'theme';
+
+.DrawerPanelBody {
+    display: flex;
+    flex-grow: 1;
+    flex-direction: column;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
+.DrawerPanelBody--spacing {
+    padding-inline: theme.$panel-body-padding-x;
+    padding-block-end: theme.$panel-body-padding-y;
+}

--- a/packages/web/src/scss/components/Drawer/_DrawerPanelHeader.scss
+++ b/packages/web/src/scss/components/Drawer/_DrawerPanelHeader.scss
@@ -1,0 +1,9 @@
+@use 'theme';
+
+.DrawerPanelHeader {
+    display: flex;
+    column-gap: theme.$panel-header-gap;
+    justify-content: flex-end;
+    padding-inline: theme.$panel-header-padding-x;
+    padding-block: theme.$panel-header-padding-y;
+}

--- a/packages/web/src/scss/components/Drawer/_theme.scss
+++ b/packages/web/src/scss/components/Drawer/_theme.scss
@@ -5,20 +5,23 @@
 @use '../../settings/transitions';
 @use '../../tools/units';
 
-$drawer-typography: tokens.$body-medium-semibold;
+$typography: tokens.$body-medium-semibold;
+$transition-duration: transitions.$duration-200;
+$transition-timing: transitions.$timing-eased-in-out;
+$backdrop-background-color: tokens.$background-backdrop;
 
-// Transition
-$drawer-transition-duration: transitions.$duration-200;
-$drawer-transition-timing: transitions.$timing-eased-in-out;
-$drawer-backdrop-background-color: tokens.$background-backdrop;
+$panel-width: units.px-to-rem(312px); // 1.
+$panel-height: auto;
+$panel-max-height: none;
+$panel-text-color: tokens.$text-primary;
+$panel-background-color: tokens.$background-primary;
+$panel-shadow: tokens.$shadow-400;
 
-// DrawerPanel
-$drawer-panel-width: units.px-to-rem(312px); // 1.
-$drawer-panel-height: auto;
-$drawer-panel-max-height: none;
-$drawer-panel-text-color: tokens.$text-primary;
-$drawer-panel-background-color: tokens.$background-primary;
-$drawer-panel-shadow: tokens.$shadow-400;
-$drawer-panel-header-gap: tokens.$space-700;
-$drawer-panel-header-padding-x: tokens.$space-700;
-$drawer-panel-header-padding-y: tokens.$space-900;
+$common-padding-x: tokens.$space-700;
+
+$panel-header-gap: tokens.$space-700;
+$panel-header-padding-x: $common-padding-x;
+$panel-header-padding-y: tokens.$space-900;
+
+$panel-body-padding-x: $common-padding-x;
+$panel-body-padding-y: tokens.$space-900;

--- a/packages/web/src/scss/components/Drawer/index.html
+++ b/packages/web/src/scss/components/Drawer/index.html
@@ -166,13 +166,13 @@
       <dialog
         id="drawer-example"
         class="Drawer Drawer--right"
-        aria-label="example-basic__title"
+        aria-label="Drawer"
       >
         <div
           class="DrawerPanel"
           data-testid="drawer-panel"
         >
-          <div class="DrawerPanel__header">
+          <header class="DrawerPanelHeader">
             <button
               type="button"
               aria-expanded="false"
@@ -191,13 +191,11 @@
               </svg>
               <span class="accessibility-hidden">Close</span>
             </button>
-          </div>
-          <div class="DrawerPanel__content">
-            <div
-              class="px-700 pb-900"
-              data-drawer-demo-content
-            >This is a Drawer content.</div>
-          </div>
+          </header>
+          <div
+            class="DrawerPanelBody DrawerPanelBody--spacing"
+            data-drawer-demo-content
+          >This is a Drawer content.</div>
         </div>
       </dialog>
       <!-- Drawer: end -->

--- a/packages/web/src/scss/components/Drawer/index.scss
+++ b/packages/web/src/scss/components/Drawer/index.scss
@@ -1,2 +1,4 @@
 @forward 'Drawer';
 @forward 'DrawerPanel';
+@forward 'DrawerPanelBody';
+@forward 'DrawerPanelHeader';

--- a/packages/web/src/scss/components/Header/preview.html
+++ b/packages/web/src/scss/components/Header/preview.html
@@ -166,8 +166,12 @@
                 </button>
               </li>
               <li class="NavigationItem NavigationItem--alignmentYCenter d-only-mobile-none d-only-tablet-none">
-                <a href="#" class="NavigationAvatar">
-                  <span class="Avatar Avatar--small" aria-label="Profile of Jiří Bárta">
+                <a
+                  href="#"
+                  class="NavigationAvatar"
+                  aria-label="Profile of Jiří Bárta"
+                >
+                  <span class="Avatar Avatar--small">
                     <svg
                       class="Icon"
                       width="20"
@@ -220,7 +224,7 @@
       aria-label="Navigation"
     >
       <div class="DrawerPanel">
-        <div class="DrawerPanel__header">
+        <header class="DrawerPanelHeader">
           <button
             type="button"
             aria-expanded="false"
@@ -239,15 +243,19 @@
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
-        </div>
-        <div class="DrawerPanel__content">
+        </header>
+        <div class="DrawerPanelBody">
           <div class="Stack Stack--spacing Stack--intermediateDividers mb-900" style="--stack-spacing: var(--spirit-space-900)">
             <div class="StackItem">
               <nav class="Navigation Navigation--vertical" aria-label="Profile">
                 <ul>
                   <li class="NavigationItem NavigationItem--alignmentYCenter">
-                    <a href="#" class="NavigationAvatar">
-                      <span class="Avatar Avatar--small" aria-label="Profile of Jiří Bárta">
+                    <a
+                      href="#"
+                      class="NavigationAvatar"
+                      aria-label="Profile of Jiří Bárta"
+                    >
+                      <span class="Avatar Avatar--small">
                         <svg
                           class="Icon"
                           width="20"
@@ -367,8 +375,12 @@
                 </button>
               </li>
               <li class="NavigationItem NavigationItem--alignmentYCenter d-only-mobile-none d-only-tablet-none">
-                <a href="#" class="NavigationAvatar">
-                  <span class="Avatar Avatar--small" aria-label="Profile of Jiří Bárta">
+                <a
+                  href="#"
+                  class="NavigationAvatar"
+                  aria-label="Profile of Jiří Bárta"
+                >
+                  <span class="Avatar Avatar--small">
                     <svg
                       class="Icon"
                       width="20"
@@ -421,7 +433,7 @@
       aria-label="Navigation"
     >
       <div class="DrawerPanel">
-        <div class="DrawerPanel__header">
+        <header class="DrawerPanelHeader">
           <button
             type="button"
             aria-expanded="false"
@@ -440,16 +452,20 @@
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
-        </div>
-        <div class="DrawerPanel__content">
+        </header>
+        <div class="DrawerPanelBody">
           <div class="Stack Stack--spacing Stack--intermediateDividers mb-900" style="--stack-spacing: var(--spirit-space-900)">
 
             <div class="StackItem">
               <nav class="Navigation Navigation--vertical" aria-label="Profile">
                 <ul>
                   <li class="NavigationItem NavigationItem--alignmentYCenter">
-                    <a href="#" class="NavigationAvatar">
-                      <span class="Avatar Avatar--small" aria-label="Profile of Jiří Bárta">
+                    <a
+                      href="#"
+                      class="NavigationAvatar"
+                      aria-label="Profile of Jiří Bárta"
+                    >
+                      <span class="Avatar Avatar--small">
                         <svg
                           class="Icon"
                           width="20"
@@ -631,13 +647,14 @@
                   <button
                     type="button"
                     class="NavigationAvatar NavigationAvatar--square"
+                    aria-label="Profile of Jiří Bárta"
                     data-spirit-toggle="dropdown"
                     data-spirit-target="#dropdown-avatar"
                     aria-expanded="false"
                     aria-controls="dropdown-avatar"
                     data-spirit-autoclose="true"
                   >
-                    <span class="Avatar Avatar--square Avatar--small" aria-label="Profile of Jiří Bárta">
+                    <span class="Avatar Avatar--square Avatar--small">
                       <svg
                         class="Icon"
                         width="20"
@@ -736,7 +753,7 @@
       aria-label="Navigation"
     >
       <div class="DrawerPanel">
-        <div class="DrawerPanel__header">
+        <header class="DrawerPanelHeader">
           <button
             type="button"
             aria-expanded="false"
@@ -755,16 +772,20 @@
             </svg>
             <span class="accessibility-hidden">Close</span>
           </button>
-        </div>
-        <div class="DrawerPanel__content">
+        </header>
+        <div class="DrawerPanelBody">
           <div class="Stack Stack--spacing Stack--startDivider Stack--intermediateDividers Stack--endDivider mb-900" style="--stack-spacing: var(--spirit-space-900)">
 
             <div class="StackItem">
               <nav class="Navigation Navigation--vertical" aria-label="Profile">
                 <ul>
                   <li class="NavigationItem NavigationItem--alignmentYCenter">
-                    <a href="#" class="NavigationAvatar NavigationAvatar--square">
-                      <span class="Avatar Avatar--small Avatar--square" aria-label="Profile of Jiří Bárta">
+                    <a
+                      href="#"
+                      class="NavigationAvatar NavigationAvatar--square"
+                      aria-label="Profile of Jiří Bárta"
+                    >
+                      <span class="Avatar Avatar--small Avatar--square">
                         <svg
                           class="Icon"
                           width="20"

--- a/packages/web/src/scss/helpers/dynamic-color/index.html
+++ b/packages/web/src/scss/helpers/dynamic-color/index.html
@@ -27,11 +27,11 @@
         aria-labelledby="dynamic-color-playground-heading"
       >
         <div class="DrawerPanel">
-          <div class="DrawerPanel__header">
+          <header class="DrawerPanelHeader">
             <button
               type="button"
               aria-expanded="false"
-              class="ControlButton ControlButton--medium text-color-scheme dynamic-color-background-interactive accessibility-tap-target ControlButton--hasBackground dynamic-color-border ControlButton--symmetrical"
+              class="ControlButton ControlButton--large text-color-scheme dynamic-color-background-interactive accessibility-tap-target ControlButton--hasBackground dynamic-color-border ControlButton--symmetrical"
               data-spirit-dismiss="offcanvas"
               data-spirit-target="#dynamic-color-playground-drawer"
               aria-controls="dynamic-color-playground-drawer"
@@ -46,8 +46,8 @@
               </svg>
               <span class="accessibility-hidden">Close</span>
             </button>
-          </div>
-          <div class="DrawerPanel__content">
+          </header>
+          <div class="DrawerPanelBody">
             <form
               id="dynamic-color-playground-form"
               class="Stack Stack--spacing p-800"


### PR DESCRIPTION
## Description

Exposes `DrawerPanelHeader` and `DrawerPanelContent` as standalone composition sub-components for `DrawerPanel` in both `web-react` and `web` packages, replacing the former `closeButton` render prop pattern.

**React (`web-react`)**
- New `DrawerPanelHeader` component — renders the header bar with `display: flex`, wraps the close button and any other heading content
- New `DrawerPanelContent` component — renders the scrollable content area; accepts `hasSpacing` prop for built-in padding
- `DrawerPanel` no longer accepts a `closeButton` prop; consumers compose `DrawerPanelHeader` + `DrawerPanelContent` directly
- `CloseButton` (from DS-2216) replaces the removed `DrawerCloseButton` inside `DrawerPanelHeader`
- `aria-label` documented and added to all `<Drawer>` demo instances so the underlying `<dialog>` has an accessible name

**Web (`web`)**
- Extracted `DrawerPanel__header` and `DrawerPanel__content` BEM elements into standalone `_DrawerPanelHeader.scss` and `_DrawerPanelContent.scss` files, forwarded in `index.scss`
- New standalone class names: `DrawerPanelHeader`, `DrawerPanelContent`, `DrawerPanelContent--hasSpacing`
- Sass theme variables scoped without component prefix (e.g. `$panel-width`, `$panel-header-gap`); `$common-padding-x` shared across header and content padding

**Both packages**
- READMEs restructured: `DrawerPanelHeader` and `DrawerPanelContent` sections, `CloseButton` documented as a sub-section of `DrawerPanelHeader`, `Accessibility` section before `Full Example`
- All demo and story files updated to use the new composition API
- HTML validation errors fixed in `Header/preview.html` (`aria-label` moved from generic `<span>` to outer interactive `<a>`/`<button>` elements)

### Additional context

This is a **BREAKING CHANGE** — consumers must replace the `closeButton` prop with the `DrawerPanelHeader` + `DrawerPanelContent` composition pattern.

### Issue reference

[DS-2656](https://almacareer.atlassian.net/browse/DS-2656)