### PR TITLE
fix(web-react): fix `File` naming collision in modal image preview story

### DIFF
--- a/packages/web-react/docs/stories/examples/FileUploadWithImagePreview.stories.tsx
+++ b/packages/web-react/docs/stories/examples/FileUploadWithImagePreview.stories.tsx
@@ -1,13 +1,14 @@
 import React, { useMemo, useState } from 'react';
 import { fn } from 'storybook/test';
 import { Button, Modal, ModalBody, ModalDialog, ModalFooter, Stack } from '../../../src/components';
-import { File, FileImagePreview } from '../../../src/components/File';
+import { File as FileAttachment, FileImagePreview } from '../../../src/components/File';
 import { useFilePreviewUrl } from '../../../src/components/File/demo/useFilePreviewUrl';
 import { FileUpload } from '../../../src/components/FileUpload';
 import { useFileQueue } from '../../../src/components/FileUpload/demo/useFileQueue';
 import type { FileUploadAttachmentsItem } from '../../../src/components/FileUpload/types';
 import { ObjectFit, ValidationStates } from '../../../src/constants';
 
+const EMPTY_FILE = new File([], '');
 const fileToKey = (name: string): string => `file__${name.replace(/\./g, '_').replace(/\s/g, '_')}`;
 
 type FileUploadCompositionType = {
@@ -357,7 +358,7 @@ export const FileUploadWithModalImagePreview = (args: FileUploadCompositionType)
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [fileToPreview, setFileToPreview] = useState<File | null>(null);
-  const previewUrl = useFilePreviewUrl(fileToPreview ?? new File([], ''));
+  const previewUrl = useFilePreviewUrl(fileToPreview ?? EMPTY_FILE);
   const { fileQueue, addToQueue, onDismiss } = useFileQueue();
 
   const items: FileUploadAttachmentsItem[] = useMemo(
@@ -419,7 +420,7 @@ export const FileUploadWithModalImagePreview = (args: FileUploadCompositionType)
       />
       <Stack aria-label={attachmentsLabel} elementType="ul" hasSpacing>
         {items.map((item) => (
-          <File
+          <FileAttachment
             key={item.id}
             editText={editText}
             hasValidationIcon={fileHasValidationIcon}


### PR DESCRIPTION
BREAKING CHANGE: Button gaps are now set automatically, so the margins inside should be removed.<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
BREAKING CHANGE: Button gaps are now set automatically, so the margins inside should be removed.