### PR TITLE
docs(repo): add breaking change checklist skill

### DIFF
--- a/.agents/skills/breaking-change-checklist/README.md
+++ b/.agents/skills/breaking-change-checklist/README.md
@@ -1,0 +1,36 @@
+# Breaking Change Checklist Skill
+
+Minimal, always-current checklist for what a breaking change to a stable Spirit API must ship with: migration
+guide entries in both packages, and a codemod (web-react only).
+
+## Usage
+
+```text
+/spirit:breaking-change-checklist
+```
+
+Use when introducing a breaking change that isn't already covered by a more specific skill:
+
+- Removing a feature flag
+- Removing/renaming a prop or changing a default
+- Any other stable-API breaking change
+
+For stabilizing an experimental component or removing a deprecation, use `spirit:stabilize-component` or
+`spirit:component-deprecation` instead — they include this checklist plus their own specific steps.
+
+## What It Covers
+
+1. Migration guide requirement (both `web` and `web-react`, current major only)
+2. Codemod requirement (web-react only, with fixtures generated via `--dry --print`)
+3. Rules for what belongs in a migration guide (stable → stable only, correct section, alphabetical order,
+   inbound anchor links kept working)
+
+## Output Quality Checklist
+
+- Migration guide section exists in both `docs/migrations/web/migration-v<N>.md` and
+  `docs/migrations/web-react/migration-v<N>.md`
+- Section sits under `## General Changes` or `## Component Changes` and keeps the alphabetical order
+- Codemod + fixtures + test exist under `packages/codemods/src/transforms/v<N>/web-react/`
+- Fixtures were generated with `--dry --print`, not hand-written
+- No intermediate unreleased API states documented in the migration guide
+- No inbound links left pointing at a heading anchor that squashing removed

--- a/.agents/skills/breaking-change-checklist/SKILL.md
+++ b/.agents/skills/breaking-change-checklist/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: spirit:breaking-change-checklist
+description: >-
+  Checklist for what a breaking change to a stable Spirit API must ship with: migration guide entries in both
+  packages, and a web-react-only codemod with fixtures. Use whenever introducing a breaking change (removing a
+  feature flag, removing/renaming a prop, changing a default) that isn't already a component stabilization or
+  deprecation removal.
+category: spirit
+displayName: Spirit Breaking Change Checklist
+---
+
+# Spirit Breaking Change Checklist
+
+Use this skill whenever a change breaks a stable, released Spirit API — removing a feature flag, removing or
+renaming a prop, changing a default value or behavior. It does not apply to everyday, non-breaking work.
+
+If the change is a **component stabilization** (`UNSTABLE_X` → `X`) or a **deprecation removal**, use
+`spirit:stabilize-component` or `spirit:component-deprecation` instead — both already include this checklist
+plus their own specific steps (renames, exports, deprecation-notice wording).
+
+## Required for Every Breaking Change
+
+1. A migration guide entry (TOC + section) in **both**:
+   - `docs/migrations/web/migration-v<N>.md`
+   - `docs/migrations/web-react/migration-v<N>.md`
+
+   `<N>` is the current major in development. Find it with `ls docs/migrations/web-react/` (highest unreleased
+   version) rather than hard-coding a number.
+
+2. A codemod — **web-react only**. There is no vanilla `web` codemod mechanism:
+   `packages/codemods/src/transforms/v<N>/` only ever contains a `web-react` subfolder
+   (`ls packages/codemods/src/transforms/v<N>/` to confirm).
+   - `packages/codemods/src/transforms/v<N>/web-react/<name>.ts`
+   - `__testfixtures__/<name>.input.tsx`
+   - `__testfixtures__/<name>.output.tsx`
+   - `__tests__/<name>.test.ts`
+
+## Migration Guides
+
+- Only document stable → stable migrations. Never include intermediate unreleased API states (e.g. a prop that
+  existed only between two unreleased BC changes).
+- Both guides separate `## General Changes` from `## Component Changes`. Put the entry under the right one, and
+  keep the sections within it sorted alphabetically by component name.
+- After squashing multiple BC changes into one section, verify that every item in the "Removed" table actually
+  existed in a stable release.
+- Squashing or renaming a section changes its heading anchor, and component docs may link to the old one. Grep
+  `docs/` and `packages/*/src/components/*/README.md` for the old anchor and update every inbound link.
+
+## Codemods
+
+- Generate output fixtures with `yarn dlx jscodeshift --dry --print -t <transform> <input>` — never hand-write them.
+  jscodeshift's exact whitespace, blank lines between top-level declarations, and import ordering must match the
+  fixture; any deviation causes the test to fail.

--- a/.agents/skills/stabilize-component/SKILL.md
+++ b/.agents/skills/stabilize-component/SKILL.md
@@ -141,6 +141,9 @@ Add **rename codemods** under the current major's transforms directory so consum
 3. Remove now-obsolete entries from each package `DEPRECATIONS.md` (e.g. the deprecation that pointed users at
    the `UNSTABLE_` component, and the removed component's deprecation block).
 
+See `spirit:breaking-change-checklist` for the rules these entries must follow (stable → stable only, section
+placement and alphabetical order, keeping inbound heading anchors alive).
+
 ## Removing a Superseded Component
 
 When stabilization also retires an older component, in the **owning** package(s):


### PR DESCRIPTION
## Description

Adds a **Spirit Breaking Change Checklist** skill so the requirements for shipping a breaking change live in one discoverable place.

What a BC to a stable API must ship with:

1. **Migration guide entries** in both `docs/migrations/web/` and `docs/migrations/web-react/`.
2. **A codemod** — `web-react` only, with fixtures and a test. There is no vanilla `web` codemod mechanism, stated explicitly so nobody goes looking for one.

Plus the rules that are easy to get wrong: document stable → stable only, respect the `General`/`Component Changes` split and its alphabetical order, fix inbound links when squashing changes a heading anchor, and generate fixtures with `yarn dlx jscodeshift --dry --print` rather than by hand.

`spirit:stabilize-component` gets a cross-link to the checklist from its Migration Docs section.

### Additional context

This started as a section in `CLAUDE.md`. Per review it moved into a skill instead — the checklist only matters while working on a breaking change, so `CLAUDE.md` would load it into every session until v6.

Docs only. Not a blocker for v5.

### Issue reference

None — internal AI tooling documentation.
