### PR TITLE
feat(web-react): introduce `spacing` prop for ButtonLink to set gap #DS-2344

### DIFF
--- a/packages/web-react/src/components/ButtonLink/ButtonLink.tsx
+++ b/packages/web-react/src/components/ButtonLink/ButtonLink.tsx
@@ -34,9 +34,13 @@ const _ButtonLink = <E extends ElementType = 'a', C = void, S = void>(
   const Component = elementType as ElementType;
 
   const { buttonLinkProps } = useButtonLinkProps(propsWithDefaults);
-  const { classProps, props: modifiedProps } = useButtonLinkStyleProps(restProps);
+  const { classProps, props: modifiedProps, styleProps: buttonLinkStyleProps } = useButtonLinkStyleProps(restProps);
   const { styleProps, props: otherProps } = useStyleProps(modifiedProps);
-  const mergedStyleProps = mergeStyleProps(Component, { classProps, styleProps, otherProps });
+  const mergedStyleProps = mergeStyleProps(Component, {
+    classProps,
+    styleProps: { ...buttonLinkStyleProps, ...styleProps },
+    otherProps,
+  });
 
   const handleClick = useLinkClick({
     ...restProps,

--- a/packages/web-react/src/components/ButtonLink/README.md
+++ b/packages/web-react/src/components/ButtonLink/README.md
@@ -53,6 +53,29 @@ visible text or add `aria-label` to the button. Using the `Hidden` component (li
 hides content from screen readers, so the `VisuallyHidden` component ensures the label is always accessible
 regardless of viewport size.
 
+### Custom Spacing
+
+You can use the `spacing` prop to apply custom spacing between button link content items (icons and text). The prop
+accepts either a spacing token (e.g. `space-600`) or an object with breakpoint keys and spacing token values.
+
+Custom spacing:
+
+```tsx
+<ButtonLink href="#" spacing="space-600">
+  <Icon name="link" />
+  Menu
+</ButtonLink>
+```
+
+Custom responsive spacing:
+
+```tsx
+<ButtonLink href="#" spacing={{ mobile: 'space-400', tablet: 'space-600', desktop: 'space-800' }}>
+  <Icon name="link" />
+  Menu
+</ButtonLink>
+```
+
 ### How to Make a Fluid ButtonLink
 
 To span a `ButtonLink` to the full width of its parent, you can use display utility classes or `Grid` to achieve the desired layout.
@@ -75,19 +98,20 @@ To span a `ButtonLink` to the full width of its parent, you can use display util
 
 ### API
 
-| Name            | Type                                                                                          | Default   | Required | Description                                                                                                                 |
-| --------------- | --------------------------------------------------------------------------------------------- | --------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `children`      | `ReactNode`                                                                                   | `null`    | ✕        | Content of the ButtonLink                                                                                                   |
-| `color`         | [Component Button dictionary][dictionary-color], [Emotion Color dictionary][dictionary-color] | `primary` | ✕        | Color variant                                                                                                               |
-| `elementType`   | `ElementType`                                                                                 | `a`       | ✕        | Type of element                                                                                                             |
-| `href`          | `string`                                                                                      | —         | ✓        | Link URL                                                                                                                    |
-| `isDisabled`    | `bool`                                                                                        | `false`   | ✕        | If true, ButtonLink is disabled                                                                                             |
-| `isLoading`     | `bool`                                                                                        | `false`   | ✕        | If true, ButtonLink is in a loading state, disabled and the Spinner is visible                                              |
-| `isSymmetrical` | `bool` \| `Responsive<bool>`                                                                  | `false`   | ✕        | If true, ButtonLink has symmetrical dimensions, use object to set responsive values, e.g. `{ mobile: true, tablet: false }` |
-| `onClick`       | `(event: ClickEvent) => void`                                                                 | —         | ✕        | JS function to call on click                                                                                                |
-| `ref`           | `ForwardedRef<HTMLAnchorElement>`                                                             | —         | ✕        | Anchor element reference                                                                                                    |
-| `size`          | [Size dictionary][dictionary-size]                                                            | `medium`  | ✕        | Size variant                                                                                                                |
-| `target`        | `string`                                                                                      | `null`    | ✕        | Link target                                                                                                                 |
+| Name            | Type                                                                                          | Default     | Required | Description                                                                                                                 |
+| --------------- | --------------------------------------------------------------------------------------------- | ----------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `children`      | `ReactNode`                                                                                   | `null`      | ✕        | Content of the ButtonLink                                                                                                   |
+| `color`         | [Component Button dictionary][dictionary-color], [Emotion Color dictionary][dictionary-color] | `primary`   | ✕        | Color variant                                                                                                               |
+| `elementType`   | `ElementType`                                                                                 | `a`         | ✕        | Type of element                                                                                                             |
+| `href`          | `string`                                                                                      | —           | ✓        | Link URL                                                                                                                    |
+| `isDisabled`    | `bool`                                                                                        | `false`     | ✕        | If true, ButtonLink is disabled                                                                                             |
+| `isLoading`     | `bool`                                                                                        | `false`     | ✕        | If true, ButtonLink is in a loading state, disabled and the Spinner is visible                                              |
+| `isSymmetrical` | `bool` \| `Responsive<bool>`                                                                  | `false`     | ✕        | If true, ButtonLink has symmetrical dimensions, use object to set responsive values, e.g. `{ mobile: true, tablet: false }` |
+| `onClick`       | `(event: ClickEvent) => void`                                                                 | —           | ✕        | JS function to call on click                                                                                                |
+| `ref`           | `ForwardedRef<HTMLAnchorElement>`                                                             | —           | ✕        | Anchor element reference                                                                                                    |
+| `size`          | [Size dictionary][dictionary-size]                                                            | `medium`    | ✕        | Size variant                                                                                                                |
+| `spacing`       | `SpaceToken` \| `Responsive<SpaceToken>`                                                      | `space-400` | ✕        | Apply [custom spacing](#custom-spacing) between button link content items                                                   |
+| `target`        | `string`                                                                                      | `null`      | ✕        | Link target                                                                                                                 |
 
 For more information see [Button][button] component. ButtonLink also contain all the appropriate
 attributes according to the type of element.

--- a/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
+++ b/packages/web-react/src/components/ButtonLink/__tests__/ButtonLink.test.tsx
@@ -43,6 +43,14 @@ describe('ButtonLink', () => {
 
   colorSchemeBasicTest(ButtonLink, Object.values(EmotionColors));
 
+  it('should apply spacing style', () => {
+    render(<ButtonLink spacing="space-600" />);
+
+    const element = screen.getByRole('button');
+
+    expect(element).toHaveStyle({ '--button-spacing': 'var(--spirit-space-600)' });
+  });
+
   it('should have default classname', () => {
     render(<ButtonLink />);
 

--- a/packages/web-react/src/components/ButtonLink/__tests__/useButtonLinkStyleProps.test.ts
+++ b/packages/web-react/src/components/ButtonLink/__tests__/useButtonLinkStyleProps.test.ts
@@ -99,4 +99,30 @@ describe('useButtonLinkStyleProps', () => {
 
     expect(result.current.classProps).toBe('Button Button--primary Button--medium');
   });
+
+  it.each([
+    // spacing, expectedStyle
+    [undefined, {}],
+    ['space-100', { '--button-spacing': 'var(--spirit-space-100)' }],
+    [
+      { mobile: 'space-100', tablet: 'space-200' },
+      {
+        '--button-spacing': 'var(--spirit-space-100)',
+        '--button-spacing-tablet': 'var(--spirit-space-200)',
+      },
+    ],
+    [
+      { mobile: 'space-100', tablet: 'space-200', desktop: 'space-400' },
+      {
+        '--button-spacing': 'var(--spirit-space-100)',
+        '--button-spacing-tablet': 'var(--spirit-space-200)',
+        '--button-spacing-desktop': 'var(--spirit-space-400)',
+      },
+    ],
+  ])('should return spacing CSS properties', (spacing, expectedStyle) => {
+    const props = { color: 'primary', size: 'medium', spacing } as SpiritButtonProps;
+    const { result } = renderHook(() => useButtonLinkStyleProps(props));
+
+    expect(result.current.styleProps).toEqual(expectedStyle);
+  });
 });

--- a/packages/web-react/src/components/ButtonLink/stories/ButtonLink.stories.tsx
+++ b/packages/web-react/src/components/ButtonLink/stories/ButtonLink.stories.tsx
@@ -58,6 +58,11 @@ const meta: Meta<typeof ButtonLink> = {
       control: 'select',
       options: [...Object.values(Sizes)],
     },
+    spacing: {
+      control: 'object',
+      description:
+        'Custom spacing between button link content items. Can be a spacing token (e.g. "space-400") or an object with breakpoint keys.',
+    },
   },
   args: {
     children: 'Click me',

--- a/packages/web-react/src/components/ButtonLink/useButtonLinkStyleProps.ts
+++ b/packages/web-react/src/components/ButtonLink/useButtonLinkStyleProps.ts
@@ -1,7 +1,8 @@
 import classNames from 'classnames';
+import { type CSSProperties } from 'react';
 import { CLASS_NAME_DISABLED } from '../../constants';
-import { useClassNamePrefix, useSymmetry } from '../../hooks';
-import { type ButtonColor, type ButtonLinkStyleProps, type ButtonSize } from '../../types';
+import { useClassNamePrefix, useSpacingStyle, useSymmetry } from '../../hooks';
+import { type ButtonColor, type ButtonLinkStyleProps, type ButtonSize, type SpacingType } from '../../types';
 import { getColorSchemeClassName, getEmotionColorNames } from '../../utils';
 import { applyColor, applySize } from '../../utils/classname';
 import { compose } from '../../utils/compose';
@@ -15,8 +16,21 @@ const getButtonLinkSizeClassname = <S = void>(className: string, size: ButtonSiz
 
 const emotionColorNames = getEmotionColorNames() as string[];
 
+interface ButtonLinkCSSProperties extends CSSProperties {
+  [key: string]: string | undefined | number;
+}
+
+export interface ButtonLinkStyles {
+  /** className props */
+  classProps: string;
+  /** Props for the button link element */
+  props: ButtonLinkStyleProps;
+  /** Style props for the element */
+  styleProps: ButtonLinkCSSProperties;
+}
+
 export function useButtonLinkStyleProps<C = void, S = void>(props: Omit<ButtonLinkStyleProps<C, S>, 'routerOptions'>) {
-  const { color, isDisabled, isLoading, isSymmetrical, size, ...restProps } = props;
+  const { color, isDisabled, isLoading, isSymmetrical, size, spacing, ...restProps } = props;
   const colorAsString = String(color);
 
   const buttonClass = useClassNamePrefix('Button');
@@ -39,8 +53,13 @@ export function useButtonLinkStyleProps<C = void, S = void>(props: Omit<ButtonLi
     symmetricalClassName,
   );
 
+  const buttonLinkStyle: ButtonLinkCSSProperties = {
+    ...(useSpacingStyle(spacing as SpacingType, 'button') as ButtonLinkCSSProperties),
+  };
+
   return {
     classProps,
     props: restProps,
+    styleProps: buttonLinkStyle,
   };
 }


### PR DESCRIPTION
The gap is now set by the component CSS, so there is no need for margins inside.

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
