### PR TITLE
feat(repo): add spirit v5 migration skill and recipes

### DIFF
--- a/.agents/skills/spirit-v5-migration/SKILL.md
+++ b/.agents/skills/spirit-v5-migration/SKILL.md
@@ -1,0 +1,384 @@
+---
+name: spirit:v5-migration
+description: >-
+  Migrates consumer apps from Spirit Design System v4 to v5, focusing on @alma-oss/spirit-web-react
+  breaking APIs, codemods, feature flags, styles, markup, and design-token renames. Use when the user asks to
+  upgrade to Spirit v5, migrate to v5, fix v5 breaking changes, or update deprecated Spirit React APIs.
+category: spirit
+displayName: Spirit v5 Migration
+---
+
+# Spirit v5 Migration
+
+Use this skill when migrating a **consumer application** to Spirit Design System v5. The primary target is
+`@alma-oss/spirit-web-react`. Always inspect application markup, styles, and token overrides too: React consumers can
+still carry obsolete CSS feature flags or renamed design tokens without importing Spirit SCSS directly.
+
+Canonical migration recipes live in [`changesets/`](changesets/). Each file represents one breaking-change topic.
+Follow documented migration paths from those files first. **The agent performs all migrations** — codemods and
+recipe edits alike. Do not leave work for the user unless you hit a hard blocker you cannot resolve (missing
+source files, unrecoverable ambiguity after inspection). When uncertain, **attempt the migration anyway** and
+mark the result `partial` with review locations in the report.
+
+## Principles
+
+- **Recipes first.** Read the matching `changesets/*.md` file before editing code for that topic.
+- **Codemods before hand-edits.** Run available codemods, then apply recipe steps for every remaining match.
+- **Agent does the work.** Every recipe step is an agent task. Never list steps for the user to do later when
+  you can edit the codebase yourself.
+- **Attempt before blocking.** Prefer an applied edit with `partial` status over `blocked` with instructions.
+- **Deterministic edits.** Prefer small, targeted changes over broad refactors.
+- **Preserve style.** Match the target app's existing formatting and patterns.
+- **Report always.** Create `spirit-v5-migration-report.md` in the migrated workspace root.
+
+## Canonical Sources
+
+| Source                  | Path                                                                       |
+| ----------------------- | -------------------------------------------------------------------------- |
+| React migration guide   | [`docs/migrations/web-react/migration-v5.md`][migration-web-react]         |
+| Web CSS migration guide | [`docs/migrations/web/migration-v5.md`][migration-web]                     |
+| Design tokens guide     | [`docs/migrations/design-tokens/migration-v5.md`][migration-design-tokens] |
+| Codemods README         | [`packages/codemods/README.md`][codemods-readme]                           |
+| v5 web-react codemods   | [`packages/codemods/src/transforms/v5/web-react/README.md`][codemods-v5]   |
+
+---
+
+## Workflow
+
+### Step 0: Classify Target Profile
+
+At discovery, classify how the repo consumes Spirit. This drives codemod flags, scan paths, and validation commands.
+
+| Profile              | Signals                                               | Codemod `-s`                         | Migration recipe                                   |
+| -------------------- | ----------------------------------------------------- | ------------------------------------ | -------------------------------------------------- |
+| **direct**           | Most files import `@alma-oss/spirit-web-react`        | omit                                 | standard workflow below                            |
+| **wrapper-monorepo** | Most files import a wrapper design-system package     | `-s @org/design-system` on app paths | [wrapper-monorepo](changesets/wrapper-monorepo.md) |
+| **mixed**            | Wrapper lib imports Spirit directly; apps use wrapper | per-path (lib direct, apps `-s`)     | [wrapper-monorepo](changesets/wrapper-monorepo.md) |
+
+Set an argument array once when needed:
+
+```bash
+IMPORT_SOURCE_ARGS=(-s "@org/design-system") # replace with detected wrapper package
+```
+
+For direct imports, use an empty array: `IMPORT_SOURCE_ARGS=()`.
+
+For **wrapper-monorepo** or **mixed** profiles, read [wrapper-monorepo](changesets/wrapper-monorepo.md) and record:
+
+- Wrapper package name (for `-s`)
+- Library path(s) that import Spirit directly (codemods without `-s`)
+- Consumer path(s) that import via the wrapper (codemods with `-s`)
+- Validation commands from the repo's `package.json` / workspace scripts
+
+### Step 1: Discover Scope
+
+Detection commands in this skill use POSIX `grep`, which is available on every target machine. Faster tools such
+as `ripgrep` are fine when the target machine has them — translate `--include="*.tsx"` to `-g "*.tsx"` and keep the
+same patterns.
+
+Identify the target app path(s), package versions, and Spirit packages in use:
+
+```bash
+# Package versions
+grep -rEn "@alma-oss/spirit" package.json yarn.lock pnpm-lock.yaml package-lock.json 2>/dev/null
+
+# Common v4 leftovers
+grep -rEn "UNSTABLE_|FileUploader|hideOnCollapse|hasValidationStateIcon|formFieldMode|isFluid|isBlock|hasArrows|ScrollViewArrows|HeaderNav|HeaderDialog|ModalCloseButton|TooltipCloseButton|DrawerCloseButton" <target-path> --include="*.tsx" --include="*.ts" --include="*.jsx" --include="*.js"
+
+# Import sources (direct Spirit vs wrapper re-exports)
+grep -rEn "from ['\"]@alma-oss/spirit-web-react" <target-path> --include="*.tsx" --include="*.ts" --include="*.jsx" --include="*.js"
+grep -rEn "from ['\"][^'\"]+" <target-path> --include="*.tsx" --include="*.ts" --include="*.jsx" --include="*.js" | grep -E "design-system|spirit-web-react"
+
+# Wrapper monorepo layout
+grep -rEn "@alma-oss/spirit-web-react" package.json
+grep -rEn "from ['\"][^'\"]+" <target-path> --include="*.tsx" --include="*.ts" | grep -vE "@alma-oss/spirit-web-react" | head   # sample non-direct imports
+
+# Heavy manual-migration signals
+grep -rEn "UNSTABLE_Picker|FileUploader|UNSTABLE_SpiritHeader|SpiritHeader" <target-path> --include="*.tsx" --include="*.ts"
+
+# Feature flags in markup/styles and renamed design tokens
+grep -rEn 'spirit-feature-enable-v5|\$enable-v5-' <target-path> --include="*.tsx" --include="*.ts" --include="*.jsx" --include="*.js" --include="*.html" --include="*.twig" --include="*.scss" --include="*.sass" --include="*.css"
+grep -rEn "form-field-filled|component-header-item|component-button-(primary|secondary)" <target-path> --include="*.scss" --include="*.sass" --include="*.css" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" --include="*.json"
+```
+
+Confirm with the user:
+
+| Input                   | Default                                                                    |
+| ----------------------- | -------------------------------------------------------------------------- |
+| Target path             | user-provided app root                                                     |
+| Target profile          | auto-detect: `direct` \| `wrapper-monorepo` \| `mixed`                     |
+| Packages to upgrade     | `@alma-oss/spirit-web-react` (+ `spirit-web` if CSS is imported directly)  |
+| Import sources (`-s`)   | auto-detect wrapper package; see [Step 0](#step-0-classify-target-profile) |
+| Node.js version         | ≥ 22 required                                                              |
+| Run codemods            | yes, when recipes list them                                                |
+| Visual snapshot updates | agent updates when migration causes expected output changes                |
+
+### Step 2: Upgrade Dependencies
+
+1. Bump Spirit packages to v5 in `package.json`.
+2. Ensure Node.js ≥ 22 (`.nvmrc`, `engines`, CI).
+3. Run the package manager install.
+4. Fix compile-time errors from [removed exports](changesets/general-upgrade-prerequisites.md) before component migrations.
+
+### Step 3: Run Codemods
+
+Run codemods from the **target app root**. Replace `<path>` with the source directory (usually `src`).
+
+Codemods match `@alma-oss/spirit-web-react` by default. When the app imports Spirit through a wrapper re-export package, pass `-s` with that package name on **every** run against those paths. See [Codemods README][codemods-readme] and [wrapper-monorepo](changesets/wrapper-monorepo.md).
+
+**Wrapper monorepo:** run codemods on the wrapper lib first (direct Spirit imports), then on consumer paths with `-s`. See [wrapper-monorepo](changesets/wrapper-monorepo.md).
+
+**Pre-flight:** transform one known file before batch runs; if output is `0 ok` with no diff, verify the codemods package built correctly (`dist/helpers` present).
+
+Omit `-s` when the app imports `@alma-oss/spirit-web-react` directly. When using a wrapper package:
+
+```bash
+IMPORT_SOURCE_ARGS=(-s "@my-org/design-system")
+```
+
+Run each transform explicitly (recommended):
+
+```bash
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/collapse-isDisposable-prop
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/alert-link-color-inherit
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/validation-state-icon-prop
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/flex-direction-values
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/forms-isFluid-prop-removal
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/unstable-fileupload-component-name
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/unstable-file-component-name
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/close-buttons-to-close-button
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/drawer-panel-close-button-composition
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/button-icon-margin-removal
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/scrollview-arrows-to-controls
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/header-unstable-to-stable
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/item-props
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/stack-wrap-children-in-stack-item
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/tag-controlbutton-size
+# Optional — only if preserving previous ControlButton heights:
+# Do not combine blindly with tag-controlbutton-size; reconcile nested Tag controls per both recipes.
+# npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/control-button-size-scale
+```
+
+Or loop over transforms (pass `-t "$transform"` per iteration):
+
+```bash
+set -e
+
+TRANSFORMS=(
+  v5/web-react/collapse-isDisposable-prop
+  v5/web-react/alert-link-color-inherit
+  v5/web-react/validation-state-icon-prop
+  v5/web-react/flex-direction-values
+  v5/web-react/forms-isFluid-prop-removal
+  v5/web-react/unstable-fileupload-component-name
+  v5/web-react/unstable-file-component-name
+  v5/web-react/close-buttons-to-close-button
+  v5/web-react/drawer-panel-close-button-composition
+  v5/web-react/button-icon-margin-removal
+  v5/web-react/scrollview-arrows-to-controls
+  v5/web-react/header-unstable-to-stable
+  v5/web-react/item-props
+  v5/web-react/stack-wrap-children-in-stack-item
+  v5/web-react/tag-controlbutton-size
+)
+for transform in "${TRANSFORMS[@]}"; do
+  npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t "$transform"
+done
+```
+
+Use `IMPORT_SOURCE_ARGS=()` when the app imports `@alma-oss/spirit-web-react` directly.
+
+Review each codemod diff. For skipped patterns (spreads, conditional JSX, `PropsProvider`), apply the matching
+recipe edits yourself — do not defer them.
+
+### Step 4: Apply All Recipe Steps
+
+Process every recipe in [Recipe Index](#recipe-index). For each topic:
+
+1. Read the recipe file.
+2. Search the target app for detection patterns.
+3. **Apply all edits** — codemod gaps, recipe steps, snapshot/CSS updates, and complex migrations (FileUploader,
+   old Header, Navigation slots, form-field markup).
+4. Mark `not-applicable` only when detection finds zero matches.
+5. Record status in the migration report.
+
+There are no user-only migration steps. Recipes labeled `agent` in the index have no codemod but still require
+agent edits in the target codebase.
+
+### Step 5: Cross-Check Markup, Styles, Flags, and Tokens
+
+Always run all cross-cutting recipes, even for React-only apps:
+
+1. [`changesets/web-markup-and-css.md`](changesets/web-markup-and-css.md) — migrate raw Spirit classes, templates, and
+   custom component style overrides when present.
+2. [`changesets/web-css-cross-check.md`](changesets/web-css-cross-check.md) — remove obsolete feature-flag classes from
+   JSX/HTML/templates and Sass variables from styles/configuration.
+3. [`changesets/design-token-renames.md`](changesets/design-token-renames.md) — migrate SCSS variables, CSS custom
+   properties, JavaScript exports, and Pagination overrides.
+
+### Step 6: Validate
+
+Use the target app's configured scripts and package manager. Inspect `package.json`, workspace configuration,
+`Makefile`, Docker Compose / CI docs, and contribution guides first; do not invent commands. Prefer the same
+entry points the app uses in CI (for example `make test-e2e` or a Docker-wrapped Playwright target when host
+`yarn test:e2e` is not how that repo runs E2E). For wrapper monorepos, validate the design-system lib before
+downstream plugins.
+
+```bash
+# Format changed files, then lint the result (when configured)
+yarn format
+yarn lint
+
+# Typecheck / build and tests (when configured)
+yarn types
+yarn build
+yarn test
+
+# Snapshot tests — update when migration causes expected output changes
+yarn test -u
+
+# Relevant visual, end-to-end, and accessibility suites (when configured).
+# Use Make/Docker wrappers when that is the project's documented runner.
+yarn test:e2e   # or: make test-e2e / docker compose … — follow the target repo
+yarn test:a11y
+```
+
+Use the equivalent `npm`, `pnpm`, workspace, Make, Docker, or repository-specific commands. Run formatters and
+linters only when they are present and configured, but record missing scripts as `not-configured` rather than
+silently skipping them.
+
+**Wrapper monorepo:** run types/tests on the wrapper package, then on downstream workspaces that had the heaviest migrations (`yarn workspace <name> test` / `test:unit` as defined in the repo).
+
+Re-run targeted searches for leftover v4 APIs, feature flags, renamed tokens, and unresolved codemod scaffolding:
+
+```bash
+grep -rEn 'TODO_drawer(IsOpen|Id|OnClose)|spirit-feature-enable-v5|\$enable-v5-' <target-path>
+```
+
+### Step 7: Write Migration Report
+
+Create `spirit-v5-migration-report.md` in the **target workspace root** using the [report template](#required-migration-report).
+
+---
+
+## Recipe Index
+
+| Recipe                                                                       | Codemod  | Handler       |
+| ---------------------------------------------------------------------------- | -------- | ------------- |
+| [wrapper-monorepo](changesets/wrapper-monorepo.md)                           | —        | agent         |
+| [general-upgrade-prerequisites](changesets/general-upgrade-prerequisites.md) | —        | agent         |
+| [design-token-renames](changesets/design-token-renames.md)                   | —        | agent         |
+| [alert-link-color](changesets/alert-link-color.md)                           | yes      | codemod+agent |
+| [dropdown-dialog-role](changesets/dropdown-dialog-role.md)                   | —        | agent         |
+| [collapse-is-disposable](changesets/collapse-is-disposable.md)               | yes      | codemod       |
+| [checkbox-composition](changesets/checkbox-composition.md)                   | —        | agent         |
+| [radio-composition](changesets/radio-composition.md)                         | —        | agent         |
+| [toggle-composition](changesets/toggle-composition.md)                       | —        | agent         |
+| [close-button-unification](changesets/close-button-unification.md)           | yes      | codemod+agent |
+| [drawer-panel-composition](changesets/drawer-panel-composition.md)           | partial  | codemod+agent |
+| [flex-direction-values](changesets/flex-direction-values.md)                 | yes      | codemod       |
+| [forms-is-fluid-removal](changesets/forms-is-fluid-removal.md)               | yes      | codemod       |
+| [unstable-picker](changesets/unstable-picker.md)                             | partial  | codemod+agent |
+| [fileupload-stabilization](changesets/fileupload-stabilization.md)           | partial  | codemod+agent |
+| [button-icon-spacing](changesets/button-icon-spacing.md)                     | yes      | codemod       |
+| [button-is-block-removal](changesets/button-is-block-removal.md)             | —        | agent         |
+| [scrollview-controls-rename](changesets/scrollview-controls-rename.md)       | yes      | codemod       |
+| [tag-controlbutton-size](changesets/tag-controlbutton-size.md)               | yes      | codemod+agent |
+| [header-stabilization](changesets/header-stabilization.md)                   | partial  | codemod+agent |
+| [item-composable-api](changesets/item-composable-api.md)                     | yes      | codemod+agent |
+| [stack-stackitem-dividers](changesets/stack-stackitem-dividers.md)           | yes      | codemod+agent |
+| [controlbutton-size-scale](changesets/controlbutton-size-scale.md)           | optional | codemod+agent |
+| [validationtext-api](changesets/validationtext-api.md)                       | yes      | codemod+agent |
+| [success-state-icons](changesets/success-state-icons.md)                     | —        | agent         |
+| [navigation-slots](changesets/navigation-slots.md)                           | —        | agent         |
+| [web-markup-and-css](changesets/web-markup-and-css.md)                       | —        | agent         |
+| [web-css-cross-check](changesets/web-css-cross-check.md)                     | —        | agent         |
+
+---
+
+## Confidence Model
+
+| Level    | When to use                                                                   |
+| -------- | ----------------------------------------------------------------------------- |
+| `high`   | Codemod applied cleanly or agent edit with a single deterministic replacement |
+| `medium` | Codemod with skipped cases the agent patched, or edit with clear before/after |
+| `low`    | Complex composition the agent migrated but needs human visual/a11y review     |
+
+---
+
+## Required Migration Report
+
+Create a report file in the workspace root named:
+
+`spirit-v5-migration-report.md`
+
+```markdown
+# Spirit v4 -> v5 Migration Report
+
+## Scope
+
+- Target: <folders/packages migrated>
+- Date: <YYYY-MM-DD>
+- Spirit packages upgraded: <list>
+- Node.js version: <version>
+- Target profile: `direct` | `wrapper-monorepo` | `mixed`
+- Wrapper package (if any): <package name>
+- Import indirection: `direct` | `wrapper` | `mixed`
+- Codemods effective: `yes` | `no` | `partial`
+
+## Migration Results
+
+### <recipe name from changesets/\*.md>
+
+- Status: `completed` | `partial` | `not-applicable` | `blocked`
+- Files updated: <number>
+- Confidence: `high` | `medium` | `low`
+- Medium/low review locations:
+  - `<path>:<line>` - <why review is needed>
+- Notes: <key decisions, caveats>
+- Remaining review (if any):
+  - `<path>:<line>` - <what the user should visually verify after agent edits>
+
+<!-- Repeat for each processed recipe -->
+
+## Validation
+
+- [ ] `yarn build` (or equivalent) passed
+- [ ] Dependency install passed; executed Spirit/codemod versions recorded
+- [ ] Formatter passed (`not-configured` if absent)
+- [ ] Linter passed (`not-configured` if absent)
+- [ ] Typecheck passed (`not-configured` if absent)
+- [ ] Unit tests passed
+- [ ] Snapshot tests reviewed/updated
+- [ ] Relevant visual/e2e/a11y checks passed (`not-configured` if absent)
+- [ ] Leftover v4 API search clean
+- [ ] Feature-flag and renamed-token searches clean
+- [ ] No unresolved codemod `TODO_*` placeholders
+
+## Summary
+
+- Total migrations processed: <number>
+- Completed: <number>
+- Partial: <number>
+- Not applicable: <number>
+- Blocked: <number>
+- Total files updated: <number>
+```
+
+## Handling Hard Blockers
+
+Use `blocked` only when the agent **cannot** edit the codebase — for example the target path is missing,
+required business logic is outside the repo, or repeated build failures cannot be resolved.
+
+When a recipe has no codemod:
+
+1. **Apply the recipe edits yourself** in the target codebase.
+2. Run build/tests and fix follow-on errors in the same session.
+3. Mark `partial` with review locations when the migration is applied but needs visual verification.
+4. Mark `blocked` only with a concrete reason the agent could not proceed, not because the task is complex.
+
+[codemods-readme]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/codemods/README.md
+[codemods-v5]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/codemods/src/transforms/v5/web-react/README.md
+[migration-design-tokens]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/migrations/design-tokens/migration-v5.md
+[migration-web-react]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/migrations/web-react/migration-v5.md
+[migration-web]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/migrations/web/migration-v5.md

--- a/.agents/skills/spirit-v5-migration/changesets/alert-link-color.md
+++ b/.agents/skills/spirit-v5-migration/changesets/alert-link-color.md
@@ -1,0 +1,34 @@
+# Alert Link Color
+
+## When It Applies
+
+Apps relying on links inside `Alert` to inherit the Alert content color.
+
+## Detection
+
+```bash
+grep -rEn "<Alert|<Link|<a " <path> --include="*.tsx" --include="*.jsx"
+```
+
+## Codemod
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/alert-link-color-inherit
+```
+
+The codemod adds `color="inherit"` to Spirit `Link` descendants of Spirit `Alert` unless a `color` prop already
+exists. It respects aliased imports and configured wrapper import sources.
+
+## Agent Edits
+
+1. Review codemod results and preserve intentional explicit colors.
+2. Add `underlined="always"` where an inherited-color link would otherwise be indistinguishable from surrounding
+   text.
+3. Migrate native `<a>` elements that relied on removed Alert CSS to Spirit `Link`, or apply the equivalent
+   `link-inherit link-underlined` classes when the app uses Spirit web CSS directly.
+
+## Report Guidance
+
+- Status: `not-applicable` when Alerts contain no links relying on inherited color.
+- Status: `completed` after link color and underline behavior are explicit.
+- Confidence: `high` for codemod edits; `medium` for native-link styling.

--- a/.agents/skills/spirit-v5-migration/changesets/button-icon-spacing.md
+++ b/.agents/skills/spirit-v5-migration/changesets/button-icon-spacing.md
@@ -1,0 +1,48 @@
+# Button Icon Spacing
+
+## When It Applies
+
+Apps with `Icon` children inside `Button`, `ButtonLink`, or `ControlButton` using margin props.
+
+## Detection
+
+```bash
+grep -rEn -A 5 '<(Button|ButtonLink|ControlButton)' <path> --include="*.tsx" --include="*.jsx" | grep -E "margin(Right|Left|X)"
+```
+
+## What Changed
+
+Buttons set spacing via `column-gap`. Remove `marginRight`, `marginLeft`, `marginX` from child `Icon` components. Use `spacing` prop on the button for non-default spacing.
+
+## Codemod
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/button-icon-margin-removal
+```
+
+## Safe Automated Edits
+
+```diff
+- <Button>
+-   <Icon name="hamburger" marginRight="space-400" />
++ <Button>
++   <Icon name="hamburger" />
+    Menu
+  </Button>
+
+- <Button>
+-   <Icon name="hamburger" marginRight="space-600" />
++ <Button spacing="space-600">
++   <Icon name="hamburger" />
+    Menu
+  </Button>
+```
+
+## Agent Edits
+
+The agent patches spacing patterns the codemod skips.
+
+## Report Guidance
+
+- Status: `completed` when codemod applied and agent patched remaining spacing cases.
+- Confidence: `high` for direct Icon margins; `medium` for other spacing patterns.

--- a/.agents/skills/spirit-v5-migration/changesets/button-is-block-removal.md
+++ b/.agents/skills/spirit-v5-migration/changesets/button-is-block-removal.md
@@ -1,0 +1,38 @@
+# Button `isBlock` Removal
+
+## When It Applies
+
+Apps using `isBlock` on `Button` or `ButtonLink`.
+
+## Detection
+
+```bash
+grep -rEn "isBlock" <path> --include="*.tsx" --include="*.jsx"
+```
+
+## Agent Edits
+
+The agent applies layout replacements for every `isBlock` match in the target codebase.
+
+```tsx
+// All breakpoints
+<div className="d-grid">
+  <Button>Full-width Button</Button>
+</div>
+
+// Mobile only
+<div className="d-grid d-tablet-block">
+  <Button>Full-width on mobile</Button>
+</div>
+
+// Responsive with Grid
+<Grid cols={{ mobile: 1, tablet: 2 }}>
+  <Button>Responsive Button</Button>
+</Grid>
+```
+
+## Report Guidance
+
+- Status: `not-applicable` if no `isBlock` usage.
+- Status: `completed` after layout replacement.
+- Confidence: `high`.

--- a/.agents/skills/spirit-v5-migration/changesets/checkbox-composition.md
+++ b/.agents/skills/spirit-v5-migration/changesets/checkbox-composition.md
@@ -1,0 +1,34 @@
+# Checkbox Composition and Spacing
+
+## When It Applies
+
+Apps using `Checkbox`, especially rows with explicit `marginY` or custom label typography.
+
+## Detection
+
+```bash
+grep -rEn "<Checkbox" <path> --include="*.tsx" --include="*.jsx"
+```
+
+## What Changed
+
+Checkbox now composes its layout from Spirit components and provides built-in `py-500` row padding.
+`Label` already owns label typography.
+
+## Codemod
+
+None.
+
+## Agent Edits
+
+1. Remove explicit `marginY="space-500"` added for the old row spacing.
+2. Stack multiple Checkbox rows with plain `<Stack>`; remove `hasSpacing` when the Stack contains only these rows,
+   because built-in padding already provides spacing.
+3. Keep `hasSpacing` when the Stack intentionally mixes Checkbox rows with other form fields.
+4. Replace `<Text emphasis="semibold">` or other custom typography passed as `label` with a plain label string.
+5. Update snapshots affected by the composition markup.
+
+## Report Guidance
+
+- Status: `completed` when redundant margins/gaps and custom label typography are removed.
+- Confidence: `high` for deterministic cleanup; `medium` for mixed custom layouts.

--- a/.agents/skills/spirit-v5-migration/changesets/close-button-unification.md
+++ b/.agents/skills/spirit-v5-migration/changesets/close-button-unification.md
@@ -1,0 +1,35 @@
+# Close Button Unification
+
+## When It Applies
+
+Apps directly using `ModalCloseButton` or `TooltipCloseButton`. Drawer close buttons are completed by the
+[drawer-panel-composition](drawer-panel-composition.md) recipe.
+
+## Detection
+
+```bash
+grep -rEn "ModalCloseButton|TooltipCloseButton|DrawerCloseButton" <path> --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx"
+```
+
+## Codemod
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/close-buttons-to-close-button
+```
+
+The codemod replaces direct Modal and Tooltip close buttons with `CloseButton`, remaps Modal props to ARIA and
+click-handler props, and preserves existing labels.
+
+## Agent Edits
+
+1. Verify migrated Modal buttons use `size="xlarge"`, `aria-controls`, `aria-expanded`, and `onClick`.
+2. Verify migrated Tooltip buttons use `aria-expanded="true"` and `onClick`.
+3. Do not add direct buttons when `ModalHeader hasCloseButton` or `TooltipPopover isDismissible` already renders
+   the internal close button.
+4. Process `DrawerCloseButton` through the Drawer recipe instead of treating it as a standalone replacement.
+
+## Report Guidance
+
+- Status: `not-applicable` when no removed close-button components are imported directly.
+- Status: `completed` when removed imports/usages are absent and ARIA wiring is valid.
+- Confidence: `high` for Modal/Tooltip codemod edits.

--- a/.agents/skills/spirit-v5-migration/changesets/collapse-is-disposable.md
+++ b/.agents/skills/spirit-v5-migration/changesets/collapse-is-disposable.md
@@ -1,0 +1,38 @@
+# Collapse `hideOnCollapse` to `isDisposable`
+
+## When It Applies
+
+Apps using `UncontrolledCollapse` with `hideOnCollapse` or vanilla Collapse triggers with `data-spirit-more`.
+
+## Detection
+
+```bash
+grep -rEn "hideOnCollapse|UncontrolledCollapse|data-spirit-more" <path> --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.twig"
+```
+
+## Codemod
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/collapse-isDisposable-prop
+```
+
+## Safe Automated Edits
+
+```diff
+- <UncontrolledCollapse hideOnCollapse … />
++ <UncontrolledCollapse isDisposable … />
+```
+
+## Agent Edits
+
+The agent applies the React prop rename when the codemod misses a match and replaces
+`data-spirit-more` with `data-spirit-is-disposable` in static markup.
+
+## Validation
+
+No remaining `hideOnCollapse` props or `data-spirit-more` attributes.
+
+## Report Guidance
+
+- Status: `completed` after codemod or agent-applied rename.
+- Confidence: `high`.

--- a/.agents/skills/spirit-v5-migration/changesets/controlbutton-size-scale.md
+++ b/.agents/skills/spirit-v5-migration/changesets/controlbutton-size-scale.md
@@ -1,0 +1,56 @@
+# ControlButton Size Scale
+
+## When It Applies
+
+Apps using `ControlButton` where previous rendered heights must be preserved.
+
+## Detection
+
+```bash
+grep -rEn '<ControlButton|spirit-feature-enable-v5-control-button-expanded-size-scale|\$enable-v5-control-button-expanded-size-scale' <path>
+```
+
+## What Changed
+
+Expanded size scale is now default. Heights remapped:
+
+| `size`   | Height before | Height now |
+| -------- | ------------- | ---------- |
+| `xsmall` | —             | 16px       |
+| `small`  | 24px          | 20px       |
+| `medium` | 32px          | 24px       |
+| `large`  | 40px          | 32px       |
+| `xlarge` | —             | 40px       |
+
+## Codemod (optional)
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/control-button-size-scale
+```
+
+**Run only if** you relied on previous heights. Shifts every `size` up one step. Skips JSX spreads and `PropsProvider` size.
+The transform matches the literal `ControlButton` JSX name rather than imports, so review aliases and same-named
+local components.
+
+## Safe Automated Edits
+
+Remove the dead `spirit-feature-enable-v5-control-button-expanded-size-scale` class from markup/class helpers and
+the `$enable-v5-control-button-expanded-size-scale` variable from Sass configuration.
+
+If preserving heights:
+
+- omitted `size` (was `medium`) → `size="large"`
+- `small` → `medium`, `medium` → `large`, `large` → `xlarge`
+
+## Agent Edits
+
+The agent patches `<ControlButton {...props} />` spreads and `PropsProvider` context sizing when detectable.
+If the app also uses ControlButton inside Tag, reconcile those final values with
+[tag-controlbutton-size](tag-controlbutton-size.md). The global and Tag-specific transforms are not safely
+composable for every original size, so inspect nested controls instead of trusting transform order.
+
+## Report Guidance
+
+- Status: `not-applicable` if no feature flag exists and the app accepts new default sizes.
+- Status: `completed` after flag cleanup and, when chosen, the optional size codemod and snapshot review.
+- Confidence: `medium` — visual breaking change.

--- a/.agents/skills/spirit-v5-migration/changesets/design-token-renames.md
+++ b/.agents/skills/spirit-v5-migration/changesets/design-token-renames.md
@@ -1,0 +1,35 @@
+# Design Token Renames
+
+## When It Applies
+
+Apps with custom Spirit theme overrides, CSS custom properties, or JavaScript token imports.
+
+## Detection
+
+```bash
+grep -rEn "form-field-filled|component-header-item|componentHeaderItem" <path> --include="*.scss" --include="*.sass" --include="*.css" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" --include="*.json"
+grep -rEn "component-button-(primary|secondary)" <path> --include="*.scss" --include="*.sass" --include="*.css" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" --include="*.json"
+```
+
+## Agent Edits
+
+1. Rename `form-field-filled-*` to `form-field-fill-*` in SCSS variables and
+   `--spirit-color-form-field-filled-*` to `--spirit-color-form-field-fill-*` in CSS custom properties.
+2. Rename `component-header-item-*` to `component-navigation-item-*` in SCSS/CSS and
+   `componentHeaderItem*` to `componentNavigationItem*` in JavaScript/TypeScript token imports.
+3. For overrides specifically styling Pagination items, replace reused `component-button-secondary-*` and
+   `component-button-primary-*` custom properties with the matching
+   `component-pagination-unselected-*` and `component-pagination-selected-*` properties from the canonical
+   design-tokens migration guide.
+4. Do not globally rename Button token overrides: Pagination migration is contextual, not a blanket token rename.
+5. Re-run detection and compile styles or build the target app.
+
+## Codemod
+
+None.
+
+## Report Guidance
+
+- Status: `not-applicable` when no old token names or Pagination-specific Button token overrides exist.
+- Status: `completed` when old names are absent and styles compile.
+- Confidence: `high` for direct renames; `medium` for identifying contextual Pagination overrides.

--- a/.agents/skills/spirit-v5-migration/changesets/drawer-panel-composition.md
+++ b/.agents/skills/spirit-v5-migration/changesets/drawer-panel-composition.md
@@ -1,0 +1,37 @@
+# DrawerPanel Composition
+
+## When It Applies
+
+Apps using `DrawerPanel`, especially its removed `closeButton` prop, `DrawerCloseButton`, or panel-level
+`hasSpacing`.
+
+## Detection
+
+```bash
+grep -rEn "DrawerPanel|DrawerCloseButton|closeButton=|hasSpacing" <path> --include="*.tsx" --include="*.jsx"
+```
+
+## Codemod
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/drawer-panel-close-button-composition
+```
+
+The codemod wraps panel content in `DrawerPanelHeader` and `DrawerPanelBody`. A `DrawerCloseButton` is scaffolded as
+`CloseButton` with intentionally undefined `TODO_drawerIsOpen`, `TODO_drawerId`, and `TODO_drawerOnClose`
+identifiers.
+
+## Agent Edits
+
+1. Replace every generated `TODO_drawer*` identifier with the actual Drawer open state, id, and close handler.
+2. Add an accessible `aria-label` to `Drawer`.
+3. Move panel-level `hasSpacing` to `DrawerPanelBody`.
+4. Place title/header content and `CloseButton size="large"` in `DrawerPanelHeader`; keep scrollable content in
+   `DrawerPanelBody`.
+5. Run typecheck/build: unresolved placeholders are a failed migration, not an acceptable partial result.
+
+## Report Guidance
+
+- Status: `not-applicable` when no DrawerPanel usage exists.
+- Status: `completed` only after all placeholders are resolved and the Drawer has an accessible name.
+- Confidence: `medium` because state and handler wiring are application-specific.

--- a/.agents/skills/spirit-v5-migration/changesets/dropdown-dialog-role.md
+++ b/.agents/skills/spirit-v5-migration/changesets/dropdown-dialog-role.md
@@ -1,0 +1,45 @@
+# Dropdown Dialog Role
+
+## When It Applies
+
+Apps using `Dropdown`, `DropdownPopover`, or `DropdownTrigger`.
+
+## Detection
+
+```bash
+grep -rEn "<DropdownPopover|<DropdownTrigger|<Dropdown" <path> --include="*.tsx" --include="*.jsx"
+```
+
+## What Changed
+
+- `DropdownPopover` renders `role="dialog"` by default.
+- `DropdownTrigger` has `aria-haspopup="dialog"` by default.
+- Keyboard: Escape closes; Tab/Shift+Tab past focusable elements closes; focus moves to first interactive element on open.
+
+## Agent Edits
+
+The agent adds accessible names and updates snapshots in the target codebase.
+
+1. Add `aria-label` or `aria-labelledby` to every `DropdownPopover` (required for ARIA dialogs).
+2. Remove redundant explicit `role="dialog"` if it was a v4 feature-flag workaround.
+3. Update snapshot tests for new `role` and `aria-haspopup` attributes.
+
+**Opt out** for navigation menus — override both popover role and trigger `aria-haspopup`:
+
+```tsx
+<Dropdown …>
+  <DropdownTrigger aria-haspopup="menu" elementType="button">Trigger</DropdownTrigger>
+  <DropdownPopover role="menu">…</DropdownPopover>
+</Dropdown>
+```
+
+## Validation
+
+- Every `DropdownPopover` has an accessible name.
+- Snapshot tests updated.
+
+## Report Guidance
+
+- Status: `completed` when all popovers named and snapshots updated.
+- Status: `partial` if some popovers need design review for opt-out.
+- Confidence: `high` for adding `aria-label`; `medium` for opt-out cases.

--- a/.agents/skills/spirit-v5-migration/changesets/fileupload-stabilization.md
+++ b/.agents/skills/spirit-v5-migration/changesets/fileupload-stabilization.md
@@ -1,0 +1,73 @@
+# FileUpload and File Stabilization
+
+## When It Applies
+
+Apps using `FileUploader`, `UNSTABLE_FileUpload`, `UNSTABLE_File`, or related types.
+
+## Detection
+
+```bash
+grep -rEn "FileUploader|UNSTABLE_FileUpload|UNSTABLE_File|UnstableFileUpload|UncontrolledFileUploader|useFileQueue" <path> --include="*.ts" --include="*.tsx"
+```
+
+## Codemods
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/unstable-fileupload-component-name
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/unstable-file-component-name
+```
+
+Handles rename of `UNSTABLE_*` to stable names and prop renames:
+
+- `linkText` → `inputUploadText`
+- `labelText` → `inputDragAndDropText`
+
+## Safe Automated Edits
+
+Stabilized names:
+
+| Before                      | After              |
+| --------------------------- | ------------------ |
+| `UNSTABLE_FileUpload`       | `FileUpload`       |
+| `UNSTABLE_File`             | `File`             |
+| `UNSTABLE_FileImagePreview` | `FileImagePreview` |
+| `UnstableFileUploadProps`   | `FileUploadProps`  |
+| `UnstableFileItem`          | `FileItem`         |
+
+## Agent Edits
+
+The agent migrates `FileUploader` in the target codebase — no codemod exists for the compound API.
+
+1. Replace `FileUploader` composition with `FileUpload` + `File` rows.
+2. Move queue logic (`addToQueue`, `onDismiss`, limits) to application state (preserve existing behavior).
+3. Keep validation in the app; pass only visual validation props to `FileUpload`.
+4. Run build/tests and fix follow-on type errors in the same session.
+
+```tsx
+// After pattern
+const [items, setItems] = useState<FileItem[]>([]);
+
+<Stack hasSpacing>
+  <FileUpload
+    id="file-upload"
+    name="attachments"
+    label="Label"
+    inputUploadText="Upload your file(s)"
+    inputDragAndDropText="or drag and drop here"
+    onFilesSelected={(files) => setItems((c) => [...c, ...files.map((f) => ({ id: f.name, label: f.name }))])}
+  />
+  <Stack elementType="ul" aria-label="Uploaded files" hasSpacing>
+    {items.map((item) => (
+      <File key={item.id} id={item.id} label={item.label} onDismiss={() => onDismiss(item.id)} />
+    ))}
+  </Stack>
+</Stack>;
+```
+
+See component READMEs for image previews and validation states.
+
+## Report Guidance
+
+- Status: `completed` when all FileUploader/UNSTABLE usages are migrated and the app builds.
+- Status: `partial` when migration is applied but queue/validation behavior needs visual QA.
+- Confidence: `high` for codemods; `medium` for FileUploader recomposition the agent applied.

--- a/.agents/skills/spirit-v5-migration/changesets/flex-direction-values.md
+++ b/.agents/skills/spirit-v5-migration/changesets/flex-direction-values.md
@@ -1,0 +1,34 @@
+# Flex Direction Values
+
+## When It Applies
+
+Apps using `Flex` with `direction="row"` or `direction="column"`.
+
+## Detection
+
+```bash
+grep -rEn 'direction="(row|column)"|direction=\{\{.*(row|column)' <path> --include="*.tsx" --include="*.jsx"
+```
+
+## Codemod
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/flex-direction-values
+```
+
+## Safe Automated Edits
+
+```diff
+- <Flex direction="row" … />
+- <Flex direction="column" … />
++ <Flex direction="horizontal" … />
++ <Flex direction="vertical" … />
+
+- <Flex direction={{ mobile: "column", tablet: "row" }} … />
++ <Flex direction={{ mobile: 'vertical', tablet: 'horizontal' }} … />
+```
+
+Only updates `Flex` imported from Spirit (respects `-s` wrapper sources). Plain `.ts` files without Spirit `Flex` usage are left unchanged.
+
+- Status: `completed` after codemod or agent-applied rename.
+- Confidence: `high`.

--- a/.agents/skills/spirit-v5-migration/changesets/forms-is-fluid-removal.md
+++ b/.agents/skills/spirit-v5-migration/changesets/forms-is-fluid-removal.md
@@ -1,0 +1,50 @@
+# Form Components `isFluid` Removal
+
+## When It Applies
+
+Apps using `isFluid` on form components.
+
+## Detection
+
+```bash
+grep -rEn "isFluid" <path> --include="*.tsx" --include="*.jsx"
+```
+
+## Affected Components
+
+The codemod covers `TextField`, `TextArea`, `Select`, `Slider`, `Toggle`, `FieldGroup`, `UNSTABLE_Picker`, and
+`UNSTABLE_UncontrolledPicker`. Remove `isFluid` from stable `FileUpload` manually.
+
+Form components are fluid by default. Use `Grid`, `Stack`, or `Container` for width control.
+
+## Codemod
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/forms-isFluid-prop-removal
+```
+
+Does not touch non-form components (`Container`, `PartnerLogo`, `SegmentedControl`).
+
+### PartnerLogo Edge Case
+
+The codemod **intentionally skips** `PartnerLogo`. Unlike form fields, `PartnerLogo` **still supports `isFluid` in v5** — it is a layout prop for fluid logo sizing, not a removed form API. Do not remove `isFluid` from `PartnerLogo` during this migration. If a leftover `isFluid` search flags `PartnerLogo`, mark it `not-applicable` for this recipe and verify against the [PartnerLogo README][partnerlogo-readme] only when v5 API docs differ.
+
+## Safe Automated Edits
+
+```diff
+- <TextField id="name" label="Name" isFluid />
++ <TextField id="name" label="Name" />
+```
+
+## Agent Edits
+
+The agent applies layout wrappers when `isFluid` was controlling width.
+
+If `isFluid` achieved a specific layout, add parent `Grid`, `Stack`, or `Container` in the target codebase.
+
+## Report Guidance
+
+- Status: `completed` when all `isFluid` props removed from form components.
+- Confidence: `high`.
+
+[partnerlogo-readme]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/PartnerLogo/README.md

--- a/.agents/skills/spirit-v5-migration/changesets/general-upgrade-prerequisites.md
+++ b/.agents/skills/spirit-v5-migration/changesets/general-upgrade-prerequisites.md
@@ -1,0 +1,33 @@
+# General Upgrade Prerequisites
+
+## When It Applies
+
+Every Spirit v5 migration. Run before component-level recipes.
+
+## Detection
+
+```bash
+grep -rEn "engines.*node|@alma-oss/spirit" package.json
+grep -rEn "@alma-oss/spirit-web-react/.*/" <path> --include="*.ts" --include="*.tsx"  # deep imports
+grep -rEn "formFieldMode" <path> --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx"
+```
+
+## Steps
+
+The agent performs these steps in the target codebase:
+
+1. **Node.js ≥ 22** — upgrade `.nvmrc`, `engines.node`, and CI matrix.
+2. **Bump packages** — `@alma-oss/spirit-web-react`, `@alma-oss/spirit-web`, `@alma-oss/spirit-design-tokens` to v5.
+3. **Fix removed exports** — TypeScript will fail on imports removed in v5. Resolve compile errors before component-level recipes; dedicated recipes cover stabilized components (e.g. [fileupload-stabilization](fileupload-stabilization.md), [header-stabilization](header-stabilization.md)).
+4. **Verify deep imports** — internal paths like `Field/` utilities may have moved; confirm they still exist.
+5. **Remove `formFieldMode` usage** — the internal form-field mode API and its vertical-spacing behavior were
+   removed; compose spacing explicitly using the current form components/layout APIs.
+
+## Codemod
+
+None for this step.
+
+## Report Guidance
+
+- Status: `completed` when packages upgraded and compile errors from removed exports resolved.
+- Confidence: `high` for package bumps; `medium` for deep-import fixes the agent applied.

--- a/.agents/skills/spirit-v5-migration/changesets/header-stabilization.md
+++ b/.agents/skills/spirit-v5-migration/changesets/header-stabilization.md
@@ -1,0 +1,62 @@
+# Header Stabilization
+
+## When It Applies
+
+Apps using `UNSTABLE_Header`, `UNSTABLE_HeaderLogo`, or the previous `Header` with subcomponents.
+
+## Detection
+
+```bash
+grep -rEn "UNSTABLE_Header|UNSTABLE_HeaderLogo|HeaderNav|HeaderDialog|HeaderMobileActions|useUnstableHeaderStyleProps" <path>
+# Local naming aliases (wrapper monorepos)
+grep -rEn "UNSTABLE_SpiritHeader|SpiritHeader|Header as " <path> --include="*.tsx" --include="*.ts"
+```
+
+## Codemod (UNSTABLE Rename Only)
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/header-unstable-to-stable
+```
+
+Renames `UNSTABLE_Header` → `Header`, `UNSTABLE_HeaderLogo` → `HeaderLogo`, and related types/hooks.
+
+Pass `-s <wrapper-package>` when imports go through a design-system wrapper.
+
+## Safe Automated Edits
+
+```diff
+- import { UNSTABLE_Header, UNSTABLE_HeaderLogo } from '@alma-oss/spirit-web-react';
++ import { Header, HeaderLogo } from '@alma-oss/spirit-web-react';
+```
+
+## Agent Edits
+
+The agent recomposes old `Header` usage in the target codebase — no codemod exists for the previous compound API.
+
+Removed subcomponents: `HeaderNav`, `HeaderDialog`, `HeaderMobileActions`, etc. Rebuild with current `Header`,
+`Navigation`, and `Drawer`. Read the existing layout and preserve behavior (logo, nav items, mobile drawer) as
+closely as the new API allows.
+
+See [Header README][header-readme] for composition examples.
+
+### Local Naming Collisions
+
+When the app already exports a component named `Header`, do **not** rename Spirit imports to bare `Header`. Import
+under an alias and keep the local name unchanged:
+
+```tsx
+import { Header as SpiritHeader, HeaderLogo as SpiritHeaderLogo } from '@org/design-system';
+
+export { Header } from './Header'; // local wrapper unchanged
+```
+
+Migrate `UNSTABLE_SpiritHeader` / `UNSTABLE_SpiritHeaderLogo` aliases to `SpiritHeader` / `SpiritHeaderLogo`
+(import aliases above). The `header-unstable-to-stable` codemod does not match these custom names — apply manually.
+
+## Report Guidance
+
+- Status: `completed` when UNSTABLE rename and any old Header recomposition are done and the app builds.
+- Status: `partial` when recomposition is applied but layout/mobile behaviour needs visual QA.
+- Confidence: `high` for codemod; `medium` for old Header migration or alias renames the agent applied.
+
+[header-readme]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/Header/README.md

--- a/.agents/skills/spirit-v5-migration/changesets/item-composable-api.md
+++ b/.agents/skills/spirit-v5-migration/changesets/item-composable-api.md
@@ -1,0 +1,71 @@
+# Item Composable API
+
+## When It Applies
+
+Apps using `Item` with `label`, `helperText`, `iconName`, or `selectionDecorator` props.
+
+## Detection
+
+```bash
+grep -rEn "<Item.*(label|helperText|iconName|selectionDecorator)" <path> --include="*.tsx" --include="*.jsx"
+grep -rEn "selectionDecorator" <path>
+```
+
+## What Changed
+
+| Before                    | After                                                 |
+| ------------------------- | ----------------------------------------------------- |
+| `label` prop              | `children` with `Label`                               |
+| `helperText` prop         | `children` with `HelperText`                          |
+| `iconName` prop           | `startSlot={<Icon name="…" />}`                       |
+| `selectionDecorator`      | `isSelected` + explicit `endSlot`                     |
+| Implicit `button` default | `div` default; set `elementType="button"` for buttons |
+
+Selection indicators in `endSlot` still use the `check-plain` icon (see [Item README][readme-item]).
+
+## Codemod
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/item-props
+```
+
+Adds `elementType="button"`, migrates slots and children. May not cover all dynamic cases.
+
+## Safe Automated Edits
+
+```diff
+- <Item label="Item" iconName="search" helperText="Helper text" isSelected />
++ <Item
++   elementType="button"
++   startSlot={<Icon name="search" color="selected" />}
++   endSlot={<Icon name="check-plain" color="selected" />}
++   isSelected
++ >
++   <Label>Item</Label>
++   <HelperText helperText="Helper text" />
++ </Item>
+```
+
+**`selectionDecorator` mapping:**
+
+- omitted or `"icon"` → trailing check icon in `endSlot` when selected
+- `"background"` → `isSelected` only
+- `"both"` → `isSelected` plus trailing check icon in `endSlot`
+
+## Agent Edits
+
+The agent applies Item API changes the codemod skips.
+
+- `isDisabled` on `elementType="a"` or `role="option"` — add `aria-disabled` explicitly.
+- Generated `startSlot` icons — add `color="selected"` when the selected design requires it; the codemod applies
+  selected color only to generated end-slot check icons.
+- Dynamic `selectionDecorator` values — migrate using the mapping table above.
+- Complex conditional Item rendering — refactor to composable API while preserving behavior.
+
+## Report Guidance
+
+- Status: `completed` when all Items migrated.
+- Status: `partial` if codemod skipped dynamic cases.
+- Confidence: `medium` — review visual result and a11y.
+
+[readme-item]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/Item/README.md

--- a/.agents/skills/spirit-v5-migration/changesets/navigation-slots.md
+++ b/.agents/skills/spirit-v5-migration/changesets/navigation-slots.md
@@ -1,0 +1,36 @@
+# Navigation Slots and Open State
+
+## When It Applies
+
+Apps using `Navigation`, `NavigationAction`, or vertical navigation with custom icons.
+
+## Detection
+
+```bash
+grep -rEn "NavigationAction|Navigation" <path> --include="*.tsx" --include="*.jsx"
+```
+
+## What Changed
+
+- `NavigationAction` supports `startSlot`/`endSlot` for content around the label.
+- Expanded category triggers get open visual state from `aria-expanded="true"`.
+- Vertical selected-state indicator (active stripe in `box` variant) removed.
+
+## Codemod
+
+None.
+
+## Agent Edits
+
+The agent applies slot migration, a11y attributes, and snapshot updates in the target codebase.
+
+1. Move icons from `NavigationAction` children to `startSlot`/`endSlot`.
+2. Set `aria-expanded="true"` on expanded category triggers.
+3. Use structural nesting for second-level items; keep icons on parent category actions only.
+4. Update snapshots if relying on selected-state stripe.
+
+## Report Guidance
+
+- Status: `not-applicable` if Navigation not used.
+- Status: `completed` after slot migration and a11y attributes.
+- Confidence: `medium`.

--- a/.agents/skills/spirit-v5-migration/changesets/radio-composition.md
+++ b/.agents/skills/spirit-v5-migration/changesets/radio-composition.md
@@ -1,0 +1,31 @@
+# Radio Composition and Spacing
+
+## When It Applies
+
+Apps using `Radio`, especially rows with explicit `marginY`.
+
+## Detection
+
+```bash
+grep -rEn "<Radio" <path> --include="*.tsx" --include="*.jsx"
+```
+
+## What Changed
+
+Radio now composes its layout from Spirit components and provides built-in `py-500` row padding.
+
+## Codemod
+
+None.
+
+## Agent Edits
+
+1. Remove explicit `marginY="space-500"` added for the old row spacing.
+2. Stack multiple Radio rows with plain `<Stack>`; remove `hasSpacing` when the Stack contains only these rows.
+3. Keep `hasSpacing` when the Stack intentionally mixes Radio rows with other form fields.
+4. Update snapshots affected by the composition markup.
+
+## Report Guidance
+
+- Status: `completed` when redundant margins/gaps are removed.
+- Confidence: `high` for deterministic cleanup; `medium` for mixed custom layouts.

--- a/.agents/skills/spirit-v5-migration/changesets/scrollview-controls-rename.md
+++ b/.agents/skills/spirit-v5-migration/changesets/scrollview-controls-rename.md
@@ -1,0 +1,35 @@
+# ScrollView Arrows to Controls
+
+## When It Applies
+
+Apps using ScrollView arrow APIs, hooks, or constants.
+
+## Detection
+
+```bash
+grep -rEn "hasArrows|ScrollViewArrows|useScrollViewArrows|arrowsScrollStep|ariaLabelArrows|SCROLL_VIEW_ARROWS" <path>
+```
+
+## Codemod
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/scrollview-arrows-to-controls
+```
+
+## Safe Automated Edits
+
+| Before                       | After                          |
+| ---------------------------- | ------------------------------ |
+| `hasArrows`                  | `hasControls`                  |
+| `arrowsScrollStep`           | `controlsScrollStep`           |
+| `ariaLabelArrows`            | `ariaLabelControls`            |
+| `ScrollViewArrows`           | `ScrollViewControls`           |
+| `useScrollViewArrows`        | `useScrollViewControls`        |
+| `{ arrows }`                 | `{ controls }`                 |
+| `SCROLL_VIEW_ARROWS_LABEL_*` | `SCROLL_VIEW_CONTROLS_LABEL_*` |
+| `classProps.arrows`          | `classProps.controls`          |
+
+## Report Guidance
+
+- Status: `completed` after codemod or agent-applied rename.
+- Confidence: `high`.

--- a/.agents/skills/spirit-v5-migration/changesets/stack-stackitem-dividers.md
+++ b/.agents/skills/spirit-v5-migration/changesets/stack-stackitem-dividers.md
@@ -1,0 +1,49 @@
+# Stack `StackItem` Dividers
+
+## When It Applies
+
+Apps using `Stack` with `hasIntermediateDividers`, `hasStartDivider`, or `hasEndDivider`.
+
+## Detection
+
+```bash
+grep -rEn "has(IntermediateDividers|StartDivider|EndDivider)" <path> --include="*.tsx" --include="*.jsx"
+```
+
+## Codemod
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/stack-wrap-children-in-stack-item
+```
+
+Wraps direct children in `StackItem`. Adds import if missing.
+
+**Skipped:** expression-container children (`{condition && <Item />}`, comments).
+
+## Safe Automated Edits
+
+```diff
+- import { Stack } from '@alma-oss/spirit-web-react';
++ import { Stack, StackItem } from '@alma-oss/spirit-web-react';
+
+- <Stack hasIntermediateDividers>
+-   <>Item 1</>
+-   <>Item 2</>
+- </Stack>
++ <Stack hasIntermediateDividers>
++   <StackItem>Item 1</StackItem>
++   <StackItem>Item 2</StackItem>
++ </Stack>
+```
+
+When `Stack` has `elementType="ul"` or `elementType="ol"`, `StackItem` defaults to `elementType="li"`.
+
+## Agent Edits
+
+The agent wraps conditional Stack children the codemod skips (`{condition && <Item />}`, mapped lists).
+
+## Report Guidance
+
+- Status: `completed` when all divider Stack children wrapped.
+- Status: `partial` if conditional children remain.
+- Confidence: `medium`.

--- a/.agents/skills/spirit-v5-migration/changesets/success-state-icons.md
+++ b/.agents/skills/spirit-v5-migration/changesets/success-state-icons.md
@@ -1,0 +1,32 @@
+# Success State Icons
+
+## When It Applies
+
+Apps with custom success validation/status icon references.
+
+## Detection
+
+```bash
+grep -rEn "check-plain|validationStateIcon|hasValidationIcon|validationState=.success." <path> --include="*.tsx" --include="*.ts" --include="*.jsx" --include="*.js" --include="*.html" --include="*.twig"
+```
+
+## What Changed
+
+Success icons in `ValidationText`, `Alert`, and `Toast` now use `success` instead of `check-plain`.
+Selection indicators such as Item and PricingPlan still use `check-plain`.
+
+## Agent Edits
+
+1. Replace custom `check-plain` references with `success` only when they represent success validation or status.
+2. Keep `check-plain` for selection/checkmark semantics.
+3. Review snapshots or visual tests for affected status components.
+
+## Codemod
+
+None.
+
+## Report Guidance
+
+- Status: `not-applicable` when the app has no custom success icon references.
+- Status: `completed` when status and selection semantics use the correct distinct icons.
+- Confidence: `medium` because the icon name alone does not reveal semantics.

--- a/.agents/skills/spirit-v5-migration/changesets/tag-controlbutton-size.md
+++ b/.agents/skills/spirit-v5-migration/changesets/tag-controlbutton-size.md
@@ -1,0 +1,36 @@
+# Tag ControlButton Size
+
+## When It Applies
+
+Apps rendering `ControlButton` inside `Tag`.
+
+## Detection
+
+```bash
+grep -rEn "<Tag|<ControlButton" <path> --include="*.tsx" --include="*.jsx"
+```
+
+## Codemod
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/tag-controlbutton-size
+```
+
+The codemod changes nested ControlButton sizes `small` → `xsmall` and `medium` → `small`, including responsive
+object values. It skips omitted/dynamic sizes and spread-provided values. It matches literal JSX names rather than
+Spirit imports, so review aliases and same-named local components.
+
+## Agent Edits
+
+1. Review all `ControlButton` descendants of `Tag`, including wrapper components and values supplied by spreads or
+   `PropsProvider`.
+2. Keep `xsmall` unchanged.
+3. If the optional global ControlButton size-preservation transform also ran, manually reconcile every nested
+   control with the final Tag mapping; the two transforms are not safely composable for every original size.
+4. Verify visual alignment for every Tag size and update expected snapshots.
+
+## Report Guidance
+
+- Status: `not-applicable` when Tags do not contain ControlButton.
+- Status: `completed` when nested controls follow the v5 size mapping.
+- Confidence: `high` for literal codemod edits; `medium` for dynamic/context sizes.

--- a/.agents/skills/spirit-v5-migration/changesets/toggle-composition.md
+++ b/.agents/skills/spirit-v5-migration/changesets/toggle-composition.md
@@ -1,0 +1,33 @@
+# Toggle Composition and Spacing
+
+## When It Applies
+
+Apps using `Toggle`, especially rows with explicit `marginY` or custom label typography.
+
+## Detection
+
+```bash
+grep -rEn "<Toggle" <path> --include="*.tsx" --include="*.jsx"
+```
+
+## What Changed
+
+Toggle now composes its layout from Spirit components and provides built-in `py-500` row padding.
+`Label` already owns label typography.
+
+## Codemod
+
+None.
+
+## Agent Edits
+
+1. Remove explicit `marginY="space-500"` added for the old row spacing.
+2. Stack multiple Toggle rows with plain `<Stack>`; remove `hasSpacing` when the Stack contains only these rows.
+3. Keep `hasSpacing` when the Stack intentionally mixes Toggle rows with other form fields.
+4. Replace `<Text emphasis="semibold">` or other custom typography passed as `label` with a plain label string.
+5. Update snapshots affected by the composition markup.
+
+## Report Guidance
+
+- Status: `completed` when redundant margins/gaps and custom label typography are removed.
+- Confidence: `high` for deterministic cleanup; `medium` for mixed custom layouts.

--- a/.agents/skills/spirit-v5-migration/changesets/unstable-picker.md
+++ b/.agents/skills/spirit-v5-migration/changesets/unstable-picker.md
@@ -1,0 +1,40 @@
+# UNSTABLE_Picker
+
+## When It Applies
+
+Apps using `UNSTABLE_Picker`, `UNSTABLE_UncontrolledPicker`, or related subcomponents. The component remains
+**UNSTABLE** in v5 — there is no stabilization codemod like `FileUpload`.
+
+## Detection
+
+```bash
+grep -rEn "UNSTABLE_Picker|UNSTABLE_UncontrolledPicker|UNSTABLE_PickerGroup|UNSTABLE_PickerItem|UNSTABLE_PickerTag" <path> --include="*.tsx" --include="*.ts"
+```
+
+## Codemod
+
+Partial — only shared breaking changes apply:
+
+- **`isFluid` removed** — handled by [forms-is-fluid-removal](forms-is-fluid-removal.md) (`UNSTABLE_Picker` and
+  `UNSTABLE_UncontrolledPicker` are in the target set).
+- Use `-s <wrapper-package>` when imports go through a design-system wrapper.
+
+## Safe Automated Edits
+
+Component names stay `UNSTABLE_*` in v5. Subcomponents (`UNSTABLE_PickerGroup`, `UNSTABLE_PickerItem`,
+`UNSTABLE_PickerTag`) keep the same names.
+
+## Agent Edits
+
+1. **Wrapper re-exports** — When the app imports Picker from a wrapper package, verify the wrapper still exports all
+   subcomponents used downstream after v5 upgrade.
+2. **`isFluid` removal** — Apply layout wrappers where `isFluid` controlled width; see
+   [forms-is-fluid-removal](forms-is-fluid-removal.md).
+3. **Checkbox/Radio inside PickerItem** — Verify the v5 item composition and spacing after the choice-control
+   markup change; do not add the non-item row padding manually.
+4. **Custom `renderTags`** — Re-verify keyboard behaviour after upgrade if using custom tag rendering.
+
+## Report Guidance
+
+- Status: `partial` when `isFluid` and wrapper exports are handled but filter UI needs visual/a11y QA.
+- Confidence: `medium` — UNSTABLE API surface is unchanged but surrounding form/layout recipes may apply.

--- a/.agents/skills/spirit-v5-migration/changesets/validationtext-api.md
+++ b/.agents/skills/spirit-v5-migration/changesets/validationtext-api.md
@@ -1,0 +1,47 @@
+# ValidationText API
+
+## When It Applies
+
+Apps using standalone `ValidationText` with `hasValidationStateIcon`.
+
+## Detection
+
+```bash
+grep -rEn "hasValidationStateIcon|ValidationText" <path> --include="*.tsx" --include="*.jsx"
+```
+
+## What Changed
+
+- `hasValidationStateIcon` removed — use `validationStateIcon` on standalone `ValidationText`.
+- Inline / form-field mode removed — compose layout with parent components.
+- Success icon changed from `check-plain` to `success`.
+
+Built-in form fields still accept `hasValidationIcon` and pass `validationStateIcon` internally.
+
+## Codemod
+
+```sh
+npx @alma-oss/spirit-codemods -p <path> -t v5/web-react/validation-state-icon-prop
+```
+
+The codemod renames standalone Spirit `ValidationText` usage only. It does not change
+`hasValidationIcon` on composed form components.
+
+## Safe Automated Edits
+
+The agent applies prop renames when the codemod misses a match.
+
+```diff
+- <ValidationText validationText="Error" hasValidationStateIcon validationState="danger" />
++ <ValidationText validationText="Error" validationStateIcon="danger" />
+```
+
+## Agent Edits
+
+The agent handles aliased/wrapped components missed by the codemod and refactors standalone `ValidationText`
+inline layouts to composable patterns.
+
+## Report Guidance
+
+- Status: `completed` when props updated and snapshots reviewed.
+- Confidence: `high` for codemod prop rename; `medium` for layout composition.

--- a/.agents/skills/spirit-v5-migration/changesets/web-css-cross-check.md
+++ b/.agents/skills/spirit-v5-migration/changesets/web-css-cross-check.md
@@ -1,0 +1,39 @@
+# Web CSS Feature Flag Cleanup
+
+## When It Applies
+
+Every app. Feature flags can remain in React `className`, static templates, project styles, Sass configuration, or
+wrapper-package source even when the app does not import Spirit SCSS directly.
+
+## Detection
+
+```bash
+grep -rEn 'spirit-feature-enable-v5|\$enable-v5-' <path> --include="*.tsx" --include="*.ts" --include="*.jsx" --include="*.js" --include="*.html" --include="*.twig" --include="*.scss" --include="*.sass" --include="*.css"
+```
+
+## Feature Flags to Remove
+
+| Markup/CSS class                                              | Sass variable                                   | Recipe                                                   |
+| ------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------------- |
+| `spirit-feature-enable-v5-tag-appearance`                     | `$enable-v5-tag-appearance`                     | Remove flag; Tag `inline-flex` appearance is now default |
+| `spirit-feature-enable-v5-control-button-expanded-size-scale` | `$enable-v5-control-button-expanded-size-scale` | [controlbutton-size-scale](controlbutton-size-scale.md)  |
+| `spirit-feature-enable-v5-container-block-formatting-context` | `$enable-v5-container-block-formatting-context` | Remove flag; Container now uses `display: flow-root`     |
+
+These flags have no effect after upgrading to v5. Apply the matching recipe for each flag found.
+
+## Agent Edits
+
+The agent removes:
+
+1. Class names from JSX `className`, HTML/Twig `class`, class-composition helpers, and tests/snapshots.
+2. Sass variables from `@use ... with (...)`, configuration maps, local variable declarations, and forwarded
+   configuration.
+3. Empty className helpers/wrappers or Sass configuration blocks left by the removal.
+
+Re-run detection after edits. A clean result is required.
+
+## Report Guidance
+
+- Status: `not-applicable` if no class or Sass flag is found.
+- Status: `completed` after removing flags from markup, styles, configuration, and snapshots.
+- Confidence: `high`.

--- a/.agents/skills/spirit-v5-migration/changesets/web-markup-and-css.md
+++ b/.agents/skills/spirit-v5-migration/changesets/web-markup-and-css.md
@@ -1,0 +1,43 @@
+# Web Markup and CSS
+
+## When It Applies
+
+Apps importing `@alma-oss/spirit-web`, rendering Spirit CSS classes in HTML/JSX/templates, or overriding Spirit
+component selectors/variables in project styles.
+
+## Detection
+
+```bash
+grep -rEn "@alma-oss/spirit-web|spirit-web/scss" package.json <path>
+grep -rEn "link-stretched|Button--block|Button--disabled|ControlButton--disabled|Tag--disabled|Flex--(row|column)|Stack--has|TextField__|Select__|TextArea__|FieldGroup|DrawerPanel__content|Toggle__input" <path> --include="*.tsx" --include="*.jsx" --include="*.html" --include="*.twig" --include="*.scss" --include="*.sass" --include="*.css"
+```
+
+## Agent Edits
+
+Apply the current `spirit-web` v5 migration guide to raw markup and custom styles, including:
+
+1. `link-stretched` → `element-stretched`.
+2. Removed component disabled modifiers → global `disabled`; preserve native `disabled`/`aria-disabled` semantics
+   and the documented ControlButton color/tap-target classes.
+3. `Flex--row`/`Flex--column` (including responsive forms) → `Flex--horizontal`/`Flex--vertical`.
+4. `Stack--hasSpacing`, `--hasIntermediateDividers`, `--hasStartDivider`, `--hasEndDivider` → modifiers without
+   `has`; ensure divider children use `StackItem`.
+5. Replace removed `Button--block` with layout utilities or Grid.
+6. Recompose legacy TextField/Select/TextArea and FieldGroup markup with Label, InputContainer, InputAddon,
+   HelperText, ValidationText, InputDetails, and layout utilities.
+7. Apply the matching React/shared recipes for Alert links, choice-control markup, DrawerPanel, FileUpload, Header,
+   Item, Navigation, ScrollView, success icons, and Tag/ControlButton sizing.
+8. Change Pagination previous/next controls from medium to small only in Pagination context.
+9. Update custom selectors and Sass variables that reference removed BEM elements or old ScrollView arrow names.
+10. Compile styles and visually verify color-scheme components whose surfaces were previously customized by
+    component-specific modifiers.
+
+## Codemod
+
+React codemods do not migrate static HTML/Twig or arbitrary custom SCSS. Apply these edits directly.
+
+## Report Guidance
+
+- Status: `not-applicable` when the app has no raw Spirit markup, web package import, or component style overrides.
+- Status: `completed` when legacy classes/selectors are absent and styles compile.
+- Confidence: `high` for direct class renames; `medium` for recomposed markup and color-scheme overrides.

--- a/.agents/skills/spirit-v5-migration/changesets/wrapper-monorepo.md
+++ b/.agents/skills/spirit-v5-migration/changesets/wrapper-monorepo.md
@@ -1,0 +1,72 @@
+# Wrapper Monorepo
+
+## When It Applies
+
+Monorepos where most application code imports Spirit through a **wrapper design-system package** that re-exports
+`@alma-oss/spirit-web-react`, instead of importing Spirit directly.
+
+Typical signals:
+
+- A workspace package like `@org/design-system` that re-exports Spirit components
+- Plugin/app code uses `from '@org/design-system'` while the wrapper lib may import `@alma-oss/spirit-web-react` directly
+- Multiple source roots (`libs/*`, `apps/*/src`, `plugins/*/src`)
+
+## Detection
+
+```bash
+# Wrapper package name(s)
+grep -rEn '"@.+/design-system"' package.json
+
+# Consumer imports via wrapper vs direct Spirit
+grep -rEn "from ['\"]@alma-oss/spirit-web-react" <path> --include="*.tsx" --include="*.ts" | wc -l
+grep -rEn "from ['\"]<wrapper-package>" <path> --include="*.tsx" --include="*.ts" | wc -l
+```
+
+Record profile as `wrapper`, `direct`, or `mixed` in the migration report.
+
+## Codemods
+
+Pass `-s` with the wrapper package name on **every** codemod run against paths that import through the wrapper.
+`@alma-oss/spirit-web-react` is matched by default, so `-s` adds wrapper sources — you do not need to repeat the
+Spirit package when both are in play.
+
+```bash
+IMPORT_SOURCE_ARGS=(-s "@org/design-system")
+npx @alma-oss/spirit-codemods -p <path> "${IMPORT_SOURCE_ARGS[@]}" -t v5/web-react/<transform>
+```
+
+When the wrapper lib imports Spirit directly but plugins use the wrapper, run codemods **per path**:
+
+1. Wrapper lib paths — omit `-s` (or only direct Spirit imports)
+2. Plugin/app paths — include `-s "@org/design-system"` (quote scoped package names in zsh/bash)
+
+If `-s` appears ineffective, stop after the one-file smoke test and diagnose the packaged CLI/version. Do not
+bypass the supported CLI with a direct, unpinned jscodeshift invocation.
+
+### Pre-Flight Smoke Test
+
+Before batch runs on hundreds of files, transform **one known hit** and inspect the diff. If the CLI reports
+`0 ok` with no errors, check codemods build output (`dist/helpers` must exist) before continuing.
+
+## Safe Automated Edits
+
+No file edits in this recipe — it defines **order and scope** for other recipes.
+
+## Agent Edits — Suggested Order
+
+1. Upgrade Spirit deps in the wrapper lib and monorepo root; install.
+2. Fix compile errors in the wrapper lib ([general-upgrade-prerequisites](general-upgrade-prerequisites.md)).
+3. Run all v5 codemods on the wrapper lib source.
+4. Run all v5 codemods on plugin/app paths with `-s` set to the wrapper package.
+5. Apply manual recipes (FileUploader, Header recomposition, Navigation slots) starting with the heaviest plugins.
+6. Update wrapper **public exports** when UNSTABLE aliases were removed upstream.
+7. Validate per workspace ([SKILL.md](../SKILL.md) Step 6 + profile validation commands).
+
+When the monorepo uses Docker for development, run install and codemods inside the same environment the team uses
+for local dev (e.g. `make install` after resolution changes).
+
+## Report Guidance
+
+- Status: `completed` when wrapper lib and all scanned consumer paths are migrated and validation passes.
+- Status: `partial` when wrapper lib is done but plugin manual migrations remain.
+- Confidence: `high` for codemod batches with verified smoke test; `medium` for mixed import layouts.


### PR DESCRIPTION
## Description

Adds an agent skill (`.agents/skills/spirit-v5-migration/`) for migrating consumer apps from Spirit Design System v4 to v5. The skill covers discovery, dependency upgrade, codemod execution, manual migration recipes, and validation reporting.

Includes:

- Main workflow in `SKILL.md` with target profiles (`direct`, `wrapper-monorepo`, `mixed`)
- Per-topic migration recipes under `changes/` (composition APIs, codemod-backed transforms, manual FileUploader/Header/Navigation migrations, CSS cross-check, wrapper monorepo guidance)

### Additional context

- React-first; codemod commands reference `@alma-oss/spirit-codemods` v5 transforms
- Wrapper monorepo profile documents quoting `-s` for scoped import sources in zsh/bash
- No runtime or package changes — documentation/skill content only

### Issue reference

_No linked Jira issue._

## Test plan

- [ ] Review `SKILL.md` workflow and profile detection steps
- [ ] Spot-check recipe files against v5 breaking changes on `release/v5-essence`
- [ ] Confirm codemod command examples match `packages/codemods` v5 transform names