### PR TITLE
docs(repo): use commit subjects for 5.0.0 breaking changes

### DIFF
--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -9,7 +9,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - **repo:** drop support for Node.js v20 and require Node.js v22 #DS-2597
 - **design-tokens,web:** rename component tokens from `header` to `navigation` #DS-2589
-- **design-tokens,web:** Filled tokens are now renamed to fill.
+- **design-tokens,web:** rename Form Field Filled tokens to Fill #DS-2502
 
 ### Features
 

--- a/packages/web-react/CHANGELOG.md
+++ b/packages/web-react/CHANGELOG.md
@@ -26,79 +26,46 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web,web-react:** drop examples with emphasized label in the Toggle and Checkbox
 - **web,web-react:** remove formFieldMode and vertical spacing from form field components
 - **web,web-react:** replace `link-stretched` with `element-stretched` helper class #DS-2653
-- **web,web-react:** align File and FileUpload with design changes #DS-2554
 - **web:** align Pagination with new design #DS-2554
 - **web-react:** align `Toast` with new design #DS-2554
 - **web:** align `Tag` with new design #DS-2554
 - **web:** align `Navigation` with new design #DS-2554
 - **web:** align `Button` sizes with action typography tokens #DS-2554
-- **web,web-react:** Spacings in Checkbox, Radio and Toggle are
-  now set using padding utility. Review all your usages.
+- **web,web-react:** use padding for Checkbox, Radio, and Toggle vertical spacings
 - **web-react:** remove `hideOnCollapse` from `UncontrolledCollapse`
-- **web,web-react:** the `closeButton` prop on `DrawerPanel` is removed.
-  Compose the panel from `DrawerPanelHeader` and `DrawerPanelContent`
-  instead.
-- **web-react:** `DrawerCloseButton`, `ModalCloseButton`, `TooltipCloseButton`, and
-  their prop types are removed. Use `CloseButton` instead.
-- **web-react:** Toggle now requires explicit margin management when used within Stack components.
+- **web,web-react:** expose `DrawerPanel` composition sub-components #DS-2656
+- **web-react:** add `CloseButton` and remove component-specific close buttons #DS-2216
+- **web-react:** update Toggle component to use composition #DS-564
 - **web,web-react:** replace `TooltipCloseButton` button with `ControlButton`
 - **web,web-react:** replace `ToastBar` close button with `ControlButton` #DS-2216
 - **web,web-react:** replace `Button` with `ControlButton` in `ModalCloseButton` #DS-2216
 - **web,web-react:** replace `DrawerCloseButton` with `ControlButton` in `Drawer` #DS-2216
-- **web-react:** Radio now requires explicit margin management when used within Stack components.
-- **web-react:** Checkbox now requires explicit margin management
-  when used within Stack components.
-- **web,web-react:** Item no longer accepts label, helperText, iconName,
-  or selectionDecorator props. Use children with startSlot/endSlot
-  and compose Label, HelperText, ValidationText, and Icon explicitly.
-- **web,web-react:** Item now renders as a div by default instead of a button.
-  Set elementType="button" when button semantics are needed.
-- **web,web-react:** The web Item markup now uses Item**content
-  and Item**slot instead of Item\_\_icon and grid-positioned Label/HelperText item styles.
-- **web,web-react:** `--disabled` modifier classes are removed from the migrated components — consumers
-  should apply the disabled utility class alongside the native disabled attribute.
+- **web-react:** update Radio component to use composition #DS-564
+- **web-react:** update Checkbox component to use composition
+- **web,web-react:** compose Item content with slots #DS-2586
+- **web,web-react:** use disabled utility for disabled color-scheme states #DS-2468
 - **repo:** drop support for Node.js v20 and require Node.js v22 #DS-2597
-- **web-react:** Remove FileUploader compound component and stabilize
-  UNSTABLE_FileUpload and UNSTABLE_File as FileUpload and File.
-- **web-react:** removed indicator for selected state in vertical navigation
-- **web,web-react:** `ControlButton` now uses the expanded size scale by default.
-  The existing `small`/`medium`/`large` sizes are remapped to smaller heights and
-  `xsmall`/`xlarge` are added. Remove the
-  `spirit-feature-enable-v5-control-button-expanded-size-scale` CSS class and the
-  `$enable-v5-control-button-expanded-size-scale` Sass flag from your project; to
-  keep the previous rendering, shift the size up (`small` → `medium`,
-  `medium` → `large`, `large` → `xlarge`).
-
+- **web-react:** stabilize FileUpload and File, remove FileUploader #DS-2592
+- **web-react:** introduce NavigationItem slots #DS-2523
+- **web,web-react:** remove `ControlButton` expanded size scale feature flag #DS-2216
 - **web-react:** remove Stack StackItem deprecation notice #DS-2639
 - **web-react:** stabilize UNSTABLE_Header and remove deprecated Header
 - **web,web-react:** rename ScrollView's arrows to controls #DS-2271
