### PR TITLE
fix(web, web-react): fix aria attributes in `Tabs` and `TabLink`

### DIFF
--- a/packages/web-react/src/components/Tabs/README.md
+++ b/packages/web-react/src/components/Tabs/README.md
@@ -139,11 +139,12 @@ Tab list link
 
 #### API
 
-| Name          | Type                         | Default | Required | Description                   |
-| ------------- | ---------------------------- | ------- | -------- | ----------------------------- |
-| `children`    | `any`                        | —       | ✕        | Child component               |
-| `elementType` | `ElementType`                | `a`     | ✕        | Type of element               |
-| `itemProps`   | `StyleProps & HTMLLIElement` | —       | ✕        | Props for parent list element |
+| Name            | Type                         | Default | Required | Description                                                                 |
+| --------------- | ---------------------------- | ------- | -------- | --------------------------------------------------------------------------- |
+| `aria-selected` | `boolean`                    | `false` | ✕        | Whether the tab link is currently selected; pass `true` for the active link |
+| `children`      | `any`                        | —       | ✕        | Child component                                                             |
+| `elementType`   | `ElementType`                | `a`     | ✕        | Type of element                                                             |
+| `itemProps`     | `StyleProps & HTMLLIElement` | —       | ✕        | Props for parent list element                                               |
 
 On top of the API options, the components accept [additional attributes][readme-additional-attributes].
 If you need more control over the styling of a component, you can use [style props][readme-style-props]

