### PR TITLE
fix(demo): dedupe icons build so storybook starts with make start

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -11,9 +11,7 @@
     "directory": "apps/demo"
   },
   "scripts": {
-    "icons:build": "shx mkdir -p public/icons && cd ../../packages/icons && yarn build && shx cp -r dist/. ../../static/assets/icons",
-    "start:prepare": "yarn icons:build",
-    "start": "yarn start:prepare && vite --host --config config/vite/app.ts",
+    "start": "vite --host --config config/vite/app.ts",
     "build": "vite build --config config/vite/app.ts",
     "preview": "vite preview --config config/vite/app.ts"
   },
@@ -27,7 +25,6 @@
     "rollup": "catalog:build",
     "sass-embedded": "catalog:build",
     "sass-true": "catalog:test",
-    "shx": "catalog:script",
     "typescript": "catalog:types",
     "vite": "catalog:build",
     "vite-plugin-handlebars": "catalog:build"

--- a/apps/demo/project.json
+++ b/apps/demo/project.json
@@ -12,10 +12,13 @@
     "copy-icons": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cp -r packages/icons/dist/svg/. static/assets/icons/svg",
+        "command": "cp -r packages/icons/dist/. static/assets/icons",
         "cwd": "{workspaceRoot}"
       },
       "dependsOn": ["@alma-oss/spirit-icons:build"]
+    },
+    "start": {
+      "dependsOn": ["copy-icons"]
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6788,7 +6788,6 @@ __metadata:
     rollup: "catalog:build"
     sass-embedded: "catalog:build"
     sass-true: "catalog:test"
-    shx: "catalog:script"
     typescript: "catalog:types"
     vite: "catalog:build"
     vite-plugin-handlebars: "catalog:build"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

`make start` was racing two icons builds (demo shell rebuild + Storybook Nx `dependsOn`), which left `.icons-tmp` behind and blocked Storybook from starting. Demo `start` now depends on the existing Nx `copy-icons` target so icons build once and get copied, instead of rebuilding in the shell script.

### Additional context

Docsite still fails under `make start` when there is no `.next` production build (`next start`); that is unrelated and out of scope here.

### Issue reference

<!-- https://jira.almacareer.tech/browse/DS-XXXX -->