-- **web,web-react:** The `ValidationText--inline` modifier and `formFieldMode`
-  handling in `ValidationText` have been removed. Use default `ValidationText`
-  styling for Checkbox and Toggle validation messages.
+- **web,web-react:** remove inline modifier from `ValidationText` components
 - **web-react:** rename hasValidationStateIcon to validationStateIcon #DS-2490
 - **web,web-react:** drop has prefix from Stack CSS modifiers #DS-1916
 - **web,web-react:** derive `ControlButton` colors from color scheme #DS-2591
 - **web,web-react:** replace check-plain with success icon for success state #DS-2098
-- **web:** Visual BC of all form fields
-- **web,web-react:** If Icon component parent sets Icon size, it is used.
-  Icon `boxSize` overrides this value.
-- **web,web-react:** `.Tag--<color>` and `.Tag--subtle` CSS rules are no
-  longer emitted. Consumers must apply a `color-scheme-on-*` class (the
-  React component does this automatically).
-- **web,web-react:** web `Button` emotion variants now require color-scheme
-  helper classes for surface colors in markup examples.
-- **web,web-react:** TooltipPopover now requires color-scheme helper for surface colors
-- **web,web-react:** web `Alert` variants now require color-scheme classes for surface colors.
+- **web:** update typography in ValidationText to use regular weight #DS-2472
+- **web,web-react:** the Icon now inherits composition size unless it explicitly overrides it
+- **web,web-react:** migrate `Tag` to color schemes #DS-2456
+- **web,web-react:** migrate `Button` and `ButtonLink` to color schemes
+- **web,web-react:** migrate `TooltipPopover` to neutral color-scheme
+- **web,web-react:** migrate `Alert` to color schemes
 - **web,web-react:** use `InputContainer` in `UNSTABLE_Picker` #DS-564
 - **web,web-react:** remove deprecated `isBlock` prop from Button and ButtonLink #DS-1897
-- **web:** TextArea now uses InputContainer instead of a custom component.
-  CharacterCounter component is now a standalone component.
-- **web,web-react:** The new `Tag` appearance (`inline-flex` layout with explicit
-  height and inside spacing) is now default. Delete the `$enable-v5-tag-appearance`
-  Sass variable and the `spirit-feature-enable-v5-tag-appearance` CSS class from
-  your project — they have no effect. See the Tag: Appearance Feature Flag Removed
-  sections in the web and web-react package Migration Guides to version 5.
-
+- **web:** use InputContainer in TextArea #DS-564
+- **web,web-react:** drop `Tag` appearance feature flag #DS-2456
 - **web,web-react:** remove deprecated `row` direction value from `Flex` #DS-1629
 
 ### Features

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -28,7 +28,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web,web-react:** remove formFieldMode and vertical spacing from form field components
 - **web,web-react:** replace `link-stretched` with `element-stretched` helper class #DS-2653
 - **web:** align inline form field components with new typography tokens #DS-2554
-- **web,web-react:** align File and FileUpload with design changes #DS-2554
 - **web:** align form field components with new typography tokens #DS-2554
 - **web:** align Pagination with new design #DS-2554
 - **web:** align `Tag` with new design #DS-2554
@@ -43,41 +42,23 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web:** align `Pill` with new design #DS-2554
 - **web:** align `Accordion` with new design #DS-2554
 - **web:** align `Button` sizes with action typography tokens #DS-2554
-- **web,web-react:** Spacings in Checkbox, Radio and Toggle are
-  now set using padding utility. Review all your usages.
-- **web,web-react:** the `closeButton` prop on `DrawerPanel` is removed.
-  Compose the panel from `DrawerPanelHeader` and `DrawerPanelContent`
-  instead.
-- **web:** Remove several styles from Toggle.
+- **web,web-react:** use padding for Checkbox, Radio, and Toggle vertical spacings
+- **web,web-react:** expose `DrawerPanel` composition sub-components #DS-2656
+- **web:** switch Toggle to composition and move its styles to the input only #DS-564
 - **web,web-react:** replace `TooltipCloseButton` button with `ControlButton`
 - **web,web-react:** replace `ToastBar` close button with `ControlButton` #DS-2216
 - **web,web-react:** replace `Button` with `ControlButton` in `ModalCloseButton` #DS-2216
 - **web,web-react:** replace `DrawerCloseButton` with `ControlButton` in `Drawer` #DS-2216
