### PR TITLE
chore(ci): migrate release workflow to github app authentication

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -19,28 +19,39 @@ jobs:
   version:
     name: 🏷️ Version
     runs-on: ubuntu-24.04
+
+    # Git operations and releases use the app token (see below); GITHUB_TOKEN only needs read access.
     permissions:
-      # create commits and releases
-      contents: write
+      contents: read
 
     steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          # fetch tags
           fetch-depth: 0
-          # the repository's remote URL is configured to use the PAT
-          # for subsequent Git operations (e.g., git push).
-          # https://github.com/settings/personal-access-tokens
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node and Install Dependencies
         uses: ./.github/actions/setup-install
 
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Setup git config
         run: |
-          git config user.name "alma-design-system-bot"
-          git config user.email "team-design-system@almacareer.com"
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: List affected packages
         run: |
@@ -51,16 +62,16 @@ jobs:
           make build
 
       - name: Dry run (preview changes only)
-        if: ${{ github.event.inputs.dryrun == 'true' }}
+        if: ${{ inputs.dryrun }}
         run: |
           make version DEBUG=true
           echo "ℹ️ Dry run complete. No commits or tags were created."
           git diff
 
       - name: Bump version (local only)
-        if: ${{ github.event.inputs.dryrun == 'false' && github.event.inputs.confirm != 'yes' }}
+        if: ${{ !inputs.dryrun && inputs.confirm != 'yes' }}
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           make version MONOREPO_TOOL_FLAGS="--no-push"
           echo "⚠️ Version created locally but NOT pushed."
@@ -68,9 +79,9 @@ jobs:
           git --no-pager show --stat --patch HEAD
 
       - name: Bump version and Create GitHub Releases
-        if: ${{ github.event.inputs.dryrun == 'false' && github.event.inputs.confirm == 'yes' }}
+        if: ${{ !inputs.dryrun && inputs.confirm == 'yes' }}
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "🚀 Creating versions, pushing, and publishing GitHub releases..."
           make version

--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -46,6 +46,7 @@ export default {
           '`[^`]+`',
           '[a-z-]+-config-spirit',
           '^use[A-Z]\\w+',
+          'npm',
         ],
       },
     ],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -324,6 +324,10 @@ PR can be merged only by the appropriate group of maintainers.
 
 ### Authentication
 
+The release process involves two independent authentication mechanisms, one per workflow.
+
+#### GitHub (`Version` Workflow)
+
 The [`Version`][version-action] workflow authenticates as a GitHub App rather than a personal access token.
 A short-lived installation token is minted per run via `actions/create-github-app-token`, using the
 `GH_APP_CLIENT_ID` and `GH_APP_PRIVATE_KEY` secrets. Commits, tags, and releases it creates are attributed to
@@ -337,6 +341,27 @@ installation in the org's [GitHub App settings][github-app-settings] (find the a
 - Confirm the app is still installed on this repository.
 - Confirm its permissions cover what the workflow needs (`contents: write`).
 - Confirm the private key hasn't been rotated without updating the `GH_APP_PRIVATE_KEY` secret.
+
+#### npm ([`Publish`][publish-action] Workflow)
+
+Once `Version` pushes a new tag, the `Publish` workflow authenticates to the npm registry using
+[OIDC Trusted Publishers][npm-trusted-publishers] instead of a stored token. GitHub issues a
+short-lived OIDC token (via `permissions: id-token: write`), which npm exchanges for a publish
+token scoped to that single run — there is no `NPM_TOKEN`/`NODE_AUTH_TOKEN` secret to manage.
+`NPM_CONFIG_PROVENANCE: true` additionally attaches build provenance to each published package.
+
+This only works because the workflow runs under the `npm-registry` GitHub Actions environment,
+and each published package (`@alma-oss/spirit-web`, `@alma-oss/spirit-web-react`,
+`@alma-oss/spirit-design-tokens`, etc.) has this exact repo, workflow file, and environment
+registered as its Trusted Publisher on npmjs.com.
+
+**If `Publish` fails with an npm authentication or 403 error**:
+
+- Confirm the `npm-registry` environment still exists and is referenced correctly in
+  [`publish.yaml`][publish-action].
+- Check the affected package's Trusted Publisher configuration on npmjs.com (package →
+  Settings → Publishing access) — the trust link is matched by exact repo/workflow
+  file/environment name, so renaming any of them silently breaks it.
 
 ### Steps to Create a New Package Version
 
@@ -425,6 +450,7 @@ After the release notes are ready, you can publish them (copy&paste from canvas)
 [lerna-home]: https://lerna.js.org
 [local-publish-testing]: tools/README.md
 [netlify-preview-gist]: https://gist.github.com/adamkudrna/694f3048c1338f07375b9b8af24afe2f
+[npm-trusted-publishers]: https://docs.npmjs.com/trusted-publishers
 [packages]: packages/
 [prettier]: https://prettier.io/
 [publish-action]: https://github.com/alma-oss/spirit-design-system/actions/workflows/publish.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,6 +322,22 @@ This project uses GitHub Actions to publish the packages automatically to npm.
 New packages are published after the new tag is pushed to the main branch.
 PR can be merged only by the appropriate group of maintainers.
 
+### Authentication
+
+The [`Version`][version-action] workflow authenticates as a GitHub App rather than a personal access token.
+A short-lived installation token is minted per run via `actions/create-github-app-token`, using the
+`GH_APP_CLIENT_ID` and `GH_APP_PRIVATE_KEY` secrets. Commits, tags, and releases it creates are attributed to
+`almaoss-spirit-design-system[bot]`. Unlike the PAT (tied to a personal account and requiring manual
+renewal), this token is org-owned, scoped to this repo, and expires automatically.
+
+**If the `Version` workflow fails with an authentication or permission error**, check the GitHub App's
+installation in the org's [GitHub App settings][github-app-settings] (find the app tied to
+`almaoss-spirit-design-system[bot]`):
+
+- Confirm the app is still installed on this repository.
+- Confirm its permissions cover what the workflow needs (`contents: write`).
+- Confirm the private key hasn't been rotated without updating the `GH_APP_PRIVATE_KEY` secret.
+
 ### Steps to Create a New Package Version
 
 Merge all appropriate PRs you want to publish into the appropriate branch
@@ -404,6 +420,7 @@ After the release notes are ready, you can publish them (copy&paste from canvas)
 [figma-mcp-server]: https://developers.figma.com/docs/figma-mcp-server/remote-server-installation/
 [figma-quickstart]: https://developers.figma.com/docs/code-connect/quickstart-guide/#before-you-begin
 [figma-react-guide]: https://developers.figma.com/docs/code-connect/react/
+[github-app-settings]: https://github.com/organizations/alma-oss/settings/apps
 [jest]: https://jestjs.io/
 [lerna-home]: https://lerna.js.org
 [local-publish-testing]: tools/README.md


### PR DESCRIPTION
## Description

The release `Version` workflow authenticated to GitHub using a personal access token (`PAT_TOKEN`) tied to an individual account, requiring manual renewal and creating a single point of failure if that account changed. This PR switches the workflow to mint a short-lived token from a GitHub App instead, so releases are attributed to `almaoss-spirit-design-system[bot]` and auth is org-owned rather than tied to a person.

### Additional context

Also documents the new auth mechanism in `CONTRIBUTING.md` under Publishing, including where to look (org GitHub App settings) if the `Version` workflow fails with an auth error.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->