### PR TITLE
fix(storybook): fix Chromatic build failing on FCC story files

### DIFF
--- a/apps/storybook/main.ts
+++ b/apps/storybook/main.ts
@@ -13,8 +13,9 @@ const isChromatic = process.env.CHROMATIC === 'true';
 const config: StorybookConfig = {
   stories: [
     '../../packages/**/*.mdx',
-    '../../packages/**/*.stories.@(ts|tsx)',
-    ...(isChromatic ? ['!../../packages/**/*.figma.stories.@(ts|tsx)'] : []),
+    isChromatic
+      ? '../../packages/**/!(*.figma).stories.@(ts|tsx)'
+      : '../../packages/**/*.stories.@(ts|tsx)',
   ],
 
   // @see: https://storybook.js.org/docs/writing-stories/tags#custom-tags

--- a/packages/web-react/src/components/Item/figma/Item.figma.stories.tsx
+++ b/packages/web-react/src/components/Item/figma/Item.figma.stories.tsx
@@ -25,7 +25,9 @@ const meta: Meta<typeof Item> = {
         }),
         isDisabled: figma.boolean('Disabled'),
         isSelected: figma.boolean('Selected'),
-        iconProps: figma.instance('Icon').getProps<{ name: string }>(),
+        iconProps: (figma.instance('Icon') as unknown as { getProps?: <T>() => T } | undefined)?.getProps?.<{
+          name: string;
+        }>(),
       },
       examples: [
         { example: 'FigmaSingleSelect', variant: { Type: 'Single select' } },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Chromatic was crashing with `TypeError: Cannot read properties of undefined (reading 'getProps')` because two things went wrong together: the glob negation entry (`!...figma.stories...`) in the `stories` array had no effect — Storybook 10 processes each entry independently via picomatch, so a standalone negation never subtracts from earlier inclusions — and `figma.instance()` returns `undefined` at runtime (it is a static-analysis stub), making the chained `.getProps()` call throw when Chromatic evaluated the story module.

The `stories` pattern is replaced with an inline extglob `!(*.figma)` that excludes `*.figma.stories.tsx` files within a single picomatch glob when `CHROMATIC=true`. The `figma.instance().getProps()` call in the `Item` figma story is also guarded with a type cast and optional chaining as a safety net.

### Issue reference

https://jira.almacareer.tech/browse/DS-2668