-- **web:** Remove several styles from Radio.
-- **web:** Remove several styles from Checkbox.
-- **web,web-react:** Item no longer accepts label, helperText, iconName,
-  or selectionDecorator props. Use children with startSlot/endSlot
-  and compose Label, HelperText, ValidationText, and Icon explicitly.
-- **web,web-react:** Item now renders as a div by default instead of a button.
-  Set elementType="button" when button semantics are needed.
-- **web,web-react:** The web Item markup now uses Item**content
-  and Item**slot instead of Item\_\_icon and grid-positioned Label/HelperText item styles.
-- **web,web-react:** `--disabled` modifier classes are removed from the migrated components — consumers
-  should apply the disabled utility class alongside the native disabled attribute.
+- **web:** switch Radio to composition and move its styles to the input only #DS-564
+- **web:** switch Checkbox to composition and move its styles to the input only #DS-564
+- **web,web-react:** compose Item content with slots #DS-2586
+- **web,web-react:** use disabled utility for disabled color-scheme states #DS-2468
 - **repo:** drop support for Node.js v20 and require Node.js v22 #DS-2597
-- **web:** Remove FileUploader SCSS/JS plugin and stabilize
-  UNSTABLE_FileUpload and UNSTABLE_File as FileUpload and File.
+- **web:** stabilize FileUpload and File, remove FileUploader #DS-2592
 - **web:** unify toggle html order with checkbox #DS-2322
-- **web:** removed indicator for selected state in vertical navigation
+- **web:** introduce NavigationItem slots #DS-2523
 - **web:** remove enable-v5-container-block-formatting-context feature flag
-- **web,web-react:** `ControlButton` now uses the expanded size scale by default.
-  The existing `small`/`medium`/`large` sizes are remapped to smaller heights and
-  `xsmall`/`xlarge` are added. Remove the
-  `spirit-feature-enable-v5-control-button-expanded-size-scale` CSS class and the
-  `$enable-v5-control-button-expanded-size-scale` Sass flag from your project; to
-  keep the previous rendering, shift the size up (`small` → `medium`,
-  `medium` → `large`, `large` → `xlarge`).
-
+- **web,web-react:** remove `ControlButton` expanded size scale feature flag #DS-2216
 - **web:** remove Stack StackItem backwards-compat CSS #DS-2639
 - **design-tokens,web:** rename component tokens from `header` to `navigation` #DS-2589
 - **web:** stabilize UNSTABLE_Header and remove deprecated Header scss
@@ -85,53 +66,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web:** replace `get-variable-if-exists` with relevant token #DS-2633
 - **web:** update `UNSTABLE_Picker` design #DS-2503
 - **web,web-react:** rename ScrollView's arrows to controls #DS-2271
-- **web:** All `InputContainer` elements now require either
-  `InputContainer--fill` or `InputContainer--outline` modifier.
-- **design-tokens,web:** Filled tokens are now renamed to fill.
-- **web,web-react:** The `ValidationText--inline` modifier and `formFieldMode`
-  handling in `ValidationText` have been removed. Use default `ValidationText`
-  styling for Checkbox and Toggle validation messages.
+- **web:** introduce fill and outline variants to form fields #DS-2502
+- **design-tokens,web:** rename Form Field Filled tokens to Fill #DS-2502
+- **web,web-react:** remove inline modifier from `ValidationText` components
 - **web,web-react:** drop has prefix from Stack CSS modifiers #DS-1916
 - **web,web-react:** derive `ControlButton` colors from color scheme #DS-2591
 - **web:** derive dynamic colors from color schemes #DS-2590
 - **web,web-react:** replace check-plain with success icon for success state #DS-2098
