### PR TITLE
docs(web-react): make FieldGroup radio and checkbox demos interactive

### DIFF
--- a/packages/web-react/src/components/FieldGroup/demo/FieldGroupGroupedCheckboxes.tsx
+++ b/packages/web-react/src/components/FieldGroup/demo/FieldGroupGroupedCheckboxes.tsx
@@ -1,12 +1,30 @@
 import React from 'react';
+import { useToggle } from '../../../hooks';
 import { Checkbox } from '../../Checkbox';
 import FieldGroup from '../FieldGroup';
 
-const FieldGroupGroupedCheckboxes = () => (
-  <FieldGroup id="field-group-grouped-checkboxes" label="Label">
-    <Checkbox id="checkbox-1" label="Checkbox Label" name="checkboxDefault" isChecked />
-    <Checkbox id="checkbox-2" label="Checkbox Label" name="checkboxDefault" />
-  </FieldGroup>
-);
+const FieldGroupGroupedCheckboxes = () => {
+  const [isFirstCheckboxChecked, toggleFirstCheckbox] = useToggle(true);
+  const [isSecondCheckboxChecked, toggleSecondCheckbox] = useToggle(false);
+
+  return (
+    <FieldGroup id="field-group-grouped-checkboxes" label="Label">
+      <Checkbox
+        id="checkbox-1"
+        label="Checkbox Label"
+        name="checkboxDefault"
+        isChecked={isFirstCheckboxChecked}
+        onChange={toggleFirstCheckbox}
+      />
+      <Checkbox
+        id="checkbox-2"
+        label="Checkbox Label"
+        name="checkboxDefault"
+        isChecked={isSecondCheckboxChecked}
+        onChange={toggleSecondCheckbox}
+      />
+    </FieldGroup>
+  );
+};
 
 export default FieldGroupGroupedCheckboxes;

--- a/packages/web-react/src/components/FieldGroup/demo/FieldGroupGroupedRadios.tsx
+++ b/packages/web-react/src/components/FieldGroup/demo/FieldGroupGroupedRadios.tsx
@@ -1,12 +1,28 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Radio } from '../../Radio';
 import FieldGroup from '../FieldGroup';
 
-const FieldGroupGroupedRadios = () => (
-  <FieldGroup id="field-group-grouped-radios" label="Label">
-    <Radio id="radio-1" label="Radio Label" name="radioDefault" isChecked />
-    <Radio id="radio-2" label="Radio Label" name="radioDefault" />
-  </FieldGroup>
-);
+const FieldGroupGroupedRadios = () => {
+  const [selectedRadio, setSelectedRadio] = useState('radio-1');
+
+  return (
+    <FieldGroup id="field-group-grouped-radios" label="Label">
+      <Radio
+        id="radio-1"
+        label="Radio Label"
+        name="radioDefault"
+        isChecked={selectedRadio === 'radio-1'}
+        onChange={() => setSelectedRadio('radio-1')}
+      />
+      <Radio
+        id="radio-2"
+        label="Radio Label"
+        name="radioDefault"
+        isChecked={selectedRadio === 'radio-2'}
+        onChange={() => setSelectedRadio('radio-2')}
+      />
+    </FieldGroup>
+  );
+};
 
 export default FieldGroupGroupedRadios;


### PR DESCRIPTION
Controlled isChecked props without onChange handlers prevented toggling in the grouped demos.

<!-- Thank you for contributing! -->

## Description

Controlled isChecked props without onChange handlers prevented toggling in the grouped demos.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
