### PR TITLE
fix(demo): fix `Button` loading icons and `Collapse` tertiary trigger

### DIFF
--- a/packages/web/src/scss/components/Button/index.html
+++ b/packages/web/src/scss/components/Button/index.html
@@ -195,7 +195,7 @@
               >
                 <span class="accessibility-hidden">Menu</span>
                 <svg
-                  class="Icon animation-spin-clockwise"
+                  class="Icon"
                   width="24"
                   height="24"
                   aria-hidden="true"
@@ -203,7 +203,7 @@
                   <use href="/assets/icons/svg/sprite.svg#hamburger" />
                 </svg>
                 <svg
-                  class="Icon"
+                  class="Icon animation-spin-clockwise"
                   width="24"
                   height="24"
                   aria-hidden="true"

--- a/packages/web/src/scss/components/Collapse/preview.html
+++ b/packages/web/src/scss/components/Collapse/preview.html
@@ -289,7 +289,6 @@
         Secondary trigger
       </button>
       <a
-        href="#"
         role="button"
         data-spirit-toggle="collapse"
         data-spirit-target="collapse-example-6"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Two demo bugs in the `spirit-web` package.
1. Loading `Button` variants didn't apply the `animation-spin-clockwise` class on the spinner icon. 
2. The `Collapse` Multiple Triggers demo had `href="#"` on the tertiary trigger anchor, causing page navigation instead of toggling the collapse.

### Issue reference

https://jira.almacareer.tech/browse/DS-2674
https://jira.almacareer.tech/browse/DS-2675