### PR TITLE
fix(web,web-react): simplify `Item` SCSS and use utility classes for bg and text

### DIFF
--- a/docs/migrations/web/migration-v5.md
+++ b/docs/migrations/web/migration-v5.md
@@ -431,7 +431,7 @@ icons, and selection indicators are no longer positioned by Item-specific grid s
 | `Item__label` or direct `Label` / `HelperText` children | `Item__content` wrapping label and supporting text                                          |
 | `HelperText HelperText--item`                           | `HelperText` inside `Item__content`                                                         |
 | Selected trailing icon without `Icon--selected`         | Trailing icon in `Item__slot` with `Icon--selected` when selected                           |
-| `Item--selected` selected background                    | `color-scheme-on-selected-subtle` selected background                                       |
+| `Item--selected` selected background                    | `color-scheme-on-selected-subtle` and `bg-color-scheme` selected background                 |
 | Implicit `<button>` as the only documented root         | Use `<div class="Item">` for static rows; choose `<button>` or `<a>` explicitly when needed |
 
 #### Migration Guide
@@ -442,7 +442,7 @@ icons, and selection indicators are no longer positioned by Item-specific grid s
 1. Wrap the main label and supporting text in `Item__content` with `role="presentation"`.
 2. Replace `Item__icon` with `Item__slot` (`role="presentation"`).
 3. Remove the `HelperText--item` modifier; place plain `HelperText` inside `Item__content`.
-4. Add `Icon--selected` to trailing selection icons and use `color-scheme-on-selected-subtle` when the background should show.
+4. Add `Icon--selected` to trailing selection icons and use `color-scheme-on-selected-subtle` and `bg-color-scheme` when the background should show.
 5. Use a non-interactive `<div class="Item">` for static or composed rows; keep `<button>` or `<a>` only when the whole row is a single action.
 
 Simple item:

--- a/packages/web-react/src/components/Item/__tests__/Item.test.tsx
+++ b/packages/web-react/src/components/Item/__tests__/Item.test.tsx
@@ -134,7 +134,8 @@ describe('Item', () => {
 
     const element = screen.getByText('Item label').closest('.Item') as HTMLElement;
 
-    expect(element).toHaveClass('color-scheme-on-selected-subtle');
+    expect(element).toHaveClass('color-scheme-on-selected-subtle', 'bg-color-scheme');
+    expect(element).not.toHaveClass('text-color-scheme');
     expect(element.querySelectorAll('.Item__slot')).toHaveLength(0);
   });
 
