### PR TITLE
fix(web): map `Pagination__link` radius to button medium radius

### DIFF
--- a/packages/web/src/scss/components/Pagination/_theme.scss
+++ b/packages/web/src/scss/components/Pagination/_theme.scss
@@ -1,4 +1,5 @@
 @use '@tokens' as tokens;
+@use '../../tools/tokens' as tokens-tools;
 @use '../../tools/units';
 
 $typography: tokens.$action-small;
@@ -9,7 +10,7 @@ $item-height: units.px-to-rem(40px);
 $item-padding-inline: tokens.$space-600;
 $item-border-width: tokens.$border-width-100;
 $item-border-style: solid;
-$item-border-radius: tokens.$radius-full;
+$item-border-radius: tokens-tools.get-variable-if-exists('button-medium-radius-mobile', tokens.$radius-full);
 
 $item-default-color: tokens.$component-pagination-unselected-content;
 $item-default-border-color: tokens.$component-pagination-unselected-border;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

A temporary hotfix to fix the pagination for Jobs.cz.

It would be good to consider whether we should also add a border radius token for the pagination, or make the components more consistent with the "Button secondary" style.

⬇️ Showcase from Jobs.cz

Before:
<img width="383" height="97" alt="image" src="https://github.com/user-attachments/assets/f9ae15c5-2339-4122-9d4e-f67b92ce5a8e" />

After:
<img width="345" height="71" alt="image" src="https://github.com/user-attachments/assets/b0cbb7a7-9f9d-4a2e-b0ed-c80d15389c6c" />

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

Follow-up issue: https://jira.almacareer.tech/browse/DS-2684

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