--- a/packages/web-react/src/components/Tabs/TabLink.tsx
+++ b/packages/web-react/src/components/Tabs/TabLink.tsx
@@ -19,7 +19,7 @@ const defaultProps: TabLinkProps = {
 const _TabLink = <E extends ElementType = 'a'>(props: SpiritTabLinkProps<E>, ref: PolymorphicRef<E>): JSX.Element => {
   const propsWithDefaults = { ...defaultProps, ...props };
   const { elementType = 'a', children, itemProps = {}, routerOptions, ...restProps } = propsWithDefaults;
-  const { href } = restProps;
+  const { href, 'aria-selected': ariaSelected = false, ...transferProps } = restProps;
 
   const Component = elementType as ElementType;
 
@@ -27,7 +27,7 @@ const _TabLink = <E extends ElementType = 'a'>(props: SpiritTabLinkProps<E>, ref
   const { styleProps: itemStyleProps, props: itemTransferProps } = useStyleProps(itemProps);
   const mergedStyleProps = mergeStyleProps(Component, { classProps: classProps.link });
 
-  const handleClick = useLinkClick({ ...restProps, routerOptions });
+  const handleClick = useLinkClick({ ...transferProps, href, routerOptions });
 
   return (
     <li
@@ -36,7 +36,15 @@ const _TabLink = <E extends ElementType = 'a'>(props: SpiritTabLinkProps<E>, ref
       className={classNames(classProps.item, itemStyleProps.className)}
       role="presentation"
     >
-      <Component {...restProps} {...mergedStyleProps} href={href} onClick={handleClick} ref={ref}>
+      <Component
+        {...transferProps}
+        {...mergedStyleProps}
+        href={href}
+        onClick={handleClick}
+        ref={ref}
+        role="tab"
+        aria-selected={ariaSelected}
+      >
         {children}
       </Component>
     </li>

--- a/packages/web-react/src/components/Tabs/__tests__/TabLink.test.tsx
+++ b/packages/web-react/src/components/Tabs/__tests__/TabLink.test.tsx
@@ -29,6 +29,30 @@ describe('TabLink', () => {
     expect(element).toHaveClass('Tabs__link');
   });
 
+  it('should have role="tab"', () => {
+    const dom = render(<TabLink href="https://www.example.com" />);
+
+    const element = dom.container.querySelector('a') as HTMLElement;
+
+    expect(element).toHaveAttribute('role', 'tab');
+  });
+
+  it('should have aria-selected="false" by default', () => {
+    const dom = render(<TabLink href="https://www.example.com" />);
+
+    const element = dom.container.querySelector('a') as HTMLElement;
+
+    expect(element).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('should have aria-selected="true" when passed', () => {
+    const dom = render(<TabLink href="https://www.example.com" aria-selected />);
+
+    const element = dom.container.querySelector('a') as HTMLElement;
+
+    expect(element).toHaveAttribute('aria-selected', 'true');
+  });
+
   it('should render button element', () => {
     const dom = render(<TabLink elementType="button">Hello World</TabLink>);
 

--- a/packages/web/src/js/Tabs.ts
+++ b/packages/web/src/js/Tabs.ts
@@ -68,7 +68,11 @@ class Tabs extends BaseComponent {
     this.activate(getElementFromSelector(element));
 
     element.removeAttribute('tabindex');
-    element.setAttribute('aria-selected', 'true');
+
+    if (element.getAttribute('role') === 'tab') {
+      element.setAttribute('aria-selected', 'true');
+    }
+
     EventHandler.trigger(element, EVENT_SHOWN, {
       relatedTarget: relatedElem,
     });
@@ -82,7 +86,10 @@ class Tabs extends BaseComponent {
     element.classList.remove(CLASS_NAME_ACTIVE);
     this.deactivate(getElementFromSelector(element));
 
-    element.setAttribute('aria-selected', 'false');
+    if (element.getAttribute('role') === 'tab') {
+      element.setAttribute('aria-selected', 'false');
+    }
+
     element.setAttribute('tabindex', '-1');
     EventHandler.trigger(element, EVENT_HIDDEN, { relatedTarget: relatedElem });
   }

--- a/packages/web/src/js/__tests__/Tabs.test.ts
+++ b/packages/web/src/js/__tests__/Tabs.test.ts
@@ -67,6 +67,30 @@ describe('Tabs', () => {
       await tab.show();
     });
 
+    it('should not set aria-selected on tabpanel after activation', async () => {
+      fixtureEl.innerHTML = `
+          <ul class="Tabs" role="tablist">
+            <li class="Tabs__item" role="presentation"><button type="button" data-spirit-target="#home" class="Tabs__link is-selected" role="tab" aria-selected="true">Home</button></li>
+            <li class="Tabs__item" role="presentation"><button type="button" id="trigger-profile" data-spirit-target="#profile" class="Tabs__link" role="tab">Profile</button></li>
+          </ul>
+          <div class="Tabs-content">
+            <div class="TabsPane is-selected" id="home" role="tabpanel"></div>
+            <div class="TabsPane" id="profile" role="tabpanel"></div>
+          </div>
+        `;
+
+      const profileTriggerEl = fixtureEl.querySelector('#trigger-profile') as HTMLElement;
+      const tab = new Tabs(profileTriggerEl);
+
+      await tab.show();
+
+      const profilePanel = fixtureEl.querySelector('#profile') as HTMLElement;
+      const homePanel = fixtureEl.querySelector('#home') as HTMLElement;
+
+      expect(profilePanel.hasAttribute('aria-selected')).toBe(false);
+      expect(homePanel.hasAttribute('aria-selected')).toBe(false);
+    });
+
     it('should not fire shown when tab is already active', async () => {
       fixtureEl.innerHTML = `
           <ul class="Tabs" role="tablist">

--- a/packages/web/src/scss/components/Tabs/README.md
+++ b/packages/web/src/scss/components/Tabs/README.md
@@ -31,10 +31,10 @@ Example usage:
     </button>
   </li>
   <li class="Tabs__item" role="presentation">
-    <a href="https://www.example.com" class="Tabs__link">Item Link</a>
+    <a href="https://www.example.com" class="Tabs__link" role="tab" aria-selected="false">Item Link</a>
   </li>
   <li class="Tabs__item d-none d-desktop-block" role="presentation">
-    <a href="https://www.example.com" class="Tabs__link">Item Link Only Desktop</a>
+    <a href="https://www.example.com" class="Tabs__link" role="tab" aria-selected="false">Item Link Only Desktop</a>
   </li>
 </ul>
 
@@ -48,7 +48,7 @@ A tab item can be a link that follows a URL:
 
 ```html
 <li class="Tabs__item" role="presentation">
-  <a href="https://www.example.com" class="Tabs__link">Link item</a>
+  <a href="https://www.example.com" class="Tabs__link" role="tab" aria-selected="false">Link item</a>
 </li>
 ```
 

--- a/packages/web/src/scss/components/Tabs/preview.html
+++ b/packages/web/src/scss/components/Tabs/preview.html
@@ -36,10 +36,20 @@
           </button>
         </li>
         <li class="Tabs__item" role="presentation">
-          <a href="https://www.example.com" class="Tabs__link">Item link</a>
+          <a
+            href="https://www.example.com"
+            class="Tabs__link"
+            role="tab"
+            aria-selected="false"
+          >Item link</a>
         </li>
         <li class="Tabs__item d-none d-desktop-block" role="presentation">
-          <a href="https://www.example.com" class="Tabs__link">Item link, desktop only</a>
+          <a
+            href="https://www.example.com"
+            class="Tabs__link"
+            role="tab"
+            aria-selected="false"
+          >Item link, desktop only</a>
         </li>
       </ul>
 
@@ -109,10 +119,20 @@
           </button>
         </li>
         <li class="Tabs__item" role="presentation">
-          <a href="https://www.example.com" class="Tabs__link">Item link</a>
+          <a
+            href="https://www.example.com"
+            class="Tabs__link"
+            role="tab"
+            aria-selected="false"
+          >Item link</a>
         </li>
         <li class="Tabs__item d-none d-desktop-block" role="presentation">
-          <a href="https://www.example.com" class="Tabs__link">Item link, desktop only</a>
+          <a
+            href="https://www.example.com"
+            class="Tabs__link"
+            role="tab"
+            aria-selected="false"
+          >Item link, desktop only</a>
         </li>
       </ul>
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

axe DevTools flagged two critical ARIA violations in the `Tabs` component.

1. The vanilla JS `activate()` / `deactivate()` methods were recursively called on the target panel, so `aria-selected` was incorrectly set on `role="tabpanel"` — an attribute that role does not allow.
2. `<a>` elements inside `<li role="presentation">` inside `role="tablist"` lacked `role="tab"`, making them invalid tablist children from the AT's perspective.

Both fixes are applied across the `web` and `web-react` packages: 
1. The JS class now guards `aria-selected` with a `role="tab"` check, preview HTML and README examples are updated.
2. The `TabLink` gains hardcoded `role="tab"` with `aria-selected` derived from the standard `aria-selected` HTML attribute (defaulting to `false`).

### Additional context

axe DevTools scan that revealed the issues:
<img width="2048" height="1233" alt="image" src="https://github.com/user-attachments/assets/d504e2fc-8dfa-43a4-84db-ef68fff21f0c" />

### Issue reference

https://jira.almacareer.tech/browse/DS-2678