-- **web:** Visual BC of all form fields
-- **web,web-react:** If Icon component parent sets Icon size, it is used.
-  Icon `boxSize` overrides this value.
-- **web,web-react:** `.Tag--<color>` and `.Tag--subtle` CSS rules are no
-  longer emitted. Consumers must apply a `color-scheme-on-*` class (the
-  React component does this automatically).
-- **web,web-react:** web `Button` emotion variants now require color-scheme
-  helper classes for surface colors in markup examples.
-- **web,web-react:** TooltipPopover now requires color-scheme helper for surface colors
-- **web,web-react:** web `Alert` variants now require color-scheme classes for surface colors.
+- **web:** update typography in ValidationText to use regular weight #DS-2472
+- **web,web-react:** the Icon now inherits composition size unless it explicitly overrides it
+- **web,web-react:** migrate `Tag` to color schemes #DS-2456
+- **web,web-react:** migrate `Button` and `ButtonLink` to color schemes
+- **web,web-react:** migrate `TooltipPopover` to neutral color-scheme
+- **web,web-react:** migrate `Alert` to color schemes
 - **web,web-react:** use `InputContainer` in `UNSTABLE_Picker` #DS-564
 - **web,web-react:** remove deprecated `isBlock` prop from Button and ButtonLink #DS-1897
-- **web:** dictionaries.generate-colors for ToastBar is removed. Migrate
-  custom CSS or overrides from --spirit-toast-bar-\* to locals and color-scheme helpers.
-- **web:** Remove color-scheme from the utilities settings and move generation to
-  helpers/color-scheme. Consumers must import the color-scheme helper entry (or the updated
-  main bundle) instead of relying on utilities-only builds for color-scheme classes. Pill and
-  ControlButton use the new component token override mixin.
-- **web:** TextArea now uses InputContainer instead of a custom component.
-  CharacterCounter component is now a standalone component.
-- **web:** Remove most of the Select styles.
-- **web:** Refactor TextField to use InputContainer and InputAddon instead
-  of it's own styles. Use ControlButton for Password Toggle.
-- **web:** Remove all FieldGroup styles.
-- **web,web-react:** The new `Tag` appearance (`inline-flex` layout with explicit
-  height and inside spacing) is now default. Delete the `$enable-v5-tag-appearance`
-  Sass variable and the `spirit-feature-enable-v5-tag-appearance` CSS class from
-  your project — they have no effect. See the Tag: Appearance Feature Flag Removed
-  sections in the web and web-react package Migration Guides to version 5.
-
+- **web:** migrate ToastBar to color schemes
+- **web:** add color-scheme scss helpers and pill component overrides
+- **web:** use InputContainer in TextArea #DS-564
+- **web:** use InputAddon and InputContainer in Select #DS-1668
+- **web:** introduce InputContainer and InputAddon components #DS-1668
+- **web:** drop FieldGroup styles and use Flex and border utility #DS-564
+- **web,web-react:** drop `Tag` appearance feature flag #DS-2456
 - **web,web-react:** remove deprecated `row` direction value from `Flex` #DS-1629
-- **web:** Remove `.Slider__input` and replace it with `.Slider`.
+- **web:** simplify Slider styles #DS-564
 - **web:** require `InputDetails--disabled` for disabled details #DS-2496
-- **web:** Remove Dropdown and Tooltip placement modificators. Introduce placement helpers.
+- **web:** unify CSS placement in Dropdown and Tooltip #DS-1104
 - **web:** replace custom validation text with ValidationText component #DS-2397
 - **web,demo:** replace custom label elements with Label component #DS-2395
-- **web:** Button gaps are now set automatically, so the margins inside should be removed.
+- **web:** introduce auto gap in Button and ControlButton #DS-2344
 
 ### Features
 


### PR DESCRIPTION
## Description

The 5.0.0 `⚠ BREAKING CHANGES` sections were an inconsistent mix of terse commit subjects and long paragraphs, and even contained leaked `Co-Authored-By` trailers. This happens because conventional-changelog takes breaking-change text from the `BREAKING CHANGE:` commit-body footer whenever one exists and ignores the subject — so entries varied purely by how each commit was authored. This rewrites every 5.0.0 breaking-change entry to the concise commit subject, strips the leaked trailers, and collapses duplicates produced by commits carrying multiple footers.

### Additional context

- Cleanup only — scoped to the already-published 5.0.0 entries in `web`, `web-react`, and `design-tokens`; no other sections or versions are touched. The release tooling will keep producing body-derived entries until a forward fix (commit-convention change or a transform on the `version` lifecycle hook) is added.
- Follow-up to #DS-2670, which removed co-author trailers elsewhere but did not reach the ones embedded inside the breaking-change notes.

### Issue reference

https://jira.almacareer.tech/browse/DS-2683