@@ -147,7 +148,8 @@ describe('Item', () => {
 
     const element = screen.getByText('Item label').closest('.Item') as HTMLElement;
 
-    expect(element).toHaveClass('disabled', 'color-scheme-on-selected-subtle');
+    expect(element).toHaveClass('disabled', 'color-scheme-on-selected-subtle', 'text-color-scheme');
+    expect(element).not.toHaveClass('bg-color-scheme');
   });
 
   it('should render end slot', () => {
@@ -171,7 +173,7 @@ describe('Item', () => {
 
     const element = screen.getByText('Item label').closest('.Item') as HTMLElement;
 
-    expect(element).toHaveClass('color-scheme-on-selected-subtle');
+    expect(element).toHaveClass('color-scheme-on-selected-subtle', 'bg-color-scheme');
     expect(element.querySelector('.Item__slot')).toContainElement(screen.getByTestId('end-slot'));
   });
 
@@ -180,7 +182,8 @@ describe('Item', () => {
 
     const element = screen.getByText('Item label').closest('.Item') as HTMLElement;
 
-    expect(element).toHaveClass('disabled');
+    expect(element).toHaveClass('disabled', 'text-color-scheme');
+    expect(element).not.toHaveClass('bg-color-scheme');
     expect(element).not.toHaveAttribute('disabled');
   });
 

--- a/packages/web-react/src/components/Item/__tests__/useItemStyleProps.test.ts
+++ b/packages/web-react/src/components/Item/__tests__/useItemStyleProps.test.ts
@@ -18,7 +18,7 @@ describe('useItemStyleProps', () => {
     const props = { isSelected: true } as SpiritItemProps;
     const { result } = renderHook(() => useItemStyleProps(props));
 
-    expect(result.current.classProps.root).toBe('Item color-scheme-on-selected-subtle');
+    expect(result.current.classProps.root).toBe('Item color-scheme-on-selected-subtle bg-color-scheme');
   });
 
   it('should return item with non-default vertical alignment', () => {
@@ -41,14 +41,14 @@ describe('useItemStyleProps', () => {
     const props = { isDisabled: true } as SpiritItemProps;
     const { result } = renderHook(() => useItemStyleProps(props));
 
-    expect(result.current.classProps.root).toBe('Item disabled');
+    expect(result.current.classProps.root).toBe('Item disabled text-color-scheme');
   });
 
   it('should return disabled selected item', () => {
     const props = { isDisabled: true, isSelected: true } as SpiritItemProps;
     const { result } = renderHook(() => useItemStyleProps(props));
 
-    expect(result.current.classProps.root).toBe('Item disabled color-scheme-on-selected-subtle');
+    expect(result.current.classProps.root).toBe('Item disabled color-scheme-on-selected-subtle text-color-scheme');
   });
 
   it('should not pass style props to returned props', () => {

--- a/packages/web-react/src/components/Item/useItemStyleProps.ts
+++ b/packages/web-react/src/components/Item/useItemStyleProps.ts
@@ -20,6 +20,8 @@ export function useItemStyleProps<P extends ItemStyleProps>(props: P): ItemStyle
   const { alignmentY, isDisabled, isSelected, ...restProps } = props;
   const itemClass = useClassNamePrefix('Item');
   const itemSelectedColorSchemeClass = getColorSchemeClassName({ color: 'selected', isSubtle: true });
+  const bgColorSchemeClass = useClassNamePrefix('bg-color-scheme');
+  const textColorSchemeClass = useClassNamePrefix('text-color-scheme');
   const itemContentClass = `${itemClass}__content`;
   const itemSlotClass = `${itemClass}__slot`;
 
@@ -30,6 +32,8 @@ export function useItemStyleProps<P extends ItemStyleProps>(props: P): ItemStyle
         [useAlignmentClass(itemClass, alignmentY as ItemAlignmentYType, 'alignmentY')]: alignmentY,
         [CLASS_NAME_DISABLED]: isDisabled,
         [itemSelectedColorSchemeClass]: isSelected,
+        [bgColorSchemeClass]: isSelected && !isDisabled,
+        [textColorSchemeClass]: isDisabled,
       }),
       slot: itemSlotClass,
     },

--- a/packages/web/src/scss/components/HelperText/index.html
+++ b/packages/web/src/scss/components/HelperText/index.html
@@ -143,7 +143,7 @@
 
       <button
         type="button"
-        class="Item color-scheme-on-selected-subtle"
+        class="Item color-scheme-on-selected-subtle bg-color-scheme"
       >
         <span class="Item__content" role="presentation">
           <span class="Label Label--item">Selected Item</span>
@@ -163,7 +163,7 @@
 
       <button
         type="button"
-        class="Item disabled"
+        class="Item disabled text-color-scheme"
       >
         <span class="Item__content" role="presentation">
           <span class="Label Label--item Label--disabled">Item label</span>

--- a/packages/web/src/scss/components/Item/README.md
+++ b/packages/web/src/scss/components/Item/README.md
@@ -46,15 +46,15 @@ Link:
 
 ## Selected State
 
-Use `color-scheme-on-selected-subtle` when the item itself should have the selected background.
-For stronger selected surfaces, use `color-scheme-on-selected-basic`.
+Use `color-scheme-on-selected-subtle` and `bg-color-scheme` when the item itself should have the selected background.
+For stronger selected surfaces, use `color-scheme-on-selected-basic` and `bg-color-scheme`.
 These color schemes do not render a checkmark or recolor slot icons on their own. If the selected state needs an icon,
 render it in `Item__slot` and add `Icon--selected` to the `Icon`.
 
 Selected with background only:
 
 ```html
-<button type="button" class="Item color-scheme-on-selected-subtle">
+<button type="button" class="Item color-scheme-on-selected-subtle bg-color-scheme">
   <span class="Item__content" role="presentation">
     <span class="Label Label--item">Item</span>
   </span>
@@ -79,7 +79,7 @@ Selected with icon only:
 Selected with background and icon:
 
 ```html
-<button type="button" class="Item color-scheme-on-selected-subtle">
+<button type="button" class="Item color-scheme-on-selected-subtle bg-color-scheme">
   <span class="Item__content" role="presentation">
     <span class="Label Label--item">Item</span>
   </span>
@@ -114,7 +114,7 @@ Leading icon:
 Leading icon, trailing selected icon, and selected background:
 
 ```html
-<button type="button" class="Item color-scheme-on-selected-subtle">
+<button type="button" class="Item color-scheme-on-selected-subtle bg-color-scheme">
   <span class="Item__slot" role="presentation">
     <svg class="Icon Icon--selected" width="24" height="24" aria-hidden="true">
       <use href="/icons/svg/sprite.svg#search" />
@@ -137,7 +137,7 @@ Compose richer rows inside `Item__content` with [HelperText][helper-text], typog
 or other inline content.
 
 ```html
-<div class="Item color-scheme-on-selected-subtle">
+<div class="Item color-scheme-on-selected-subtle bg-color-scheme">
   <span class="Item__slot" role="presentation">
     <svg class="Icon Icon--selected" width="24" height="24" aria-hidden="true">
       <use href="/icons/svg/sprite.svg#folder-dualtone" />
@@ -261,13 +261,15 @@ and `Item__content` should align differently on the cross axis.
 
 ## Disabled State
 
-The `.disabled` utility styles the disabled appearance only. Add the native `disabled` attribute on `<button>` yourself.
+The `disabled` and `text-color-scheme` utility classes style the disabled appearance only. Add the native `disabled` attribute on `<button>` yourself.
 For `<a>`, `role="option"`, or other non-button roots, add `aria-disabled="true"` explicitly.
+
+Do not add `bg-color-scheme` to the selected disabled Item.
 
 Button:
 
 ```html
-<button type="button" class="Item disabled" disabled>
+<button type="button" class="Item disabled text-color-scheme" disabled>
   <span class="Item__content" role="presentation">
     <span class="Label Label--item Label--disabled">Item</span>
   </span>
@@ -277,7 +279,7 @@ Button:
 Link:
 
 ```html
-<a href="#" class="Item disabled" aria-disabled="true">
+<a href="#" class="Item disabled text-color-scheme" aria-disabled="true">
   <span class="Item__content" role="presentation">
     <span class="Label Label--item Label--disabled">Item</span>
   </span>
@@ -289,7 +291,7 @@ Link:
 Non-interactive root:
 
 ```html
-<div class="Item disabled" aria-disabled="true">
+<div class="Item disabled text-color-scheme" aria-disabled="true">
   <span class="Item__content" role="presentation">
     <span class="Label Label--item Label--disabled">Item</span>
   </span>
@@ -366,13 +368,13 @@ Choose the Item root semantics according to what the row does:
 - `color-scheme-on-selected-subtle` is visual only. It does not imply `aria-selected`, `aria-current`, or a widget role. The parent widget owns those semantics because listbox options, menu items, grid rows, and links all use different markup.
 - Decorative slot icons should use `aria-hidden="true"` or the documented Icon conventions. `Icon--selected` is visual only and must not replace the ARIA state.
 - Inline text highlighting with `<strong>` is fine for visual emphasis, but it does not announce selection or activation state.
-- The `.disabled` utility styles the disabled appearance only. Add the native `disabled` attribute on `<button>` yourself. For `<a>`, `role="option"`, or other non-button roots, add `aria-disabled="true"` explicitly. See [Disabled State](#disabled-state).
+- The `disabled` and `text-color-scheme` utility classes style the disabled appearance only. Add the native `disabled` attribute on `<button>` yourself. For `<a>`, `role="option"`, or other non-button roots, add `aria-disabled="true"` explicitly. See [Disabled State](#disabled-state).
 
 For a listbox-like parent, add [`option`][mdn-option-role] semantics and selected state explicitly.
 The parent widget must implement the keyboard interaction contract for the chosen role:
 
 ```html
-<div class="Item color-scheme-on-selected-subtle" role="option" aria-selected="true">
+<div class="Item color-scheme-on-selected-subtle bg-color-scheme" role="option" aria-selected="true">
   <span class="Item__content" role="presentation">
     <span class="Label Label--item">Item</span>
   </span>

--- a/packages/web/src/scss/components/Item/_Item.scss
+++ b/packages/web/src/scss/components/Item/_Item.scss
@@ -1,5 +1,4 @@
-// 1. Only for `disabled` state we change the text color to the disabled color. We keep the background color as is.
-// 2. Keep interactive controls in any slot (e.g. a remove button or link) clickable above a
+// 1. Keep interactive controls in any slot (e.g. a remove button or link) clickable above a
 //    stretched overlay that spans the whole Item, by lifting them into their own stacking context.
 
 @use 'theme';
@@ -25,32 +24,26 @@
     padding: theme.$padding-y theme.$padding-x;
     margin-block: 0;
     border-radius: theme.$border-radius;
-    background-color: color-scheme.background-color(theme.$background-color-state-default);
+    background-color: theme.$background-color-state-default;
 
     &:has(:active) {
         text-decoration: none;
     }
 
     &:active {
-        background-color: color-scheme.background-color(theme.$background-color-state-active);
+        background-color: theme.$background-color-state-active;
     }
 
     @media (hover: hover) {
         &:hover {
             text-decoration: none;
-            background-color: color-scheme.background-color(theme.$background-color-state-hover);
+            background-color: theme.$background-color-state-hover;
         }
     }
 
     &[role='option'] {
         cursor: cursors.$buttons;
     }
-}
-
-// 1.
-.Item.disabled {
-    color: color-scheme.color();
-    background-color: theme.$background-color-state-default;
 }
 
 .Item__content {
@@ -62,7 +55,7 @@
     display: flex;
 }
 
-// 2.
+// 1.
 .Item__slot :where(a, button) {
     position: relative;
     z-index: 1;

--- a/packages/web/src/scss/components/Item/index.html
+++ b/packages/web/src/scss/components/Item/index.html
@@ -52,7 +52,7 @@
 
         <button
           type="button"
-          class="Item color-scheme-on-selected-subtle"
+          class="Item color-scheme-on-selected-subtle bg-color-scheme"
         >
           <span class="Item__content" role="presentation">
             <span class="Label Label--item">Item label</span>
@@ -92,7 +92,7 @@
 
         <button
           type="button"
-          class="Item color-scheme-on-selected-subtle"
+          class="Item color-scheme-on-selected-subtle bg-color-scheme"
         >
           <span class="Item__content" role="presentation">
             <span class="Label Label--item">Item label</span>
@@ -127,7 +127,7 @@
 
       <button
         type="button"
-        class="Item color-scheme-on-selected-subtle disabled"
+        class="Item color-scheme-on-selected-subtle disabled text-color-scheme"
         disabled
       >
         <span class="Item__content" role="presentation">
@@ -137,7 +137,7 @@
 
       <button
         type="button"
-        class="Item color-scheme-on-selected-subtle disabled"
+        class="Item color-scheme-on-selected-subtle disabled text-color-scheme"
         disabled
       >
         <span class="Item__content" role="presentation">
@@ -181,7 +181,7 @@
 
       <button
         type="button"
-        class="Item color-scheme-on-selected-subtle"
+        class="Item color-scheme-on-selected-subtle bg-color-scheme"
       >
         <span class="Item__content" role="presentation">
           <span class="Label Label--item">Item label</span>
@@ -201,7 +201,7 @@
 
       <button
         type="button"
-        class="Item color-scheme-on-selected-subtle disabled"
+        class="Item color-scheme-on-selected-subtle disabled text-color-scheme"
         disabled
       >
         <span class="Item__content" role="presentation">
@@ -212,7 +212,7 @@
 
       <button
         type="button"
-        class="Item color-scheme-on-selected-subtle disabled"
+        class="Item color-scheme-on-selected-subtle disabled text-color-scheme"
         disabled
       >
         <span class="Item__content" role="presentation">
@@ -365,7 +365,7 @@
 
       <button
         type="button"
-        class="Item color-scheme-on-selected-subtle"
+        class="Item color-scheme-on-selected-subtle bg-color-scheme"
       >
         <span class="Item__slot" role="presentation">
           <svg
@@ -452,7 +452,7 @@
           aria-label="Last searches"
         >
 
-          <li class="Item Item--alignmentYTop color-scheme-on-selected-subtle">
+          <li class="Item Item--alignmentYTop color-scheme-on-selected-subtle bg-color-scheme">
             <span class="Item__slot" role="presentation">
               <svg
                 class="Icon"
@@ -523,7 +523,7 @@
             </span>
           </li>
 
-          <li class="Item Item--alignmentYTop disabled">
+          <li class="Item Item--alignmentYTop disabled text-color-scheme">
             <span class="Item__slot" role="presentation">
               <svg
                 class="Icon"
@@ -573,7 +573,7 @@
           role="grid"
         >
 
-          <div class="Item Item--alignmentYTop color-scheme-on-selected-subtle" role="row">
+          <div class="Item Item--alignmentYTop color-scheme-on-selected-subtle bg-color-scheme" role="row">
             <span class="Item__slot" role="presentation">
               <svg
                 class="Icon"
@@ -742,7 +742,7 @@
 
           <li class="StackItem" role="presentation">
             <div
-              class="Item color-scheme-on-selected-subtle"
+              class="Item color-scheme-on-selected-subtle bg-color-scheme"
               role="option"
               aria-selected="true"
             >

--- a/packages/web/src/scss/components/Label/index.html
+++ b/packages/web/src/scss/components/Label/index.html
@@ -166,7 +166,7 @@
 
       <button
         type="button"
-        class="Item color-scheme-on-selected-subtle"
+        class="Item color-scheme-on-selected-subtle bg-color-scheme"
       >
         <span class="Item__content" role="presentation">
           <span class="Label Label--item">Selected Item</span>
@@ -185,7 +185,7 @@
 
       <button
         type="button"
-        class="Item disabled"
+        class="Item disabled text-color-scheme"
       >
         <span class="Item__content" role="presentation">
           <span class="Label Label--item Label--disabled">Disabled Item</span>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

`Item` previously applied selected and disabled colors through SCSS color-scheme mixins on the component itself, which made state styling implicit and harder to align with the rest of the v5 color-scheme utility pattern. This change moves that responsibility to explicit `bg-color-scheme` and `text-color-scheme` classes: selected items get the background utility, disabled items get the text utility, and selected + disabled items get only `text-color-scheme` so the selected background does not override the disabled appearance.

The web demos, migration guide, and web-react `Item` style props are updated to match. Item SCSS now uses plain theme tokens for default/hover/active backgrounds.

### Additional context

- When both `isSelected` and `isDisabled` are true, only `text-color-scheme` is applied (no `bg-color-scheme`).
- Unrelated local changes on the branch (Checkbox/Radio/Toggle) are not included in this commit.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

## Test plan

- [x] `yarn test:unit src/components/Item/__tests__/`
- [ ] Visual check of Item demos (selected, disabled, selected + disabled)