### PR TITLE
feat(vite-plugin-spirit-icons): strip clip paths and normalize named fills #DS-2462

### DIFF
--- a/packages/vite-plugin-spirit-icons/src/__tests__/buildSvg.test.ts
+++ b/packages/vite-plugin-spirit-icons/src/__tests__/buildSvg.test.ts
@@ -53,13 +53,14 @@ describe('buildSvg', () => {
     it('should normalize default icons to use currentColor and ignore fill="none"', () => {
       const svgName = 'close.svg';
       const svgContent =
-        '<svg viewBox="0 0 24 24"><path fill="#000000" /><path fill="none" stroke="#FF0000" /><circle fill="#ABCDEF" /></svg>';
+        '<svg viewBox="0 0 24 24"><path fill="#000000" /><path fill="black" /><path fill="none" stroke="#FF0000" /><circle fill="#ABCDEF" /></svg>';
 
       const output = normalizeSvgColors(svgName, svgContent);
 
       expect(output).not.toContain('#000000');
+      expect(output).not.toContain('fill="black"');
       expect(output).not.toContain('#ABCDEF');
-      expect(output.match(/fill="currentColor"/g)?.length).toBe(2);
+      expect(output.match(/fill="currentColor"/g)?.length).toBe(3);
       expect(output).toContain('fill="none"');
     });
   });
