### PR TITLE
fix(web, web-react): fix `Navigation` a11y issues in demos and `NavigationAvatar`

### DIFF
--- a/apps/demo/partials/header.hbs
+++ b/apps/demo/partials/header.hbs
@@ -34,7 +34,7 @@
       <!-- Desktop Main Navigation: end -->
 
       <!-- Desktop Secondary Navigation: start -->
-      <nav class="Navigation Navigation--horizontal ml-auto" aria-label="Secondary Navigation">
+      <nav class="Navigation Navigation--horizontal ml-auto" aria-label="Demo, secondary">
         <ul>
          <li class="NavigationItem NavigationItem--alignmentYCenter d-desktop-none">
           <button
@@ -96,7 +96,7 @@
         <!-- Drawer Main Navigation: end -->
 
         <!-- Drawer Secondary Navigation: start -->
-        <nav class="Navigation Navigation--vertical" aria-label="Secondary Navigation">
+        <nav class="Navigation Navigation--vertical" aria-label="Demo, secondary">
           <ul>
             <li class="NavigationItem NavigationItem--alignmentYCenter">
               {{> themeSwitcher isLabelHidden=false id="theme-select-drawer"}}

--- a/packages/web-react/src/components/Header/demo/HeaderWithNavigation.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithNavigation.tsx
@@ -26,8 +26,12 @@ const HeaderWithNavigation = () => {
             <HeaderLogo href="#" aria-label="JobBoard homepage">
               <ProductLogo>{defaultSvgLogo}</ProductLogo>
             </HeaderLogo>
-            <MainNavigation />
-            <SecondaryHorizontalNavigation id="drawer-navigation" handleOpenDrawer={() => setDrawerOpen(true)} />
+            <MainNavigation aria-label="Main with menu, desktop" />
+            <SecondaryHorizontalNavigation
+              id="drawer-navigation"
+              aria-label="Secondary with menu, desktop"
+              handleOpenDrawer={() => setDrawerOpen(true)}
+            />
           </Flex>
         </Container>
       </Header>
@@ -48,10 +52,10 @@ const HeaderWithNavigation = () => {
                 <ProfileNavigation />
               </StackItem>
               <StackItem>
-                <MainNavigation direction="vertical" />
+                <MainNavigation direction="vertical" aria-label="Main with menu, mobile" />
               </StackItem>
               <StackItem>
-                <SecondaryVerticalNavigation />
+                <SecondaryVerticalNavigation aria-label="Secondary with menu, mobile" />
               </StackItem>
             </Stack>
           </DrawerPanelBody>

--- a/packages/web-react/src/components/Header/demo/HeaderWithNavigation/MainNavigation.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithNavigation/MainNavigation.tsx
@@ -4,15 +4,17 @@ import { type NavigationActionVariantsType, type SpiritNavigationProps } from '.
 import { Navigation, NavigationAction, NavigationItem } from '../../../Navigation';
 
 interface MainNavigationProps extends Partial<SpiritNavigationProps> {
+  'aria-label'?: string;
   variant?: NavigationActionVariantsType;
 }
 
 export const MainNavigation = ({
+  'aria-label': ariaLabel,
   direction = Direction.HORIZONTAL,
   variant = ShapeVariants.BOX,
 }: Partial<MainNavigationProps>) => (
   <Navigation
-    aria-label="Main Navigation"
+    aria-label={ariaLabel}
     direction={direction}
     {...(isDirectionHorizontal(direction) ? { hideOn: ['mobile', 'tablet'] } : {})}
   >

--- a/packages/web-react/src/components/Header/demo/HeaderWithNavigation/SecondaryHorizontalNavigation.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithNavigation/SecondaryHorizontalNavigation.tsx
@@ -8,14 +8,16 @@ import { VisuallyHidden } from '../../../VisuallyHidden';
 
 interface SecondaryHorizontalNavigationProps {
   id: string;
+  'aria-label': string;
   handleOpenDrawer: (event: ClickEvent) => void;
 }
 
 const SecondaryHorizontalNavigation: FunctionComponent<SecondaryHorizontalNavigationProps> = ({
   id,
+  'aria-label': ariaLabel,
   handleOpenDrawer,
 }) => (
-  <Navigation marginLeft="auto" aria-label="Secondary Navigation">
+  <Navigation marginLeft="auto" aria-label={ariaLabel}>
     <NavigationItem>
       <Button color="tertiary" size="small" isSymmetrical>
         <Icon name="search" />

--- a/packages/web-react/src/components/Header/demo/HeaderWithNavigation/SecondaryVerticalNavigation.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithNavigation/SecondaryVerticalNavigation.tsx
@@ -2,8 +2,12 @@ import React from 'react';
 import { ButtonLink } from '../../../ButtonLink';
 import { Navigation, NavigationItem } from '../../../Navigation';
 
-const SecondaryVerticalNavigation = () => (
-  <Navigation aria-label="Secondary Navigation" direction="vertical">
+interface SecondaryVerticalNavigationProps {
+  'aria-label': string;
+}
+
+const SecondaryVerticalNavigation = ({ 'aria-label': ariaLabel }: SecondaryVerticalNavigationProps) => (
+  <Navigation aria-label={ariaLabel} direction="vertical">
     <NavigationItem>
       <ButtonLink href="#" color="secondary" size="small">
         Log In

--- a/packages/web-react/src/components/Header/demo/HeaderWithNavigationAndNestedItems.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithNavigationAndNestedItems.tsx
@@ -27,8 +27,11 @@ const HeaderWithNavigationAndNestedItems = () => {
             <HeaderLogo href="#" aria-label="JobBoard homepage">
               <ProductLogo>{defaultSvgLogo}</ProductLogo>
             </HeaderLogo>
-            <MainHorizontalNavigation />
-            <SecondaryHorizontalNavigation handleOpenDrawer={() => setDrawerOpen(true)} />
+            <MainHorizontalNavigation aria-label="Main with menu and nested items, desktop" />
+            <SecondaryHorizontalNavigation
+              aria-label="Secondary with menu and nested items, desktop"
+              handleOpenDrawer={() => setDrawerOpen(true)}
+            />
           </Flex>
         </Container>
       </Header>
@@ -61,10 +64,10 @@ const HeaderWithNavigationAndNestedItems = () => {
                 <ProfileNavigation isSquare />
               </StackItem>
               <StackItem>
-                <MainVerticalNavigation />
+                <MainVerticalNavigation aria-label="Main with menu and nested items, mobile" />
               </StackItem>
               <StackItem>
-                <SecondaryVerticalNavigation />
+                <SecondaryVerticalNavigation aria-label="Secondary with menu and nested items, mobile" />
               </StackItem>
             </Stack>
           </DrawerPanelBody>

--- a/packages/web-react/src/components/Header/demo/HeaderWithNavigationAndNestedItems/MainHorizontalNavigation.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithNavigationAndNestedItems/MainHorizontalNavigation.tsx
@@ -2,8 +2,12 @@ import React from 'react';
 import { Navigation, NavigationAction, NavigationItem } from '../../../Navigation';
 import MainHorizontalNavigationDropdown from './MainHorizontalNavigationDropdown';
 
-export const MainHorizontalNavigation = () => (
-  <Navigation aria-label="Main Navigation" hideOn={['mobile', 'tablet']}>
+interface MainHorizontalNavigationProps {
+  'aria-label': string;
+}
+
+export const MainHorizontalNavigation = ({ 'aria-label': ariaLabel }: MainHorizontalNavigationProps) => (
+  <Navigation aria-label={ariaLabel} hideOn={['mobile', 'tablet']}>
     <NavigationItem>
       <NavigationAction href="#" aria-current="page" isSelected>
         Selected

--- a/packages/web-react/src/components/Header/demo/HeaderWithNavigationAndNestedItems/MainVerticalNavigation.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithNavigationAndNestedItems/MainVerticalNavigation.tsx
@@ -4,11 +4,15 @@ import { Icon } from '../../../Icon';
 import { Navigation, NavigationAction, NavigationItem } from '../../../Navigation';
 import CollapseNavigation from './CollapseNavigation';
 
-const DrawerWithNavigation = () => {
+interface DrawerWithNavigationProps {
+  'aria-label': string;
+}
+
+const DrawerWithNavigation = ({ 'aria-label': ariaLabel }: DrawerWithNavigationProps) => {
   const { isOpen: isCollapseOpen, toggleHandler: toggleCollapseHandler } = useCollapse(false);
 
   return (
-    <Navigation aria-label="Main Navigation" direction="vertical">
+    <Navigation aria-label={ariaLabel} direction="vertical">
       <NavigationItem>
         <NavigationAction href="#" aria-current="page" isSelected>
           Selected

--- a/packages/web-react/src/components/Header/demo/HeaderWithNavigationAndNestedItems/SecondaryHorizontalNavigation.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithNavigationAndNestedItems/SecondaryHorizontalNavigation.tsx
@@ -8,11 +8,15 @@ import { VisuallyHidden } from '../../../VisuallyHidden';
 import SecondaryHorizontalNavigationDropdown from '../HeaderWithNavigation/SecondaryHorizontalNavigationDropdown';
 
 interface SecondaryHorizontalNavigationProps {
+  'aria-label': string;
   handleOpenDrawer: (event: ClickEvent) => void;
 }
 
-const SecondaryHorizontalNavigation: FunctionComponent<SecondaryHorizontalNavigationProps> = ({ handleOpenDrawer }) => (
-  <Navigation marginLeft="auto" aria-label="Secondary Navigation">
+const SecondaryHorizontalNavigation: FunctionComponent<SecondaryHorizontalNavigationProps> = ({
+  'aria-label': ariaLabel,
+  handleOpenDrawer,
+}) => (
+  <Navigation marginLeft="auto" aria-label={ariaLabel}>
     <NavigationItem>
       <Button color="tertiary" size="small" isSymmetrical>
         <Icon name="search" />

--- a/packages/web-react/src/components/Header/demo/HeaderWithNavigationAndNestedItems/SecondaryVerticalNavigation.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithNavigationAndNestedItems/SecondaryVerticalNavigation.tsx
@@ -2,8 +2,12 @@ import React from 'react';
 import { ButtonLink } from '../../../ButtonLink';
 import { Navigation, NavigationItem } from '../../../Navigation';
 
-const SecondaryVerticalNavigation = () => (
-  <Navigation aria-label="Secondary Navigation" direction="vertical">
+interface SecondaryVerticalNavigationProps {
+  'aria-label': string;
+}
+
+const SecondaryVerticalNavigation = ({ 'aria-label': ariaLabel }: SecondaryVerticalNavigationProps) => (
+  <Navigation aria-label={ariaLabel} direction="vertical">
     <NavigationItem>
       <ButtonLink href="#" color="secondary" size="small">
         Log Out

--- a/packages/web-react/src/components/Header/demo/HeaderWithPillNavigation.tsx
+++ b/packages/web-react/src/components/Header/demo/HeaderWithPillNavigation.tsx
@@ -26,8 +26,12 @@ const HeaderWithPillNavigation = () => {
             <HeaderLogo href="#" aria-label="JobBoard homepage">
               <ProductLogo>{defaultSvgLogo}</ProductLogo>
             </HeaderLogo>
-            <MainNavigation variant="pill" />
-            <SecondaryHorizontalNavigation id="drawer-navigation-pill" handleOpenDrawer={() => setDrawerOpen(true)} />
+            <MainNavigation variant="pill" aria-label="Main with pill menu, desktop" />
+            <SecondaryHorizontalNavigation
+              id="drawer-navigation-pill"
+              aria-label="Secondary with pill menu, desktop"
+              handleOpenDrawer={() => setDrawerOpen(true)}
+            />
           </Flex>
         </Container>
       </Header>
@@ -53,10 +57,10 @@ const HeaderWithPillNavigation = () => {
                 <ProfileNavigation />
               </StackItem>
               <StackItem>
-                <MainNavigation direction="vertical" variant="pill" />
+                <MainNavigation direction="vertical" variant="pill" aria-label="Main with pill menu, mobile" />
               </StackItem>
               <StackItem>
-                <SecondaryVerticalNavigation />
+                <SecondaryVerticalNavigation aria-label="Secondary with pill menu, mobile" />
               </StackItem>
             </Stack>
           </DrawerPanelBody>

--- a/packages/web-react/src/components/Header/figma/Header.figma.tsx
+++ b/packages/web-react/src/components/Header/figma/Header.figma.tsx
@@ -43,7 +43,7 @@ const HeaderWithNavigationLoggedIn = ({ itemVariant }: { itemVariant: Navigation
                 </NavigationAction>
               </NavigationItem>
             </Navigation>
-            <Navigation marginLeft="auto" aria-label="Secondary Navigation">
+            <Navigation marginLeft="auto" aria-label="Secondary">
               <NavigationItem alignmentY="center" hideOn={['mobile', 'tablet']}>
                 <NavigationAvatar avatarContent={<Icon name="profile" />} aria-label="Profile of Jiří Bárta">
                   My Account
@@ -98,7 +98,7 @@ const HeaderWithNavigationLoggedIn = ({ itemVariant }: { itemVariant: Navigation
                 </Navigation>
               </StackItem>
               <StackItem>
-                <Navigation aria-label="Main Navigation" direction="vertical">
+                <Navigation aria-label="Main" direction="vertical">
                   <NavigationItem>
                     <NavigationAction href="#" isSelected variant={itemVariant}>
                       Selected
@@ -117,7 +117,7 @@ const HeaderWithNavigationLoggedIn = ({ itemVariant }: { itemVariant: Navigation
                 </Navigation>
               </StackItem>
               <StackItem>
-                <Navigation aria-label="Secondary Navigation" direction="vertical">
+                <Navigation aria-label="Secondary Vertical" direction="vertical">
                   <NavigationItem>
                     <ButtonLink href="#" color="secondary">
                       Log Out
@@ -161,7 +161,7 @@ const HeaderWithNavigationLoggedOut = ({ itemVariant }: { itemVariant: Navigatio
                 </NavigationAction>
               </NavigationItem>
             </Navigation>
-            <Navigation marginLeft="auto" aria-label="Secondary Navigation">
+            <Navigation marginLeft="auto" aria-label="Secondary">
               <NavigationItem hideOn={['mobile', 'tablet']}>
                 <ButtonLink href="#" color="secondary">
                   Register
@@ -225,7 +225,7 @@ const HeaderWithNavigationLoggedOut = ({ itemVariant }: { itemVariant: Navigatio
                 </Navigation>
               </StackItem>
               <StackItem>
-                <Navigation aria-label="Secondary Navigation" direction="vertical">
+                <Navigation aria-label="Secondary Vertical" direction="vertical">
                   <NavigationItem>
                     <ButtonLink href="#" color="secondary">
                       Register

--- a/packages/web-react/src/components/Navigation/NavigationAvatar.tsx
+++ b/packages/web-react/src/components/Navigation/NavigationAvatar.tsx
@@ -39,7 +39,7 @@ const _NavigationAvatar = <E extends ElementType = 'a'>(
 
   return (
     <ElementTag {...otherProps} {...mergedStyleProps} ref={ref}>
-      <Avatar size={avatarSize} isSquare={isSquare}>
+      <Avatar size={avatarSize} isSquare={isSquare} aria-hidden="true">
         {avatarContent}
       </Avatar>
       {children}

--- a/packages/web-react/src/components/Navigation/README.md
+++ b/packages/web-react/src/components/Navigation/README.md
@@ -16,8 +16,8 @@ The `Navigation` is a `nav` wrapper for navigation items.
 The `Navigation` component can be horizontal or vertical. Use `direction` prop to set the orientation. Default direction is `horizontal`.
 
 ```tsx
-<Navigation aria-label="Main Navigation">{/* Navigation items go here */}</Navigation>
-<Navigation aria-label="Main Navigation" direction="vertical">
+<Navigation aria-label="Main">{/* Navigation items go here */}</Navigation>
+<Navigation aria-label="Main" direction="vertical">
   {/* Navigation items go here */}
 </Navigation>
 ```
@@ -223,7 +223,7 @@ and [escape hatches][readme-escape-hatches].
 With NavigationAction/NavigationAvatar components:
 
 ```tsx
-<Navigation aria-label="Main Navigation">
+<Navigation aria-label="Main">
   <NavigationItem>
     <NavigationAction href="#" aria-current="page" isSelected>
       Selected Link
@@ -250,7 +250,7 @@ With NavigationAction/NavigationAvatar components:
 With Buttons:
 
 ```tsx
-<Navigation aria-label="Secondary Navigation">
+<Navigation aria-label="Secondary">
   <NavigationItem>
     <ButtonLink href="#">Button</ButtonLink>
   </NavigationItem>

--- a/packages/web-react/src/components/Navigation/__tests__/NavigationAvatar.accessibility.test.tsx
+++ b/packages/web-react/src/components/Navigation/__tests__/NavigationAvatar.accessibility.test.tsx
@@ -1,0 +1,53 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { accessibilityTest } from '@local/tests';
+import { Icon } from '../../Icon';
+import Navigation from '../Navigation';
+import NavigationAvatar from '../NavigationAvatar';
+import NavigationItem from '../NavigationItem';
+
+jest.mock('../../../hooks/useIcon');
+
+describe('NavigationAvatar accessibility', () => {
+  accessibilityTest(
+    (props) => (
+      <Navigation aria-label="Main">
+        <NavigationItem>
+          <NavigationAvatar
+            {...props}
+            avatarContent={<Icon name="profile" />}
+            href="#"
+            aria-label="Profile of Jiří Bárta"
+          >
+            My Account
+          </NavigationAvatar>
+        </NavigationItem>
+      </Navigation>
+    ),
+    '[aria-label="Profile of Jiří Bárta"]',
+  );
+
+  accessibilityTest(
+    (props) => (
+      <Navigation aria-label="Main">
+        <NavigationItem>
+          <NavigationAvatar {...props} avatarContent={<Icon name="profile" />} elementType="div">
+            My Account
+          </NavigationAvatar>
+        </NavigationItem>
+      </Navigation>
+    ),
+    '.NavigationAvatar',
+  );
+
+  it('should mark inner Avatar as decorative', () => {
+    const { container } = render(
+      <NavigationAvatar avatarContent={<Icon name="profile" />} href="#">
+        My Account
+      </NavigationAvatar>,
+    );
+
+    expect(container.querySelector('.Avatar')).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/packages/web-react/src/components/Navigation/demo/NavigationAvatarBasic.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationAvatarBasic.tsx
@@ -2,17 +2,17 @@ import React from 'react';
 import Navigation from '../Navigation';
 import NavigationAvatar from '../NavigationAvatar';
 import NavigationItem from '../NavigationItem';
-import { AVATAR_ARIA_LABEL, AVATAR_CONTENT, AVATAR_TEXT } from './navigationAvatarDemoHelpers';
+import { AVATAR_CONTENT, AVATAR_TEXT } from './navigationAvatarDemoHelpers';
 
 const NavigationAvatarBasic = () => (
   <Navigation aria-label="Avatar">
     <NavigationItem>
-      <NavigationAvatar avatarContent={AVATAR_CONTENT} aria-label={AVATAR_ARIA_LABEL} elementType="div">
+      <NavigationAvatar avatarContent={AVATAR_CONTENT} elementType="div">
         {AVATAR_TEXT}
       </NavigationAvatar>
     </NavigationItem>
     <NavigationItem>
-      <NavigationAvatar avatarContent={AVATAR_CONTENT} isSquare aria-label={AVATAR_ARIA_LABEL} elementType="div">
+      <NavigationAvatar avatarContent={AVATAR_CONTENT} isSquare elementType="div">
         {AVATAR_TEXT}
       </NavigationAvatar>
     </NavigationItem>

--- a/packages/web-react/src/components/Navigation/demo/NavigationAvatarBasic.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationAvatarBasic.tsx
@@ -5,7 +5,7 @@ import NavigationItem from '../NavigationItem';
 import { AVATAR_ARIA_LABEL, AVATAR_CONTENT, AVATAR_TEXT } from './navigationAvatarDemoHelpers';
 
 const NavigationAvatarBasic = () => (
-  <Navigation aria-label="NavigationAvatar">
+  <Navigation aria-label="Avatar">
     <NavigationItem>
       <NavigationAvatar avatarContent={AVATAR_CONTENT} aria-label={AVATAR_ARIA_LABEL} elementType="div">
         {AVATAR_TEXT}

--- a/packages/web-react/src/components/Navigation/demo/NavigationAvatarWithDropdown.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationAvatarWithDropdown.tsx
@@ -19,7 +19,7 @@ const NavigationAvatarWithDropdown = () => {
   const [isSquareDropdownOpen, toggleSquareDropdown] = useToggle();
 
   return (
-    <Navigation aria-label="NavigationAvatar">
+    <Navigation aria-label="Avatar with Dropdown">
       <NavigationItem alignmentY="stretch">
         <Dropdown
           alignmentX="stretch"

--- a/packages/web-react/src/components/Navigation/demo/NavigationAvatarWithLink.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationAvatarWithLink.tsx
@@ -5,7 +5,7 @@ import NavigationItem from '../NavigationItem';
 import { AVATAR_ARIA_LABEL, AVATAR_CONTENT, AVATAR_TEXT } from './navigationAvatarDemoHelpers';
 
 const NavigationAvatarWithLink = () => (
-  <Navigation aria-label="NavigationAvatar">
+  <Navigation aria-label="Avatar with Link">
     <NavigationItem>
       <NavigationAvatar avatarContent={AVATAR_CONTENT} aria-label={AVATAR_ARIA_LABEL} href="#">
         {AVATAR_TEXT}

--- a/packages/web-react/src/components/Navigation/demo/NavigationHorizontal.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationHorizontal.tsx
@@ -3,7 +3,7 @@ import Navigation from '../Navigation';
 import NavigationItem from '../NavigationItem';
 
 const NavigationHorizontal = () => (
-  <Navigation aria-label="Main Navigation">
+  <Navigation aria-label="Main">
     <NavigationItem>Item</NavigationItem>
   </Navigation>
 );

--- a/packages/web-react/src/components/Navigation/demo/NavigationHorizontalWithBoxAction.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationHorizontalWithBoxAction.tsx
@@ -4,7 +4,7 @@ import NavigationAction from '../NavigationAction';
 import NavigationItem from '../NavigationItem';
 
 const NavigationHorizontalWithBoxAction = () => (
-  <Navigation aria-label="Main Navigation">
+  <Navigation aria-label="Horizontal with Box NavigationAction">
     <NavigationItem>
       <NavigationAction href="/">Link</NavigationAction>
     </NavigationItem>

--- a/packages/web-react/src/components/Navigation/demo/NavigationHorizontalWithButtons.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationHorizontalWithButtons.tsx
@@ -4,7 +4,7 @@ import Navigation from '../Navigation';
 import NavigationItem from '../NavigationItem';
 
 const NavigationHorizontalWithButtons = () => (
-  <Navigation aria-label="Navigation with Buttons">
+  <Navigation aria-label="Horizontal with Buttons">
     <NavigationItem>
       <ButtonLink href="#">Button</ButtonLink>
     </NavigationItem>

--- a/packages/web-react/src/components/Navigation/demo/NavigationHorizontalWithDropdown.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationHorizontalWithDropdown.tsx
@@ -23,7 +23,7 @@ const NavigationHorizontalWithDropdown = () => {
   const [isNavigationActionDropdownOpen, setIsNavigationActionDropdownOpen] = useState(false);
 
   return (
-    <Navigation aria-label="Main Navigation">
+    <Navigation aria-label="Nested Horizontal Box with Dropdown">
       <NavigationItem>
         <NavigationAction href="/">Link</NavigationAction>
       </NavigationItem>

--- a/packages/web-react/src/components/Navigation/demo/NavigationHorizontalWithPillAction.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationHorizontalWithPillAction.tsx
@@ -4,7 +4,7 @@ import NavigationAction from '../NavigationAction';
 import NavigationItem from '../NavigationItem';
 
 const NavigationHorizontalWithPillAction = () => (
-  <Navigation aria-label="Main Navigation">
+  <Navigation aria-label="Horizontal with Pill NavigationAction">
     <NavigationItem>
       <NavigationAction href="/" variant="pill">
         Link

--- a/packages/web-react/src/components/Navigation/demo/NavigationVertical.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationVertical.tsx
@@ -3,7 +3,7 @@ import Navigation from '../Navigation';
 import NavigationItem from '../NavigationItem';
 
 const NavigationVertical = () => (
-  <Navigation aria-label="Main Navigation" direction="vertical">
+  <Navigation aria-label="Vertical" direction="vertical">
     <NavigationItem>Item</NavigationItem>
   </Navigation>
 );

--- a/packages/web-react/src/components/Navigation/demo/NavigationVerticalWithBoxAction.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationVerticalWithBoxAction.tsx
@@ -4,7 +4,7 @@ import NavigationAction from '../NavigationAction';
 import NavigationItem from '../NavigationItem';
 
 const NavigationVerticalWithBoxAction = () => (
-  <Navigation aria-label="Main Navigation" direction="vertical">
+  <Navigation aria-label="Vertical with Box NavigationAction" direction="vertical">
     <NavigationItem>
       <NavigationAction href="/">Link</NavigationAction>
     </NavigationItem>

--- a/packages/web-react/src/components/Navigation/demo/NavigationVerticalWithBoxActionAndStartIcons.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationVerticalWithBoxActionAndStartIcons.tsx
@@ -7,7 +7,7 @@ import NavigationAction from '../NavigationAction';
 import NavigationItem from '../NavigationItem';
 
 const NavigationVerticalWithBoxActionAndStartIcons = () => (
-  <Navigation aria-label="Main Navigation with Start Icons" direction="vertical">
+  <Navigation aria-label="Vertical with Box NavigationAction and Start/End Slots" direction="vertical">
     <NavigationItem>
       <NavigationAction href="/" startSlot={<Icon name="profile" />} endSlot={<Pill color="informative">12</Pill>}>
         Link

--- a/packages/web-react/src/components/Navigation/demo/NavigationVerticalWithButtons.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationVerticalWithButtons.tsx
@@ -4,7 +4,7 @@ import Navigation from '../Navigation';
 import NavigationItem from '../NavigationItem';
 
 const NavigationVerticalWithButtons = () => (
-  <Navigation aria-label="Navigation with Buttons" direction="vertical">
+  <Navigation aria-label="Vertical with Buttons" direction="vertical">
     <NavigationItem>
       <ButtonLink href="#">Button</ButtonLink>
     </NavigationItem>

--- a/packages/web-react/src/components/Navigation/demo/NavigationVerticalWithCollapse.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationVerticalWithCollapse.tsx
@@ -9,7 +9,7 @@ const NavigationVerticalWithCollapse = () => {
   const { isOpen, toggleHandler } = useCollapse(true);
 
   return (
-    <Navigation aria-label="Subnavigation Item States" direction="vertical">
+    <Navigation aria-label="Nested Vertical" direction="vertical">
       <NavigationItem>
         <NavigationAction href="/">Home</NavigationAction>
       </NavigationItem>

--- a/packages/web-react/src/components/Navigation/demo/NavigationVerticalWithPillAction.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationVerticalWithPillAction.tsx
@@ -4,7 +4,7 @@ import NavigationAction from '../NavigationAction';
 import NavigationItem from '../NavigationItem';
 
 const NavigationVerticalWithPillAction = () => (
-  <Navigation aria-label="Main Navigation" direction="vertical">
+  <Navigation aria-label="Vertical with Pill NavigationAction" direction="vertical">
     <NavigationItem>
       <NavigationAction href="/" variant="pill">
         Link

--- a/packages/web-react/src/components/Navigation/demo/NavigationVerticalWithPillActionAndStartIcons.tsx
+++ b/packages/web-react/src/components/Navigation/demo/NavigationVerticalWithPillActionAndStartIcons.tsx
@@ -7,7 +7,7 @@ import NavigationAction from '../NavigationAction';
 import NavigationItem from '../NavigationItem';
 
 const NavigationVerticalWithPillActionAndStartIcons = () => (
-  <Navigation aria-label="Main Navigation with Start Icons and Pill Action" direction="vertical">
+  <Navigation aria-label="Vertical with Pill NavigationAction and Start/End Slots" direction="vertical">
     <NavigationItem>
       <NavigationAction
         href="/"

--- a/packages/web/src/scss/components/Header/README.md
+++ b/packages/web/src/scss/components/Header/README.md
@@ -157,7 +157,7 @@ Use the composition mentioned above to create the layout you need.
         </ul>
       </nav>
 
-      <nav class="Navigation ml-auto" aria-label="Secondary Navigation">
+      <nav class="Navigation ml-auto" aria-label="Secondary">
         <ul>
           <li>
             <button class="Button Button--tertiary Button--medium Button--symmetrical">

--- a/packages/web/src/scss/components/Header/preview.html
+++ b/packages/web/src/scss/components/Header/preview.html
@@ -128,7 +128,7 @@
             </div>
           </a>
 
-          <nav class="Navigation Navigation--horizontal d-only-mobile-none d-only-tablet-none" aria-label="Main Navigation">
+          <nav class="Navigation Navigation--horizontal d-only-mobile-none d-only-tablet-none" aria-label="Main with menu, desktop">
             <ul>
               <li class="NavigationItem NavigationItem--alignmentYCenter">
                 <a
@@ -146,7 +146,7 @@
             </ul>
           </nav>
 
-          <nav class="Navigation Navigation--horizontal ml-auto" aria-label="Secondary Navigation">
+          <nav class="Navigation Navigation--horizontal ml-auto" aria-label="Secondary with menu, desktop">
             <ul>
               <li class="NavigationItem NavigationItem--alignmentYCenter">
                 <button
@@ -273,7 +273,7 @@
             </div>
 
             <div class="StackItem">
-              <nav class="Navigation Navigation--vertical" aria-label="Main Navigation">
+              <nav class="Navigation Navigation--vertical" aria-label="Main with menu, mobile">
                 <ul>
                   <li class="NavigationItem NavigationItem--alignmentYCenter">
                     <a
@@ -293,7 +293,7 @@
             </div>
 
             <div class="StackItem">
-              <nav class="Navigation Navigation--vertical" aria-label="Secondary Navigation">
+              <nav class="Navigation Navigation--vertical" aria-label="Secondary with menu, mobile">
                 <ul>
                   <li class="NavigationItem NavigationItem--alignmentYCenter">
                     <a href="#" class="Button Button--secondary Button--small">Log In</a>
@@ -337,7 +337,7 @@
             </div>
           </a>
 
-          <nav class="Navigation Navigation--horizontal d-only-mobile-none d-only-tablet-none" aria-label="Main Navigation">
+          <nav class="Navigation Navigation--horizontal d-only-mobile-none d-only-tablet-none" aria-label="Main with pill menu, desktop">
             <ul>
               <li class="NavigationItem NavigationItem--alignmentYCenter">
                 <a
@@ -355,7 +355,7 @@
             </ul>
           </nav>
 
-          <nav class="Navigation Navigation--horizontal ml-auto" aria-label="Secondary Navigation">
+          <nav class="Navigation Navigation--horizontal ml-auto" aria-label="Secondary with pill menu, desktop">
             <ul>
               <li class="NavigationItem NavigationItem--alignmentYCenter">
                 <button
@@ -483,7 +483,7 @@
             </div>
 
             <div class="StackItem">
-              <nav class="Navigation Navigation--vertical" aria-label="Main Navigation">
+              <nav class="Navigation Navigation--vertical" aria-label="Main with pill menu, mobile">
                 <ul>
                   <li class="NavigationItem NavigationItem--alignmentYCenter">
                     <a
@@ -503,7 +503,7 @@
             </div>
 
             <div class="StackItem">
-              <nav class="Navigation Navigation--vertical" aria-label="Secondary Navigation">
+              <nav class="Navigation Navigation--vertical" aria-label="Secondary with pill menu, mobile">
                 <ul>
                   <li class="NavigationItem NavigationItem--alignmentYCenter">
                     <a href="#" class="Button Button--secondary Button--small">Log In</a>
@@ -547,7 +547,7 @@
             </div>
           </a>
 
-          <nav class="Navigation Navigation--horizontal d-only-mobile-none d-only-tablet-none" aria-label="Main Navigation">
+          <nav class="Navigation Navigation--horizontal d-only-mobile-none d-only-tablet-none" aria-label="Main with menu and nested items, desktop">
             <ul>
               <li class="NavigationItem NavigationItem--alignmentYCenter">
                 <a
@@ -627,7 +627,7 @@
             </ul>
           </nav>
 
-          <nav class="Navigation Navigation--horizontal ml-auto" aria-label="Secondary Navigation">
+          <nav class="Navigation Navigation--horizontal ml-auto" aria-label="Secondary with menu and nested items, desktop">
             <ul>
               <li class="NavigationItem NavigationItem--alignmentYCenter">
                 <button class="Button Button--tertiary Button--small Button--symmetrical">
@@ -803,7 +803,7 @@
             </div>
 
             <div class="StackItem">
-              <nav class="Navigation Navigation--vertical" aria-label="Main Navigation">
+              <nav class="Navigation Navigation--vertical" aria-label="Main with menu and nested items, mobile">
                 <ul>
                   <li class="NavigationItem NavigationItem--alignmentYCenter">
                     <a
@@ -867,7 +867,7 @@
             </div>
 
             <div class="StackItem">
-              <nav class="Navigation Navigation--vertical" aria-label="Secondary Navigation">
+              <nav class="Navigation Navigation--vertical" aria-label="Secondary with menu and nested items, mobile">
                 <ul>
                   <li class="NavigationItem NavigationItem--alignmentYCenter">
                     <a href="#" class="Button Button--secondary Button--small">Log Out</a>

--- a/packages/web/src/scss/components/Navigation/README.md
+++ b/packages/web/src/scss/components/Navigation/README.md
@@ -145,12 +145,12 @@ in sync for you.
 The `NavigationAvatar` is a component that is styled to be used as a navigation action with an avatar.
 
 ```html
-<a href="#" class="NavigationAvatar">
-  <span class="Avatar Avatar--small" aria-label="Profile of Jiří Bárta">
+<a href="#" class="NavigationAvatar" aria-label="Profile of Jiří Bárta">
+  <div class="Avatar Avatar--small" aria-hidden="true">
     <svg class="Icon" width="20" height="20" aria-hidden="true">
       <use href="/assets/icons/svg/sprite.svg#profile" />
     </svg>
-  </span>
+  </div>
   <span class="typography-action-small">My Account</span>
 </a>
 ```
@@ -158,12 +158,12 @@ The `NavigationAvatar` is a component that is styled to be used as a navigation 
 If you want the avatar to be square, don't forget to add the `NavigationAvatar--square` modifier to the `NavigationAvatar` component.
 
 ```html
-<a href="#" class="NavigationAvatar NavigationAvatar--square">
-  <span class="Avatar Avatar--square Avatar--small" aria-label="Profile of Jiří Bárta">
+<a href="#" class="NavigationAvatar NavigationAvatar--square" aria-label="Profile of Jiří Bárta">
+  <div class="Avatar Avatar--square Avatar--small" aria-hidden="true">
     <svg class="Icon" width="20" height="20" aria-hidden="true">
       <use href="/assets/icons/svg/sprite.svg#profile" />
     </svg>
-  </span>
+  </div>
   <span class="typography-action-small">My Account</span>
 </a>
 ```
@@ -177,12 +177,12 @@ The avatar inside `NavigationAvatar` can have different sizes. Use the `Avatar--
 Available sizes: `xsmall`, `small`, `medium`, `large`, `xlarge`.
 
 ```html
-<a href="#" class="NavigationAvatar">
-  <span class="Avatar Avatar--xsmall" aria-label="Profile of Jiří Bárta">
+<a href="#" class="NavigationAvatar" aria-label="Profile of Jiří Bárta">
+  <div class="Avatar Avatar--xsmall" aria-hidden="true">
     <svg class="Icon" width="16" height="16" aria-hidden="true">
       <use href="/assets/icons/svg/sprite.svg#profile" />
     </svg>
-  </span>
+  </div>
   <span class="typography-action-small">My Account</span>
 </a>
 ```
@@ -190,12 +190,12 @@ Available sizes: `xsmall`, `small`, `medium`, `large`, `xlarge`.
 You can also use responsive sizes with breakpoint-specific classes, e.g. `Avatar--tablet--<size>` or `Avatar--desktop--<size>`.
 
 ```html
-<a href="#" class="NavigationAvatar">
-  <span class="Avatar Avatar--small Avatar--tablet--medium Avatar--desktop--large" aria-label="Profile of Jiří Bárta">
+<a href="#" class="NavigationAvatar" aria-label="Profile of Jiří Bárta">
+  <div class="Avatar Avatar--small Avatar--tablet--medium Avatar--desktop--large" aria-hidden="true">
     <svg class="Icon" width="20" height="20" aria-hidden="true">
       <use href="/assets/icons/svg/sprite.svg#profile" />
     </svg>
-  </span>
+  </div>
   <span class="typography-action-small">My Account</span>
 </a>
 ```
@@ -219,12 +219,12 @@ With NavigationAction and NavigationAvatar components:
       <a class="NavigationAction NavigationAction--box" href="#">Link</a>
     </li>
     <li class="NavigationItem NavigationItem--alignmentYCenter">
-      <a href="#" class="NavigationAvatar">
-        <span class="Avatar Avatar--small" aria-label="Profile of Jiří Bárta">
+      <a href="#" class="NavigationAvatar" aria-label="Profile of Jiří Bárta">
+        <div class="Avatar Avatar--small" aria-hidden="true">
           <svg class="Icon" width="20" height="20" aria-hidden="true">
             <use href="/assets/icons/svg/sprite.svg#profile" />
           </svg>
-        </span>
+        </div>
         <span class="typography-action-small">My Account</span>
       </a>
     </li>
@@ -244,12 +244,12 @@ With Buttons and NavigationAvatar:
       <a href="#" class="Button Button--medium Button--secondary">Button</a>
     </li>
     <li class="NavigationItem NavigationItem--alignmentYCenter">
-      <a href="#" class="NavigationAvatar">
-        <span class="Avatar Avatar--small" aria-label="Profile of Jiří Bárta">
+      <a href="#" class="NavigationAvatar" aria-label="Profile of Jiří Bárta">
+        <div class="Avatar Avatar--small" aria-hidden="true">
           <svg class="Icon" width="20" height="20" aria-hidden="true">
             <use href="/assets/icons/svg/sprite.svg#profile" />
           </svg>
-        </span>
+        </div>
         <span class="typography-action-small">My Account</span>
       </a>
     </li>

--- a/packages/web/src/scss/components/Navigation/README.md
+++ b/packages/web/src/scss/components/Navigation/README.md
@@ -16,14 +16,14 @@ The `Navigation` is a `nav` wrapper for lists of actions or other navigation com
 The `Navigation` component can be horizontal or vertical.
 
 ```html
-<nav class="Navigation Navigation--horizontal" aria-label="Horizontal Main Navigation">
+<nav class="Navigation Navigation--horizontal" aria-label="Main">
   <ul>
     <li>
       <!-- action -->
     </li>
   </ul>
 </nav>
-<nav class="Navigation Navigation--vertical" aria-label="Vertical Main Navigation">
+<nav class="Navigation Navigation--vertical" aria-label="Main">
   <ul>
     <li>
       <!-- action -->
@@ -205,7 +205,7 @@ You can also use responsive sizes with breakpoint-specific classes, e.g. `Avatar
 With NavigationAction and NavigationAvatar components:
 
 ```html
-<nav class="Navigation Navigation--horizontal" aria-label="Main Navigation">
+<nav class="Navigation Navigation--horizontal" aria-label="Main">
   <ul>
     <li class="NavigationItem NavigationItem--alignmentYCenter">
       <a class="NavigationAction NavigationAction--box NavigationAction--selected" href="#" aria-current="page"
@@ -235,7 +235,7 @@ With NavigationAction and NavigationAvatar components:
 With Buttons and NavigationAvatar:
 
 ```html
-<nav class="Navigation Navigation--horizontal" aria-label="Secondary Navigation">
+<nav class="Navigation Navigation--horizontal" aria-label="Secondary">
   <ul>
     <li class="NavigationItem NavigationItem--alignmentYCenter">
       <a href="#" class="Button Button--medium Button--primary">Button</a>

--- a/packages/web/src/scss/components/Navigation/preview.html
+++ b/packages/web/src/scss/components/Navigation/preview.html
@@ -7,7 +7,7 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <div>
-        <nav class="Navigation Navigation--horizontal" aria-label="Main Navigation">
+        <nav class="Navigation Navigation--horizontal" aria-label="Main">
           <ul>
             <li class="NavigationItem NavigationItem--alignmentYCenter">
               Item
@@ -31,7 +31,7 @@
     <div class="docs-Stack docs-Stack--stretch">
 
       <div>
-        <nav class="Navigation Navigation--vertical" aria-label="Vertical Navigation">
+        <nav class="Navigation Navigation--vertical" aria-label="Vertical">
           <ul>
             <li class="NavigationItem NavigationItem--alignmentYCenter">
               Item
@@ -54,7 +54,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <nav class="Navigation Navigation--horizontal" aria-label="Horizontal Navigation with NavigationAction">
+      <nav class="Navigation Navigation--horizontal" aria-label="Horizontal with NavigationAction">
         <ul>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
             <a href="#" class="NavigationAction NavigationAction--box">Link</a>
@@ -86,7 +86,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <nav class="Navigation Navigation--vertical" aria-label="Vertical Navigation with NavigationAction">
+      <nav class="Navigation Navigation--vertical" aria-label="Vertical with NavigationAction">
         <ul>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
             <a href="#" class="NavigationAction NavigationAction--box">Link</a>
@@ -118,7 +118,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <nav class="Navigation Navigation--vertical" aria-label="Vertical Navigation with Box NavigationAction and Start/End Slots">
+      <nav class="Navigation Navigation--vertical" aria-label="Vertical with Box NavigationAction and Start/End Slots">
         <ul>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
             <a href="#" class="NavigationAction NavigationAction--box">
@@ -202,7 +202,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <nav class="Navigation Navigation--horizontal" aria-label="Horizontal Navigation with Buttons">
+      <nav class="Navigation Navigation--horizontal" aria-label="Horizontal with Buttons">
         <ul>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
             <a href="#" class="Button Button--medium Button--primary">
@@ -231,7 +231,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <nav class="Navigation Navigation--vertical" aria-label="Vertical Navigation with Buttons">
+      <nav class="Navigation Navigation--vertical" aria-label="Vertical with Buttons">
         <ul>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
             <a href="#" class="Button Button--medium Button--primary">
@@ -260,7 +260,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <nav class="Navigation Navigation--horizontal" aria-label="Nested Horizontal Navigation">
+      <nav class="Navigation Navigation--horizontal" aria-label="Nested Horizontal">
         <ul>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
             <a href="#" class="NavigationAction NavigationAction--box">Link</a>
@@ -342,7 +342,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <nav class="Navigation Navigation--vertical" aria-label="Nested Vertical Navigation">
+      <nav class="Navigation Navigation--vertical" aria-label="Nested Vertical">
         <ul>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
             <a href="#" class="NavigationAction NavigationAction--box">Home</a>
@@ -419,7 +419,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <nav class="Navigation Navigation--horizontal" aria-label="Horizontal Navigation with Pill NavigationAction">
+      <nav class="Navigation Navigation--horizontal" aria-label="Horizontal with Pill NavigationAction">
         <ul>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
             <a href="#" class="NavigationAction NavigationAction--pill">Link</a>
@@ -451,7 +451,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <nav class="Navigation Navigation--vertical" aria-label="Vertical Navigation with Pill NavigationAction">
+      <nav class="Navigation Navigation--vertical" aria-label="Vertical with Pill NavigationAction">
         <ul>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
             <a href="#" class="NavigationAction NavigationAction--pill">Link</a>
@@ -483,7 +483,7 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <nav class="Navigation Navigation--vertical" aria-label="Vertical Navigation with Pill NavigationAction and Start/End Slots">
+      <nav class="Navigation Navigation--vertical" aria-label="Vertical with Pill NavigationAction and Start/End Slots">
         <ul>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
             <a href="#" class="NavigationAction NavigationAction--pill">
@@ -567,11 +567,11 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <nav class="Navigation Navigation--horizontal" aria-label="NavigationAvatar">
+      <nav class="Navigation Navigation--horizontal" aria-label="Avatar">
         <ul>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
             <div class="NavigationAvatar">
-              <span class="Avatar Avatar--small" aria-label="Profile of Jiří Bárta">
+              <div class="Avatar Avatar--small" aria-hidden="true">
                 <svg
                   class="Icon"
                   width="20"
@@ -580,13 +580,13 @@
                 >
                   <use href="/assets/icons/svg/sprite.svg#profile" />
                 </svg>
-              </span>
+              </div>
               My Account
             </div>
           </li>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
             <div class="NavigationAvatar NavigationAvatar--square">
-              <span class="Avatar Avatar--square Avatar--small" aria-label="Profile of Jiří Bárta">
+              <div class="Avatar Avatar--square Avatar--small" aria-hidden="true">
                 <svg
                   class="Icon"
                   width="20"
@@ -595,7 +595,7 @@
                 >
                   <use href="/assets/icons/svg/sprite.svg#profile" />
                 </svg>
-              </span>
+              </div>
               My Account
             </div>
           </li>
@@ -616,11 +616,15 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <nav class="Navigation Navigation--horizontal" aria-label="NavigationAvatar">
+      <nav class="Navigation Navigation--horizontal" aria-label="Avatar with Link">
         <ul>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
-            <a href="#" class="NavigationAvatar">
-              <span class="Avatar Avatar--small" aria-label="Profile of Jiří Bárta">
+            <a
+              href="#"
+              class="NavigationAvatar"
+              aria-label="Profile of Jiří Bárta"
+            >
+              <div class="Avatar Avatar--small" aria-hidden="true">
                 <svg
                   class="Icon"
                   width="20"
@@ -629,13 +633,17 @@
                 >
                   <use href="/assets/icons/svg/sprite.svg#profile" />
                 </svg>
-              </span>
+              </div>
               My Account
             </a>
           </li>
           <li class="NavigationItem NavigationItem--alignmentYCenter">
-            <a href="#" class="NavigationAvatar NavigationAvatar--square">
-              <span class="Avatar Avatar--square Avatar--small" aria-label="Profile of Jiří Bárta">
+            <a
+              href="#"
+              class="NavigationAvatar NavigationAvatar--square"
+              aria-label="Profile of Jiří Bárta"
+            >
+              <div class="Avatar Avatar--square Avatar--small" aria-hidden="true">
                 <svg
                   class="Icon"
                   width="20"
@@ -644,7 +652,7 @@
                 >
                   <use href="/assets/icons/svg/sprite.svg#profile" />
                 </svg>
-              </span>
+              </div>
               My Account
             </a>
           </li>
@@ -665,20 +673,21 @@
 
     <div class="docs-Stack docs-Stack--stretch">
 
-      <nav class="Navigation Navigation--horizontal" aria-label="NavigationAvatar">
+      <nav class="Navigation Navigation--horizontal" aria-label="Avatar with Dropdown">
         <ul>
           <li class="NavigationItem NavigationItem--alignmentYStretch">
             <div class="Dropdown Dropdown--alignmentXStretch Dropdown--alignmentYStretch">
               <button
                 type="button"
                 class="NavigationAvatar"
-                data-spirit-toggle="dropdown"
-                data-spirit-target="#navigation-avatar"
-                aria-expanded="false"
                 aria-controls="navigation-avatar"
+                aria-expanded="false"
+                aria-label="Profile of Jiří Bárta"
                 data-spirit-autoclose="true"
+                data-spirit-target="#navigation-avatar"
+                data-spirit-toggle="dropdown"
               >
-                <span class="Avatar Avatar--small" aria-label="Profile of Jiří Bárta">
+                <span class="Avatar Avatar--small" aria-hidden="true">
                   <svg
                     class="Icon"
                     width="20"
@@ -742,13 +751,14 @@
               <button
                 type="button"
                 class="NavigationAvatar NavigationAvatar--square"
-                data-spirit-toggle="dropdown"
-                data-spirit-target="#navigation-avatar-square"
-                aria-expanded="false"
                 aria-controls="navigation-avatar-square"
+                aria-expanded="false"
+                aria-label="Profile of Jiří Bárta"
                 data-spirit-autoclose="true"
+                data-spirit-target="#navigation-avatar-square"
+                data-spirit-toggle="dropdown"
               >
-                <span class="Avatar Avatar--square Avatar--small" aria-label="Profile of Jiří Bárta">
+                <span class="Avatar Avatar--square Avatar--small" aria-hidden="true">
                   <svg
                     class="Icon"
                     width="20"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

### Identified Accessibility Issues

#### 1. Elements must only used permitted ARIA attributes 
**Cause:**
`NavigationAvatar` had `aria-label` on the inner `Avatar` element, which has no interactive role — ARIA 1.2 prohibits this and AT silently ignores it.

**Solution:**
In `NavigationAvatar`, `aria-label` moves to the outer interactive element and `Avatar` is marked `aria-hidden="true"` at the component level. As a result, screen readers now announce only the outer label (e.g. "Profile of Jiří Bárta") instead of the previously concatenated "Profile of Jiří Bárta My Account". The non-interactive `elementType="div"` variant has `aria-label` removed entirely.

#### 2. Landmarks should have a unique role or role/label/title (i.e. accessible name) combination
**Cause:**
Navigation demo components used duplicate `aria-label` values (e.g. "Main Navigation" on 13 different previews), making `<nav>` landmarks indistinguishable for screen reader users.

**Solution:** 
Each demo now has a unique, descriptive landmark label. The word "Navigation" has been removed from all `aria-label` values on `<nav>` elements — screen readers already announce the element's "navigation" role, so including it in the label is redundant and results in e.g. "Main Navigation navigation". Header demo sub-components that are reused across multiple parents now accept `aria-label` as a prop so the label is set at the call site, not hardcoded.

<img width="2048" height="1233" alt="image" src="https://github.com/user-attachments/assets/3d3e45f4-c686-4334-b853-c6a366708b97" />

### Additional context

`aria-hidden="true"` on the inner `Avatar` is a component-level change. Consumers passing an image with a meaningful `alt` as `avatarContent` should ensure the outer `NavigationAvatar` `aria-label` covers the full accessible name.

### Issue reference

https://jira.almacareer.tech/browse/DS-2677