### PR TITLE
docs(release-notes): add 2026-07-29 release notes #DS-2700

### DIFF
--- a/docs/release-notes/2026-07-29.md
+++ b/docs/release-notes/2026-07-29.md
@@ -1,0 +1,45 @@
+# 2026-07-29 Spirit Design System Release Notes
+
+📢 🚀 🎉 Ahoy, we have a new release with features and improvements. Here we go.
+
+## General Changes
+
+We've added the all-sides margin utility classes (`m-*`) and fixed `Tag` min-height.
+
+## News in Packages
+
+&nbsp;
+
+📦 **Web _5.0.2_** `@alma-oss/spirit-web`
+
+### Bug Fixes
+
+- Add missing margin utility class generation #DS-2682 ([4fee011](https://github.com/alma-oss/spirit-design-system/commit/4fee011c96154ea9727fa18a23fbbdfc002096e1))
+- Set only correct min-height in `Tag` #DS-2690 ([8ebb3a8](https://github.com/alma-oss/spirit-design-system/commit/8ebb3a88ecdd15a4346fd771efde833f164cdd9f))
+
+[Full changelog](https://github.com/alma-oss/spirit-design-system/compare/@alma-oss/spirit-web@5.0.1...@alma-oss/spirit-web@5.0.2)
+
+## What's Next 🔮
+
+- **Combobox**
+  Multi-select combobox with inline filtering for job positions, locations, and similar search-style filters — currently in testing.
+
+- **Split Tag**
+  A tag that can host a nested select, starting with the Jobs.cz search distance/radius control.
+
+- **Progress Bar**
+  A new progress indicator for standalone use and inside file upload flows — design work is starting in Figma.
+
+🎯 You can see more of our [quarterly targets outlook in Notion](https://www.notion.so/almacareer/Spirit-DS-team-Quarterly-Goals-878e92d5b74543039e513c0160fb9117).
+
+## We'd Love to Hear Your Feedback
+
+💬 If you have any ideas, suggestions, or requests regarding the newly introduced unstable components, or if you just need help or want to report a bug or wrong behavior, please get in touch with us on our Slack channel: [#spirit-design-system-support_cs_en](https://slack.com/archives/C068XPSDWQN).
+
+&nbsp;
+
+🐙 Everything is available in our [repository on GitHub](https://github.com/alma-oss/spirit-design-system/).
+
+&nbsp;
+
+Thank you for staying with us!


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

We need Slack-ready release notes for the 2026-07-29 publish so consumers can see what shipped in `@alma-oss/spirit-web-react@5.2.0` and `@alma-oss/spirit-web@5.0.2`. This adds `docs/release-notes/2026-07-29.md` with package highlights and a short What's Next section from the current/next sprint.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

https://jira.almacareer.tech/browse/DS-2700

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
