### PR TITLE
chore(repo): remove ai co-author trailers from changelogs

### DIFF
--- a/packages/codemods/CHANGELOG.md
+++ b/packages/codemods/CHANGELOG.md
@@ -28,8 +28,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   keep the previous rendering, shift the size up (`small` → `medium`,
   `medium` → `large`, `large` → `xlarge`).
 
-Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
-
 - **web,web-react:** rename ScrollView's arrows to controls #DS-2271
 
 ### Features

--- a/packages/web-react/CHANGELOG.md
+++ b/packages/web-react/CHANGELOG.md
@@ -54,8 +54,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   keep the previous rendering, shift the size up (`small` → `medium`,
   `medium` → `large`, `large` → `xlarge`).
 
-Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
-
 - **web-react:** remove Stack StackItem deprecation notice #DS-2639
 - **web-react:** stabilize UNSTABLE_Header and remove deprecated Header
 - **web,web-react:** rename ScrollView's arrows to controls #DS-2271
@@ -85,8 +83,6 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
   Sass variable and the `spirit-feature-enable-v5-tag-appearance` CSS class from
   your project — they have no effect. See the Tag: Appearance Feature Flag Removed
   sections in the web and web-react package Migration Guides to version 5.
-
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 
 - **web,web-react:** remove deprecated `row` direction value from `Flex` #DS-1629
 

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -68,8 +68,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   keep the previous rendering, shift the size up (`small` → `medium`,
   `medium` → `large`, `large` → `xlarge`).
 
-Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
-
 - **web:** remove Stack StackItem backwards-compat CSS #DS-2639
 - **design-tokens,web:** rename component tokens from `header` to `navigation` #DS-2589
 - **web:** stabilize UNSTABLE_Header and remove deprecated Header scss
@@ -116,8 +114,6 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
   Sass variable and the `spirit-feature-enable-v5-tag-appearance` CSS class from
   your project — they have no effect. See the Tag: Appearance Feature Flag Removed
   sections in the web and web-react package Migration Guides to version 5.
-
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 
 - **web,web-react:** remove deprecated `row` direction value from `Flex` #DS-1629
 - **web:** Remove `.Slider__input` and replace it with `.Slider`.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

AI co-author footers from commit bodies (e.g. `Co-Authored-By: Claude ...`) leaked into generated `CHANGELOG.md` files because Lerna/conventional-changelog includes full commit bodies in breaking change notes. This PR manually removes the existing occurrences from affected changelogs.

### Additional context

Automated changelog sanitization via a release script was considered but intentionally left out of scope for now.

### Issue reference

https://jira.almacareer.tech/browse/DS-2670

## Test plan

- [x] No AI trailer matches remain in affected `CHANGELOG.md` files