@@ -82,7 +83,7 @@ describe('buildSvg', () => {
       (readFileSyncMock as jest.Mock).mockImplementation((filePath: string) => {
         const name = path.basename(filePath);
         if (name === 'alpha.svg') {
-          return '<svg viewBox="0 0 24 24"><path fill="#000000" /></svg>';
+          return '<svg viewBox="0 0 24 24"><defs><clipPath id="clip"><rect width="24" height="24" /></clipPath></defs><g clip-path="url(#clip)"><path fill="#000000" /></g></svg>';
         }
         if (name === 'beta-dualtone.svg') {
           return `<svg viewBox="0 0 24 24"><rect fill="${DUALTONE_COLOR_BACKGROUND_DEFAULT}" /><path fill="${DUALTONE_COLOR_BORDER_DEFAULT}" /></svg>`;
@@ -112,6 +113,15 @@ describe('buildSvg', () => {
       expect(spriteContent).toContain('<symbol id="alpha"');
       expect(spriteContent).toContain('<symbol id="beta-dualtone"');
       expect(spriteContent).toContain('<symbol id="gamma-colored"');
+      expect(spriteContent).not.toContain('<clipPath');
+      expect(spriteContent).not.toContain('clip-path=');
+
+      const alphaContent = (writeFileSyncMock as jest.Mock).mock.calls.find(
+        ([filePath]) => filePath === path.join(distDir, 'alpha.svg'),
+      )[1];
+
+      expect(alphaContent).not.toContain('<clipPath');
+      expect(alphaContent).not.toContain('clip-path=');
       // Sprite wrapper
       expect(spriteContent.startsWith('<svg')).toBe(true);
       expect(spriteContent.trim().endsWith('</svg>')).toBe(true);

--- a/packages/vite-plugin-spirit-icons/src/__tests__/shared.test.ts
+++ b/packages/vite-plugin-spirit-icons/src/__tests__/shared.test.ts
@@ -1,4 +1,10 @@
-import { filterSvgFiles, getIconType, ICON_TYPE_COLORED, ICON_TYPE_DUALTONE } from '../steps/shared';
+import {
+  filterSvgFiles,
+  getIconType,
+  ICON_TYPE_COLORED,
+  ICON_TYPE_DUALTONE,
+  stripSvgClipPaths,
+} from '../steps/shared';
 
 describe('shared icon helpers', () => {
   describe('filterSvgFiles', () => {
@@ -29,6 +35,84 @@ describe('shared icon helpers', () => {
 
     it('should return default for non-matching svg names', () => {
       expect(getIconType('user-colored.png')).toBe('default');
+    });
+  });
+
+  describe('stripSvgClipPaths', () => {
+    it('should leave SVG without clip paths unchanged', () => {
+      const svgContent = '<svg viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="currentColor" /></svg>';
+
+      expect(stripSvgClipPaths(svgContent)).toBe(svgContent);
+    });
+
+    it('should remove clipPath inside defs and empty defs wrapper', () => {
+      const svgContent =
+        '<svg viewBox="0 0 24 24"><defs><clipPath id="a"><rect width="24" height="24" /></clipPath></defs><path d="M0 0h24v24H0z" /></svg>';
+
+      expect(stripSvgClipPaths(svgContent)).toBe(
+        '<svg viewBox="0 0 24 24"><path d="M0 0h24v24H0z" /></svg>',
+      );
+    });
+
+    it('should remove standalone clipPath elements', () => {
+      const svgContent =
+        '<svg viewBox="0 0 24 24"><clipPath id="a"><rect width="24" height="24" /></clipPath><path d="M0 0h24v24H0z" /></svg>';
+
+      expect(stripSvgClipPaths(svgContent)).toBe(
+        '<svg viewBox="0 0 24 24"><path d="M0 0h24v24H0z" /></svg>',
+      );
+    });
+
+    it('should remove the clip-path attribute and keep the g element', () => {
+      const svgContent = '<svg viewBox="0 0 24 24"><g clip-path="url(#a)"><path d="M0 0h24v24H0z" /></g></svg>';
+
+      expect(stripSvgClipPaths(svgContent)).toBe(
+        '<svg viewBox="0 0 24 24"><g><path d="M0 0h24v24H0z" /></g></svg>',
+      );
+    });
+
+    it('should keep other g attributes while removing clip-path', () => {
+      const svgContent =
+        '<svg viewBox="0 0 24 24"><g id="icon" clip-path="url(#a)" fill="none"><path d="M0 0h24v24H0z" /></g></svg>';
+
+      expect(stripSvgClipPaths(svgContent)).toBe(
+        '<svg viewBox="0 0 24 24"><g id="icon" fill="none"><path d="M0 0h24v24H0z" /></g></svg>',
+      );
+    });
+
+    it('should keep nested groups intact', () => {
+      const svgContent =
+        '<svg viewBox="0 0 24 24"><g clip-path="url(#a)"><g id="inner"><path d="M0 0h24v24H0z" /></g><path d="M1 1h2v2H1z" /></g><rect width="24" height="24" /></svg>';
+
+      expect(stripSvgClipPaths(svgContent)).toBe(
+        '<svg viewBox="0 0 24 24"><g><g id="inner"><path d="M0 0h24v24H0z" /></g><path d="M1 1h2v2H1z" /></g><rect width="24" height="24" /></svg>',
+      );
+    });
+
+    it('should remove clip-path attributes from nested groups', () => {
+      const svgContent =
+        '<svg viewBox="0 0 24 24"><g clip-path="url(#a)"><g clip-path="url(#b)"><path d="M0 0h24v24H0z" /></g></g></svg>';
+
+      expect(stripSvgClipPaths(svgContent)).toBe(
+        '<svg viewBox="0 0 24 24"><g><g><path d="M0 0h24v24H0z" /></g></g></svg>',
+      );
+    });
+
+    it('should remove clip-path attributes from non-group elements', () => {
+      const svgContent = '<svg viewBox="0 0 24 24"><path clip-path="url(#a)" d="M0 0h24v24H0z" /></svg>';
+
+      expect(stripSvgClipPaths(svgContent)).toBe(
+        '<svg viewBox="0 0 24 24"><path d="M0 0h24v24H0z" /></svg>',
+      );
+    });
+
+    it('should strip clip path definitions and attributes together', () => {
+      const svgContent =
+        '<svg viewBox="0 0 24 24"><defs><clipPath id="a"><rect width="24" height="24" /></clipPath></defs><g clip-path="url(#a)"><path d="M0 0h24v24H0z" /></g></svg>';
+
+      expect(stripSvgClipPaths(svgContent)).toBe(
+        '<svg viewBox="0 0 24 24"><g><path d="M0 0h24v24H0z" /></g></svg>',
+      );
     });
   });
 });

--- a/packages/vite-plugin-spirit-icons/src/steps/buildSvg.ts
+++ b/packages/vite-plugin-spirit-icons/src/steps/buildSvg.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { cssVariablePrefix } from '@alma-oss/spirit-design-tokens';
-import { filterSvgFiles, getIconType, ICON_TYPE_DUALTONE, ICON_TYPE_COLORED, Logger } from './shared';
+import { filterSvgFiles, getIconType, ICON_TYPE_DUALTONE, ICON_TYPE_COLORED, Logger, stripSvgClipPaths } from './shared';
 
 const consoleLogger: Logger = {
   info: (msg) => console.log(msg),
@@ -31,7 +31,7 @@ export const normalizeSvgColors = (fileName: string, svgContent: string): string
       return svgContent;
 
     default:
-      return svgContent.replace(/fill="#\w+"/g, 'fill="currentColor"');
+      return svgContent.replace(/fill="(?!none|currentColor)(?:#[\da-fA-F]+|[a-zA-Z]+)"/g, 'fill="currentColor"');
   }
 };
 
@@ -52,7 +52,8 @@ export const normalizeAndCopySvg = (srcDir: string, distDir: string, logger: Log
         const svgPath = path.join(srcDir, svg);
         const svgDistPath = path.join(distDir, svg);
         const svgContent = fs.readFileSync(svgPath, 'utf8');
-        const svgContentNormalized = normalizeSvgColors(svg, svgContent);
+        const svgContentStripped = stripSvgClipPaths(svgContent);
+        const svgContentNormalized = normalizeSvgColors(svg, svgContentStripped);
         const svgSpriteContent = svgContentNormalized
           .replace(/<svg.*(viewBox="(\d+\s){3}\d+").*>/, `<symbol id="${svg.slice(0, -4)}" $1>`)
           .replace(/<\/svg>/g, '</symbol>');

--- a/packages/vite-plugin-spirit-icons/src/steps/shared.ts
+++ b/packages/vite-plugin-spirit-icons/src/steps/shared.ts
@@ -23,3 +23,16 @@ export const getIconType = (fileName: string): string => {
 
   return 'default';
 };
+
+export const stripSvgClipPaths = (svgContent: string): string => {
+  let result = svgContent;
+
+  while (/<clipPath\b/i.test(result)) {
+    result = result.replace(/<defs\b[^>]*>\s*<clipPath\b[^>]*>[\s\S]*?<\/clipPath>\s*<\/defs>/gi, '');
+    result = result.replace(/<clipPath\b[^>]*>[\s\S]*?<\/clipPath>/gi, '');
+  }
+
+  result = result.replace(/<defs\b[^>]*>\s*<\/defs>/gi, '');
+
+  return result.replace(/\sclip-path="url\([^)]+\)"/gi, '');
+};


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description
Cyborg needs a few missing SVG processing capabilities in the icons Vite plugin. 

-  adds stripping of Figma-generated `<clipPath>` / `clip-path` noise during the build 
-  normalizes named fills like `fill="black"` to `currentColor` so default icons stay themeable

### Additional context
Clip-path removal unwraps `<g>` elements that only carried a `clip-path` attribute; groups with other attributes keep those attributes.

### Issue reference
https://jira.almacareer.tech/browse/DS-2462

### How to test
Add (or temporarily edit) an SVG under `packages/icons/src/svg/` that contains <clipPath> / clip-path="url(...)" and  `fill="black".`

Build icons:
`yarn workspace @alma-oss/spirit-icons run build`

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
