### PR TITLE
fix(web): add missing `m-` margin utility class generation

### DIFF
--- a/packages/web/src/scss/settings/_utilities.scss
+++ b/packages/web/src/scss/settings/_utilities.scss
@@ -141,6 +141,18 @@ $utilities: (
             none,
         ),
     ),
+    'margin': (
+        responsive: true,
+        property: margin,
+        class: m,
+        generate-custom-properties: false,
+        values: map.merge(
+                tokens.$spaces,
+                (
+                    auto: auto,
+                )
+            ),
+    ),
     'margin-x': (
         responsive: true,
         property: margin-inline,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

The `margin` style prop (mapped to the `m-` utility class prefix) was defined in `web-react` but had no corresponding entry in the SCSS utilities settings, so `m-{space-token}` classes were never generated. This adds the missing `'margin'` entry to `settings/_utilities.scss`, enabling `m-0`, `m-100`…`m-1700`, `m-auto`, and their responsive variants (`m-tablet-*`, `m-desktop-*`) — matching the pattern already in place for all other margin directional variants.

### Issue reference

https://jira.almacareer.tech/browse/DS-2682