### PR TITLE
refactor(web-react, web): use `CloseButton` in `Picker` tag removal #DS-2703

### DIFF
--- a/packages/web-react/src/components/UNSTABLE_Picker/UNSTABLE_PickerTag.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Picker/UNSTABLE_PickerTag.tsx
@@ -4,10 +4,9 @@ import React, { useMemo } from 'react';
 import { Sizes } from '../../constants';
 import { useI18n } from '../../hooks';
 import { replaceTranslationParams } from '../../translations';
-import { ControlButton } from '../ControlButton';
-import { Icon } from '../Icon';
+import { CloseButton } from '../CloseButton';
 import { Tag } from '../Tag';
-import { PICKER_NESTED_CONTROL_BUTTON_SIZE_MAP, PICKER_NESTED_SIZE_MAP } from './constants';
+import { PICKER_NESTED_CLOSE_BUTTON_SIZE_MAP, PICKER_NESTED_SIZE_MAP } from './constants';
 import { usePickerContext } from './PickerContext';
 import type { SpiritUnstablePickerTagProps } from './types';
 import { getNodeText } from './utils';
@@ -24,7 +23,7 @@ const UNSTABLE_PickerTag = ({
   const { t } = useI18n();
   const { size = Sizes.MEDIUM, tagDescriptionId } = usePickerContext();
 
-  const removeButtonAriaLabel =
+  const removeButtonLabel =
     removeLabel ??
     replaceTranslationParams(t('picker.removeItemLabel'), {
       itemLabel: getNodeText(label),
@@ -57,16 +56,13 @@ const UNSTABLE_PickerTag = ({
     >
       <div role="gridcell" aria-colindex={1} className="d-contents">
         {children ?? <span>{label}</span>}
-        <ControlButton
-          aria-label={removeButtonAriaLabel}
+        <CloseButton
           isDisabled={isDisabled}
-          isSymmetrical
+          label={removeButtonLabel}
           onClick={onRemove}
-          size={PICKER_NESTED_CONTROL_BUTTON_SIZE_MAP[size]}
+          size={PICKER_NESTED_CLOSE_BUTTON_SIZE_MAP[size]}
           {...(tagKeyboardProps && { tabIndex: tagKeyboardProps.removeButtonTabIndex })}
-        >
-          <Icon name="close" />
-        </ControlButton>
+        />
       </div>
     </Tag>
   );

--- a/packages/web-react/src/components/UNSTABLE_Picker/__tests__/UNSTABLE_Picker.test.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Picker/__tests__/UNSTABLE_Picker.test.tsx
@@ -82,7 +82,7 @@ describe('UNSTABLE_Picker', () => {
 
     expect(screen.getByRole('row', { name: 'Czech' })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByLabelText('Remove Czech'));
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Czech' }));
 
     expect(onSelectionChange).toHaveBeenCalledWith([]);
   });

--- a/packages/web-react/src/components/UNSTABLE_Picker/constants.ts
+++ b/packages/web-react/src/components/UNSTABLE_Picker/constants.ts
@@ -17,8 +17,8 @@ export const PICKER_NESTED_SIZE_MAP: Record<PickerShellSize, SizeExtendedDiction
   [Sizes.LARGE]: SizesExtended.MEDIUM,
 };
 
-/** Maps picker shell size to ControlButton size inside nested tags. */
-export const PICKER_NESTED_CONTROL_BUTTON_SIZE_MAP: Record<PickerShellSize, SizeExtendedDictionaryType> = {
+/** Maps picker shell size to CloseButton size inside nested tags. */
+export const PICKER_NESTED_CLOSE_BUTTON_SIZE_MAP: Record<PickerShellSize, SizeExtendedDictionaryType> = {
   [Sizes.SMALL]: SizesExtended.XSMALL,
   [Sizes.MEDIUM]: SizesExtended.XSMALL,
   [Sizes.LARGE]: SizesExtended.XSMALL,

--- a/packages/web/src/scss/components/UNSTABLE_Picker/README.md
+++ b/packages/web/src/scss/components/UNSTABLE_Picker/README.md
@@ -118,14 +118,11 @@ Place a hidden `<span>` with a unique `id` anywhere in the `<body>` and referenc
     <!-- Tag content start -->
     <div role="gridcell" aria-colindex="1" class="d-contents">
       <span>Czech</span>
-      <button
-        type="button"
-        aria-label="Remove Czech"
-        class="ControlButton ControlButton--xsmall ControlButton--symmetrical"
-      >
+      <button type="button" class="ControlButton ControlButton--xsmall ControlButton--symmetrical">
         <svg class="Icon" width="16" height="16" aria-hidden="true">
           <use href="/icons/svg/sprite.svg#close" />
         </svg>
+        <span class="accessibility-hidden">Remove Czech</span>
       </button>
     </div>
     <!-- Tag content end -->
@@ -309,14 +306,11 @@ Each size expects a specific Tag and ControlButton size inside the selection are
         >
           <div role="gridcell" aria-colindex="1" class="d-contents">
             <span>Czech</span>
-            <button
-              type="button"
-              aria-label="Remove Czech"
-              class="ControlButton ControlButton--xsmall ControlButton--symmetrical"
-            >
+            <button type="button" class="ControlButton ControlButton--xsmall ControlButton--symmetrical">
               <svg class="Icon" width="16" height="16" aria-hidden="true">
                 <use href="/icons/svg/sprite.svg#close" />
               </svg>
+              <span class="accessibility-hidden">Remove Czech</span>
             </button>
           </div>
         </div>
@@ -410,15 +404,11 @@ inside the selection area (remove buttons) to disable the Picker.
         <div role="row" tabindex="0" aria-label="Czech" class="Tag Tag--selected Tag--small disabled">
           <div role="gridcell" aria-colindex="1" class="d-contents">
             <span>Czech</span>
-            <button
-              type="button"
-              aria-label="Remove Czech"
-              class="ControlButton ControlButton--xsmall ControlButton--symmetrical"
-              disabled
-            >
+            <button type="button" class="ControlButton ControlButton--xsmall ControlButton--symmetrical" disabled>
               <svg class="Icon" width="16" height="16" aria-hidden="true">
                 <use href="/icons/svg/sprite.svg#close" />
               </svg>
+              <span class="accessibility-hidden">Remove Czech</span>
             </button>
           </div>
         </div>

--- a/packages/web/src/scss/components/UNSTABLE_Picker/picker-demo.mjs
+++ b/packages/web/src/scss/components/UNSTABLE_Picker/picker-demo.mjs
@@ -3,6 +3,7 @@
 export const SELECTOR_TAG_ROW = '[data-tag-row]';
 export const SELECTOR_TAG_LABEL = '[data-tag-label]';
 export const SELECTOR_TAG_CLOSE = '[data-tag-close]';
+export const SELECTOR_TAG_CLOSE_LABEL = '[data-tag-close-label]';
 
 export const ID_SELECTION_LABEL_TEMPLATE = 'picker-selection-label-template';
 export const ID_TAG_TEMPLATE = 'picker-tag-template';
@@ -59,7 +60,7 @@ function createTag(tagLabel, selectionEl, onClose, sizeConfig, tagClass, isDisab
 
   const removeButton = tag.querySelector(SELECTOR_TAG_CLOSE);
 
-  removeButton.setAttribute('aria-label', `Remove ${tagLabel}`);
+  removeButton.querySelector(SELECTOR_TAG_CLOSE_LABEL).textContent = `Remove ${tagLabel}`;
   removeButton.setAttribute('tabindex', '-1');
 
   if (sizeConfig) {

--- a/packages/web/src/scss/components/UNSTABLE_Picker/preview.html
+++ b/packages/web/src/scss/components/UNSTABLE_Picker/preview.html
@@ -50,7 +50,6 @@
       <span data-tag-label><!-- Tag label comes here --></span>
       <button
         type="button"
-        aria-label="Remove"
         class="ControlButton ControlButton--xsmall ControlButton--hasBackground ControlButton--symmetrical dynamic-color-background-interactive dynamic-color-border accessibility-tap-target"
         data-tag-close
       >
@@ -62,6 +61,10 @@
         >
           <use href="/assets/icons/svg/sprite.svg#close" />
         </svg>
+        <span
+          class="accessibility-hidden"
+          data-tag-close-label
+        >Remove</span>
       </button>
     </div>
   </div>

--- a/packages/web/src/scss/components/UNSTABLE_Picker/publication-time-picker-demo.mjs
+++ b/packages/web/src/scss/components/UNSTABLE_Picker/publication-time-picker-demo.mjs
@@ -6,6 +6,7 @@ import {
   SELECTOR_TAG_ROW,
   SELECTOR_TAG_LABEL,
   SELECTOR_TAG_CLOSE,
+  SELECTOR_TAG_CLOSE_LABEL,
   initPopoverBehavior,
 } from './picker-demo';
 
@@ -44,7 +45,7 @@ function renderPublicationTimeSelection(selectionEl, popoverEl) {
   row.setAttribute('aria-label', radioLabel);
   row.setAttribute('tabindex', '0');
   tag.querySelector(SELECTOR_TAG_LABEL).textContent = radioLabel;
-  tag.querySelector(SELECTOR_TAG_CLOSE).setAttribute('aria-label', `Remove ${radioLabel}`);
+  tag.querySelector(SELECTOR_TAG_CLOSE_LABEL).textContent = `Remove ${radioLabel}`;
 
   const resetToDefault = () => {
     if (anyRadio) anyRadio.checked = true;

--- a/packages/web/src/scss/components/UNSTABLE_Picker/salary-picker-demo.mjs
+++ b/packages/web/src/scss/components/UNSTABLE_Picker/salary-picker-demo.mjs
@@ -6,6 +6,7 @@ import {
   SELECTOR_TAG_ROW,
   SELECTOR_TAG_LABEL,
   SELECTOR_TAG_CLOSE,
+  SELECTOR_TAG_CLOSE_LABEL,
   initPopoverBehavior,
 } from './picker-demo';
 
@@ -66,7 +67,7 @@ export function initSalaryPicker() {
     row.setAttribute('tabindex', '0');
     tag.querySelector(SELECTOR_TAG_LABEL).textContent = label;
     tag.querySelector(SELECTOR_TAG_LABEL).style.fontVariantNumeric = 'tabular-nums';
-    tag.querySelector(SELECTOR_TAG_CLOSE).setAttribute('aria-label', `Remove ${label}`);
+    tag.querySelector(SELECTOR_TAG_CLOSE_LABEL).textContent = `Remove ${label}`;
     tag.querySelector(SELECTOR_TAG_CLOSE).addEventListener('click', function (event) {
       event.preventDefault();
       event.stopPropagation();


### PR DESCRIPTION
## Description

The `Picker`'s selected-tag remove button was assembled from a raw `ControlButton` + `Icon`, duplicating markup that the shared `CloseButton` component already provides. This swaps it for `CloseButton` so the remove control reuses the standard, accessible close-button implementation; the accessible name now comes from `CloseButton`'s visually-hidden label (via the `label` prop) instead of an `aria-label`. `CloseButton` renders a `ControlButton` under the hood, so the visual output and class list are unchanged.

### Additional context

- The web (HTML) demos and README are updated in lockstep so the HTML and React demos still render 1:1 — the tag remove button now uses an `accessibility-hidden` label span instead of an `aria-label` attribute.
- Renamed the internal constant `PICKER_NESTED_CONTROL_BUTTON_SIZE_MAP` → `PICKER_NESTED_CLOSE_BUTTON_SIZE_MAP` (not exported from the package index).

### Issue reference

https://jira.almacareer.tech/browse/DS-2703